### PR TITLE
Add issue templates and basic CI with Actions

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -1,0 +1,33 @@
+---
+name: Bug report
+about: Tell us about a bug
+labels: kind/bug
+---
+
+### TL;DR
+<!-- Describe the bug in 1-2 sentences. -->
+
+**Expected behavior**
+<!-- What did you expect to happen? -->
+
+**Observed behavior**
+<!-- What did happened instead? -->
+
+### Reproduction
+<!-- What did you do? Provide a list of steps taken. -->
+
+1.  Went to ...
+2.  Ran ...
+3.  Clicked on ...
+
+**Screenshots**
+<!-- If relevant, include screenshots. If not, delete this section. -->
+
+**Environment**
+<!-- Complete the following information about your environment. -->
+- OS:
+- Browser:
+- Version:
+
+**Additional information**
+<!-- Are you doing something out of the ordinary? -->

--- a/.github/ISSUE_TEMPLATE/feature..md
+++ b/.github/ISSUE_TEMPLATE/feature..md
@@ -1,0 +1,24 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: kind/feature
+---
+
+### TL;DR
+<!-- Describe the feature in 1-2 sentences. -->
+
+### Design
+
+**Proposal**
+<!-- Provide more detail on the proposal. What would it look like? -->
+
+**Alternatives considered**
+<!-- Have you explored other ways to solve this? -->
+
+**Resources**
+<!-- Please provide links to relevant documentation or examples. -->
+
+- [Link to documentation](TODO)
+
+**Additional information**
+<!-- Are you doing something out of the ordinary? -->

--- a/.github/ISSUE_TEMPLATE/question.md
+++ b/.github/ISSUE_TEMPLATE/question.md
@@ -1,0 +1,9 @@
+---
+name: Question
+about: Ask us a question.
+labels: kind/question
+---
+
+### Question
+<!-- Ask your question in 1-2 sentences. -->
+<!-- If you're sharing code, please use ``` codeblocks -->

--- a/.github/SECURITY.md
+++ b/.github/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+To report a suspected vulnerability, please contact
+exposure-notifications-feedback@google.com and include the steps to
+produce the vulnerability.

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,44 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: test
+on:
+  push:
+    branches:
+    - master
+  pull_request:
+    branches:
+    - master
+
+jobs:
+  test:
+    name: unit
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-go@v2
+      with:
+        go-version: '1.14'
+    - uses: actions/cache@v2
+      with:
+        path: ~/go/pkg/mod
+        key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+        restore-keys: |
+          ${{ runner.os }}-go-
+    - name: Get dependencies
+      run: go get -t ./...
+    - name: Lint
+      run: make fmtcheck staticcheck spellcheck
+    - name: Test
+      run: make test

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -37,7 +37,7 @@ func NewTestDatabaseWithConfig(tb testing.TB) (*Database, *Config) {
 	tb.Helper()
 
 	if testing.Short() {
-		tb.Skipf("🚧 Skipping database tests (short!")
+		tb.Skipf("🚧 Skipping database tests (short)!")
 	}
 
 	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_DATABASE_TESTS")); skip {


### PR DESCRIPTION
At least until we get prow setup, we can have GitHub Actions run tests and do linting.