### PR TITLE
Alternative sign-in page using Identity Platform

### DIFF
--- a/cmd/server/assets/login.html
+++ b/cmd/server/assets/login.html
@@ -1,0 +1,107 @@
+{{define "login"}}
+<!doctype html>
+<html lang="en">
+
+<head>
+    {{template "head" .}}
+
+    {{template "firebase" .}}
+</head>
+
+<body>
+    {{template "navbar" .}}
+
+    <main role="main" class="container">
+        {{template "flash" .}}
+        <div class="alert alert-warning" role="alert" id="message"></div>
+
+        <div class="card mb-3">
+            <div class="card-body">
+                <form>
+                    {{ .csrfField }}
+                    <div class="row form-group">
+                        <label for="email" class="col-sm-3">Email</label>
+                        <div class="col-sm-9">
+                            <div class="input-group p-0 shadow-sm">
+                                <input type="text" id="email" name="email" class="form-control" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row form-group">
+                        <label for="pwd" class="col-sm-3">Password</label>
+                        <div class="col-sm-9">
+                            <div class="input-group p-0 shadow-sm">
+                                <input type="password" id="pwd" name="pwd" class="form-control" />
+                            </div>
+                        </div>
+                    </div>
+
+                    <div class="row form-group">
+                        <div class="offset-sm-3 col-sm-9">
+                            <button id="submit" class="btn btn-primary btn-block">Login</button>
+                        </div>
+                    </div>
+                </form>
+            </div>
+        </div>
+    </main>
+
+    {{template "scripts" .}}
+
+    <script>
+        $(function () {
+            $submit = $('#submit');
+            $message = $('#message');
+
+            $submit.on('click', function (event) {
+                // Disable the submit button so we only attempt once.
+                $submit.prop('disabled', true);
+
+                $email = $('#email');
+                $pwd = $('#pwd');
+
+                firebase.auth().signInWithEmailAndPassword($email.val(), $pwd.val()).catch(function (error) {
+                    $message.text(error.message);
+                    $submit.prop('disabled', false);
+                });
+            });
+        });
+
+        firebase.auth().onAuthStateChanged(function (user) {
+            $message = $('#message');
+            if (user) {
+                $message.text("Welcome, " + user.email);
+
+                user.getIdToken().then(
+                    idToken => {
+                        $.ajax({
+                            type: 'POST',
+                            url: "/session",
+                            data: { idToken: idToken },
+                            headers: { "X-CSRF-Token": "{{.csrfToken}}" },
+                            contentType: 'application/x-www-form-urlencoded',
+                            success: function (returnData) {
+                                // The user successfully signed in, redirect to realm selection.
+                                window.location.assign('/realm');
+                            },
+                            error: function (xhr, status, e) {
+                                // There was an error finding the user. Redirect to the
+                                // signout page to clear the firebase cookie and any session
+                                // data.
+                                //
+                                // The flash data may have more detailed error messages, which
+                                // will be displayed on the signout page.
+                                window.location.assign("/signout");
+                            }
+                        })
+                    })
+            } else {
+                $message.text("No user signed in.");
+            }
+        });
+    </script>
+</body>
+
+</html>
+{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/home"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/index"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realm"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
@@ -165,6 +166,14 @@ func realMain(ctx context.Context) error {
 		sessionController := session.New(ctx, auth, config, db, h)
 		sub.Handle("/signout", sessionController.HandleDelete()).Methods("GET")
 		sub.Handle("/session", sessionController.HandleCreate()).Methods("POST")
+	}
+
+	{
+		sub := r.PathPrefix("/login").Subrouter()
+		sub.Use(rateLimit)
+
+		loginController := login.New(ctx, config, h)
+		sub.Handle("", loginController.HandleLogin()).Methods("GET")
 	}
 
 	{

--- a/pkg/controller/login/controller.go
+++ b/pkg/controller/login/controller.go
@@ -32,7 +32,7 @@ type Controller struct {
 	logger *zap.SugaredLogger
 }
 
-// New creates a new index controller. The index controller is thread-safe.
+// New creates a new login controller.
 func New(ctx context.Context, config *config.ServerConfig, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx)
 

--- a/pkg/controller/login/controller.go
+++ b/pkg/controller/login/controller.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines the controller for the login page.
+package login
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	config *config.ServerConfig
+	h      *render.Renderer
+	logger *zap.SugaredLogger
+}
+
+// New creates a new index controller. The index controller is thread-safe.
+func New(ctx context.Context, config *config.ServerConfig, h *render.Renderer) *Controller {
+	logger := logging.FromContext(ctx)
+
+	return &Controller{
+		config: config,
+		h:      h,
+		logger: logger,
+	}
+}

--- a/pkg/controller/login/login.go
+++ b/pkg/controller/login/login.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines the controller for the login page.
+package login
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+func (c *Controller) HandleLogin() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// If there's a firebase cookie in the session, try to redirect to /home. If
+		// the cookie is invalid, the auth middleware will pick it up, delete the
+		// cookie from the session, and kick them back here.
+		session := controller.SessionFromContext(ctx)
+		if session != nil {
+			if c := controller.FirebaseCookieFromSession(session); c != "" {
+				http.Redirect(w, r, "/home", http.StatusSeeOther)
+				return
+			}
+		}
+
+		m := controller.TemplateMapFromContext(ctx)
+		m["firebase"] = c.config.Firebase
+		c.h.RenderHTML(w, "login", m)
+	})
+}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Create an alternative login page
    * Will Unblock us from using the Identity Platform login w/ multi-factor
* At the moment it's overly verbose with an alert bar at the top. We'll make it pretty later.
* Will someday replace our index.html login

Note: FirebaseUI does not support multi-factor auth. That's a shame because it does all the html for us and it is pretty.

![Screenshot from 2020-08-18 14-00-35](https://user-images.githubusercontent.com/36240966/90565209-64583f80-e15b-11ea-984e-2ac9e4eafc86.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Create a new login page without firebaseUI
```
