### PR TITLE
Issue185

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -40,6 +40,12 @@ const (
 	ErrVerifyCodeNotFound = "code_not_found"
 	// ErrVerifyCodeUserUnauth indicates the code does not belong to the requesting user.
 	ErrVerifyCodeUserUnauth = "code_user_unauthorized"
+	// ErrUnsupportedTestType indicates the client is unable to process the appropriate test type
+	// in thise case, the user should be directed to upgrade their app / operating system.
+	ErrUnsupportedTestType = "unsupported_test_type"
+	// ErrInvalidTestType indicates the client says it supports a test type this server doesn't
+	// know about.
+	ErrInvalidTestType = "invalid_test_type"
 
 	// Certificate API responses
 	// ErrTokenInvalid indicates the token provided is unknown or already used
@@ -142,9 +148,23 @@ type CheckCodeStatusResponse struct {
 // VerifyCodeRequest is the request structure for exchanging a short term Verification Code
 // (OTP) for a long term token (a JWT) that can later be used to sign TEKs.
 //
+// 'code' is either the issued short code or long code issued to the user. Either one is
+//   acceptable. Note that they normally have different expiry times.
+// 'accept' is a list of accepted test types by the client. Acceptable values are
+//   - ["confirmed"]
+//   - ["confirmed", "likely"]  == ["likely"]
+//   - ["confirmed", "likely", "negative"] == ["negative"]
+//   These values form a hierarchy, if a client will accept 'likely' they must accept
+//   both confirmed and likely. 'negative' indicates you accept confirmed, likely, and negative.
+//   A client can pass in the complete list they accept or the "highest" value they can accept.
+//   If this value is omitted or is empty, the client agrees to accept ALL possible
+//   test types, including test types that may be introduced in the future.
+//
+//
 // Requires API key in a HTTP header, X-API-Key: APIKEY
 type VerifyCodeRequest struct {
-	VerificationCode string `json:"code"`
+	VerificationCode string   `json:"code"`
+	AcceptTestTypes  []string `json:"accept,omitempty"`
 }
 
 // VerifyCodeResponse either contains an error, or contains the test parameters

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -42,6 +42,7 @@ const (
 	ErrVerifyCodeUserUnauth = "code_user_unauthorized"
 	// ErrUnsupportedTestType indicates the client is unable to process the appropriate test type
 	// in thise case, the user should be directed to upgrade their app / operating system.
+	// Accompanied by an HTTP status of StatusPreconditionFailed (412).
 	ErrUnsupportedTestType = "unsupported_test_type"
 	// ErrInvalidTestType indicates the client says it supports a test type this server doesn't
 	// know about.

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"fmt"
+	"strings"
+)
+
+// AcceptTypes is a map of string to struct.
+type AcceptTypes map[string]struct{}
+
+// GetAcceptedTestTypes validates the AcceptedTestTypes of a VerifyCodeRequest
+// and upconverts the list into a set (map) of the effective accepted test types.
+// If an invalid test type is in the API request, an error is returned.
+func (v *VerifyCodeRequest) GetAcceptedTestTypes() (AcceptTypes, error) {
+	accepted := AcceptTypes{}
+	if len(v.AcceptTestTypes) == 0 {
+		accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely, TestTypeNegative)
+		return accepted, nil
+	}
+
+	for _, testType := range v.AcceptTestTypes {
+		testType = strings.ToLower(testType)
+		switch testType {
+		case TestTypeConfirmed:
+			accepted.AddAcceptTypes(TestTypeConfirmed)
+		case TestTypeLikely:
+			accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely)
+		case TestTypeNegative:
+			accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely, TestTypeNegative)
+		default:
+			return nil, fmt.Errorf("invalid accepted test type: %v", testType)
+		}
+	}
+
+	return accepted, nil
+}
+
+// AddAcceptTypes takes a list of acceptable types and converts it to a map.
+func (a AcceptTypes) AddAcceptTypes(types ...string) {
+	for _, t := range types {
+		a[t] = struct{}{}
+	}
+}

