### PR TITLE
Add generic cache interfaces

### DIFF
--- a/pkg/cache/cacher.go
+++ b/pkg/cache/cacher.go
@@ -1,0 +1,118 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cache implements an caches for objects.
+package cache
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"reflect"
+	"time"
+)
+
+var (
+	ErrMissingFetchFunc = fmt.Errorf("missing fetch function")
+	ErrNotFound         = fmt.Errorf("key not found")
+	ErrStopped          = fmt.Errorf("cacher is stopped")
+)
+
+// FetchFunc is a function used to Fetch in a cacher.
+type FetchFunc func() (interface{}, error)
+
+// Cacher is an interface that defines caching.
+type Cacher interface {
+	// Closer closes the cache, cleaning up any stale entries. A closed cache is
+	// no longer valid and attempts to call methods should return an error or
+	// (less preferred) panic.
+	io.Closer
+
+	// Fetch retrieves the named item from the cache. If the item does not exist,
+	// it calls FetchFunc to create the item. If FetchFunc returns an error, the
+	// error is bubbled up the stack and no value is cached. If FetchFunc
+	// succeeds, the value is cached for the provided TTL.
+	Fetch(context.Context, string, interface{}, time.Duration, FetchFunc) error
+
+	// Read gets an item from the cache and reads it into the provided interface.
+	// If it does not exist, it returns ErrNotFound.
+	Read(context.Context, string, interface{}) error
+
+	// Write adds an item to the cache, overwriting if it already exists, caching
+	// for TTL. It returns any errors that occur on writing.
+	Write(context.Context, string, interface{}, time.Duration) error
+
+	// Delete removes an item from the cache, returning any errors that occur.
+	Delete(context.Context, string) error
+}
+
+// toValue converts the given interface into it's value, making sure its a
+// concrete type.
+func toValue(i interface{}) (reflect.Value, error) {
+	v := reflect.ValueOf(i)
+
+	if !v.IsValid() {
+		return reflect.Value{}, fmt.Errorf("value is invalid")
+	}
+
+	for v.CanAddr() {
+		v = v.Addr()
+	}
+
+	for v.Type().Kind() == reflect.Ptr {
+		if v.IsNil() {
+			v.Set(reflect.New(v.Type().Elem()))
+		}
+		v = v.Elem()
+	}
+
+	return v, nil
+}
+
+// readInto reads in into out, setting the value of out to the value of in.
+func readInto(in, out interface{}) error {
+	ov, err := toValue(out)
+	if err != nil {
+		return err
+	}
+
+	if !ov.CanSet() {
+		return fmt.Errorf("cannot decode into unassignable value")
+	}
+
+	iv, err := toValue(in)
+	if err != nil {
+		return err
+	}
+
+	// Get a pointer to the in interface, since the pointer might be the thing
+	// that implements the out interface.
+	iptr := reflect.New(iv.Type())
+	iptr.Elem().Set(iv)
+
+	ovt := ov.Type()
+	ivt := iv.Type()
+	iptrt := iptr.Type()
+
+	switch {
+	case ivt.ConvertibleTo(ovt):
+		ov.Set(iv.Convert(ovt))
+	case iptrt.ConvertibleTo(ovt):
+		ov.Set(iptr.Convert(ovt))
+	default:
+		return fmt.Errorf("cannot convert from %v to %v", ivt, ovt)
+	}
+
+	return nil
+}

