### PR TITLE
add well defined errorCode strings in responses

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -25,11 +25,36 @@ const (
 	TestTypeLikely = "likely"
 	// TestTypeNegative is the string that represents a negative test.
 	TestTypeNegative = "negative"
+
+	// error_code definitions for the APIs.
+	// General
+	ErrUnparsableRequest = "unparsable_request"
+	ErrInternal          = "internal_server_error"
+
+	// Verify API responses
+	// ErrVerifyCodeInvalid indicates the code entered is unknown or already used.
+	ErrVerifyCodeInvalid = "code_invalid"
+	// ErrVerifyCodeExpired indicates the code provided is known to the server, but expired.
+	ErrVerifyCodeExpired = "code_expired"
+
+	// Certificate API responses
+	// ErrTokenInvalid indicates the token provided is unknown or already used
+	ErrTokenInvalid = "token_invalid"
+	// ErrTokenExpired indicates that the token provided is known but expired.
+	ErrTokenExpired = "token_expired"
+	// ErrHMACInvalid indicates that the HMAC that is being signed is invalid (wrong length)
+	ErrHMACInvalid = "hmac_invalid"
 )
 
 // ErrorReturn defines the common error type.
 type ErrorReturn struct {
-	Error string `json:"error"`
+	Error     string `json:"error"`
+	ErrorCode string `json:"error_code"`
+}
+
+// InternalError constructs a generic internal error.
+func InternalError() *ErrorReturn {
+	return Errorf("internal error").WithCode(ErrInternal)
 }
 
 // Errorf creates an ErrorReturn w/ the formateed message.
@@ -46,10 +71,17 @@ func Error(err error) *ErrorReturn {
 	return &ErrorReturn{Error: err.Error()}
 }
 
+// WithCode adds an error code to an ErrorReturn
+func (e *ErrorReturn) WithCode(code string) *ErrorReturn {
+	e.ErrorCode = code
+	return e
+}
+
 // CSRFResponse is the return type when requesting an AJAX CSRF token.
 type CSRFResponse struct {
 	CSRFToken string `json:"csrftoken"`
 	Error     string `json:"error"`
+	ErrorCode string `json:"errorCode`
 }
 
 // IssueCodeRequest defines the parameters to request an new OTP (short term)
@@ -68,6 +100,7 @@ type IssueCodeResponse struct {
 	ExpiresAt          string `json:"expiresAt"`          // RFC1123 string formatted timestamp, in UTC.
 	ExpiresAtTimestamp int64  `json:"expiresAtTimestamp"` // Unix, seconds since the epoch. Still UTC.
 	Error              string `json:"error"`
+	ErrorCode          string `json:"error_code,omitempty"`
 }
 
 // VerifyCodeRequest is the request structure for exchanging a short term Verification Code
