### PR TITLE
Gracefully stop and cleanup servers

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -19,11 +19,12 @@ package main
 import (
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/certapi"
@@ -32,8 +33,10 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/verifyapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/gcpkms"
+	"github.com/google/exposure-notifications-verification-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
 	"github.com/sethvargo/go-limiter/httplimit"
+	"github.com/sethvargo/go-signalcontext"
 
 	"github.com/google/exposure-notifications-server/pkg/cache"
 
@@ -42,50 +45,66 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, done := signalcontext.OnInterrupt()
+
+	err := realMain(ctx)
+	done()
+
+	logger := logging.FromContext(ctx)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	logger.Info("successful shutdown")
+}
+
+func realMain(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+
 	config, err := config.NewAPIServerConfig(ctx)
 	if err != nil {
-		log.Fatalf("config error: %v", err)
+		return fmt.Errorf("failed to process config: %w", err)
 	}
+
 	// Setup database
 	db, err := config.Database.Open()
 	if err != nil {
-		log.Fatalf("db connection failed: %v", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()
 
 	// Setup signer
 	signer, err := gcpkms.New(ctx)
 	if err != nil {
-		log.Fatalf("error creating KeyManager: %v", err)
+		return fmt.Errorf("failed to crate key manager: %w", err)
 	}
 
+	// Create the router
 	r := mux.NewRouter()
 
 	// Setup rate limiter
 	store, err := ratelimit.RateLimiterFor(ctx, &config.RateLimit)
 	if err != nil {
-		log.Fatalf("failed to create limiter: %v", err)
+		return fmt.Errorf("failed to create limiter: %w", err)
 	}
 	defer store.Close()
 
 	httplimiter, err := httplimit.NewMiddleware(store, apiKeyFunc())
 	if err != nil {
-		log.Fatalf("failed to create limiter middleware: %v", err)
+		return fmt.Errorf("failed to create limiter middleware: %w", err)
 	}
 	r.Use(httplimiter.Handle)
 
 	// Setup API auth
 	apiKeyCache, err := cache.New(config.APIKeyCacheDuration)
 	if err != nil {
-		log.Fatalf("error establishing API Key cache: %v", err)
+		return fmt.Errorf("failed to create apikey cache: %w", err)
 	}
 	// Install the APIKey Auth Middleware
 	r.Use(middleware.APIKeyAuth(ctx, db, apiKeyCache, database.APIUserTypeDevice).Handle)
 
 	publicKeyCache, err := cache.New(config.PublicKeyCacheDuration)
 	if err != nil {
-		log.Fatalf("error establishing Public Key Cache: %v", err)
+		return fmt.Errorf("failed to create publickey cache: %w", err)
 	}
 
 	r.Handle("/api/verify", verifyapi.New(ctx, config, db, signer)).Methods("POST")
@@ -96,8 +115,32 @@ func main() {
 		Handler: handlers.CombinedLoggingHandler(os.Stdout, r),
 		Addr:    "0.0.0.0:" + strconv.Itoa(config.Port),
 	}
-	log.Printf("Listening on: 127.0.0.1:%v", config.Port)
-	log.Fatal(srv.ListenAndServe())
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Infow("server listening", "port", config.Port)
+
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-errCh:
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("failed to shutdown server")
+	}
+
+	return nil
 }
 
 func apiKeyFunc() httplimit.KeyFunc {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -17,11 +17,12 @@ package main
 import (
 	"context"
 	"crypto/sha1"
+	"errors"
 	"fmt"
-	"log"
 	"net/http"
 	"os"
 	"strconv"
+	"time"
 
 	firebase "firebase.google.com/go"
 
@@ -37,9 +38,11 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/signout"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/sethvargo/go-limiter/httplimit"
+	"github.com/sethvargo/go-signalcontext"
 
 	httpcontext "github.com/gorilla/context"
 	"github.com/gorilla/csrf"
@@ -48,51 +51,67 @@ import (
 )
 
 func main() {
-	ctx := context.Background()
+	ctx, done := signalcontext.OnInterrupt()
+
+	err := realMain(ctx)
+	done()
+
+	logger := logging.FromContext(ctx)
+	if err != nil {
+		logger.Fatal(err)
+	}
+	logger.Info("successful shutdown")
+}
+
+func realMain(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+
 	config, err := config.NewServerConfig(ctx)
 	if err != nil {
-		log.Fatalf("config error: %v", err)
+		return fmt.Errorf("failed to process config: %w", err)
 	}
+
 	// Setup database
 	db, err := config.Database.Open()
 	if err != nil {
-		log.Fatalf("db connection failed: %v", err)
+		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()
 
 	// Setup firebase
 	app, err := firebase.NewApp(ctx, config.FirebaseConfig())
 	if err != nil {
-		log.Fatalf("failed to setup firebase: %v", err)
+		return fmt.Errorf("failed to setup firebase: %w", err)
 	}
 	auth, err := app.Auth(ctx)
 	if err != nil {
-		log.Fatalf("failed to configure firebase auth: %v", err)
+		return fmt.Errorf("failed to configure firebase: %w", err)
 	}
 
-	// Create our HTML renderer.
-	renderHTML := render.LoadHTMLGlob(config.AssetsPath + "/*")
-
+	// Create the router
 	r := mux.NewRouter()
 
-	// Setup rate limiter
+	// Create our HTML renderer
+	renderHTML := render.LoadHTMLGlob(config.AssetsPath + "/*")
+	r.Use(html.New(config).Handle)
+
+	// Setup rate limiting
 	store, err := ratelimit.RateLimiterFor(ctx, &config.RateLimit)
 	if err != nil {
-		log.Fatalf("failed to create limiter: %v", err)
+		return fmt.Errorf("failed to create limiter: %w", err)
 	}
 	defer store.Close()
 
 	httplimiter, err := httplimit.NewMiddleware(store, userEmailKeyFunc())
 	if err != nil {
-		log.Fatalf("failed to create limiter middleware: %v", err)
+		return fmt.Errorf("failed to create limiter middleware: %w", err)
 	}
 	r.Use(httplimiter.Handle)
 
-	r.Use(html.New(config).Handle)
-	// install the CSRF protection middleware.
+	// Install the CSRF protection middleware.
 	csrfAuthKey, err := config.CSRFKey()
 	if err != nil {
-		log.Fatalf("unable to configure CSRF protection: %v", err)
+		return fmt.Errorf("failed to configure CSRF: %w", err)
 	}
 	// TODO(mikehelmick) - there are many more configuration options for CSRF protection.
 	r.Use(csrf.Protect(
@@ -142,8 +161,32 @@ func main() {
 		Handler: handlers.CombinedLoggingHandler(os.Stdout, r),
 		Addr:    "0.0.0.0:" + strconv.Itoa(config.Port),
 	}
-	log.Printf("Listening on :%v", config.Port)
-	log.Fatal(srv.ListenAndServe())
+
+	errCh := make(chan error, 1)
+	go func() {
+		logger.Infow("server listening", "port", config.Port)
+
+		if err := srv.ListenAndServe(); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			select {
+			case errCh <- err:
+			default:
+			}
+		}
+	}()
+
+	select {
+	case <-ctx.Done():
+	case <-errCh:
+		return fmt.Errorf("server error: %w", err)
+	}
+
+	shutdownCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if err := srv.Shutdown(shutdownCtx); err != nil {
+		return fmt.Errorf("failed to shutdown server")
+	}
+
+	return nil
 }
 
 func userEmailKeyFunc() httplimit.KeyFunc {

--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/sethvargo/go-gcpkms v0.0.0-20200507180216-f1fca850aed2
 	github.com/sethvargo/go-limiter v0.2.2
 	github.com/sethvargo/go-retry v0.1.0
+	github.com/sethvargo/go-signalcontext v0.0.0-20200717124333-74520d456356
 	github.com/sirupsen/logrus v1.6.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
 	go.opencensus.io v0.22.4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1082,6 +1082,8 @@ github.com/sethvargo/go-limiter v0.2.2 h1:9MsQb01jSwXyuuU4v2KIVtTisvzIQgUpHUEyVo
 github.com/sethvargo/go-limiter v0.2.2/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=
+github.com/sethvargo/go-signalcontext v0.0.0-20200717124333-74520d456356 h1:Poma+F9hLo3cYepsi8OzOsq/ks6MBU4/L7yDvnRnv5A=
+github.com/sethvargo/go-signalcontext v0.0.0-20200717124333-74520d456356/go.mod h1:PXu9UmR2f7mmp8kEwgkKmaDbxq/PbqixkiC66WIkkWE=
 github.com/shirou/gopsutil v0.0.0-20190901111213-e4ec7b275ada/go.mod h1:WWnYX4lzhCH5h/3YBfyVA3VbLYjlMZZAQcW9ojMexNc=
 github.com/shirou/gopsutil v2.19.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v2.20.4+incompatible h1:cMT4rxS55zx9NVUnCkrmXCsEB/RNfG9SwHY9evtX8Ng=


### PR DESCRIPTION
We can merge as-is, or wait until https://github.com/google/exposure-notifications-server/pull/742 and then I'll use that to remove some of the duplication around listening for cleanup signals.