### PR TITLE
Allow customizing database backup location

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -42,7 +42,7 @@ resource "google_sql_database_instance" "db-inst" {
 
     backup_configuration {
       enabled    = true
-      location   = "us"
+      location   = var.database_backup_location
       start_time = "02:00"
     }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -47,6 +47,13 @@ variable "database_name" {
   default = "en-verification"
 }
 
+variable "database_backup_location" {
+  type    = string
+  default = "us"
+
+  description = "Location in which to backup the database."
+}
+
 # The location for the app engine; this implicitly defines the region for
 # scheduler jobs as specified by the cloudscheduler_location variable but the
 # values are sometimes different (as in the default values) so they are kept as


### PR DESCRIPTION
Fixes GH-194

**Release Note**

```release-note
Allow customizing database backup location (defaults unchanged)
```
