### PR TITLE
Spelling Nits

### DIFF
--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -42,7 +42,7 @@ type AdminAPIServerConfig struct {
 
 	CodeDuration        time.Duration `env:"CODE_DURATION,default=1h"`
 	CodeDigits          uint          `env:"CODE_DIGITS,default=8"`
-	CollisionRetryCount uint          `env:"COLISSION_RETRY_COUNT,default=6"`
+	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 }
 
@@ -75,7 +75,7 @@ func (c *AdminAPIServerConfig) Validate() error {
 	return nil
 }
 
-func (c *AdminAPIServerConfig) GetColissionRetryCount() uint {
+func (c *AdminAPIServerConfig) GetCollisionRetryCount() uint {
 	return c.CollisionRetryCount
 }
 
@@ -87,7 +87,7 @@ func (c *AdminAPIServerConfig) GetVerificationCodeDuration() time.Duration {
 	return c.CodeDuration
 }
 
-func (c *AdminAPIServerConfig) GetVerficationCodeDigits() uint {
+func (c *AdminAPIServerConfig) GetVerificationCodeDigits() uint {
 	return c.CodeDigits
 }
 

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -19,8 +19,8 @@ import "time"
 // IssueAPIConfig is an interface that represents what is needed of the verification
 // code issue API.
 type IssueAPIConfig interface {
-	GetColissionRetryCount() uint
+	GetCollisionRetryCount() uint
 	GetAllowedSymptomAge() time.Duration
 	GetVerificationCodeDuration() time.Duration
-	GetVerficationCodeDigits() uint
+	GetVerificationCodeDigits() uint
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -59,7 +59,7 @@ type ServerConfig struct {
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
 	CodeDuration        time.Duration `env:"CODE_DURATION,default=1h"`
 	CodeDigits          uint          `env:"CODE_DIGITS,default=8"`
-	CollisionRetryCount uint          `env:"COLISSION_RETRY_COUNT,default=6"`
+	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
@@ -88,7 +88,7 @@ func (c *ServerConfig) Validate() error {
 		Var  time.Duration
 		Name string
 	}{
-		{c.SessionDuration, "SESSION_DUATION"},
+		{c.SessionDuration, "SESSION_DURATION"},
 		{c.RevokeCheckPeriod, "REVOKE_CHECK_DURATION"},
 		{c.CodeDuration, "CODE_DURATION"},
 		{c.AllowedSymptomAge, "ALLOWED_PAST_SYMPTOM_DAYS"},
@@ -103,7 +103,7 @@ func (c *ServerConfig) Validate() error {
 	return nil
 }
 
-func (c *ServerConfig) GetColissionRetryCount() uint {
+func (c *ServerConfig) GetCollisionRetryCount() uint {
 	return c.CollisionRetryCount
 }
 
@@ -115,7 +115,7 @@ func (c *ServerConfig) GetVerificationCodeDuration() time.Duration {
 	return c.CodeDuration
 }
 
-func (c *ServerConfig) GetVerficationCodeDigits() uint {
+func (c *ServerConfig) GetVerificationCodeDigits() uint {
 	return c.CodeDigits
 }
 

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -88,7 +88,7 @@ func (c *Controller) validateToken(verToken string, publicKey crypto.PublicKey) 
 		if kid == c.config.TokenSigningKeyID {
 			return publicKey, nil
 		}
-		return nil, fmt.Errorf("no public key for pecified 'kid' not found: %v", kid)
+		return nil, fmt.Errorf("no public key for specified 'kid' not found: %v", kid)
 	})
 	if err != nil {
 		c.logger.Errorf("invalid verification token: %v", err)

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -65,7 +65,7 @@ func (c *Controller) shouldCleanup() error {
 		// in case this was not found, create a new record.
 		cStatCache, err = c.db.CreateCleanup(database.CleanupName)
 		if err != nil {
-			return fmt.Errorf("error attempting to backfil cleanup config: %v", err)
+			return fmt.Errorf("error attempting to backfill cleanup config: %v", err)
 		}
 	}
 

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -111,7 +111,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		// Generate verification code
 		codeRequest := otp.Request{
 			DB:            c.db,
-			Length:        c.config.GetVerficationCodeDigits(),
+			Length:        c.config.GetVerificationCodeDigits(),
 			ExpiresAt:     expiryTime,
 			TestType:      request.TestType,
 			SymptomDate:   symptomDate,
@@ -121,7 +121,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			RealmID:       realm.ID,
 		}
 
-		code, err := codeRequest.Issue(ctx, c.config.GetColissionRetryCount())
+		code, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
 		if err != nil {
 			logger.Errorw("failed to issue code", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))

--- a/pkg/controller/issueapi/issueapi.go
+++ b/pkg/controller/issueapi/issueapi.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package issueapi implements the API handler for taking a code requst, assigning
+// Package issueapi implements the API handler for taking a code request, assigning
 // an OTP, saving it to the database and returning the result.
 // This is invoked over AJAX from the Web frontend.
 package issueapi


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Just reading through code, fixing typos


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Minor spelling fixes

Environment variable 'COLISSION_RETRY_COUNT' renamed 'COLLISION_RETRY_COUNT'
Server config field  'SESSION_DUATION' to 'SESSION_DURATION'
```