### PR TITLE
Allow migrations to pass if a default realm already exists

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -236,7 +236,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				defaultRealm := Realm{
 					Name: "Default",
 				}
-				if err := tx.Create(&defaultRealm).Error; err != nil {
+				if err := tx.FirstOrCreate(&defaultRealm).Error; err != nil {
 					return err
 				}
 


### PR DESCRIPTION
Fixes GH-213

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow migrations to succeed in the case a "default" realm already exists
```
