### PR TITLE
Add a /healthz

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -72,7 +72,6 @@ func realMain(ctx context.Context) error {
 
 	// Create the router
 	r := mux.NewRouter()
-	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Setup rate limiter
 	store, err := memorystore.New(&memorystore.Config{
@@ -95,6 +94,8 @@ func realMain(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
+
+	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Setup API auth
 	apiKeyCache, err := cache.New(config.APIKeyCacheDuration)

--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -71,6 +72,7 @@ func realMain(ctx context.Context) error {
 
 	// Create the router
 	r := mux.NewRouter()
+	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Setup rate limiter
 	store, err := memorystore.New(&memorystore.Config{

--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -95,7 +95,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
 
-	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
+	r.Handle("/healthz", controller.HandleHealthz(ctx, h, &config.Database)).Methods("GET")
 
 	// Setup API auth
 	apiKeyCache, err := cache.New(config.APIKeyCacheDuration)

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -100,7 +100,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
 
-	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
+	r.Handle("/healthz", controller.HandleHealthz(ctx, h, &config.Database)).Methods("GET")
 
 	// Setup API auth
 	apiKeyCache, err := cache.New(config.APIKeyCacheDuration)

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -24,6 +24,7 @@ import (
 	"os"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/certapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/verifyapi"
@@ -98,6 +99,8 @@ func realMain(ctx context.Context) error {
 	if err != nil {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
+
+	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Setup API auth
 	apiKeyCache, err := cache.New(config.APIKeyCacheDuration)

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -70,7 +70,7 @@ func realMain(ctx context.Context) error {
 
 	// Create the router
 	r := mux.NewRouter()
-	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
+	r.Handle("/healthz", controller.HandleHealthz(ctx, h, &config.Database)).Methods("GET")
 
 	// Cleanup handler doesn't require authentication - does use locking to ensure
 	// database isn't tipped over by cleanup.

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/cleanup"
 	"github.com/google/exposure-notifications-verification-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -69,6 +70,7 @@ func realMain(ctx context.Context) error {
 
 	// Create the router
 	r := mux.NewRouter()
+	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Cleanup handler doesn't require authentication - does use locking to ensure
 	// database isn't tipped over by cleanup.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -137,6 +137,7 @@ func realMain(ctx context.Context) error {
 	// Install the handlers that don't require authentication first on the main router.
 	indexController := index.New(ctx, config, h)
 	r.Handle("/", indexController.HandleIndex()).Methods("GET")
+	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
 
 	// Session handling
 	sessionController := session.New(ctx, auth, config, db, h)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -137,7 +137,7 @@ func realMain(ctx context.Context) error {
 	// Install the handlers that don't require authentication first on the main router.
 	indexController := index.New(ctx, config, h)
 	r.Handle("/", indexController.HandleIndex()).Methods("GET")
-	r.Handle("/healthz", controller.HandleHealthz(h, &config.Database)).Methods("GET")
+	r.Handle("/healthz", controller.HandleHealthz(ctx, h, &config.Database)).Methods("GET")
 
 	// Session handling
 	sessionController := session.New(ctx, auth, config, db, h)

--- a/go.mod
+++ b/go.mod
@@ -45,7 +45,7 @@ require (
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/sys v0.0.0-20200728102440-3e129f6d46b1 // indirect
-	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e // indirect
+	golang.org/x/time v0.0.0-20200630173020-3af7569d3a1e
 	golang.org/x/tools v0.0.0-20200731060945-b5fad4ed8dd6
 	google.golang.org/genproto v0.0.0-20200731012542-8145dea6a485
 	google.golang.org/grpc v1.31.0 // indirect

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
-	"github.com/google/exposure-notifications-verification-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 
 	"golang.org/x/time/rate"
@@ -17,7 +16,6 @@ var (
 )
 
 func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Config) http.Handler {
-	logger := logging.FromContext(hctx).Named("healthz")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		params := r.URL.Query()
@@ -25,15 +23,13 @@ func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Confi
 			if rl.Allow() {
 				db, err := cfg.Open(ctx)
 				if err != nil {
-					logger.Errorw("database error", "error", err)
-					h.JSON500(w, render.ErrInternal)
+					InternalError(w, r, h, err)
 					return
 				}
 				defer db.Close()
 
 				if err := db.Ping(ctx); err != nil {
-					logger.Errorw("database error", "error", err)
-					h.JSON500(w, render.ErrInternal)
+					InternalError(w, r, h, err)
 					return
 				}
 			}

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -15,23 +15,23 @@ var (
 	rl = rate.NewLimiter(rate.Every(time.Minute), 1)
 )
 
-func HandleHealthz(h *render.Renderer, cfg *database.Config) http.Handler {
+func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Config) http.Handler {
+	logger := logging.FromContext(hctx).Named("healthz")
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		logger := logging.FromContext(ctx).Named("healthz")
 		params := r.URL.Query()
 		if s := params.Get("service"); s == "database" {
 			if rl.Allow() {
 				db, err := cfg.Open(ctx)
 				if err != nil {
-					logger.Errorw("database error", err)
+					logger.Errorw("database error", "error", err)
 					h.JSON500(w, err)
 					return
 				}
 				defer db.Close()
 
 				if err := db.Ping(ctx); err != nil {
-					logger.Errorw("database error", err)
+					logger.Errorw("database error", "error", err)
 					h.JSON500(w, err)
 					return
 				}

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -26,14 +26,14 @@ func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Confi
 				db, err := cfg.Open(ctx)
 				if err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, h.InternalError)
+					h.JSON500(w, render.InternalError)
 					return
 				}
 				defer db.Close()
 
 				if err := db.Ping(ctx); err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, h.InternalError)
+					h.JSON500(w, render.InternalError)
 					return
 				}
 			}

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -1,0 +1,34 @@
+package controller
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+func HandleHealthz(h *render.Renderer, cfg *database.Config) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		logger := logging.FromContext(ctx).Named("healthz")
+		params := r.URL.Query()
+		if s := params.Get("service"); s == "database" {
+			db, err := cfg.Open(ctx)
+			if err != nil {
+				logger.Errorw("database error", err)
+				h.JSON500(w, err)
+				return
+			}
+			defer db.Close()
+
+			if err := db.Ping(); err != nil {
+				logger.Errorw("database error", err)
+				h.JSON500(w, err)
+				return
+			}
+		}
+
+		h.RenderJSON(w, http.StatusOK, nil)
+	})
+}

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -26,14 +26,14 @@ func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Confi
 				db, err := cfg.Open(ctx)
 				if err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, render.InternalError)
+					h.JSON500(w, render.ErrInternal)
 					return
 				}
 				defer db.Close()
 
 				if err := db.Ping(ctx); err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, render.InternalError)
+					h.JSON500(w, render.ErrInternal)
 					return
 				}
 			}

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -1,6 +1,7 @@
 package controller
 
 import (
+	"context"
 	"net/http"
 	"time"
 
@@ -25,14 +26,14 @@ func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Confi
 				db, err := cfg.Open(ctx)
 				if err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, err)
+					h.JSON500(w, h.InternalError)
 					return
 				}
 				defer db.Close()
 
 				if err := db.Ping(ctx); err != nil {
 					logger.Errorw("database error", "error", err)
-					h.JSON500(w, err)
+					h.JSON500(w, h.InternalError)
 					return
 				}
 			}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -93,6 +93,11 @@ func (db *Database) Close() error {
 	return db.db.Close()
 }
 
+// Ping attempts a connection and closes it to the database.
+func (db *Database) Ping() error {
+	return db.db.DB().Ping()
+}
+
 // IsNotFound determines if an error is a record not found.
 func IsNotFound(err error) bool {
 	return errors.Is(err, gorm.ErrRecordNotFound) || gorm.IsRecordNotFoundError(err)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -94,8 +94,8 @@ func (db *Database) Close() error {
 }
 
 // Ping attempts a connection and closes it to the database.
-func (db *Database) Ping() error {
-	return db.db.DB().Ping()
+func (db *Database) Ping(ctx context.Context) error {
+	return db.db.DB().PingContext(ctx)
 }
 
 // IsNotFound determines if an error is a record not found.

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -26,6 +26,11 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	// InternalError is a generic error we can display to users.
+	InternalError = "We have encountered an internal error."
+)
+
 // Renderer is responsible for rendering various content and templates like HTML
 // and JSON responses.
 type Renderer struct {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -28,7 +28,7 @@ import (
 
 var (
 	// InternalError is a generic error we can display to users.
-	InternalError = fmt.Errorf("We have encountered an internal error.")
+	ErrInternal = fmt.Errorf("we have encountered an internal error")
 )
 
 // Renderer is responsible for rendering various content and templates like HTML

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -26,11 +26,6 @@ import (
 	"go.uber.org/zap"
 )
 
-var (
-	// InternalError is a generic error we can display to users.
-	ErrInternal = fmt.Errorf("we have encountered an internal error")
-)
-
 // Renderer is responsible for rendering various content and templates like HTML
 // and JSON responses.
 type Renderer struct {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -26,9 +26,9 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
+var (
 	// InternalError is a generic error we can display to users.
-	InternalError = "We have encountered an internal error."
+	InternalError = fmt.Errorf("We have encountered an internal error.")
 )
 
 // Renderer is responsible for rendering various content and templates like HTML


### PR DESCRIPTION
Some progress towards #180

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a /healthz handler that can be hit by probers. if /healthz?service=database we can also find out if the database connection is working.
* This is useful for lightweight health checking

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds a /healthz to all server binaries for healthchecking.
```
