### PR TITLE
pkg/database: alleviate User CRUD load by a distributed cache

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -76,6 +76,8 @@ func realMain(ctx context.Context) error {
 	}
 	defer db.Close()
 
+	db.SetRedisPool(config.RedisPool)
+
 	// Setup firebase
 	app, err := firebase.NewApp(ctx, config.FirebaseConfig())
 	if err != nil {

--- a/go.mod
+++ b/go.mod
@@ -31,6 +31,7 @@ require (
 	github.com/mikehelmick/go-chaff v0.3.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
+	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/prometheus/client_golang v1.7.1 // indirect
 	github.com/prometheus/statsd_exporter v0.17.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -30,8 +30,8 @@ require (
 	github.com/mattn/go-colorable v0.1.7 // indirect
 	github.com/mikehelmick/go-chaff v0.3.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
-	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencensus-integrations/redigo v2.0.1+incompatible
+	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/prometheus/client_golang v1.7.1 // indirect
 	github.com/prometheus/statsd_exporter v0.17.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1034,7 +1034,6 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
-github.com/opencensus-integrations/redigo v1.6.0 h1:vcwI9XLlGPeEkUlOCx5YqFoMFSdjavYMTNRWgJ9YSJw=
 github.com/opencensus-integrations/redigo v2.0.1+incompatible h1:1EbXlxudNBcuUYZk5EMvSswbu8jwZbxLO241AThg8xk=
 github.com/opencensus-integrations/redigo v2.0.1+incompatible/go.mod h1:iH5qq3BZppLeyPZP0Hy2qffpbcppAl58otmaERGeJaQ=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=

--- a/go.sum
+++ b/go.sum
@@ -1034,6 +1034,9 @@ github.com/onsi/gomega v1.7.1/go.mod h1:XdKZgCCFLUoM/7CFJVPcG8C1xQ1AJ0vpAezJrB7J
 github.com/onsi/gomega v1.9.0 h1:R1uwffexN6Pr340GtYRIdZmAiN4J+iw6WG4wog1DUXg=
 github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoTdcA=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/opencensus-integrations/redigo v1.6.0 h1:vcwI9XLlGPeEkUlOCx5YqFoMFSdjavYMTNRWgJ9YSJw=
+github.com/opencensus-integrations/redigo v2.0.1+incompatible h1:1EbXlxudNBcuUYZk5EMvSswbu8jwZbxLO241AThg8xk=
+github.com/opencensus-integrations/redigo v2.0.1+incompatible/go.mod h1:iH5qq3BZppLeyPZP0Hy2qffpbcppAl58otmaERGeJaQ=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -64,10 +64,9 @@ type ServerConfig struct {
 	RateLimit ratelimit.Config
 
 	// Redis configuration
-	RedisHost         string `env:"REDIS_HOST,default=127.0.0.1"`
-	RedisPort         string `env:"REDIS_PORT,default=6379"`
-	RedisPassword     string `env:"REDIS_PASSWORD"`
-	RedisDatabaseName string `env:"REDIS_DATABASENAME"`
+	RedisHost     string `env:"REDIS_HOST,default=127.0.0.1"`
+	RedisPort     string `env:"REDIS_PORT,default=6379"`
+	RedisPassword string `env:"REDIS_PASSWORD"`
 
 	RedisPool *redis.Pool
 }
@@ -83,7 +82,8 @@ func NewServerConfig(ctx context.Context) (*ServerConfig, error) {
 	if !config.DevMode {
 		redisPool := &redis.Pool{
 			Dial: func() (redis.Conn, error) {
-				return redis.Dial("tcp", config.RedisDatabaseName, redis.DialPassword(config.RedisPassword))
+				hostPort := config.RedisHost + ":" + config.RedisPort
+				return redis.Dial("tcp", hostPort, redis.DialPassword(config.RedisPassword))
 			},
 			TestOnBorrow: func(conn redis.Conn, at time.Time) error {
 				if time.Since(at) < 5*time.Minute {

--- a/pkg/database/redis_cache_test.go
+++ b/pkg/database/redis_cache_test.go
@@ -1,0 +1,326 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"encoding/json"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+
+	"github.com/opencensus-integrations/redigo/redis"
+)
+
+type redisCommandInterceptorConn struct {
+	redis.ConnWithContext
+
+	mu   sync.RWMutex
+	seqs []*redisSequence
+}
+
+type redisSequence struct {
+	Kind    string
+	Command string
+	Args    []interface{}
+}
+
+func (rcic *redisCommandInterceptorConn) SendContext(ctx context.Context, commandName string, args ...interface{}) error {
+	rcic.mu.Lock()
+	rcic.seqs = append(rcic.seqs, &redisSequence{"SEND", commandName, args})
+	rcic.mu.Unlock()
+
+	return rcic.ConnWithContext.SendContext(ctx, commandName, args...)
+}
+
+func (rcic *redisCommandInterceptorConn) DoContext(ctx context.Context, commandName string, args ...interface{}) (interface{}, error) {
+	rcic.mu.Lock()
+	rcic.seqs = append(rcic.seqs, &redisSequence{"DO", commandName, args})
+	rcic.mu.Unlock()
+
+	return rcic.ConnWithContext.DoContext(ctx, commandName, args...)
+}
+
+func (rcic *redisCommandInterceptorConn) CloseContext(ctx context.Context) error {
+	rcic.mu.Lock()
+	rcic.seqs = append(rcic.seqs, &redisSequence{Kind: "CLOSE"})
+	rcic.mu.Unlock()
+
+	return rcic.ConnWithContext.CloseContext(ctx)
+}
+
+func TestRedisAsPassthroughCache(t *testing.T) {
+	// Skip if Redis is not enabled.
+	redisConn, err := redis.Dial("tcp", "127.0.0.1:6379")
+	if err != nil {
+		t.Skipf("Redis could not be reached: %v", err)
+	}
+
+	redisInterceptor := &redisCommandInterceptorConn{ConnWithContext: redisConn.(redis.ConnWithContext)}
+	defer redisInterceptor.CloseContext(context.Background())
+
+	// Okay Redis is available, now use it.
+	db := NewTestDatabase(t)
+	redisPool := &redis.Pool{
+		Dial: func() (redis.Conn, error) {
+			return redisInterceptor, nil
+		},
+	}
+	db.SetRedisPool(redisPool)
+
+	email := "dr@example.com"
+	user := User{
+		Email:       email,
+		Name:        "Dr Example",
+		Admin:       false,
+		Disabled:    false,
+		Realms:      []*Realm{},
+		AdminRealms: []*Realm{},
+	}
+
+	if err := db.SaveUser(&user); err != nil {
+		t.Fatalf("error creating user: %v", err)
+	}
+	userV1JSON, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := db.FindUser(email)
+	if err != nil {
+		t.Fatalf("error reading user from db: %v", err)
+	}
+
+	if diff := cmp.Diff(user, *got, approxTime); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+
+	user.Admin = true
+	if err := db.SaveUser(&user); err != nil {
+		t.Fatalf("error updating user: %v", err)
+	}
+	userV2JSON, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err = db.FindUser(email)
+	if err != nil {
+		t.Fatalf("error reading user from db: %v", err)
+	}
+
+	if diff := cmp.Diff(user, *got, approxTime); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+
+	got, err = db.GetUser(user.ID)
+	if err != nil {
+		t.Fatalf("error reading user from db by ID: %v", err)
+	}
+
+	if diff := cmp.Diff(user, *got, approxTime); diff != "" {
+		t.Fatalf("mismatch (-want, +got):\n%s", diff)
+	}
+
+	user.Disabled = true
+	if err := db.SaveUser(&user); err != nil {
+		t.Fatalf("error failed to disable user: %v", err)
+	}
+
+	time.Sleep(time.Millisecond * 5)
+
+	delCount, err := db.PurgeUsers(time.Millisecond)
+	if err != nil {
+		t.Fatalf("failed to purge users: %v", err)
+	}
+	if g, w := delCount, int64(1); g != w {
+		t.Fatalf("failed to purge all users, count mismatch: got %d want %d", g, w)
+	}
+	userV3JSON, err := json.Marshal(user)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Now we shall compare with the results.
+	want := []*redisSequence{
+		// 1. The first User.save(...)
+		{Kind: "SEND", Command: "MULTI"},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", userV1JSON,
+			},
+		},
+		// Set that TTL so that the user data expires after a day unconditionally.
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", float64(86400),
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_id", user.ID, userV1JSON,
+			},
+		},
+		// Set that TTL so that the user data expires after a day unconditionally.
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_id", user.ID, float64(86400),
+			},
+		},
+		{
+			Kind:    "DO",
+			Command: "EXEC",
+		},
+
+		// 2. The db.FindUser(email)
+		{
+			Kind:    "DO",
+			Command: "GET",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com",
+			},
+		},
+
+		// 3. The db.Save(...) after User.Admin = true
+		{
+			Kind:    "SEND",
+			Command: "MULTI",
+		},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", userV2JSON,
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", float64(86400),
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_id", user.ID, userV2JSON,
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_id", user.ID, float64(86400),
+			},
+		},
+		{
+			Kind:    "DO",
+			Command: "EXEC",
+		},
+
+		// 4. The db.FindUser(email)
+		{
+			Kind:    "DO",
+			Command: "GET",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com",
+			},
+		},
+
+		// 5. The db.FindUser(email)
+		{
+			Kind:    "DO",
+			Command: "GET",
+			Args: []interface{}{
+				"USERS_id", user.ID,
+			},
+		},
+
+		// 6. Disable the user.
+		{
+			Kind:    "SEND",
+			Command: "MULTI",
+		},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", userV3JSON,
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com", float64(86400),
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "SET",
+			Args: []interface{}{
+				"USERS_id", user.ID, userV3JSON,
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "EXPIRE",
+			Args: []interface{}{
+				"USERS_id", user.ID, float64(86400),
+			},
+		},
+		{
+			Kind:    "DO",
+			Command: "EXEC",
+		},
+
+		// 7. The deletion.
+		{
+			Kind:    "SEND",
+			Command: "MULTI",
+		},
+		{
+			Kind:    "SEND",
+			Command: "DEL",
+			Args: []interface{}{
+				"USERS_email", "dr@example.com",
+			},
+		},
+		{
+			Kind:    "SEND",
+			Command: "DEL",
+			Args: []interface{}{
+				"USERS_id", user.ID,
+			},
+		},
+		{
+			Kind:    "DO",
+			Command: "EXEC",
+		},
+	}
+	if diff := cmp.Diff(redisInterceptor.seqs, want); diff != "" {
+		t.Fatalf("Redis sequence mismatch: got - want +\n%s", diff)
+	}
+}


### PR DESCRIPTION
Adds Redis as a pass-through cache for the methods of *Database
for CRUD for users. Write-throughs are performed on Create and Update,
Read-through for Read, and Deletion for Delete.

This change has an escape hatch for disjoint consistency with
that database in that, if a value isn't updated, its value will
expire in 1 day (86,400 seconds)

Also added tests to verify the pass-through by intercepting each
command sent in.

Fixes #30