### PR TITLE
enroll for sms registration

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -39,7 +39,6 @@
         </div>
       </div>
     </div>
-    </div>
   </main>
 
   {{template "scripts" .}}

--- a/cmd/server/assets/login/registerphone.html
+++ b/cmd/server/assets/login/registerphone.html
@@ -21,23 +21,36 @@
 
     <div class="card mb-3">
       <div class="card-body">
-        <div class="row form-group">
-          <label for="phone" class="col-sm-3">Phone number</label>
-          <div class="col-sm-9">
-            <div class="input-group p-0 shadow-sm">
-              <input type="tel" id="phone" name="phone" class="form-control" />
+        <form id="registerForm" action="/" method="POST">
+          <div class="row form-group">
+            <label for="display" class="col-sm-3">Display Name</label>
+            <div class="col-sm-9">
+              <div class="input-group p-0 shadow-sm">
+                <input type="text" id="display" name="display" class="form-control" value="Personal Phone" />
+              </div>
+              <small class="form-text text-muted">
+                Your 2nd factor auth will appear with this title.
+              </small>
             </div>
-            <small class="form-text text-muted">
-              Format: +1 123-456-7890. Standard SMS rates may apply.
-            </small>
           </div>
-        </div>
+          <div class="row form-group">
+            <label for="phone" class="col-sm-3">Phone number</label>
+            <div class="col-sm-9">
+              <div class="input-group p-0 shadow-sm">
+                <input type="tel" id="phone" name="phone" class="form-control" />
+              </div>
+              <small class="form-text text-muted">
+                Format: +1 123-456-7890. Standard SMS rates may apply.
+              </small>
+            </div>
+          </div>
 
-        <div class="row form-group">
-          <div class="offset-sm-3 col-sm-9">
-            <button id="register" class="btn btn-primary btn-block">Register</button>
+          <div class="row form-group">
+            <div class="offset-sm-3 col-sm-9">
+              <button type="submit" id="register" class="btn btn-primary btn-block">Register</button>
+            </div>
           </div>
-        </div>
+        </form>
       </div>
     </div>
   </main>
@@ -56,10 +69,19 @@
       });
 
     $(function () {
+      let $displayName = $('#display')
+      let $submit = $('#register')
       let $phone = $('#phone')
+      let $form = $('#registerForm')
 
-      $('#register').on('click', function (event) {
-        firebase.auth().currentUser.multiFactor.getSession().then(function (multiFactorSession) {
+      $form.on('submit', function (event) {
+        event.preventDefault();
+
+        // Disable the submit button so we only attempt once.
+        $submit.prop('disabled', true);
+
+        let user = firebase.auth().currentUser
+        user.multiFactor.getSession().then(function (multiFactorSession) {
           // Specify the phone number and pass the MFA session.
           var phoneInfoOptions = {
             phoneNumber: $phone.val(),
@@ -69,16 +91,21 @@
           // Send SMS verification code.
           return phoneAuthProvider.verifyPhoneNumber(
             phoneInfoOptions, window.recaptchaVerifier);
-        }).then(
-          function (verificationId) {
-            var verificationCode = window.prompt('Please enter the verification ' +
-              'code that was sent to your mobile device.');
-            // TODO: enroll the credential
-          },
-          function (err) {
-            clearExistingFlash();
-            flash(err.message)
-          });
+        }).then(function (verificationId) {
+          var verificationCode = window.prompt('Please enter the verification ' +
+            'code that was sent to your mobile device.');
+          var cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
+          var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+          // Complete enrollment.
+          return user.multiFactor.enroll(multiFactorAssertion, $displayName.val());
+        }).then(function () {
+          clearExistingFlash();
+          flash("SMS authentication enrolled successfully", "success");
+        }).catch(function (err) {
+          clearExistingFlash();
+          flash(err.message);
+        }
+        );
       });
     });
   </script>


### PR DESCRIPTION
Issue #https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Actually enroll the phone number with a display name
     * someday better input formatting would probably help the experience
* I've found a novel way to lock myself out
    * Our login doesn't actually handle the 2nd factor challenge yet

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow for SMS enrollment
```
