### PR TITLE
SMS Deep links and settings

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -18,7 +18,7 @@
 <header>
   <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     <div class="container">
-      <a class="navbar-brand" href="#">{{if .currentRealm}}{{.currentRealm.Name}}{{else}}V{{end}}</a>
+      <a class="navbar-brand" href="#">{{if .currentRealm}}{{.currentRealm.Name}}{{if .currentRealm.RegionCode}} - {{.currentRealm.RegionCode}}{{end}}{{else}}V{{end}}</a>
       <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar" aria-expanded="false" aria-label="Toggle navigation">
         <span class="navbar-toggler-icon"></span>
       </button>

--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -52,7 +52,7 @@
               {{end}}
               <small class="form-text text-muted">
                 Used in creating deep link SMS for multi-helath authority apps. Region should
-                be ISO 3166-1 country codes and ISO 3166-2 subdivision codes where applicable.
+                be <a href="https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes">ISO 3166-1 country codes and ISO 3166-2 subdivision codes</a> where applicable.
                 For example, Washington State would be <code>US-WA</code>.
               </small>
             </div>
@@ -111,7 +111,7 @@
         </div>
         <div class="card-body">
           <div class="form-group row">
-            <label for="codeLength" class="col-sm-3">Code length:</label>
+            <label for="codeLength" class="col-sm-3">Short code characters:</label>
             <div class="col-sm-9">
               <select class="form-control{{if $realm.ErrorsFor "codeLength"}} is-invalid{{end}}" name="codeLength" id="codeLength">
                 {{range $cl := .shortCodeLengths}}
@@ -119,7 +119,7 @@
                 {{end}}
               </select>
               <small class="form-text text-muted">
-                The 'short' verification code is intended to be read over the phone to the
+                The short verification code is intended to be dictated over the phone to the
                 person and is <code>6</code>, <code>7</code>, or <code>8</code> digits in length.
               </small>
             </div>
@@ -144,21 +144,7 @@
           </div>
 
           <div class="form-group row">
-            <label for="codeLength" class="col-sm-3">Send long codes in SMS:</label>
-            <div class="col-sm-9">
-              <select class="form-control{{if $realm.ErrorsFor "UseSMSLongCodes"}} is-invalid{{end}}" name="UseSMSLongCodes" id="UseSMSLongCodes">
-                <option value="true" {{if $realm.UseSMSLongCodes}}selected{{end}}>Yes</option>
-                <option value="false" {{if not $realm.UseSMSLongCodes}}selected{{end}}>No</option>
-              </select>
-              <small class="form-text text-muted">
-                If enabled, a longer code will be send via SMS to the user, using a deep link protocol
-                that can be registered by your application allowing for one click diagnosis reporting.
-              </small>
-            </div>
-          </div>
-
-          <div class="form-group row">
-            <label for="codeLength" class="col-sm-3">Long code length:</label>
+            <label for="codeLength" class="col-sm-3">Long code characters:</label>
             <div class="col-sm-9">
               <select class="form-control{{if $realm.ErrorsFor "longCodeLength"}} is-invalid{{end}}" name="longCodeLength" id="longCodeLength">
                 {{range $cl := .longCodeLengths}}
@@ -190,64 +176,37 @@
           </div>
 
           <div class="form-group row">
-            <label for="name" class="col-sm-3">Deep link protocol:</label>
+            <label for="name" class="col-sm-3">SMS text template:</label>
             <div class="col-sm-9">
-              <input type="text" id="deepLinkProtocol" name="deepLinkProtocol" class="form-control{{if $realm.ErrorsFor "deepLinkProtocol"}} is-invalid{{end}}" value="{{$realm.DeepLinkProtocol}}" />
-              {{if $realm.ErrorsFor "deepLinkProtocol"}}
+              <textarea id="SMSTextTemplate" name="SMSTextTemplate" class="form-control{{if $realm.ErrorsFor "SMSTextTemplate"}} is-invalid{{end}}">{{$realm.SMSTextTemplate}}</textarea>
+              {{if $realm.ErrorsFor "SMSTextTemplate"}}
               <div class="invalid-feedback">
-                {{joinStrings ($realm.ErrorsFor "deepLinkProtocol") ", "}}
+                {{joinStrings ($realm.ErrorsFor "SMSTextTemplate") ", "}}
               </div>
               {{end}}
               <small class="form-text text-muted">
