### PR TITLE
Always reset the buffer before rendering

### DIFF
--- a/pkg/render/html.go
+++ b/pkg/render/html.go
@@ -55,6 +55,7 @@ func (r *Renderer) RenderHTMLStatus(w http.ResponseWriter, code int, tmpl string
 
 	// Acquire a renderer
 	b := r.rendererPool.Get().(*bytes.Buffer)
+	b.Reset()
 	defer r.rendererPool.Put(b)
 
 	// Render into the renderer

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -57,6 +57,7 @@ func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{})
 
 	// Acquire a renderer
 	b := r.rendererPool.Get().(*bytes.Buffer)
+	b.Reset()
 	defer r.rendererPool.Put(b)
 
 	// Render into the renderer

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -80,6 +80,7 @@ func (r *Renderer) loadTemplates() error {
 	if err != nil {
 		return fmt.Errorf("failed to load templates: %w", err)
 	}
+	tmpl = tmpl.Option("missingkey=zero")
 	r.templates = tmpl
 	return nil
 }


### PR DESCRIPTION
## Proposed Changes

This fixes an error where a true crash (e.g. panic) leaves the buffer filled. Then, next time it's used in the pool, it has partial data and renders weird JSON/HTML.

This also updates our templates to always use the "zero" value when something does not exist.

**Release Note**

```release-note
Always reset render buffer before use.
```
