### PR TITLE
Fix panic on codestatus

### DIFF
--- a/pkg/controller/codestatus/api.go
+++ b/pkg/controller/codestatus/api.go
@@ -32,6 +32,7 @@ func (c *Controller) HandleCheckCodeStatus() http.Handler {
 		code, errCode, err := c.CheckCodeStatus(r, request.UUID)
 		if err != nil {
 			c.h.RenderJSON(w, errCode, err)
+			return
 		}
 
 		c.h.RenderJSON(w, http.StatusOK,


### PR DESCRIPTION
Fixes GH-326

No release note since this was never deployed

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
