### PR TITLE
Fix code display in UI and verification checks against HMAC values.

### DIFF
--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -183,10 +183,13 @@ func (db *Database) VerifyCodeAndIssueToken(realmID uint, verCode string, accept
 			return err
 		}
 
-		// Checks which code is being used and if that makes it expired.
-		if vc.IsCodeExpired(verCode) {
+		if expired, err := db.IsCodeExpired(&vc, verCode); err != nil {
+			db.logger.Debugw("error checking code expiration", "error", err)
+			return ErrVerificationCodeExpired
+		} else if expired {
 			return ErrVerificationCodeExpired
 		}
+
 		if vc.Claimed {
 			return ErrVerificationCodeUsed
 		}

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -96,7 +96,7 @@ func (db *Database) IsCodeExpired(v *VerificationCode, code string) (bool, error
 	switch {
 	case v.Code == code || v.Code == hmacedCode:
 		return !v.ExpiresAt.After(now), nil
-	case v.LongCode == code || v.Code == hmacedCode:
+	case v.LongCode == code || v.LongCode == hmacedCode:
 		return !v.LongExpiresAt.After(now), nil
 	default:
 		return true, fmt.Errorf("not found")

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -84,13 +84,10 @@ func (v *VerificationCode) FormatSymptomDate() string {
 // IsCodeExpired checks to see if the actual code provides is the
 // short or long code and deteriminies if it is expired based on that.
 func (db *Database) IsCodeExpired(v *VerificationCode, code string) (bool, error) {
-	hmacedCode := code
-	if len(code) < 20 {
-		var err error
-		hmacedCode, err = db.hmacVerificationCode(code)
-		if err != nil {
-			return false, fmt.Errorf("failed to create hmac: %w", err)
-		}
+	// it's possible that this could be called with the already HMACd version.
+	hmacedCode, err := db.hmacVerificationCode(code)
+	if err != nil {
+		return false, fmt.Errorf("failed to create hmac: %w", err)
 	}
 	now := time.Now().UTC()
 	switch {

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -96,13 +96,14 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 	logger := logging.FromContext(ctx)
 	var verificationCode database.VerificationCode
 	var err error
+	var code, longCode string
 	for i := uint(0); i < retryCount; i++ {
-		code, err := GenerateCode(o.ShortLength)
+		code, err = GenerateCode(o.ShortLength)
 		if err != nil {
 			logger.Errorf("code generation error: %v", err)
 			continue
 		}
-		longCode := code
+		longCode = code
 		if o.LongLength > 0 {
 			longCode, err = GenerateAlphanumericCode(o.LongLength)
 			if err != nil {
@@ -132,5 +133,5 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 	if err != nil {
 		return "", "", "", err
 	}
-	return verificationCode.Code, verificationCode.LongCode, verificationCode.UUID, nil
+	return code, longCode, verificationCode.UUID, nil
 }

--- a/pkg/otp/code_test.go
+++ b/pkg/otp/code_test.go
@@ -100,7 +100,7 @@ func TestIssue(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't find previously saved code")
 		}
-		if exp, err := verCode.IsCodeExpired(code); exp || err != nil {
+		if exp, err := db.IsCodeExpired(verCode, code); exp || err != nil {
 			t.Fatalf("loaded code doesn't match requested code, %v %v", exp, err)
 		}
 	}
@@ -110,7 +110,7 @@ func TestIssue(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't find previously saved code")
 		}
-		if exp, err := verCode.IsCodeExpired(code); !exp || err != nil {
+		if exp, err := db.IsCodeExpired(verCode, code); exp || err != nil {
 			t.Fatalf("loaded code doesn't match requested code")
 		}
 	}

--- a/pkg/otp/code_test.go
+++ b/pkg/otp/code_test.go
@@ -100,8 +100,8 @@ func TestIssue(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't find previously saved code")
 		}
-		if verCode != nil && verCode.Code != code {
-			t.Fatalf("loaded code doesn't match requested code")
+		if exp, err := verCode.IsCodeExpired(code); exp || err != nil {
+			t.Fatalf("loaded code doesn't match requested code, %v %v", exp, err)
 		}
 	}
 
@@ -110,7 +110,7 @@ func TestIssue(t *testing.T) {
 		if err != nil {
 			t.Errorf("didn't find previously saved code")
 		}
-		if verCode != nil && verCode.LongCode != code {
+		if exp, err := verCode.IsCodeExpired(code); !exp || err != nil {
 			t.Fatalf("loaded code doesn't match requested code")
 		}
 	}


### PR DESCRIPTION

## Proposed Changes

* Return plain text verification codes (short/long) to controller instead of hmac version
* On expiration check both plaintext and hmac version when matching for expiration date

**Release Note**

```release-note
BUG FIX - check expiration correctly after verification code HMAC upgrade.
```