--- a/pkg/api/util_test.go
+++ b/pkg/api/util_test.go
@@ -1,0 +1,101 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestGetAcceptedTestTypes(t *testing.T) {
+	allTypes := AcceptTypes{
+		"confirmed": struct{}{},
+		"likely":    struct{}{},
+		"negative":  struct{}{},
+	}
+	upToConfirmed := AcceptTypes{
+		"confirmed": struct{}{},
+	}
+	upToLikely := AcceptTypes{
+		"confirmed": struct{}{},
+		"likely":    struct{}{},
+	}
+
+	cases := []struct {
+		name  string
+		input []string
+		want  AcceptTypes
+		err   string
+	}{
+		{
+			name:  "default_empty",
+			input: []string{},
+			want:  allTypes,
+		},
+		{
+			name:  "invalid",
+			input: []string{"SELF-REPORTED"},
+			want:  nil,
+			err:   "invalid accepted test type: self-reported",
+		},
+		{
+			name:  "full_suite",
+			input: []string{"CONFIRMED", "Likely", "negative"},
+			want:  allTypes,
+		},
+		{
+			name:  "just_confirmed",
+			input: []string{"confirmed"},
+			want:  upToConfirmed,
+		},
+		{
+			name:  "confirmed_likely",
+			input: []string{"confirmed", "likely"},
+			want:  upToLikely,
+		},
+		{
+			name:  "just_likely",
+			input: []string{"likely"},
+			want:  upToLikely,
+		},
+		{
+			name:  "just_negative",
+			input: []string{"negative"},
+			want:  allTypes,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			v := VerifyCodeRequest{
+				AcceptTestTypes: tc.input,
+			}
+			got, err := v.GetAcceptedTestTypes()
+			if err != nil && tc.err == "" {
+				t.Fatalf("unexpected error: %v", err)
+			} else if err == nil && tc.err != "" {
+				t.Fatalf("expected error: %q, got: nil", tc.err)
+			} else if err != nil && !strings.Contains(err.Error(), tc.err) {
+				t.Fatalf("expected error %q, got: %v", tc.err, err)
+			}
+
+			if diff := cmp.Diff(tc.want, got); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		})
+	}
+}

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -107,6 +107,8 @@ func (c *Controller) HandleVerify() http.Handler {
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification code invalid").WithCode(api.ErrTokenInvalid))
 			case errors.Is(err, database.ErrVerificationCodeNotFound):
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification code invalid").WithCode(api.ErrTokenInvalid))
+			case errors.Is(err, database.ErrUnsupportedTestType):
+				c.h.RenderJSON(w, http.StatusPreconditionFailed, api.Errorf("verification code has unsupported test type").WithCode(api.ErrUnsupportedTestType))
 			default:
 				c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
 			}

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -87,9 +87,17 @@ func (c *Controller) HandleVerify() http.Handler {
 			return
 		}
 
+		// Process and validate the requested acceptable test types.
+		acceptTypes, err := request.GetAcceptedTestTypes()
+		if err != nil {
+			c.logger.Errorf("invalid accept test types", "error", err)
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrInvalidTestType))
+			return
+		}
+
 		// Exchange the short term verification code for a long term verification token.
 		// The token can be used to sign TEKs later.
-		verificationToken, err := c.db.VerifyCodeAndIssueToken(authApp.RealmID, request.VerificationCode, c.config.VerificationTokenDuration)
+		verificationToken, err := c.db.VerifyCodeAndIssueToken(authApp.RealmID, request.VerificationCode, acceptTypes, c.config.VerificationTokenDuration)
 		if err != nil {
 			c.logger.Errorw("failed to issue verification token", "error", err)
 			switch {


### PR DESCRIPTION
Fixes #185

## Proposed Changes

* Introduce capability for verification clients to assert which test types they accept
* If the client passes nothing, they accept all test types (legacy behavior is un changed)

**Release Note**

```release-note
When clients are validating verification codes, they can provide a list of test types that they are willing to accept. The default is to accept all test types.
```