@@ -82,10 +115,11 @@ type VerifyCodeRequest struct {
 // (type and [optional] date) as well as the verification token. The verification token
 // may be sent back on a valid VerificationCertificateRequest later.
 type VerifyCodeResponse struct {
-	TestType          string `json:"testtype"`
-	SymptomDate       string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
-	VerificationToken string `json:"token"`       // JWT - signed, not encrypted.
-	Error             string `json:"error"`
+	TestType          string `json:"testtype,omitempty"`
+	SymptomDate       string `json:"symptomDate,omitempty"` // ISO 8601 formatted date, YYYY-MM-DD
+	VerificationToken string `json:"token,omitempty"`       // JWT - signed, not encrypted.
+	Error             string `json:"error,omitempty"`
+	ErrorCode         string `json:"error_code,omitempty"`
 }
 
 // VerificationCertificateRequest is used to accept a long term token and
@@ -103,6 +137,7 @@ type VerificationCertificateRequest struct {
 // a signed certificate that can be presented to the configured exposure
 // notifications server to publish keys along w/ the certified diagnosis.
 type VerificationCertificateResponse struct {
-	Certificate string `json:"certificate"`
-	Error       string `json:"error"`
+	Certificate string `json:"certificate,omitempty"`
+	Error       string `json:"error,omitempty"`
+	ErrorCode   string `json:"error_code,omitempty"`
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -81,7 +81,7 @@ func (e *ErrorReturn) WithCode(code string) *ErrorReturn {
 type CSRFResponse struct {
 	CSRFToken string `json:"csrftoken"`
 	Error     string `json:"error"`
-	ErrorCode string `json:"errorCode`
+	ErrorCode string `json:"errorCode"`
 }
 
 // IssueCodeRequest defines the parameters to request an new OTP (short term)
@@ -100,7 +100,7 @@ type IssueCodeResponse struct {
 	ExpiresAt          string `json:"expiresAt"`          // RFC1123 string formatted timestamp, in UTC.
 	ExpiresAtTimestamp int64  `json:"expiresAtTimestamp"` // Unix, seconds since the epoch. Still UTC.
 	Error              string `json:"error"`
-	ErrorCode          string `json:"error_code,omitempty"`
+	ErrorCode          string `json:"errorCode,omitempty"`
 }
 
 // VerifyCodeRequest is the request structure for exchanging a short term Verification Code
@@ -119,7 +119,7 @@ type VerifyCodeResponse struct {
 	SymptomDate       string `json:"symptomDate,omitempty"` // ISO 8601 formatted date, YYYY-MM-DD
 	VerificationToken string `json:"token,omitempty"`       // JWT - signed, not encrypted.
 	Error             string `json:"error,omitempty"`
-	ErrorCode         string `json:"error_code,omitempty"`
+	ErrorCode         string `json:"errorCode,omitempty"`
 }
 
 // VerificationCertificateRequest is used to accept a long term token and
@@ -139,5 +139,5 @@ type VerificationCertificateRequest struct {
 type VerificationCertificateResponse struct {
 	Certificate string `json:"certificate,omitempty"`
 	Error       string `json:"error,omitempty"`
-	ErrorCode   string `json:"error_code,omitempty"`
+	ErrorCode   string `json:"errorCode,omitempty"`
 }

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -15,6 +15,7 @@
 package certapi
 
 import (
+	"errors"
 	"net/http"
 	"time"
 
@@ -22,6 +23,7 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/base64util"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/jwthelper"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
@@ -33,6 +35,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {
+			c.logger.Errorf("missing authorized app")
 			controller.MissingAuthorizedApp(w, r, c.h)
 			return
 		}
@@ -40,7 +43,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		publicKey, err := c.getPublicKey(ctx, c.config.TokenSigningKey)
 		if err != nil {
 			c.logger.Errorw("failed to get public key", "error", err)
-			c.h.RenderJSON(w, http.StatusInternalServerError, nil)
+			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
 			return
 		}
 
@@ -48,20 +51,21 @@ func (c *Controller) HandleCertificate() http.Handler {
 		signer, err := c.signer.NewSigner(ctx, c.config.CertificateSigningKey)
 		if err != nil {
 			c.logger.Errorw("failed to get signer", "error", err)
-			c.h.RenderJSON(w, http.StatusInternalServerError, nil)
+			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
 			return
 		}
 
 		var request api.VerificationCertificateRequest
 		if err := controller.BindJSON(w, r, &request); err != nil {
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			c.logger.Errorf("failed to parse json request", "error", err)
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenInvalid))
 			return
 		}
 
 		// Parse and validate the verification token.
 		tokenID, subject, err := c.validateToken(request.VerificationToken, publicKey)
 		if err != nil {
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenInvalid))
 			return
 		}
 
@@ -69,12 +73,12 @@ func (c *Controller) HandleCertificate() http.Handler {
 		hmacBytes, err := base64util.DecodeString(request.ExposureKeyHMAC)
 		if err != nil {
 			c.h.RenderJSON(w, http.StatusBadRequest,
-				api.Errorf("exposure key HMAC is not a valid base64: %v", err))
+				api.Errorf("exposure key HMAC is not a valid base64: %v", err).WithCode(api.ErrHMACInvalid))
 			return
 		}
 		if len(hmacBytes) != 32 {
 			c.h.RenderJSON(w, http.StatusBadRequest,
-				api.Errorf("exposure key HMAC is not the correct length, want: 32 got: %v", len(hmacBytes)))
+				api.Errorf("exposure key HMAC is not the correct length, want: 32 got: %v", len(hmacBytes)).WithCode(api.ErrHMACInvalid))
 			return
 		}
 
@@ -99,7 +103,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		certificate, err := jwthelper.SignJWT(certToken, signer)
 		if err != nil {
 			c.logger.Errorw("failed to sign certificate", "error", err)
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrInternal))
 			return
 		}
 
@@ -107,6 +111,14 @@ func (c *Controller) HandleCertificate() http.Handler {
 		// client can retry.
 		if err := c.db.ClaimToken(authApp.RealmID, tokenID, subject); err != nil {
 			c.logger.Errorw("failed to claim token", "tokenID", tokenID, "error", err)
+			switch {
+			case errors.Is(err, database.ErrTokenExpired):
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenExpired))
+			case errors.Is(err, database.ErrTokenUsed):
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
+			case errors.Is(err, database.ErrTokenMetadataMismatch):
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
+			}
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 			return
 		}

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -118,8 +118,9 @@ func (c *Controller) HandleCertificate() http.Handler {
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
 			case errors.Is(err, database.ErrTokenMetadataMismatch):
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
+			default:
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 			}
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 			return
 		}
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -33,6 +33,7 @@ import (
 // primarily here to catch if someone, in the future, accidentially includes a
 // bad status code.
 var allowedResponseCodes = map[int]struct{}{
+	200: {},
 	400: {},
 	401: {},
 	404: {},


### PR DESCRIPTION
part of #134 

**Release Note**

```release-note
Verification and certificate APIs have well defined error codes for localization on the client side.
```
