### PR TITLE
Add SMS interfaces and Twilio implementation

### DIFF
--- a/pkg/sms/noop.go
+++ b/pkg/sms/noop.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sms
+
+import (
+	"context"
+)
+
+var _ Provider = (*Noop)(nil)
+
+// Noop does nothing.
+type Noop struct{}
+
+// NewNoop creates a new SMS sender that does nothing.
+func NewNoop(_ context.Context) (Provider, error) {
+	return &Noop{}, nil
+}
+
+// SendSMS does nothing.
+func (p *Noop) SendSMS(_ context.Context, _, _, _ string) error {
+	return nil
+}

--- a/pkg/sms/sms.go
+++ b/pkg/sms/sms.go
@@ -1,0 +1,60 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package sms defines interfaces for sending SMS text messages.
+//
+// Although exported, this package is non intended for general consumption. It
+// is a shared dependency between multiple exposure notifications projects. We
+// cannot guarantee that there won't be breaking changes in the future.
+package sms
+
+import (
+	"context"
+	"fmt"
+)
+
+// ProviderType represents a type of SMS provider.
+type ProviderType string
+
+const (
+	ProviderTypeNoop   ProviderType = "NOOP"
+	ProviderTypeTwilio ProviderType = "TWILIO"
+)
+
+// Config represents configuration for an SMS provider.
+type Config struct {
+	ProviderType ProviderType
+
+	// Twilio options
+	TwilioAccountSid string
+	TwilioAuthToken  string
+	TwilioFromNumber string
+}
+
+type Provider interface {
+	// SendSMS sends an SMS text message from the given number to the given number
+	// with the provided message.
+	SendSMS(ctx context.Context, from, to, message string) error
+}
+
+func ProviderFor(ctx context.Context, c *Config) (Provider, error) {
+	switch typ := c.ProviderType; typ {
+	case ProviderTypeNoop:
+		return NewNoop(ctx)
+	case ProviderTypeTwilio:
+		return NewTwilio(ctx, c.TwilioAccountSid, c.TwilioAuthToken)
+	default:
+		return nil, fmt.Errorf("unknown sms provider type: %v", typ)
+	}
+}

--- a/pkg/sms/twilio.go
+++ b/pkg/sms/twilio.go
@@ -1,0 +1,95 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sms
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+	"net/url"
+	"strings"
+	"time"
+)
+
+var _ Provider = (*Twilio)(nil)
+
+// Twilio sends messages via the Twilio API.
+type Twilio struct {
+	client *http.Client
+}
+
+// NewTwilio creates a new Twilio SMS sender with the given auth.
+func NewTwilio(ctx context.Context, accountSid, authToken string) (Provider, error) {
+	client := &http.Client{
+		Timeout:   5 * time.Second,
+		Transport: &twilioAuthRoundTripper{accountSid, authToken},
+	}
+
+	return &Twilio{
+		client: client,
+	}, nil
+}
+
+// SendSMS sends a message using the Twilio API.
+func (p *Twilio) SendSMS(ctx context.Context, from, to, message string) error {
+	params := url.Values{}
+	params.Set("To", to)
+	params.Set("From", from)
+	params.Set("Body", message)
+	body := strings.NewReader(params.Encode())
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/Messages.json", body)
+	if err != nil {
+		return fmt.Errorf("failed to build request: %w", err)
+	}
+
+	resp, err := p.client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to make request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if code := resp.StatusCode; code < 200 || code > 299 {
+		respBody, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("twilio error %d, but failed to read body: %w", code, err)
+		}
+		return fmt.Errorf("twilio error %d: %s", code, respBody)
+	}
+
+	return nil
+}
+
+// twilioAuthRoundTripper is an http.RoundTripper that updates the
+// authentication and headers to match Twilio's API.
+type twilioAuthRoundTripper struct {
+	accountSid, authToken string
+}
+
+// RoundTrip implements http.RoundTripper.
+func (rt *twilioAuthRoundTripper) RoundTrip(r *http.Request) (*http.Response, error) {
+	r.URL = &url.URL{
+		Scheme: "https",
+		Host:   "api.twilio.com",
+		Path:   "/2010-04-01/Accounts/" + rt.accountSid + "/" + strings.Trim(r.URL.Path, "/"),
+	}
+
+	r.SetBasicAuth(rt.accountSid, rt.authToken)
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+
+	return http.DefaultTransport.RoundTrip(r)
+}

--- a/pkg/sms/twilio_test.go
+++ b/pkg/sms/twilio_test.go
@@ -1,0 +1,97 @@
+package sms
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+)
+
+func TestTwilio_SendSMS(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skipf("🚧 Skipping twilio tests (short)!")
+	}
+
+	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_TWILIO_TESTS")); skip {
+		t.Skipf("🚧 Skipping twilio tests (SKIP_TWILIO_TESTS is set)!")
+	}
+
+	accountSid := os.Getenv("TWILIO_ACCOUNT_SID")
+	if accountSid == "" {
+		t.Fatalf("missing TWILIO_ACCOUNT_SID")
+	}
+
+	authToken := os.Getenv("TWILIO_AUTH_TOKEN")
+	if authToken == "" {
+		t.Fatalf("missing TWILIO_AUTH_TOKEN")
+	}
+
+	cases := []struct {
+		name string
+		from string
+		to   string
+		err  bool
+	}{
+		// The following numbers are "magic numbers" from Twilio to force their API
+		// to return errors for testing:
+		//
+		// https://www.twilio.com/docs/iam/test-credentials#test-sms-messages-parameters-From
+		{
+			name: "invalid",
+			from: "+15005550006",
+			to:   "+15005550001",
+			err:  true,
+		},
+		{
+			name: "unroutable",
+			from: "+15005550006",
+			to:   "+15005550002",
+			err:  true,
+		},
+		{
+			name: "international",
+			from: "+15005550006",
+			to:   "+15005550003",
+			err:  true,
+		},
+		{
+			name: "blocked",
+			from: "+15005550006",
+			to:   "+15005550004",
+			err:  true,
+		},
+		{
+			name: "incapable",
+			from: "+15005550006",
+			to:   "+15005550009",
+			err:  true,
+		},
+		{
+			name: "sends",
+			from: "+15005550006",
+			to:   "+15005550006",
+			err:  false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			ctx := context.Background()
+			twilio, err := NewTwilio(ctx, accountSid, authToken)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			err = twilio.SendSMS(ctx, tc.from, tc.to, "testing 123")
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This doesn't add any envconfig because we're going to want this to be multitenant and stored in the database.

@mikehelmick do we want to provision a Twilio account so we can inject the test credentials into the build for CI?