--- a/pkg/cache/cacher_test.go
+++ b/pkg/cache/cacher_test.go
@@ -1,0 +1,196 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"crypto/rand"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+type testStruct struct {
+	Public  string
+	private int64
+
+	in testEmbeddedStruct
+}
+
+type testEmbeddedStruct struct {
+	Public  []byte
+	private float64
+}
+
+func testRandomKey(tb testing.TB) string {
+	tb.Helper()
+
+	b := make([]byte, 32)
+	if _, err := rand.Read(b); err != nil {
+		tb.Fatal(err)
+	}
+	return base64.RawStdEncoding.EncodeToString(b)
+}
+
+func exerciseCacher(t *testing.T, cacher Cacher) {
+	cases := []struct {
+		name string
+		do   func(tb testing.TB)
+	}{
+		{
+			name: "int",
+			do: func(tb testing.TB) {
+				in := 5
+				var out int
+				exerciseType(tb, cacher, in, &out)
+			},
+		},
+		{
+			name: "int64",
+			do: func(tb testing.TB) {
+				in := int64(5)
+				var out int64
+				exerciseType(tb, cacher, in, &out)
+			},
+		},
+		{
+			name: "float",
+			do: func(tb testing.TB) {
+				in := 5.0
+				var out float64
+				exerciseType(tb, cacher, in, &out)
+			},
+		},
+		{
+			name: "string",
+			do: func(tb testing.TB) {
+				in := int64(5)
+				var out int64
+				exerciseType(tb, cacher, in, &out)
+			},
+		},
+		{
+			name: "struct",
+			do: func(tb testing.TB) {
+				in := testStruct{
+					Public:  "foo",
+					private: 4,
+					in: testEmbeddedStruct{
+						Public:  []byte("\x12"),
+						private: 5,
+					},
+				}
+				var out testStruct
+				exerciseType(tb, cacher, in, &out)
+			},
+		},
+	}
+
+	t.Run("exercise", func(t *testing.T) {
+		for _, tc := range cases {
+			tc := tc
+
+			t.Run(tc.name, func(t *testing.T) {
+				t.Parallel()
+				tc.do(t)
+			})
+		}
+	})
+
+	t.Run("close", func(t *testing.T) {
+		ctx := context.Background()
+
+		if err := cacher.Close(); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := cacher.Read(ctx, "foo", nil); !errors.Is(err, ErrStopped) {
+			t.Errorf("expected %#v to be %#v", err, ErrStopped)
+		}
+		if err := cacher.Write(ctx, "foo", nil, 0); !errors.Is(err, ErrStopped) {
+			t.Errorf("expected %#v to be %#v", err, ErrStopped)
+		}
+		if err := cacher.Delete(ctx, "foo"); !errors.Is(err, ErrStopped) {
+			t.Errorf("expected %#v to be %#v", err, ErrStopped)
+		}
+		if err := cacher.Fetch(ctx, "foo", nil, 0, nil); !errors.Is(err, ErrStopped) {
+			t.Errorf("expected %#v to be %#v", err, ErrStopped)
+		}
+
+		// Closing again should not panic
+		if err := cacher.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+}
+
+func exerciseType(tb testing.TB, cacher Cacher, in, out interface{}) {
+	tb.Helper()
+
+	ctx := context.Background()
+	key := testRandomKey(tb)
+
+	// Ensure the value isn't cached already
+	if err := cacher.Read(ctx, key, out); !errors.Is(err, ErrNotFound) {
+		tb.Fatalf("expected %#v to be %#v", err, ErrNotFound)
+	}
+
+	// Write value that's expired
+	if err := cacher.Write(ctx, key, in, 10*time.Millisecond); err != nil {
+		tb.Fatal(err)
+	}
+
+	time.Sleep(500 * time.Millisecond)
+
+	// Ensure value is expired
+	if err := cacher.Read(ctx, key, out); !errors.Is(err, ErrNotFound) {
+		tb.Fatalf("expected %#v to be %#v", err, ErrNotFound)
+	}
+
+	// Write value missing func
+	if err := cacher.Fetch(ctx, key, out, 1*time.Second, nil); !errors.Is(err, ErrMissingFetchFunc) {
+		tb.Fatalf("expected %#v to be %#v", err, ErrMissingFetchFunc)
+	}
+
+	// Write value returns error
+	if err := cacher.Fetch(ctx, key, out, 1*time.Second, func() (interface{}, error) {
+		return nil, fmt.Errorf("nope")
+	}); err == nil {
+		tb.Fatal("expected error")
+	}
+
+	// Write value through cache
+	if err := cacher.Fetch(ctx, key, out, 10*time.Minute, func() (interface{}, error) {
+		return in, nil
+	}); err != nil {
+		tb.Fatal(err)
+	}
+
+	// Ensure value is cached
+	if err := cacher.Read(ctx, key, out); err != nil {
+		tb.Fatal(err)
+	}
+	if got, want := in, reflect.ValueOf(out).Elem().Interface(); !reflect.DeepEqual(got, want) {
+		tb.Fatalf("expected %#v to be %#v", got, want)
+	}
+
+	// Delete cached value
+	if err := cacher.Delete(ctx, key); err != nil {
+		tb.Fatal(err)
+	}
+}

--- a/pkg/cache/in_memory.go
+++ b/pkg/cache/in_memory.go
@@ -1,0 +1,235 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"sync"
+	"sync/atomic"
+	"time"
+)
+
+var _ Cacher = (*inMemory)(nil)
+
+// inMemory is an in-memory cache implementation. It's good for local
+// development and testing, but isn't recommended in production as the caches
+// aren't shared among instances.
+type inMemory struct {
+	data map[string]*item
+	mu   sync.RWMutex
+
+	stopped uint32
+	stopCh  chan struct{}
+}
+
+type item struct {
+	value   interface{}
+	expires int64
+}
+
+type InMemoryConfig struct {
+	// GCInterval is how frequently to purge stale entries from the cache.
+	GCInterval time.Duration
+}
+
+// NewInMemory creates a new in-memory cache.
+func NewInMemory(i *InMemoryConfig) (Cacher, error) {
+	if i == nil {
+		i = new(InMemoryConfig)
+	}
+
+	gcInterval := 4 * time.Hour
+	if i.GCInterval > 0 {
+		gcInterval = i.GCInterval
+	}
+
+	c := &inMemory{
+		data:   make(map[string]*item),
+		stopCh: make(chan struct{}),
+	}
+	go c.cleanup(gcInterval)
+
+	return c, nil
+}
+
+// Fetch attempts to retrieve the given key from the cache. If successful, it
+// returns the value. If the value does not exist, it calls f and caches the
+// result of f in the cache for ttl. The ttl is calculated from the time the
+// value is inserted, not the time the function is called.
+func (c *inMemory) Fetch(_ context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	now := time.Now().UnixNano()
+
+	// Try a read-only lock first
+	c.mu.RLock()
+	if i, ok := c.data[key]; ok && now < i.expires {
+		c.mu.RUnlock()
+		return readInto(i.value, out)
+	}
+	c.mu.RUnlock()
+
+	// Now acquire a full lock, it's possible another goroutine wrote between our
+	// read and write lock.
+	c.mu.Lock()
+	if i, ok := c.data[key]; ok && now < i.expires {
+		c.mu.Unlock()
+		return readInto(i.value, out)
+	}
+
+	// The value is not in the cache (or the value exists but has expired), call f
+	// to get a new value.
+	if f == nil {
+		c.mu.Unlock()
+		return ErrMissingFetchFunc
+	}
+
+	val, err := f()
+	if err != nil {
+		c.mu.Unlock()
+		return err
+	}
+
+	if err := readInto(val, out); err != nil {
+		return err
+	}
+
+	c.data[key] = &item{
+		value: val,
+		// Explicitly re-caputure the time instead of using now.
+		expires: time.Now().UnixNano() + int64(ttl),
+	}
+	c.mu.Unlock()
+
+	return nil
+}
+
+// Write adds a new item to the cache with the given TTL.
+func (c *inMemory) Write(_ context.Context, key string, value interface{}, ttl time.Duration) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	c.mu.Lock()
+	c.data[key] = &item{
+		value:   value,
+		expires: time.Now().UnixNano() + int64(ttl),
+	}
+	c.mu.Unlock()
+	return nil
+}
+
+// Read fetches the value at the key. If the value does not exist, it returns
+// ErrNotFound. If the types are incompatible, it returns an error.
+func (c *inMemory) Read(_ context.Context, key string, out interface{}) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	now := time.Now().UnixNano()
+
+	c.mu.RLock()
+	if i, ok := c.data[key]; ok {
+		// Item is still valid
+		if now < i.expires {
+			c.mu.RUnlock()
+			return readInto(i.value, out)
+		}
+
+		// Item has expired, defer deletion (we don't have an exclusive lock)
+		go c.purge(key, i.expires)
+	}
+	c.mu.RUnlock()
+
+	return ErrNotFound
+}
+
+// Delete removes an item from the cache, if it exists, regardless of TTL. It
+// returns a boolean indicating whether the value was removed.
+func (c *inMemory) Delete(_ context.Context, key string) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	c.mu.Lock()
+	delete(c.data, key)
+	c.mu.Unlock()
+	return nil
+}
+
+// Close completely stops the cacher. It is not safe to use after closing.
+func (c *inMemory) Close() error {
+	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
+		return nil
+	}
+
+	close(c.stopCh)
+
+	c.mu.Lock()
+	c.data = nil
+	c.mu.Unlock()
+	return nil
+}
+
+// purge removes an item by key in the cache. If the item does not exist, it
+// does nothing. If the item exists, but the expected expiration time is
+// different, it does nothing. The expected expiration time is used to handle a
+// race where the item is updated by another routine.
+func (c *inMemory) purge(key string, expectedTTL int64) {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return
+	}
+
+	select {
+	case <-c.stopCh:
+	default:
+	}
+
+	c.mu.Lock()
+	if c.data != nil {
+		if i, ok := c.data[key]; ok && i.expires == expectedTTL {
+			delete(c.data, key)
+		}
+	}
+	c.mu.Unlock()
+}
+
+// cleanup deletes stale entries from the cache. Read operations are already a
+// write-through cache, so this is run infrequently. It's designed to catch very
+// old stale values that are no longer used.
+func (c *inMemory) cleanup(interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+
+	for {
+		select {
+		case <-c.stopCh:
+			return
+		case <-ticker.C:
+		}
+
+		now := time.Now().UnixNano()
+
+		c.mu.Lock()
+		for k, i := range c.data {
+			if i.expires < now {
+				delete(c.data, k)
+			}
+		}
+		c.mu.Unlock()
+	}
+}

