### PR TITLE
Accept SMS authentication

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -39,12 +39,23 @@
         </div>
       </div>
     </div>
-    </div>
+
+    <div id="recaptcha-container" class="center-block"></div>
   </main>
 
   {{template "scripts" .}}
 
   <script>
+    window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
+      'recaptcha-container',
+      { 'size': 'invisible' }
+    );
+
+    recaptchaVerifier.render()
+      .then(function (widgetId) {
+        window.recaptchaWidgetId = widgetId;
+      });
+
     $(function () {
       let $form = $('#loginForm');
       let $submit = $('#submit');
@@ -62,9 +73,42 @@
             clearExistingFlash();
           })
           .catch(function (error) {
-            clearExistingFlash();
-            flash(error.message, "danger")
-            $submit.prop('disabled', false);
+            if (error.code == 'auth/multi-factor-auth-required') {
+              resolver = error.resolver;
+              let selectedIndex = 0 // TODO: show list of factors
+              if (resolver.hints[selectedIndex].factorId === firebase.auth.PhoneMultiFactorGenerator.FACTOR_ID) {
+
+                let phoneInfoOptions = {
+                  multiFactorHint: resolver.hints[selectedIndex],
+                  session: resolver.session
+                };
+                let phoneAuthProvider = new firebase.auth.PhoneAuthProvider();
+                return phoneAuthProvider.verifyPhoneNumber(phoneInfoOptions, recaptchaVerifier)
+                  .then(function (verificationId) {
+                    let verificationCode = window.prompt('Please enter the verification ' +
+                      'code that was sent to your mobile device.');
+
+                    // Ask user for the SMS verification code.
+                    let cred = firebase.auth.PhoneAuthProvider.credential(
+                      verificationId, verificationCode);
+                    let multiFactorAssertion =
+                      firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+                    // Complete sign-in.
+                    return resolver.resolveSignIn(multiFactorAssertion)
+                  }).catch(function (error) {
+                    clearExistingFlash();
+                    flash(error.message, "danger");
+                    $submit.prop('disabled', false);
+                  });
+              } else {
+                clearExistingFlash();
+                flash("unsupported 2nd factor authentication type", "danger");
+              }
+            } else {
+              clearExistingFlash();
+              flash(error.message, "danger");
+              $submit.prop('disabled', false);
+            }
           });
       });
 


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/141

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Accepts SMS as the second factor for auth
    * Assumes (badly) that there is only one second factor
    * uses window.alert for input which is not ideal for now

TODO:
    * Allow other auth factors
     * Present a choice for auth factors
     * Replace alert with real html 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Accept SMS codes for 2 factor auth
```
