### PR TITLE
Docker updates

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,4 @@
+.git
+scripts
+tools
+terraform

--- a/Dockerfile
+++ b/Dockerfile
@@ -12,16 +12,20 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14 AS builder
+FROM golang:1.14-alpine AS builder
 
 ARG SERVICE
 
-RUN apt-get -qq update && apt-get -yqq install upx
+# git needed for building Go
+# upx for optimizing binary
+# binutils for strip command
+RUN apk add --no-cache git upx binutils
 
-ENV GO111MODULE=on \
-  CGO_ENABLED=0 \
-  GOOS=linux \
-  GOARCH=amd64
+ENV GOPROXY="https://proxy.golang.org"
+ENV GO111MODULE=on
+ENV CGO_ENABLED=0
+ENV GOOS=linux
+ENV GOARCH=amd64
 
 WORKDIR /src
 COPY . .
@@ -36,7 +40,6 @@ RUN go build \
 
 RUN strip /bin/service
 RUN upx -q -9 /bin/service
-
 
 FROM scratch
 COPY --from=builder /etc/ssl/certs/ca-certificates.crt /etc/ssl/certs/


### PR DESCRIPTION
Updates our dockerfile

 - Move to Alpine - current image has less vulnerabilities than ubuntu. Less of an issue since we aren't running on ubuntu, but #shrugs
 - Add a docker ignore to prevent adding files we don't want in our images. Less of an issue because we are using seperate run container, but a best practice.
 - Split out env layers for easier reading
 - Add goproxy env arg to speed build time by grabbing from secure proxy server. 
