### PR TITLE
Initial cloud build for auto building of all images

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,0 +1,47 @@
+steps:
+- id: 'apiserver'
+  name: 'docker'
+  args: [
+    'build',
+    '--tag',
+    'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/apiserver:${COMMIT_SHA}',
+    '--build-arg',
+    'SERVICE=apiserver',
+    '.',
+  ]
+- id: 'cleanup'
+  name: 'docker'
+  args: [
+    'build',
+    '--tag',
+    'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/cleanup:${COMMIT_SHA}',
+    '--build-arg',
+    'SERVICE=cleanup',
+    '.',
+  ]
+- id: 'server'
+  name: 'docker'
+  args: [
+    'build',
+    '--tag',
+    'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/server:${COMMIT_SHA}',
+    '--build-arg',
+    'SERVICE=server',
+    '.',
+  ]
+- id: 'adminapi'
+  name: 'docker'
+  args: [
+    'build',
+    '--tag',
+    'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/adminapi:${COMMIT_SHA}',
+    '--build-arg',
+    'SERVICE=adminapi',
+    '.',
+  ]
+images: [
+  'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/server:${COMMIT_SHA}',
+  'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/apiserver:${COMMIT_SHA}',
+  'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/cleanup:${COMMIT_SHA}',
+  'gcr.io/${PROJECT_ID}/github.com/google/exposure-notifications-verification-server/cmd/adminapi:${COMMIT_SHA}',
+]


### PR DESCRIPTION
First step of cloud build automation is to set up trigger on commits to `main` to autobuild to gcr. Decided to go this route instead of wrapping the existing build script because I didn't want to build an image with gcloud, git and bash all in it. Downsides to this are these builds happen in serial, but not a big deal.