### PR TITLE
fix content-type on return and a stray 200 code

### DIFF
--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -75,7 +75,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		var request api.VerifyCodeRequest
 		if err := controller.BindJSON(w, r, &request); err != nil {
 			c.logger.Errorw("bad request", "error", err)
-			c.h.RenderJSON(w, http.StatusOK, api.Error(err).WithCode(api.ErrUnparsableRequest))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
 			return
 		}
 

--- a/pkg/jsonclient/client.go
+++ b/pkg/jsonclient/client.go
@@ -50,12 +50,18 @@ func MakeRequest(ctx context.Context, client *http.Client, url string, headers h
 		return fmt.Errorf("creating request: %w", err)
 	}
 	req.Header = headers
-	req.Header.Add("content-type", "application/json")
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
 	r, err := client.Do(req)
 	if err != nil {
 		return fmt.Errorf("sending request: %w", err)
 	}
 	defer r.Body.Close()
+
+	logger.Debugf("http status: %s (%d)", http.StatusText(r.StatusCode), r.StatusCode)
+	for k, v := range r.Header {
+		logger.Debugf("response header: %q: %v", k, v)
+	}
 
 	body, err := ioutil.ReadAll(r.Body)
 	if err != nil {

--- a/pkg/render/html.go
+++ b/pkg/render/html.go
@@ -86,8 +86,8 @@ func (r *Renderer) RenderHTMLStatus(w http.ResponseWriter, code int, tmpl string
 	}
 
 	// Rendering worked, flush to the response
-	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "text/html; charset=UTF-8")
+	w.WriteHeader(code)
 	if _, err := b.WriteTo(w); err != nil {
 		// We couldn't write the buffer. We can't change the response header or
 		// content type if we got this far, so the best option we have is to log the

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -46,8 +46,8 @@ func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{})
 	if !r.AllowedResponseCode(code) {
 		r.logger.Errorw("unregistered response code", "code", code)
 
-		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
 		msg := escapeJSON(fmt.Sprintf("%d is not a registered response code", code))
 		fmt.Fprintf(w, jsonErrTmpl, msg)
 		return
@@ -55,8 +55,8 @@ func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{})
 
 	// Avoid marshaling nil data.
 	if data == nil {
-		w.WriteHeader(code)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(code)
 
 		// Return an OK response.
 		if code >= 200 && code < 300 {
@@ -83,15 +83,15 @@ func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{})
 		}
 		msg = escapeJSON(msg)
 
-		w.WriteHeader(http.StatusInternalServerError)
 		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusInternalServerError)
 		fmt.Fprintf(w, jsonErrTmpl, msg)
 		return
 	}
 
 	// Rendering worked, flush to the response
-	w.WriteHeader(code)
 	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(code)
 	if _, err := b.WriteTo(w); err != nil {
 		// We couldn't write the buffer. We can't change the response header or
 		// content type if we got this far, so the best option we have is to log the


### PR DESCRIPTION

## Proposed Changes

* set correct content-type return header
* one case where error was returning 200
*

**Release Note**

```release-note
Proper content-type set on all HTTP responses.
```
