### PR TITLE
Separate database config loading from connection opening

### DIFF
--- a/cmd/add-realm/main.go
+++ b/cmd/add-realm/main.go
@@ -60,8 +60,11 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	db, err := config.Open(ctx)
+	db, err := config.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -80,8 +80,11 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup database
-	db, err := config.Database.Open(ctx)
+	db, err := config.Database.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -83,8 +83,11 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup database
-	db, err := config.Database.Open(ctx)
+	db, err := config.Database.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -72,8 +72,11 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup database
-	db, err := config.Database.Open(ctx)
+	db, err := config.Database.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -57,8 +57,11 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to process config: %w", err)
 	}
 
-	db, err := dbConfig.Open(ctx)
+	db, err := dbConfig.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -93,8 +93,11 @@ func realMain(ctx context.Context) error {
 	sessions.Options.SameSite = http.SameSiteStrictMode
 
 	// Setup database
-	db, err := config.Database.Open(ctx)
+	db, err := config.Database.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -21,8 +21,12 @@ func HandleHealthz(hctx context.Context, h *render.Renderer, cfg *database.Confi
 		params := r.URL.Query()
 		if s := params.Get("service"); s == "database" {
 			if rl.Allow() {
-				db, err := cfg.Open(ctx)
+				db, err := cfg.Load(ctx)
 				if err != nil {
+					InternalError(w, r, h, err)
+					return
+				}
+				if err := db.Open(ctx); err != nil {
 					InternalError(w, r, h, err)
 					return
 				}

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -50,13 +50,16 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to parse config: %w", err)
 	}
 
-	db, err := config.Open(ctx)
+	db, err := config.Load(ctx)
 	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
 		return fmt.Errorf("failed to connect to database: %w", err)
 	}
 	defer db.Close()
 
-	// Create two users
+	// Create users
 	user := &database.User{Email: "user@example.com", Name: "Demo User"}
 	if err := db.SaveUser(user); err != nil {
 		return fmt.Errorf("failed to create user: %w", err)
@@ -68,6 +71,12 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create admin: %w", err)
 	}
 	logger.Infow("created admin", "admin", admin)
+
+	super := &database.User{Email: "super@example.com", Name: "Super User", Admin: true}
+	if err := db.SaveUser(super); err != nil {
+		return fmt.Errorf("failed to create super: %w", err)
+	}
+	logger.Infow("created super", "super", super)
 
 	// Create a realm
 	realm1 := &database.Realm{


### PR DESCRIPTION
The previous "Open" command would parse the configuration and then establish the connection. This separates into two separate invocations. This is important because retrying Open() was actually unsafe in local development because config parsing mutated state. By moving config parsing to be separate, we can parse once, then call Open() as many times as we'd like.

**Release Note**

```release-note
NONE
```
