### PR TITLE
Fix the handler for checkcodestatus

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -128,7 +128,7 @@ func realMain(ctx context.Context) error {
 
 	issueapiController := issueapi.New(ctx, config, db, h)
 	r.Handle("/api/issue", issueapiController.HandleIssue()).Methods("POST")
-	r.Handle("/api/checkcodestatus", issueapiController.HandleIssue()).Methods("POST")
+	r.Handle("/api/checkcodestatus", issueapiController.HandleCheckCodeStatus()).Methods("POST")
 
 	srv, err := server.New(config.Port)
 	if err != nil {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/234

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fixes the handler for the checkcodestatus endpoint
* This is reorganized better in https://github.com/google/exposure-notifications-verification-server/pull/227 but I've pulled this bit out of it

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes the handler for the checkcodestatus endpoint
```
