### PR TITLE
Emit ID for verification code

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -63,7 +63,7 @@ type IssueCodeRequest struct {
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.
 type IssueCodeResponse struct {
-	ID                 uint   `json:"id"` // Handle which allows the issuer to track status of the issued verification code.
+	ID                 string `json:"id"` // Handle which allows the issuer to track status of the issued verification code.
 	VerificationCode   string `json:"code"`
 	ExpiresAt          string `json:"expiresAt"`          // RFC1123 string formatted timestamp, in UTC.
 	ExpiresAtTimestamp int64  `json:"expiresAtTimestamp"` // Unix, seconds since the epoch. Still UTC.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -23,7 +23,7 @@ const (
 	TestTypeConfirmed = "confirmed"
 	// TestTypeLikely is the string that represents a clinical diagnosis.
 	TestTypeLikely = "likely"
-	// TestTypeNegative is the string that represents a netgative test.
+	// TestTypeNegative is the string that represents a negative test.
 	TestTypeNegative = "negative"
 )
 
@@ -63,13 +63,14 @@ type IssueCodeRequest struct {
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.
 type IssueCodeResponse struct {
+	ID                 uint   `json:"id"` // Handle which allows the issuer to track status of the issued verification code.
 	VerificationCode   string `json:"code"`
 	ExpiresAt          string `json:"expiresAt"`          // RFC1123 string formatted timestamp, in UTC.
 	ExpiresAtTimestamp int64  `json:"expiresAtTimestamp"` // Unix, seconds since the epoch. Still UTC.
 	Error              string `json:"error"`
 }
 
-// VerifyCodeRequest is the request structure for exchanging a shor term Verification Code
+// VerifyCodeRequest is the request structure for exchanging a short term Verification Code
 // (OTP) for a long term token (a JWT) that can later be used to sign TEKs.
 //
 // Requires API key in a HTTP header, X-API-Key: APIKEY
@@ -79,7 +80,7 @@ type VerifyCodeRequest struct {
 
 // VerifyCodeResponse either contains an error, or contains the test parameters
 // (type and [optional] date) as well as the verification token. The verification token
-// may be snet back on a valid VerificationCertificateRequest later.
+// may be sent back on a valid VerificationCertificateRequest later.
 type VerifyCodeResponse struct {
 	TestType          string `json:"testtype"`
 	SymptomDate       string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
@@ -89,7 +90,7 @@ type VerifyCodeResponse struct {
 
 // VerificationCertificateRequest is used to accept a long term token and
 // an HMAC of the TEKs.
-// The details of the HMAC calculation are avialble at:
+// The details of the HMAC calculation are available at:
 // https://github.com/google/exposure-notifications-server/blob/main/docs/design/verification_protocol.md
 //
 // Requires API key in a HTTP header, X-API-Key: APIKEY

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -15,6 +15,8 @@
 package issueapi
 
 import (
+	"encoding/base64"
+	"encoding/binary"
 	"fmt"
 	"net/http"
 	"strings"
@@ -143,9 +145,13 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 		}
 
+		var intAsBytes []byte
+		binary.LittleEndian.PutUint64(intAsBytes, uint64(id))
+		idString := base64.StdEncoding.EncodeToString(intAsBytes)
+
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.IssueCodeResponse{
-				ID:                 id,
+				ID:                 idString,
 				VerificationCode:   code,
 				ExpiresAt:          expiryTime.Format(time.RFC1123),
 				ExpiresAtTimestamp: expiryTime.Unix(),

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -121,7 +121,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			RealmID:       realm.ID,
 		}
 
-		code, id, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
+		id, code, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
 		if err != nil {
 			logger.Errorw("failed to issue code", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -121,7 +121,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			RealmID:       realm.ID,
 		}
 
-		code, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
+		code, id, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
 		if err != nil {
 			logger.Errorw("failed to issue code", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))
@@ -145,6 +145,7 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.IssueCodeResponse{
+				ID:                 id,
 				VerificationCode:   code,
 				ExpiresAt:          expiryTime.Format(time.RFC1123),
 				ExpiresAtTimestamp: expiryTime.Unix(),

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -15,8 +15,8 @@
 package issueapi
 
 import (
-	"encoding/base64"
 	"encoding/binary"
+	"encoding/hex"
 	"fmt"
 	"net/http"
 	"strings"
@@ -145,10 +145,10 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 		}
 
-		// Convert the uint to an encoded string for the response.
+		// Convert the uint to an encoded hex string for the response.
 		var intAsBytes []byte
 		binary.LittleEndian.PutUint64(intAsBytes, uint64(id))
-		idString := base64.URLEncoding.EncodeToString(intAsBytes)
+		idString := hex.EncodeToString(intAsBytes)
 
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.IssueCodeResponse{

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -145,6 +145,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 		}
 
+		// Convert the uint to an encoded string for the response.
 		var intAsBytes []byte
 		binary.LittleEndian.PutUint64(intAsBytes, uint64(id))
 		idString := base64.URLEncoding.EncodeToString(intAsBytes)

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -147,7 +147,7 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		var intAsBytes []byte
 		binary.LittleEndian.PutUint64(intAsBytes, uint64(id))
-		idString := base64.StdEncoding.EncodeToString(intAsBytes)
+		idString := base64.URLEncoding.EncodeToString(intAsBytes)
 
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.IssueCodeResponse{

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -42,7 +42,7 @@ var (
 	ErrTestTooOld         = errors.New("test date is more than 14 day ago")
 )
 
-// VerificationCode represnts a verification code in the database.
+// VerificationCode represents a verification code in the database.
 type VerificationCode struct {
 	gorm.Model
 	RealmID       uint   // VerificationCodes belong to exactly one realm when issued.
@@ -74,7 +74,7 @@ func (v *VerificationCode) FormatSymptomDate() string {
 	return v.SymptomDate.Format("2006-01-02")
 }
 
-// IsExpired returns ture if a verification code has expired.
+// IsExpired returns true if a verification code has expired.
 func (v *VerificationCode) IsExpired() bool {
 	return !v.ExpiresAt.After(time.Now())
 }

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -58,15 +58,14 @@ type Request struct {
 	IssuingApp    *database.AuthorizedApp
 }
 
-// Issue wiill generate a verification code and save it to the database, based
-// on the paremters provited.
-func (o *Request) Issue(ctx context.Context, retryCount uint) (string, error) {
+// Issue will generate a verification code and save it to the database, based
+// on the paremters provided.
+func (o *Request) Issue(ctx context.Context, retryCount uint) (string, uint, error) {
 	logger := logging.FromContext(ctx)
-	var code string
+	var verificationCode database.VerificationCode
 	var err error
-	var i uint
-	for i = 0; i < retryCount; i++ {
-		code, err = GenerateCode(o.Length)
+	for i := uint(0); i < retryCount; i++ {
+		code, err := GenerateCode(o.Length)
 		if err != nil {
 			logger.Errorf("code generation error: %v", err)
 			continue
@@ -88,6 +87,8 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, error) {
 			break // successful save, nil error, break out.
 		}
 	}
-	return code, err
-
+	if err != nil {
+		return "", 0, err
+	}
+	return verificationCode.Code, verificationCode.ID, nil
 }

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -60,7 +60,7 @@ type Request struct {
 
 // Issue will generate a verification code and save it to the database, based
 // on the paremters provided.
-func (o *Request) Issue(ctx context.Context, retryCount uint) (string, uint, error) {
+func (o *Request) Issue(ctx context.Context, retryCount uint) (uint, string, error) {
 	logger := logging.FromContext(ctx)
 	var verificationCode database.VerificationCode
 	var err error
@@ -88,7 +88,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, uint, err
 		}
 	}
 	if err != nil {
-		return "", 0, err
+		return 0, "", err
 	}
-	return verificationCode.Code, verificationCode.ID, nil
+	return verificationCode.ID, verificationCode.Code, nil
 }

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -70,7 +70,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (uint, string, err
 			logger.Errorf("code generation error: %v", err)
 			continue
 		}
-		verificationCode := database.VerificationCode{
+		verificationCode = database.VerificationCode{
 			RealmID:     o.RealmID,
 			Code:        code,
 			TestType:    strings.ToLower(o.TestType),

--- a/pkg/otp/code_test.go
+++ b/pkg/otp/code_test.go
@@ -72,7 +72,7 @@ func TestIssue(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't find previously saved code")
 		}
-		if verCode.Code != code {
+		if verCode != nil && verCode.Code != code {
 			t.Fatalf("loaded code doesn't match requested code")
 		}
 	}

--- a/pkg/otp/code_test.go
+++ b/pkg/otp/code_test.go
@@ -56,7 +56,7 @@ func TestIssue(t *testing.T) {
 			ExpiresAt: time.Now().Add(time.Hour),
 			TestType:  "confirmed",
 		}
-		code, err := otp.Issue(ctx, 10)
+		_, code, err := otp.Issue(ctx, 10)
 		if err != nil {
 			t.Errorf("error generating code: %v", err)
 		}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/109

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Include the Database ID for the issued verification code. This will be later used in a new API to check the claimed/unclaimed status of the code.

### Open Question
* Are there any security concerns with using this DB handle / do we need to create an artificial GUID key for this purpose. The DB key is an auto-increment uint which may allow for scraping or counting; However the user must be authenticated to retrieve code status.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Include ID in the issue VerificationCode response
```
