### PR TITLE
rename interface from signer to keys

### DIFF
--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -48,7 +48,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		}
 
 		// Get the signer based on Key configuration.
-		signer, err := c.signer.NewSigner(ctx, c.config.CertificateSigningKey)
+		signer, err := c.kms.NewSigner(ctx, c.config.CertificateSigningKey)
 		if err != nil {
 			c.logger.Errorw("failed to get signer", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())

--- a/pkg/gcpkms/gcpkms.go
+++ b/pkg/gcpkms/gcpkms.go
@@ -20,19 +20,19 @@ import (
 	"crypto"
 
 	kms "cloud.google.com/go/kms/apiv1"
-	"github.com/google/exposure-notifications-verification-server/pkg/signer"
+	"github.com/google/exposure-notifications-verification-server/pkg/keys"
 	"github.com/sethvargo/go-gcpkms/pkg/gcpkms"
 )
 
 // Compile time check that GCPKeyManager satisfies signer interface
-var _ signer.KeyManager = (*GCPKeyManager)(nil)
+var _ keys.Manager = (*GCPKeyManager)(nil)
 
 // GCPKeyManager providers a crypto.Signer that uses GCP KSM to sign bytes.
 type GCPKeyManager struct {
 	client *kms.KeyManagementClient
 }
 
-func New(ctx context.Context) (signer.KeyManager, error) {
+func New(ctx context.Context) (keys.Manager, error) {
 	client, err := kms.NewKeyManagementClient(ctx)
 	if err != nil {
 		return nil, err

--- a/pkg/keys/keys.go
+++ b/pkg/keys/keys.go
@@ -12,17 +12,15 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package signer defines the interface for signing.
-// TODO(mikehelmick) - this needs to be simplified. Do away w/ dynamic registry
-// and more more towards what we have in exposure-notifications-server
-// Make signing impl in exposure-notifications-server in pkg so we can depend on it.
-package signer
+// Package keys defines the interface for signing.
+package keys
 
 import (
 	"context"
 	"crypto"
 )
 
-type KeyManager interface {
+// Manager represents the interface to the Key Management System.
+type Manager interface {
 	NewSigner(ctx context.Context, keyID string) (crypto.Signer, error)
 }


### PR DESCRIPTION
Refactor before #149 

## Proposed Changes

* Rename signer package to keys

**Release Note**

```release-note
Potentially breaking: Renamed pkg/signer to pkg/keys and renamed the interface from KeyManager to Manager
```
