### PR TITLE
Don't let legacy-login actually log in

### DIFF
--- a/cmd/server/assets/login/legacylogin.html
+++ b/cmd/server/assets/login/legacylogin.html
@@ -21,15 +21,9 @@
 
   <script type="text/javascript">
     var uiConfig = {
-      'callbacks': {
-        // Called when the user has been successfully signed in.
-        'signInSuccess': function (user, credential, redirectUrl) {
-          setSession(user)
-          return false
-        }
-      },
-      'credentialHelper': firebaseui.auth.CredentialHelper.NONE,
-      'signInOptions': [
+      signInSuccessUrl: "/",
+      credentialHelper: firebaseui.auth.CredentialHelper.NONE,
+      signInOptions: [
         firebase.auth.EmailAuthProvider.PROVIDER_ID
       ],
 
@@ -45,7 +39,7 @@
     var ui = new firebaseui.auth.AuthUI(firebase.auth());
 
     function getCookie(name) {
-      var v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
+      let v = document.cookie.match('(^|;) ?' + name + '=([^;]*)(;|$)');
       return v ? v[2] : null;
     }
 

--- a/cmd/server/assets/login/verifyemail.html
+++ b/cmd/server/assets/login/verifyemail.html
@@ -53,8 +53,6 @@
 
     firebase.auth().onAuthStateChanged(function (user) {
       if (!user) {
-        // TODO(whaught): we we seem to get here on first login.
-        // Investigate why the user is not populated properly
         window.location.assign("/signout");
         return
       }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The old firebase login doesn't seem to set session/user the same way as the new identity platform
    * Its not worth our time to make that work - this is headed for replacement
    * Instead we just redirect back to our own login
   * https://github.com/google/exposure-notifications-verification-server/pull/302 will remove soon
* Only new-user-creation works here
