### PR TITLE
Fix up indexes after MT upgrade.

### DIFF
--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -39,13 +39,12 @@ const (
 // the verification protocol.
 type AuthorizedApp struct {
 	gorm.Model
-	Name       string      `gorm:"type:varchar(100);unique_index"`
+	// AuthorizedApps belong to exactly one realm.
+	RealmID    uint        `gorm:"unique_index:realm_apikey_name"`
+	Realm      *Realm      // for loading the owning realm.
+	Name       string      `gorm:"type:varchar(100);unique_index:realm_apikey_name"`
 	APIKey     string      `gorm:"type:varchar(100);unique_index"`
 	APIKeyType APIUserType `gorm:"default:0"`
-
-	// AuthorizedApps belong to exactly one realm.
-	RealmID uint
-	Realm   *Realm
 }
 
 func (a *AuthorizedApp) IsAdminType() bool {


### PR DESCRIPTION
* drop unique authorized app by name index so different realms can use same name
* change that to a composide realm+name index so a realm doesn't use the same name twice.

Part of the fun of #104