### PR TITLE
 Add support for `IGNORE_UNCLEAN_REPO` env var in build script.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -19,7 +19,7 @@ set -eEuo pipefail
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 ALL_SERVICES="apiserver,cleanup,server,adminapi"
 
-if [ -n "$(git status --porcelain)" ]; then
+if [ -z "${IGNORE_UNCLEAN_REPO:-}" -a -n "$(git status --porcelain)" ]; then
   echo "✋ Uncommitted local changes!" >&2
   exit 1
 fi


### PR DESCRIPTION
This is to bypass the check of repo cleanliness for local development.