-                Used to send deep links over sms, for example <code>ens://v?r=US-WA&c=ABCD1234</code>.
-                The protocol setting here should include the protocol up through the <code>?</code>,
-                so the in this example, the protocol setting is <code>ens://v?</code>
-              </small>
-            </div>
-          </div>
-
-          <div class="form-group row">
-            <label for="codeLength" class="col-sm-3">Include region in deep link:</label>
-            <div class="col-sm-9">
-              <select class="form-control{{if $realm.ErrorsFor "DeepLinkRegion"}} is-invalid{{end}}" name="DeepLinkRegion" id="DeepLinkRegion">
-                <option value="true" {{if $realm.DeepLinkRegion}}selected{{end}}>Yes</option>
-                <option value="false" {{if not $realm.DeepLinkRegion}}selected{{end}}>No</option>
-              </select>
-              <small class="form-text text-muted">
-                If enabled, your realm's region designation will be included in the SMS deep link.
-              </small>
-            </div>
-          </div>
-
-          <div class="form-group row">
-            <label for="name" class="col-sm-3">SMS text greeting:</label>
-            <div class="col-sm-9">
-              <input type="text" id="SMSTextGreeting" name="SMSTextGreeting" class="form-control{{if $realm.ErrorsFor "SMSTextGreeting"}} is-invalid{{end}}" value="{{$realm.SMSTextGreeting}}" />
-              {{if $realm.ErrorsFor "SMSTextGreeting"}}
-              <div class="invalid-feedback">
-                {{joinStrings ($realm.ErrorsFor "SMSTextGreeting") ", "}}
-              </div>
-              {{end}}
-              <small class="form-text text-muted">
-                The SMS message will be constructed as <code>[greeting] [code or link] [expiry]</code>. The overall
+                The SMS message will be constructed based on the template you provide. The overall
                 length of of the SMS message should not exceede 160 characters, or your message will need to be split
-                in transit and may not be joined correctly. Examples:
+                in transit and may not be joined correctly. There are some special strings that you can use
+                to substitute items. Your SMS template <em>MUST</em> contain either the <code>[code]</code> or
+                <code>[longcode]</code>.
                 <ul>
-                  <li>No deep link / short codes in SMS</li>
-                  <ul>
-                    <li>If you have an 8 digit code, valid for 60 minutes the fixed piece of your message is
-                      <code> 12345678 Expires in 60 minutes</code>. That is <code>31</code> characters, leaving
-                      you with 129 characters for your greeting.
-                    </li>
-                  </ul>
-                  <li>With a deep link and long code in SMS</li>
-                  <ul>
-                    <li>If you are using 16 digit codes, valid for 24 hours using a deep link protocol as
-                      described above. In that case, the fixed piece of your message is
-                      <code> ens://v?r=US-WA&c=12345678ABCDEFGH Expires in 24 hours</code>. That is
-                      <code>56</code> characters, leaving you with 104 characters for your greeting.
-                    </li>
-                  </ul>
+                  <li><code>[region]</code>The region setting (set on this page).</li>
+                  <li><code>[code]</code>The 'short' verification code.</li>                  
+                  <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units).</li>
+                  <li><code>[longcode]</code>The 'long' verification code</li>
+                  <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+                </ul>
+
+                Here are some example SMS templates.
+                <ul>
+                  <li>Send short code in SMS (<code>104</code> characters with 8 digit codes and 60 minute expiration):
+                      <pre>State of Wonder Dept. of Health, your exposure notifications code is [code] and expires in [expires] minutes</pre>
+                  </li>
+                  <li>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration):
+                      <pre>You have tested positive for Covid-19. Click here to share anonymous data for exposure notifications
+                        dohen://v?c=[longcode] (Expires in [longexpires] hours)</pre>
+                  </li>
                 </ul>
               </small>
             </div>