--- a/pkg/cache/in_memory_test.go
+++ b/pkg/cache/in_memory_test.go
@@ -1,0 +1,35 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"testing"
+)
+
+func TestInMemory(t *testing.T) {
+	t.Parallel()
+
+	cacher, err := NewInMemory(nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() {
+		if err := cacher.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	exerciseCacher(t, cacher)
+}

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -1,0 +1,80 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"sync/atomic"
+	"time"
+)
+
+var _ Cacher = (*noop)(nil)
+
+// noop is a full pass-through cache.
+type noop struct {
+	stopped uint32
+}
+
+// NewNoop creates a new noop cache.
+func NewNoop() (Cacher, error) {
+	return &noop{}, nil
+}
+
+// Fetch calls FetchFunc and does no caching.
+func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+	if f == nil {
+		return ErrMissingFetchFunc
+	}
+	val, err := f()
+	if err != nil {
+		return err
+	}
+	return readInto(val, out)
+}
+
+// Write does nothing.
+func (c *noop) Write(_ context.Context, _ string, _ interface{}, ttl time.Duration) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+	return nil
+}
+
+// Read always returns ErrNotFound.
+func (c *noop) Read(_ context.Context, _ string, _ interface{}) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+	return ErrNotFound
+}
+
+// Delete does nothing.
+func (c *noop) Delete(_ context.Context, _ string) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+	return nil
+}
+
+// Close stops the cacher.
+func (c *noop) Close() error {
+	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
+		return nil
+	}
+	return nil
+}

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -34,7 +34,7 @@ func NewNoop() (Cacher, error) {
 
 // Fetch calls FetchFunc and does no caching.
 func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) error {
-	if atomic.LoadUint32(&c.stopped) == 1 {
+	if c.isStopped() {
 		return ErrStopped
 	}
 	if f == nil {
@@ -49,7 +49,7 @@ func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Du
 
 // Write does nothing.
 func (c *noop) Write(_ context.Context, _ string, _ interface{}, ttl time.Duration) error {
-	if atomic.LoadUint32(&c.stopped) == 1 {
+	if c.isStopped() {
 		return ErrStopped
 	}
 	return nil
@@ -57,7 +57,7 @@ func (c *noop) Write(_ context.Context, _ string, _ interface{}, ttl time.Durati
 
 // Read always returns ErrNotFound.
 func (c *noop) Read(_ context.Context, _ string, _ interface{}) error {
-	if atomic.LoadUint32(&c.stopped) == 1 {
+	if c.isStopped() {
 		return ErrStopped
 	}
 	return ErrNotFound
@@ -65,7 +65,7 @@ func (c *noop) Read(_ context.Context, _ string, _ interface{}) error {
 
 // Delete does nothing.
 func (c *noop) Delete(_ context.Context, _ string) error {
-	if atomic.LoadUint32(&c.stopped) == 1 {
+	if c.isStopped() {
 		return ErrStopped
 	}
 	return nil
@@ -77,4 +77,9 @@ func (c *noop) Close() error {
 		return nil
 	}
 	return nil
+}
+
+// isStopped returns true if the cacher is stopped.
+func (c *noop) isStopped() bool {
+	return atomic.LoadUint32(&c.stopped) == 1
 }

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -1,0 +1,259 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"bytes"
+	"context"
+	"encoding/gob"
+	"errors"
+	"fmt"
+	"strings"
+	"sync/atomic"
+	"time"
+
+	redigo "github.com/gomodule/redigo/redis"
+)
+
+var _ Cacher = (*redis)(nil)
+
+// redis is an shared cache implementation backed by Redis. It's ideal for
+// production installations since the cache is shared among all services.
+type redis struct {
+	pool *redigo.Pool
+
+	stopped uint32
+	stopCh  chan struct{}
+}
+
+type RedisConfig struct {
+	// Prefix is a string to prepend to all cache keys before saving. This is
+	// useful on a shared service where you don't want to clash with the wrong
+	// cache values.
+	Prefix string
+
+	// Address is the redis address.
+	Address string
+
+	// Username and Password are used for authentication.
+	Username, Password string
+}
+
+// NewRedis creates a new in-memory cache.
+func NewRedis(i *RedisConfig) (Cacher, error) {
+	if i == nil {
+		i = new(RedisConfig)
+	}
+
+	addr := "127.0.0.1:6379"
+	if i.Address != "" {
+		addr = i.Address
+	}
+
+	c := &redis{
+		pool: &redigo.Pool{
+			Dial: func() (redigo.Conn, error) {
+				return redigo.Dial("tcp", addr,
+					redigo.DialUsername(i.Username),
+					redigo.DialPassword(i.Password))
+			},
+			TestOnBorrow: func(conn redigo.Conn, _ time.Time) error {
+				_, err := conn.Do("PING")
+				return err
+			},
+
+			// TODO: make configurable
+			MaxIdle:   0,
+			MaxActive: 0,
+		},
+		stopCh: make(chan struct{}),
+	}
+
+	return c, nil
+}
+
+// Fetch attempts to retrieve the given key from the cache. If successful, it
+// returns the value. If the value does not exist, it calls f and caches the
+// result of f in the cache for ttl. The ttl is calculated from the time the
+// value is inserted, not the time the function is called.
+func (c *redis) Fetch(ctx context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) (retErr error) {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	fn := func(conn redigo.Conn) error {
+		cached, err := redigo.String(conn.Do("GET", key))
+		if err != nil && !errors.Is(err, redigo.ErrNil) {
+			return fmt.Errorf("failed to GET key: %w", err)
+		}
+
+		// Found a value
+		if cached != "" {
+			r := strings.NewReader(cached)
+			if err := gob.NewDecoder(r).Decode(out); err != nil {
+				return fmt.Errorf("failed to decode cached value: %w", err)
+			}
+			return nil
+		}
+
+		// No value found
+		if f == nil {
+			return ErrMissingFetchFunc
+		}
+		val, err := f()
+		if err != nil {
+			return err
+		}
+		if err := readInto(val, out); err != nil {
+			return err
+		}
+
+		// Encode the value
+		var encoded bytes.Buffer
+		if err := gob.NewEncoder(&encoded).Encode(val); err != nil {
+			return fmt.Errorf("failed to encode value: %w", err)
+		}
+
+		if _, err := conn.Do("WATCH", key); err != nil {
+			return fmt.Errorf("failed to WATCH key: %w", err)
+		}
+
+		if _, err := conn.Do("MULTI"); err != nil {
+			return fmt.Errorf("failed to MULTI: %w", err)
+		}
+
+		if _, err := conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.String()); err != nil {
+			err = fmt.Errorf("failed to PSETEX: %w", err)
+
+			if _, derr := conn.Do("DISCARD"); derr != nil {
+				err = fmt.Errorf("failed to DISCARD: %v, original error: %w", derr, err)
+			}
+
+			return err
+		}
+
+		if _, err := conn.Do("EXEC"); err != nil {
+			return fmt.Errorf("failed to EXEC: %w", err)
+		}
+
+		return nil
+	}
+
+	// This is a CAS operation, so retry
+	var err error
+	for i := 0; i < 5; i++ {
+		err = c.withConn(fn)
+		if err == nil {
+			break
+		}
+	}
+
+	return err
+}
+
+// Write adds a new item to the cache with the given TTL.
+func (c *redis) Write(ctx context.Context, key string, value interface{}, ttl time.Duration) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	return c.withConn(func(conn redigo.Conn) error {
+		var encoded bytes.Buffer
+		if err := gob.NewEncoder(&encoded).Encode(value); err != nil {
+			return fmt.Errorf("failed to encode value: %w", err)
+		}
+
+		if _, err := redigo.String(conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.String())); err != nil {
+			return fmt.Errorf("failed to PSETEX value: %w", err)
+		}
+		return nil
+	})
+}
+
+// Read fetches the value at the key. If the value does not exist, it returns
+// ErrNotFound.
+func (c *redis) Read(ctx context.Context, key string, out interface{}) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	return c.withConn(func(conn redigo.Conn) error {
+		val, err := redigo.String(conn.Do("GET", key))
+		if err != nil && !errors.Is(err, redigo.ErrNil) {
+			return fmt.Errorf("failed to GET value: %w", err)
+		}
+		if val == "" {
+			return ErrNotFound
+		}
+
+		r := strings.NewReader(val)
+		if err := gob.NewDecoder(r).Decode(out); err != nil {
+			return fmt.Errorf("failed to decode cached value: %w", err)
+		}
+		return nil
+	})
+
+}
+
+// Delete removes an item from the cache, if it exists, regardless of TTL. It
+// returns a boolean indicating whether the value was removed.
+func (c *redis) Delete(ctx context.Context, key string) error {
+	if atomic.LoadUint32(&c.stopped) == 1 {
+		return ErrStopped
+	}
+
+	return c.withConn(func(conn redigo.Conn) error {
+		if _, err := conn.Do("DEL", key); err != nil && !errors.Is(err, redigo.ErrNil) {
+			return fmt.Errorf("failed to DEL: %w", err)
+		}
+		return nil
+	})
+}
+
+// Close completely stops the cacher. It is not safe to use after closing.
+func (c *redis) Close() error {
+	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
+		return nil
+	}
+	close(c.stopCh)
+	if err := c.pool.Close(); err != nil {
+		return fmt.Errorf("failed to close pool: %w", err)
+	}
+	return nil
+}
+
+// withConn runs the function with a conn, ensuring cleanup of the connection.
+func (c *redis) withConn(f func(conn redigo.Conn) error) error {
+	if f == nil {
+		return fmt.Errorf("missing function")
+	}
+
+	conn := c.pool.Get()
+	if err := conn.Err(); err != nil {
+		return fmt.Errorf("connection is not usable: %w", err)
+	}
+
+	if err := f(conn); err != nil {
+		if cerr := conn.Close(); cerr != nil {
+			return fmt.Errorf("failed to close connection: %v, original error: %w", cerr, err)
+		}
+		return err
+	}
+
+	if err := conn.Close(); err != nil {
+		return fmt.Errorf("failed to close connection: %w", err)
+	}
+	return nil
+}

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -1,0 +1,103 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cache
+
+import (
+	"context"
+	"os"
+	"strconv"
+	"testing"
+	"time"
+
+	"github.com/ory/dockertest"
+	"github.com/sethvargo/go-retry"
+)
+
+func TestRedis(t *testing.T) {
+	t.Parallel()
+
+	if testing.Short() {
+		t.Skipf("🚧 Skipping database tests (short)!")
+	}
+
+	if skip, _ := strconv.ParseBool(os.Getenv("SKIP_REDIS_TESTS")); skip {
+		t.Skipf("🚧 Skipping database tests (SKIP_REDIS_TESTS is set)!")
+	}
+
+	ctx := context.Background()
+
+	pool, err := dockertest.NewPool("")
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	container, err := pool.RunWithOptions(&dockertest.RunOptions{
+		Repository: "redis",
+		Tag:        "6-alpine",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Ensure container is cleaned up.
+	t.Cleanup(func() {
+		if err := pool.Purge(container); err != nil {
+			t.Errorf("failed to cleanup redis container: %v", err)
+		}
+	})
+
+	// Get the host. On Mac, Docker runs in a VM.
+	host := container.GetBoundIP("6379/tcp")
+	port := container.GetPort("6379/tcp")
+
+	// Create the cacher
+	cacher, err := NewRedis(&RedisConfig{
+		Address: host + ":" + port,
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Close the cacher when done
+	t.Cleanup(func() {
+		if err := cacher.Close(); err != nil {
+			t.Fatal(err)
+		}
+	})
+
+	// Wait for the container to start - we'll retry connections in a loop below,
+	// but there's no point in trying immediately.
+	time.Sleep(1 * time.Second)
+
+	// Wait for the container to be ready.
+	b, err := retry.NewFibonacci(500 * time.Millisecond)
+	if err != nil {
+		t.Fatal(err)
+	}
+	b = retry.WithMaxRetries(5, b)
+	b = retry.WithCappedDuration(2*time.Second, b)
+
+	if err := retry.Do(ctx, b, func(_ context.Context) error {
+		if err := cacher.Delete(ctx, "foo"); err != nil {
+			return retry.RetryableError(err)
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Run tests
+	exerciseCacher(t, cacher)
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -22,12 +22,13 @@ import (
 	"fmt"
 
 	"github.com/google/exposure-notifications-server/pkg/base64util"
-	"github.com/google/exposure-notifications-server/pkg/cache"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/jinzhu/gorm"
 	"go.uber.org/zap"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 
 	// ensure the postgres dialiect is compiled in.
 	_ "github.com/jinzhu/gorm/dialects/postgres"
@@ -39,8 +40,8 @@ type Database struct {
 	db     *gorm.DB
 	config *Config
 
-	// cacher is an internal write-through cache for frequent lookups.
-	cacher *cache.Cache
+	// cacher is a write-through cache for frequent lookups.
+	cacher cache.Cacher
 
 	// keyManager is used to encrypt/decrypt values.
 	keyManager keys.KeyManager
@@ -56,7 +57,7 @@ type Database struct {
 // key managers. It does NOT connect to the database.
 func (c *Config) Load(ctx context.Context) (*Database, error) {
 	// Create the cacher.
-	cacher, err := cache.New(c.CacheTTL)
+	cacher, err := cache.NewInMemory(nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create cache: %w", err)
 	}


### PR DESCRIPTION
Part of the stats work, this adds a new cacher interface which can use an in-memory or redis-based implementation. Fields have to be public per the laws of the reflection, although I'm using gob, so we could implement custom marshalers if we really need private fields to be in the cached object.

I didn't switch to Redis or make any of this configurable because I'm trying to keep the PR small and do it piece-meal. 

**Release Note**

```release-note
NONE
```
