### PR TITLE
upgrade terraform module to tf 0.13

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -138,9 +138,21 @@ variable "server_custom_domain" {
 
 terraform {
   required_providers {
-    google      = "~> 3.32"
-    google-beta = "~> 3.32"
-    null        = "~> 2.1"
-    random      = "~> 2.3"
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.32"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.32"
+    }
+    null = {
+      source  = "hashicorp/null"
+      version = "~> 2.1"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = "~> 2.3"
+    }
   }
 }

--- a/terraform/versions.tf
+++ b/terraform/versions.tf
@@ -1,0 +1,3 @@
+terraform {
+  required_version = ">= 0.13"
+}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* terraform module now requires Terraform 0.13

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The terraform module now requires Terraform 0.13
```