--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -41,6 +41,23 @@
             </div>
           </div>
 
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Region code:</label>
+            <div class="col-sm-9">
+              <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}" />
+              {{if $realm.ErrorsFor "regionCode"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                Used in creating deep link SMS for multi-helath authority apps. Region should
+                be ISO 3166-1 country codes and ISO 3166-2 subdivision codes where applicable.
+                For example, Washington State would be <code>US-WA</code>.
+              </small>
+            </div>
+          </div>
+
           <div class="form-group row mb-0">
             <label class="col-sm-3">Allowed tests:</label>
             <div class="col-sm-9">
@@ -86,6 +103,157 @@
             </div>
           </div>
         </div>
+      </div>
+
+      <div class="card mb-3">
+        <div class="card-header">
+          Verification code configuration
+        </div>
+        <div class="card-body">
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Code length:</label>
+            <div class="col-sm-9">
+              <select class="form-control{{if $realm.ErrorsFor "codeLength"}} is-invalid{{end}}" name="codeLength" id="codeLength">
+                {{range $cl := .shortCodeLengths}}
+                <option value="{{$cl}}" {{if (eq $cl $realm.CodeLength)}}selected{{end}}>{{$cl}}</option>
+                {{end}}
+              </select>
+              <small class="form-text text-muted">
+                The 'short' verification code is intended to be read over the phone to the
+                person and is <code>6</code>, <code>7</code>, or <code>8</code> digits in length.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Code expires after:</label>
+            <div class="col-sm-8">
+              <select class="form-control{{if $realm.ErrorsFor "CodeDurationSeconds"}} is-invalid{{end}}" name="codeDuration" id="codeDuration">
+                {{$current := $realm.GetCodeDurationMinutes}}
+                {{range $scm := .shortCodeMinutes}}
+                <option value="{{$scm}}" {{if (eq $scm $current)}}selected{{end}}>{{$scm}}</option>
+                {{end}}
+              </select>
+              <small class="form-text text-muted">
+                The short code can be valid from anywhere between <code>5</code> and <code>60</code>
+                minutes. If you are using SMS deeplinks, it is recommended to keep this duration
+                short and let the long code be valid for a longer period (up to <code>24</code> hours).
+              </small>
+            </div>
+            <div class="col-sm-1">minutes</div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Send long codes in SMS:</label>
+            <div class="col-sm-9">
+              <select class="form-control{{if $realm.ErrorsFor "UseSMSLongCodes"}} is-invalid{{end}}" name="UseSMSLongCodes" id="UseSMSLongCodes">
+                <option value="true" {{if $realm.UseSMSLongCodes}}selected{{end}}>Yes</option>
+                <option value="false" {{if not $realm.UseSMSLongCodes}}selected{{end}}>No</option>
+              </select>
+              <small class="form-text text-muted">
+                If enabled, a longer code will be send via SMS to the user, using a deep link protocol
+                that can be registered by your application allowing for one click diagnosis reporting.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Long code length:</label>
+            <div class="col-sm-9">
+              <select class="form-control{{if $realm.ErrorsFor "longCodeLength"}} is-invalid{{end}}" name="longCodeLength" id="longCodeLength">
+                {{range $cl := .longCodeLengths}}
+                <option value="{{$cl}}" {{if (eq $cl $realm.LongCodeLength)}}selected{{end}}>{{$cl}}</option>
+                {{end}}
+              </select>
+              <small class="form-text text-muted">
+                The 'long' verification code is only delivered over SMS, is more complex with <code>12</code> -
+                <code>16</code> alphanumeric characters, and is never shown to a human. It is recommended
+                to leave this at the default of <code>16</code> digits.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Long code expires after:</label>
+            <div class="col-sm-8">
+              <select class="form-control{{if $realm.ErrorsFor "LongCodeDurationSeconds"}} is-invalid{{end}}" name="longCodeDuration" id="longCodeDuration">
+                {{$current := $realm.GetLongCodeDurationHours}}
+                {{range $lch := .longCodeHours}}
+                <option value="{{$lch}}" {{if (eq $lch $current)}}selected{{end}}>{{$lch}}</option>
+                {{end}}
+              </select>
+              <small class="form-text text-muted">
+                The long code can be valid between <code>1</code> and <code>24</code> hours.
+              </small>
+            </div>
+            <div class="col-sm-1">hours</div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Deep link protocol:</label>
+            <div class="col-sm-9">
+              <input type="text" id="deepLinkProtocol" name="deepLinkProtocol" class="form-control{{if $realm.ErrorsFor "deepLinkProtocol"}} is-invalid{{end}}" value="{{$realm.DeepLinkProtocol}}" />
+              {{if $realm.ErrorsFor "deepLinkProtocol"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "deepLinkProtocol") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                Used to send deep links over sms, for example <code>ens://v?r=US-WA&c=ABCD1234</code>.
+                The protocol setting here should include the protocol up through the <code>?</code>,
+                so the in this example, the protocol setting is <code>ens://v?</code>
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Include region in deep link:</label>
+            <div class="col-sm-9">
+              <select class="form-control{{if $realm.ErrorsFor "DeepLinkRegion"}} is-invalid{{end}}" name="DeepLinkRegion" id="DeepLinkRegion">
+                <option value="true" {{if $realm.DeepLinkRegion}}selected{{end}}>Yes</option>
+                <option value="false" {{if not $realm.DeepLinkRegion}}selected{{end}}>No</option>
+              </select>
+              <small class="form-text text-muted">
+                If enabled, your realm's region designation will be included in the SMS deep link.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">SMS text greeting:</label>
+            <div class="col-sm-9">
+              <input type="text" id="SMSTextGreeting" name="SMSTextGreeting" class="form-control{{if $realm.ErrorsFor "SMSTextGreeting"}} is-invalid{{end}}" value="{{$realm.SMSTextGreeting}}" />
+              {{if $realm.ErrorsFor "SMSTextGreeting"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "SMSTextGreeting") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                The SMS message will be constructed as <code>[greeting] [code or link] [expiry]</code>. The overall
+                length of of the SMS message should not exceede 160 characters, or your message will need to be split
+                in transit and may not be joined correctly. Examples:
+                <ul>
+                  <li>No deep link / short codes in SMS</li>
+                  <ul>
+                    <li>If you have an 8 digit code, valid for 60 minutes the fixed piece of your message is
+                      <code> 12345678 Expires in 60 minutes</code>. That is <code>31</code> characters, leaving
+                      you with 129 characters for your greeting.
+                    </li>
+                  </ul>
+                  <li>With a deep link and long code in SMS</li>
+                  <ul>
+                    <li>If you are using 16 digit codes, valid for 24 hours using a deep link protocol as
+                      described above. In that case, the fixed piece of your message is
+                      <code> ens://v?r=US-WA&c=12345678ABCDEFGH Expires in 24 hours</code>. That is
+                      <code>56</code> characters, leaving you with 104 characters for your greeting.
+                    </li>
+                  </ul>
+                </ul>
+              </small>
+            </div>
+          </div>
+
+        </div>        
       </div>
 
       <div class="card mb-3">

--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -189,7 +189,7 @@
                 length of of the SMS message should not exceede 160 characters, or your message will need to be split
                 in transit and may not be joined correctly. There are some special strings that you can use
                 to substitute items. Your SMS template <em>MUST</em> contain either the <code>[code]</code> or
-                <code>[longcode]</code>.
+                <code>[longcode]</code>.         
                 <ul>
                   <li><code>[region]</code>The region setting (set on this page).</li>
                   <li><code>[code]</code>The 'short' verification code.</li>                  
@@ -198,7 +198,8 @@
                   <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
                 </ul>
 
-                Here are some example SMS templates.
+                Here are some example SMS templates. The recommended usage is to include the long code in the SMS, and make
+                it clickable by registering a customer URI handler for your app.
                 <ul>
                   <li>Send short code in SMS (<code>104</code> characters with 8 digit codes and 60 minute expiration):
                       <pre>State of Wonder Dept. of Health, your exposure notifications code is [code] and expires in [expires] minutes</pre>

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -43,8 +43,6 @@ type AdminAPIServerConfig struct {
 	Port                string        `env:"PORT,default=8080"`
 	APIKeyCacheDuration time.Duration `env:"API_KEY_CACHE_DURATION,default=5m"`
 
-	CodeDuration        time.Duration `env:"CODE_DURATION,default=1h"`
-	CodeDigits          uint          `env:"CODE_DIGITS,default=8"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 }
@@ -66,7 +64,6 @@ func (c *AdminAPIServerConfig) Validate() error {
 	}{
 		{c.APIKeyCacheDuration, "API_KEY_CACHE_DURATION"},
 		{c.AllowedSymptomAge, "ALLOWED_PAST_SYMPTOM_DAYS"},
-		{c.CodeDuration, "CODE_DURATION"},
 	}
 
 	for _, f := range fields {
@@ -84,14 +81,6 @@ func (c *AdminAPIServerConfig) GetCollisionRetryCount() uint {
 
 func (c *AdminAPIServerConfig) GetAllowedSymptomAge() time.Duration {
 	return c.AllowedSymptomAge
-}
-
-func (c *AdminAPIServerConfig) GetVerificationCodeDuration() time.Duration {
-	return c.CodeDuration
-}
-
-func (c *AdminAPIServerConfig) GetVerificationCodeDigits() uint {
-	return c.CodeDigits
 }
 
 func (c *AdminAPIServerConfig) ObservabilityExporterConfig() *observability.Config {

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -21,6 +21,4 @@ import "time"
 type IssueAPIConfig interface {
 	GetCollisionRetryCount() uint
 	GetAllowedSymptomAge() time.Duration
-	GetVerificationCodeDuration() time.Duration
-	GetVerificationCodeDigits() uint
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -56,8 +56,6 @@ type ServerConfig struct {
 
 	// Application Config
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
-	CodeDuration        time.Duration `env:"CODE_DURATION,default=1h"`
-	CodeDigits          uint          `env:"CODE_DIGITS,default=8"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 
@@ -89,7 +87,6 @@ func (c *ServerConfig) Validate() error {
 	}{
 		{c.SessionDuration, "SESSION_DURATION"},
 		{c.RevokeCheckPeriod, "REVOKE_CHECK_DURATION"},
-		{c.CodeDuration, "CODE_DURATION"},
 		{c.AllowedSymptomAge, "ALLOWED_PAST_SYMPTOM_DAYS"},
 	}
 
@@ -108,14 +105,6 @@ func (c *ServerConfig) GetCollisionRetryCount() uint {
 
 func (c *ServerConfig) GetAllowedSymptomAge() time.Duration {
 	return c.AllowedSymptomAge
-}
-
-func (c *ServerConfig) GetVerificationCodeDuration() time.Duration {
-	return c.CodeDuration
-}
-
-func (c *ServerConfig) GetVerificationCodeDigits() uint {
-	return c.CodeDigits
 }
 
 func (c *ServerConfig) ObservabilityExporterConfig() *observability.Config {

--- a/pkg/controller/home/home.go
+++ b/pkg/controller/home/home.go
@@ -83,7 +83,7 @@ func (c *Controller) HandleHome() http.Handler {
 		m["maxDate"] = now.Format("2006-01-02")
 		m["minDate"] = now.Add(c.pastDaysDuration).Format("2006-01-02")
 		m["maxSymptomDays"] = c.displayAllowedDays
-		m["duration"] = c.config.CodeDuration.String()
+		m["duration"] = realm.GetCodeDuration().String()
 		m["hasSMSConfig"] = hasSMSConfig
 		c.h.RenderHTML(w, "home", m)
 	})

--- a/pkg/controller/home/home.go
+++ b/pkg/controller/home/home.go
@@ -83,7 +83,7 @@ func (c *Controller) HandleHome() http.Handler {
 		m["maxDate"] = now.Format("2006-01-02")
 		m["minDate"] = now.Add(c.pastDaysDuration).Format("2006-01-02")
 		m["maxSymptomDays"] = c.displayAllowedDays
-		m["duration"] = realm.GetCodeDuration().String()
+		m["duration"] = realm.CodeDuration.Duration.String()
 		m["hasSMSConfig"] = hasSMSConfig
 		c.h.RenderHTML(w, "home", m)
 	})

--- a/pkg/controller/realmadmin/save.go
+++ b/pkg/controller/realmadmin/save.go
@@ -48,12 +48,9 @@ func (c *Controller) HandleSave() http.Handler {
 
 		CodeLength          uint   `form:"codeLength"`
 		CodeDurationMinutes int64  `form:"codeDuration"`
-		UseSMSLongCodes     bool   `form:"UseSMSLongCodes"`
 		LongCodeLength      uint   `form:"longCodeLength"`
 		LongCodeHours       int64  `form:"longCodeDuration"`
-		DeepLinkProtocol    string `form:"deepLinkProtocol"`
-		DeepLinkRegion      bool   `form:"DeepLinkRegion"`
-		SMSTextGreeting     string `form:"SMSTextGreeting"`
+		SMSTextTemplate     string `form:"SMSTextTemplate"`
 
 		TwilioAccountSid string `form:"twilio_account_sid"`
 		TwilioAuthToken  string `form:"twilio_auth_token"`
@@ -96,15 +93,10 @@ func (c *Controller) HandleSave() http.Handler {
 		realm.RegionCode = form.RegionCode
 		realm.AllowedTestTypes = form.AllowedTestTypes
 		realm.CodeLength = form.CodeLength
-		codeDuration := time.Minute * time.Duration(form.CodeDurationMinutes)
-		realm.CodeDurationSeconds = int64(codeDuration.Seconds())
-		realm.UseSMSLongCodes = form.UseSMSLongCodes
+		realm.CodeDuration.Duration = time.Duration(form.CodeDurationMinutes) * time.Minute
 		realm.LongCodeLength = form.LongCodeLength
-		longCodeDuration := time.Hour * time.Duration(form.LongCodeHours)
-		realm.LongCodeDurationSeconds = int64(longCodeDuration.Seconds())
-		realm.DeepLinkProtocol = form.DeepLinkProtocol
-		realm.DeepLinkRegion = form.DeepLinkRegion
-		realm.SMSTextGreeting = form.SMSTextGreeting
+		realm.LongCodeDuration.Duration = time.Hour * time.Duration(form.LongCodeHours)
+		realm.SMSTextTemplate = form.SMSTextTemplate
 		if err := c.db.SaveRealm(realm); err != nil {
 			flash.Error("Failed to update realm: %v", err)
 			c.renderShow(ctx, w, realm, nil)

--- a/pkg/database/duration.go
+++ b/pkg/database/duration.go
@@ -1,0 +1,52 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"database/sql"
+	"database/sql/driver"
+	"fmt"
+	"time"
+)
+
+var _ sql.Scanner = (*DurationSeconds)(nil)
+var _ driver.Valuer = (*DurationSeconds)(nil)
+
+// DurationSeconds is a custom type for writing and reating a time.Duration to be stored
+// as seconds in the database.
+type DurationSeconds struct {
+	Duration time.Duration
+}
+
+// Scan takes a int64 value in seconds and converts that to a time.Duration
+func (d *DurationSeconds) Scan(src interface{}) error {
+	if src == nil {
+		d.Duration = 0
+		return nil
+	}
+	v, ok := src.(int64)
+	if !ok {
+		return fmt.Errorf("invalid scan type")
+	}
+	d.Duration = time.Duration(v) * time.Second
+	return nil
+}
+
+// Value converts the internal time.Duration value to seconds and returns
+// that value as an int64 for saving to the database.
+func (d DurationSeconds) Value() (driver.Value, error) {
+	v := int64(d.Duration.Seconds())
+	return v, nil
+}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -589,20 +589,49 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			},
 		},
 		{
-			ID: "00026-AddSMSDeeplinkFields",
+			ID: "00026-EnableExtension_citext",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Infof("db migrations: adding SMS deeplink settings")
-				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
-					return err
+				logger.Infof("db migrations: enabling citext extension")
+				return tx.Exec("CREATE EXTENSION citext").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("DROP EXTENSION citext").Error
+			},
+		},
+		{
+			ID: "00027-AlterColumns_citext",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Infof("db migrations: setting columns to case insensitive")
+				sqls := []string{
+					"ALTER TABLE authorized_apps ALTER COLUMN name TYPE CITEXT",
+					"ALTER TABLE realms ALTER COLUMN name TYPE CITEXT",
+					"ALTER TABLE users ALTER COLUMN email TYPE CITEXT",
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
 				}
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
+				sqls := []string{
+					"ALTER TABLE authorized_apps ALTER COLUMN name TYPE TEXT",
+					"ALTER TABLE realms ALTER COLUMN name TYPE TEXT",
+					"ALTER TABLE users ALTER COLUMN email TYPE TEXT",
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
 				return nil
 			},
 		},
 		{
-			ID: "00027-AddSMSDeeplinkFields",
+			ID: "00028-AddSMSDeeplinkFields",
 			Migrate: func(tx *gorm.DB) error {
 				logger.Infof("db migrations: adding SMS deeplink settings")
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
@@ -611,6 +640,24 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
+				dropColumns := []string{
+					"use_sms_long_codes",
+					"use_sms_long_codes",
+					"long_code_length",
+					"long_code_duration_seconds",
+					"region_code",
+					"code_length",
+					"code_duration_seconds",
+					"deep_link_protocol",
+					"deep_link_region",
+					"sms_text_greeting",
+				}
+				for _, col := range dropColumns {
+					stmt := fmt.Sprintf("ALTER TABLE realms DROP COLUMN %s", col)
+					if err := tx.Exec(stmt).Error; err != nil {
+						return fmt.Errorf("unable to execute '%v': %w", stmt, err)
+					}
+				}
 				return nil
 			},
 		},

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -641,16 +641,12 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			},
 			Rollback: func(tx *gorm.DB) error {
 				dropColumns := []string{
-					"use_sms_long_codes",
-					"use_sms_long_codes",
 					"long_code_length",
-					"long_code_duration_seconds",
+					"long_code_duration",
 					"region_code",
 					"code_length",
-					"code_duration_seconds",
-					"deep_link_protocol",
-					"deep_link_region",
-					"sms_text_greeting",
+					"code_duration",
+					"sms_text_template",
 				}
 				for _, col := range dropColumns {
 					stmt := fmt.Sprintf("ALTER TABLE realms DROP COLUMN %s", col)

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -232,11 +232,9 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					return err
 				}
 				logger.Info("Create the DEFAULT realm")
-				// Create the default realm.
-				defaultRealm := Realm{
-					Name: "Default",
-				}
-				if err := tx.FirstOrCreate(&defaultRealm).Error; err != nil {
+				// Create the default realm with all of the default settings.
+				defaultRealm := NewRealmWithDefaults("Default")
+				if err := tx.FirstOrCreate(defaultRealm).Error; err != nil {
 					return err
 				}
 
@@ -253,9 +251,9 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				for _, u := range users {
 					logger.Infof("added user: %v to default realm", u.ID)
 
-					u.AddRealm(&defaultRealm)
+					u.AddRealm(defaultRealm)
 					if u.Admin {
-						u.AddRealmAdmin(&defaultRealm)
+						u.AddRealmAdmin(defaultRealm)
 					}
 
 					if err := tx.Save(u).Error; err != nil {
@@ -591,44 +589,28 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			},
 		},
 		{
-			ID: "00026-EnableExtension_citext",
+			ID: "00026-AddSMSDeeplinkFields",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Infof("db migrations: enabling citext extension")
-				return tx.Exec("CREATE EXTENSION citext").Error
-			},
-			Rollback: func(tx *gorm.DB) error {
-				return tx.Exec("DROP EXTENSION citext").Error
-			},
-		},
-		{
-			ID: "00026-AlterColumns_citext",
-			Migrate: func(tx *gorm.DB) error {
-				logger.Infof("db migrations: setting columns to case insensitive")
-				sqls := []string{
-					"ALTER TABLE authorized_apps ALTER COLUMN name TYPE CITEXT",
-					"ALTER TABLE realms ALTER COLUMN name TYPE CITEXT",
-					"ALTER TABLE users ALTER COLUMN email TYPE CITEXT",
-				}
-
-				for _, sql := range sqls {
-					if err := tx.Exec(sql).Error; err != nil {
-						return err
-					}
+				logger.Infof("db migrations: adding SMS deeplink settings")
+				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
+					return err
 				}
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				sqls := []string{
-					"ALTER TABLE authorized_apps ALTER COLUMN name TYPE TEXT",
-					"ALTER TABLE realms ALTER COLUMN name TYPE TEXT",
-					"ALTER TABLE users ALTER COLUMN email TYPE TEXT",
+				return nil
+			},
+		},
+		{
+			ID: "00027-AddSMSDeeplinkFields",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Infof("db migrations: adding SMS deeplink settings")
+				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
+					return err
 				}
-
-				for _, sql := range sqls {
-					if err := tx.Exec(sql).Error; err != nil {
-						return err
-					}
-				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
 				return nil
 			},
 		},

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -1,0 +1,39 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import "testing"
+
+func TestSMS(t *testing.T) {
+	realm := NewRealmWithDefaults("test")
+	realm.RegionCode = "US-WA"
+
+	{
+		got := realm.BuildSMSText("12345678", "abcdefgh12345678")
+		want := "This is your Exposure Notifications Verification code: ens://v?r=US-WA&c=abcdefgh12345678 Expires in 24 hours"
+		if got != want {
+			t.Errorf("SMS text wrong, want: %q got %q", want, got)
+		}
+	}
+
+	{
+		realm.SMSTextTemplate = "State of Wonder, Covid-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
+		got := realm.BuildSMSText("654321", "asdflkjasdlkfjl")
+		want := "State of Wonder, Covid-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
+		if got != want {
+			t.Errorf("SMS text wrong, want: %q got %q", want, got)
+		}
+	}
+}

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -80,16 +80,20 @@ func (v *VerificationCode) FormatSymptomDate() string {
 // IsCodeExpired checks to see if the actual code provides is the
 // short or long code and deteriminies if it is expired based on that.
 func (v *VerificationCode) IsCodeExpired(code string) bool {
-	now := time.Now()
-	if v.Code == code {
+	now := time.Now().UTC()
+	switch code {
+	case v.Code:
 		return !v.ExpiresAt.After(now)
+	case v.LongCode:
+		return !v.LongExpiresAt.After(now)
+	default:
+		return true
 	}
-	return !v.LongExpiresAt.After(now)
 }
 
 // IsExpired returns true if a verification code has expired.
 func (v *VerificationCode) IsExpired() bool {
-	now := time.Now()
+	now := time.Now().UTC()
 	return v.ExpiresAt.Before(now) && v.LongExpiresAt.Before(now)
 }
 

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -30,10 +30,8 @@ import (
 )
 
 const (
-	// a 32 character charset devides evenly over 256, allowing random bytes
-	// to be mapped evenly onto this space without any bias.
-	// Apologies to the letters that were left out.
-	charset = "abcdefghijklmnopqrstuv0123456789"
+	// all lowercase characters plus 0-9
+	charset = "abcdefghijklmnopqrstuvwxyz0123456789"
 )
 
 // GenerateCode creates a new OTP code.
@@ -57,15 +55,23 @@ func GenerateCode(length uint) (string, error) {
 // base64 encode to that length string.
 // For example 16 character string requires 12 bytes.
 func GenerateAlphanumericCode(length uint) (string, error) {
-	buffer := make([]byte, length)
-	if _, err := rand.Read(buffer); err != nil {
+	var result string
+	for i := uint(0); i < length; i++ {
+		ch, err := randomFromCharset()
+		if err != nil {
+			return "", err
+		}
+		result = result + ch
+	}
+	return result, nil
+}
+
+func randomFromCharset() (string, error) {
+	n, err := rand.Int(rand.Reader, big.NewInt(int64(len(charset))))
+	if err != nil {
 		return "", err
 	}
-	for i, v := range buffer {
-		buffer[i] = charset[v%byte(len(charset))]
-	}
-
-	return string(buffer), nil
+	return string(charset[n.Int64()]), nil
 }
 
 // Request represents the parameters of a verification code request.

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -29,6 +29,13 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 )
 
+const (
+	// a 32 character charset devides evenly over 256, allowing random bytes
+	// to be mapped evenly onto this space without any bias.
+	// Apologies to the letters that were left out.
+	charset = "abcdefghijklmnopqrstuv0123456789"
+)
+
 // GenerateCode creates a new OTP code.
 func GenerateCode(length uint) (string, error) {
 	limit := big.NewInt(0)
@@ -45,40 +52,68 @@ func GenerateCode(length uint) (string, error) {
 	return result, nil
 }
 
+// GenerateAlphanumericCode will generate an alpha numberic code.
+// It uses the length to estimate how many bytes of randomness will
+// base64 encode to that length string.
+// For example 16 character string requires 12 bytes.
+func GenerateAlphanumericCode(length uint) (string, error) {
+	buffer := make([]byte, length)
+	if _, err := rand.Read(buffer); err != nil {
+		return "", err
+	}
+	for i, v := range buffer {
+		buffer[i] = charset[v%byte(len(charset))]
+	}
+
+	return string(buffer), nil
+}
+
 // Request represents the parameters of a verification code request.
 type Request struct {
-	DB            *database.Database
-	RealmID       uint
-	Length        uint
-	ExpiresAt     time.Time
-	TestType      string
-	SymptomDate   *time.Time
-	MaxSymptomAge time.Duration
-	IssuingUser   *database.User
-	IssuingApp    *database.AuthorizedApp
+	DB             *database.Database
+	RealmID        uint
+	ShortLength    uint
+	ShortExpiresAt time.Time
+	LongLength     uint
+	LongExpiresAt  time.Time
+	TestType       string
+	SymptomDate    *time.Time
+	MaxSymptomAge  time.Duration
+	IssuingUser    *database.User
+	IssuingApp     *database.AuthorizedApp
 }
 
 // Issue will generate a verification code and save it to the database, based on
-// the paremters provided. It returns the code, a UUID for accessing the code,
-// and any errors.
-func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, error) {
+// the paremters provided. It returns the short code, long code, a UUID for
+// accessing the code, and any errors.
+func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, string, error) {
 	logger := logging.FromContext(ctx)
 	var verificationCode database.VerificationCode
 	var err error
 	for i := uint(0); i < retryCount; i++ {
-		code, err := GenerateCode(o.Length)
+		code, err := GenerateCode(o.ShortLength)
 		if err != nil {
 			logger.Errorf("code generation error: %v", err)
 			continue
 		}
+		longCode := code
+		if o.LongLength > 0 {
+			longCode, err = GenerateAlphanumericCode(o.LongLength)
+			if err != nil {
+				logger.Errorf("long code generation error: %v", err)
+				continue
+			}
+		}
 		verificationCode = database.VerificationCode{
-			RealmID:     o.RealmID,
-			Code:        code,
-			TestType:    strings.ToLower(o.TestType),
-			SymptomDate: o.SymptomDate,
-			ExpiresAt:   o.ExpiresAt,
-			IssuingUser: o.IssuingUser,
-			IssuingApp:  o.IssuingApp,
+			RealmID:       o.RealmID,
+			Code:          code,
+			LongCode:      longCode,
+			TestType:      strings.ToLower(o.TestType),
+			SymptomDate:   o.SymptomDate,
+			ExpiresAt:     o.ShortExpiresAt,
+			LongExpiresAt: o.LongExpiresAt,
+			IssuingUser:   o.IssuingUser,
+			IssuingApp:    o.IssuingApp,
 		}
 		// If a verification code already exists, it will fail to save, and we retry.
 		if err := o.DB.SaveVerificationCode(&verificationCode, o.MaxSymptomAge); err != nil {
@@ -89,7 +124,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, e
 		}
 	}
 	if err != nil {
-		return "", "", err
+		return "", "", "", err
 	}
-	return verificationCode.Code, verificationCode.UUID, nil
+	return verificationCode.Code, verificationCode.LongCode, verificationCode.UUID, nil
 }

--- a/pkg/otp/code_test.go
+++ b/pkg/otp/code_test.go
@@ -56,8 +56,8 @@ func TestGenerateAlphanumericCode(t *testing.T) {
 		t.Log(code)
 
 		for i, c := range code {
-			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'v')) {
-				t.Errorf("code[%v]: %v outside expected range 0-9,a-v", i, c)
+			if !((c >= '0' && c <= '9') || (c >= 'a' && c <= 'z')) {
+				t.Errorf("code[%v]: %v outside expected range 0-9,a-z", i, c)
 			}
 		}
 	}


### PR DESCRIPTION
Fixes #138
Fixes #143
Fixes #213 

## Proposed Changes

* add region designator for a realm, i.e. `US-WA`
* Generate both 'short' and 'long' codes
 * short codes have shorter timeouts and are meant to read over the phone, long codes only over SMS
 * long codes are alphamumeric a-v,0-9
* Option to use deep links for codes in SMS
 * for example `ens://v?r=US-WA&c=ABCD1234`
* add all of these settings into the realm setting page

![image](https://user-images.githubusercontent.com/92319/90322025-f239ed80-df03-11ea-8710-267b025e6117.png)


**Release Note**

```release-note
Short and long verification codes issued at the same time. Long codes can be valid for up to 24 hours. Option to generate a SMS 'deeplink' to make it so the code doesn't need to be copied / retyped. Settings screen for realm settings.
```
