### PR TITLE
Add tracing to jsonclient

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -45,6 +45,7 @@ require (
 	github.com/sethvargo/go-signalcontext v0.1.0
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/stretchr/testify v1.6.1 // indirect
+	go.opencensus.io v0.22.4
 	go.uber.org/zap v1.15.0
 	golang.org/x/crypto v0.0.0-20200728195943-123391ffb6de // indirect
 	golang.org/x/sys v0.0.0-20200808120158-1030fc2bf1d9 // indirect

--- a/pkg/jsonclient/client.go
+++ b/pkg/jsonclient/client.go
@@ -24,6 +24,9 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"go.opencensus.io/plugin/ochttp"
+	"go.opencensus.io/plugin/ochttp/propagation/tracecontext"
 )
 
 // MakeRequest uses an HTTP client to send and receive JSON based on interface{}.
@@ -32,6 +35,12 @@ func MakeRequest(ctx context.Context, client *http.Client, url string, headers h
 	data, err := json.Marshal(input)
 	if err != nil {
 		return err
+	}
+
+	// Set transport to have tracing data.
+	client.Transport = &ochttp.Transport{
+		Base:        client.Transport,
+		Propagation: &tracecontext.HTTPFormat{},
 	}
 
 	buffer := bytes.NewBuffer(data)


### PR DESCRIPTION
https://github.com/google/exposure-notifications-verification-server/issues/180

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds trace headers to requests originating with the jsonclient

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
