### PR TITLE
Require user emails be verified to authenticate

### DIFF
--- a/cmd/server/assets/login/verifyemail.html
+++ b/cmd/server/assets/login/verifyemail.html
@@ -14,7 +14,7 @@
     <main role="main" class="container">
         {{template "flash" .}}
 
-        <div class="card mb-3">
+        <div id="first-card" class="card mb-3">
             <h1>Email Verification</h1>
             <p id="subtitle">Use this page to verify your login email address</p>
 
@@ -41,7 +41,7 @@
                 let user = firebase.auth().currentUser
                 if (!user.emailVerified) {
                     user.sendEmailVerification().then(function () {
-                        $('body').prepend('<div class="alert alert-warning" role="alert" id="message">Verification email sent.</div>')
+                        $('main').prepend('<div class="alert alert-warning" role="alert" id="message">Verification email sent.</div>')
                         $verify.prop('disabled', true);
                     }
                     );

--- a/cmd/server/assets/login/verifyemail.html
+++ b/cmd/server/assets/login/verifyemail.html
@@ -14,7 +14,7 @@
     <main role="main" class="container">
         {{template "flash" .}}
 
-        <div id="first-card" class="card mb-3">
+        <div class="card mb-3">
             <h1>Email Verification</h1>
             <p id="subtitle">Use this page to verify your login email address</p>
 


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Requires that user have verified email address
    * if not, redirects to verification page

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Require all users have verified email address to log-in
```
