### PR TITLE
Require all email addresses be verified

### DIFF
--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -6,8 +6,11 @@
 
 <!doctype html>
 <html lang="en">
+
 <head>
   {{template "head" .}}
+
+  {{template "firebase" .}}
 </head>
 
 <body>
@@ -36,6 +39,9 @@
         <div class="mb-3">
           {{$user.Email}}
         </div>
+
+        <strong>Email Verified</strong>
+        <div id="verified" class="mb-3">false</div>
 
         <strong>Admin</strong>
         <div class="mb-3">
@@ -77,6 +83,19 @@
   </main>
 
   {{template "scripts" .}}
+  <script type="text/javascript">
+    firebase.auth().onAuthStateChanged(function (user) {
+      $ver = $('#verified');
+      if (user) {
+        if (user.emailVerified) {
+          $ver.text('true')
+        } else {
+          $ver.text('false')
+        }
+      }
+    });
+  </script>
 </body>
+
 </html>
 {{end}}

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -70,5 +70,6 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, user
 	m := controller.TemplateMapFromContext(ctx)
 	m["user"] = user
 	m["stats"] = stats
+	m["firebase"] = c.config.Firebase
 	c.h.RenderHTML(w, "users/show", m)
 }


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Requires that user have verified email address
    * if not, redirects to verification page

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Require all users have verified email address to log-in
```
