### PR TITLE
Fix cloudbuild and Docker optimizations

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,14 +12,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM golang:1.14-alpine AS builder
+FROM golang:1.14 AS builder
 
 ARG SERVICE
 
-# git needed for building Go
-# upx for optimizing binary
-# binutils for strip command
-RUN apk add --no-cache git upx binutils
+RUN apt -qq update && apt -yqq install upx
 
 ENV GOPROXY="https://proxy.golang.org"
 ENV GO111MODULE=on

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,6 +1,9 @@
+timeout: 40m
 steps:
 - id: 'apiserver'
   name: 'docker'
+  timeout: 10m
+  waitFor: ["-"]
   args: [
     'build',
     '--tag',
@@ -11,6 +14,8 @@ steps:
   ]
 - id: 'cleanup'
   name: 'docker'
+  timeout: 10m
+  waitFor: ["-"]
   args: [
     'build',
     '--tag',
@@ -21,6 +26,8 @@ steps:
   ]
 - id: 'server'
   name: 'docker'
+  timeout: 10m
+  waitFor: ["-"]
   args: [
     'build',
     '--tag',
@@ -31,6 +38,8 @@ steps:
   ]
 - id: 'adminapi'
   name: 'docker'
+  timeout: 10m
+  waitFor: ["-"]
   args: [
     'build',
     '--tag',

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -1,4 +1,6 @@
 timeout: 40m
+options:
+  machineType: 'N1_HIGHCPU_8'
 steps:
 - id: 'apiserver'
   name: 'docker'


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Reverts docker file to ubuntu for building, it's faster
* Sets build server to multi cpu for building in parallel faster
* Parallelizes steps
 * Adds timeouts, mainly specified in case there are weird network delays. Example build in screenshot

![Screen Shot 2020-08-05 at 22 40 53](https://user-images.githubusercontent.com/20201/89484577-cd5bb280-d76c-11ea-8f16-92df2edcb1d2.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switches build environment for Dockerfile back to ubuntu from Alpine.
```
