### PR TITLE
Create an email verification page

### DIFF
--- a/cmd/server/assets/login/verifyemail.html
+++ b/cmd/server/assets/login/verifyemail.html
@@ -1,0 +1,69 @@
+{{define "login/verifyemail"}}
+<!doctype html>
+<html lang="en">
+
+<head>
+    {{template "head" .}}
+
+    {{template "firebase" .}}
+</head>
+
+<body>
+    {{template "navbar" .}}
+
+    <main role="main" class="container">
+        {{template "flash" .}}
+
+        <div class="card mb-3">
+            <h1>Email Verification</h1>
+            <p id="subtitle">Use this page to verify your login email address</p>
+
+            <div class="row form-group">
+                <div class="col-sm-9">
+                    <button id="verify" class="btn btn-primary btn-block">Send Verification Email</button>
+                </div>
+            </div>
+
+            <div>
+                <p>
+                    <a href="/home">&larr; Go home</a>
+                </p>
+            </div>
+        </div>
+    </main>
+
+    {{template "scripts" .}}
+
+    <script>
+        $(function () {
+            $verify = $('#verify');
+            $verify.on('click', function (event) {
+                let user = firebase.auth().currentUser
+                if (!user.emailVerified) {
+                    user.sendEmailVerification().then(function () {
+                        $('body').prepend('<div class="alert alert-warning" role="alert" id="message">Verification email sent.</div>')
+                        $verify.prop('disabled', true);
+                    }
+                    );
+                }
+            });
+        });
+
+        firebase.auth().onAuthStateChanged(function (user) {
+            $subtitle = $('#subtitle');
+            if (user) {
+                if (user.emailVerified) {
+                    $subtitle.text("Welcome, " + user.email + ". Your email has already been verified.");
+                    $('#verify').prop('disabled', true);
+                } else {
+                    $subtitle.text("Welcome, " + user.email + ". Please verify your email to continue.");
+                }
+            } else {
+                window.location.assign("/login");
+            }
+        });
+    </script>
+</body>
+
+</html>
+{{end}}

--- a/cmd/server/assets/login/verifyemail.html
+++ b/cmd/server/assets/login/verifyemail.html
@@ -20,7 +20,7 @@
 
             <div class="row form-group">
                 <div class="col-sm-9">
-                    <button id="verify" class="btn btn-primary btn-block">Send Verification Email</button>
+                    <button id="verify" class="btn btn-primary btn-block" disabled>Send Verification Email</button>
                 </div>
             </div>
 
@@ -54,9 +54,9 @@
             if (user) {
                 if (user.emailVerified) {
                     $subtitle.text("Welcome, " + user.email + ". Your email has already been verified.");
-                    $('#verify').prop('disabled', true);
                 } else {
                     $subtitle.text("Welcome, " + user.email + ". Please verify your email to continue.");
+                    $('#verify').prop('disabled', false);
                 }
             } else {
                 window.location.assign("/login");

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -181,6 +181,7 @@ func realMain(ctx context.Context) error {
 		// TODO(whaught): these are duplicated so they serve at this path for ajax
 		sessionController := session.New(ctx, auth, config, db, h)
 		sub.Handle("/session", sessionController.HandleCreate()).Methods("POST")
+		sub.Handle("/verifyemail", loginController.HandleVerifyEmail()).Methods("GET")
 	}
 
 	{

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -176,12 +176,12 @@ func realMain(ctx context.Context) error {
 
 		loginController := login.New(ctx, config, h)
 		sub.Handle("", loginController.HandleLogin()).Methods("GET")
+		sub.Handle("/verifyemail", loginController.HandleVerifyEmail()).Methods("GET")
 
 		// Session handling
 		// TODO(whaught): these are duplicated so they serve at this path for ajax
 		sessionController := session.New(ctx, auth, config, db, h)
 		sub.Handle("/session", sessionController.HandleCreate()).Methods("POST")
-		sub.Handle("/verifyemail", loginController.HandleVerifyEmail()).Methods("GET")
 	}
 
 	{

--- a/pkg/controller/login/verifyemail.go
+++ b/pkg/controller/login/verifyemail.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines the controller for the login page.
+package login
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+func (c *Controller) HandleVerifyEmail() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		m := controller.TemplateMapFromContext(ctx)
+		m["firebase"] = c.config.Firebase
+		c.h.RenderHTML(w, "login/verifyemail", m)
+	})
+}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Creates a new page for email verification

Next: 
1)  middleware to require verified email
2) knock out existing index login

![verified](https://user-images.githubusercontent.com/36240966/90673684-ed7b7f00-e20c-11ea-9963-ed2f569830d3.png)
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Page for email verification
```
