### PR TITLE
Unify on BadRequest

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,6 +220,29 @@ client **MUST NOT** process. Client's should sporadically issue chaff requests.
     }
     ```
 
+#### API Response Codes
+
+-   `400` - The client made a bad/invalid request. Search the JSON response body
+    for the `"errors"` key. The body may be empty.
+
+-   `401` - The client is unauthorized. This could be an invalid API key or
+    revoked permissions. This usually has no `"errors"` key, but clients can try
+    to read the JSON body to see if there's additional information (it may be
+    empty)
+
+-   `404` - The client made a request to an invalid URL (routing error). Do not
+    retry.
+
+-   `405` - The client used the wrong HTTP verb. Do not retry.
+
+-   `429` - The client is rate limited. Check the `X-Retry-After` header to
+    determine when to retry the request. Clients can also monitor the
+    `X-RateLimit-Remaining` header that's returned with all responses to
+    determine their rate limit and rate limit expiration.
+
+-   `5xx` - Internal server error. Clients should retry with a reasonable
+    backoff algorithm and maximum cap.
+
 
 ### Test Utilities
 

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -56,7 +56,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			// if it's a user logged in, we can pull realm from the context.
 			realm = controller.RealmFromContext(ctx)
 			if realm == nil {
-				c.h.RenderJSON(w, http.StatusUnprocessableEntity, api.Errorf("missing realm"))
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("missing realm"))
 				return
 			}
 		}
@@ -72,14 +72,14 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 			if smsProvider == nil {
 				err := fmt.Errorf("phone provided, but no sms provider is configured")
-				c.h.RenderJSON(w, http.StatusUnprocessableEntity, api.Error(err))
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 			}
 		}
 
 		// Verify the test type
 		request.TestType = strings.ToLower(request.TestType)
 		if _, ok := c.validTestType[request.TestType]; !ok {
-			c.h.RenderJSON(w, http.StatusUnprocessableEntity, api.Errorf("invalid test type"))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("invalid test type"))
 			return
 		}
 
@@ -90,7 +90,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		var symptomDate *time.Time
 		if request.SymptomDate != "" {
 			if parsed, err := time.Parse("2006-01-02", request.SymptomDate); err != nil {
-				c.h.RenderJSON(w, http.StatusUnprocessableEntity, api.Errorf("failed to process symptom onset date: %v", err))
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("failed to process symptom onset date: %v", err))
 				return
 			} else {
 				parsed = parsed.Local()
@@ -98,7 +98,7 @@ func (c *Controller) HandleIssue() http.Handler {
 					err := fmt.Errorf("symptom onset date must be on/after %v and on/before %v",
 						minDate.Format("2006-01-02"),
 						maxDate.Format("2006-01-02"))
-					c.h.RenderJSON(w, http.StatusUnprocessableEntity, api.Error(err))
+					c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 					return
 				}
 				symptomDate = &parsed

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -38,6 +38,21 @@ import (
 // The buffers are fetched via a sync.Pool to reduce allocations and improve
 // performance.
 func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{}) {
+	// Hello there reader! If you've made it here, you're likely wondering why
+	// you're getting an error about response codes. For client-interop, it's very
+	// important that we retain and maintain the allowed list of response codes.
+	// Adding a new response code requires coordination with the client team so
+	// they can update their applications to handle that new response code.
+	if !r.AllowedResponseCode(code) {
+		r.logger.Errorw("unregistered response code", "code", code)
+
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Header().Set("Content-Type", "application/json")
+		msg := escapeJSON(fmt.Sprintf("%d is not a registered response code", code))
+		fmt.Fprintf(w, jsonErrTmpl, msg)
+		return
+	}
+
 	// Avoid marshaling nil data.
 	if data == nil {
 		w.WriteHeader(code)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -28,6 +28,19 @@ import (
 	"go.uber.org/zap"
 )
 
+// allowedResponseCodes are the list of allowed response codes. This is
+// primarily here to catch if someone, in the future, accidentially includes a
+// bad status code.
+var allowedResponseCodes = map[int]struct{}{
+	400: {},
+	401: {},
+	404: {},
+	405: {},
+	413: {},
+	429: {},
+	500: {},
+}
+
 // Renderer is responsible for rendering various content and templates like HTML
 // and JSON responses.
 type Renderer struct {
@@ -103,4 +116,11 @@ func loadTemplates(tmpl *template.Template, root string) error {
 
 		return nil
 	})
+}
+
+// AllowedResponseCode returns true if the code is a permitted response code,
+// false otherwise.
+func (r *Renderer) AllowedResponseCode(code int) bool {
+	_, ok := allowedResponseCodes[code]
+	return ok
 }


### PR DESCRIPTION
This reduces the number of error codes that clients need to check against to:

- `400` - search for `"errors"` key in JSON response
- `401` - unauthorized, usually with no `"errors"`, but clients can try to read the JSON body to see if there's additional information (it may be empty)
- `404` - routing error (app coding error)
- `405` - wrong HTTP method (app coding error)
- `429` - rate limited, check headers `X-Retry-After` to determine when to retry
- `5xx` - internal server error

**Release Note**

```release-note
Standardize known HTTP response codes on 400, 401, 404, 405, 429, and 5xx.
```
