### PR TITLE
Switch to JSON encoding for cacher, decouple cacher from db

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -16,6 +16,7 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
 	"fmt"
 	"net/http"
 	"os"
@@ -93,7 +94,9 @@ func realMain(ctx context.Context) error {
 	sessions.Options.SameSite = http.SameSiteStrictMode
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, "server:", &config.Cache)
+	// TODO(sethvargo): switch to HMAC
+	cacher, err := cache.CacherFor(ctx, &config.Cache, cache.MultiKeyFunc(
+		cache.HashKeyFunc(sha1.New), cache.PrefixKeyFunc("server:")))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/pkg/cache/cacher_test.go
+++ b/pkg/cache/cacher_test.go
@@ -26,15 +26,12 @@ import (
 )
 
 type testStruct struct {
-	Public  string
-	private int64
-
-	in testEmbeddedStruct
+	Public string
+	In     testEmbeddedStruct
 }
 
 type testEmbeddedStruct struct {
-	Public  []byte
-	private float64
+	Public []byte
 }
 
 func testRandomKey(tb testing.TB) string {
@@ -88,11 +85,9 @@ func exerciseCacher(t *testing.T, cacher Cacher) {
 			name: "struct",
 			do: func(tb testing.TB) {
 				in := testStruct{
-					Public:  "foo",
-					private: 4,
-					in: testEmbeddedStruct{
-						Public:  []byte("\x12"),
-						private: 5,
+					Public: "foo",
+					In: testEmbeddedStruct{
+						Public: []byte("\x12"),
 					},
 				}
 				var out testStruct

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -38,17 +38,17 @@ type Config struct {
 	RedisPassword string `env:"REDIS_PASSWORD"`
 }
 
-func CacherFor(ctx context.Context, prefix string, c *Config) (Cacher, error) {
+func CacherFor(ctx context.Context, c *Config, keyFunc KeyFunc) (Cacher, error) {
 	switch typ := c.Type; typ {
 	case TypeNoop:
 		return NewNoop()
 	case TypeInMemory:
 		return NewInMemory(&InMemoryConfig{
-			Prefix: prefix,
+			KeyFunc: keyFunc,
 		})
 	case TypeRedis:
 		return NewRedis(&RedisConfig{
-			Prefix:   prefix,
+			KeyFunc:  keyFunc,
 			Address:  c.RedisAddress,
 			Username: c.RedisUsername,
 			Password: c.RedisPassword,

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -30,7 +30,7 @@ const (
 
 // Config represents configuration for a cacher.
 type Config struct {
-	Type CacherType `env:"TYPE, default=NOOP"`
+	Type CacherType `env:"TYPE, default=IN_MEMORY"`
 
 	// Redis options
 	RedisAddress  string `env:"REDIS_ADDRESS"`

--- a/pkg/cache/in_memory.go
+++ b/pkg/cache/in_memory.go
@@ -132,7 +132,7 @@ func (c *inMemory) Fetch(_ context.Context, key string, out interface{}, ttl tim
 		expires: time.Now().UnixNano() + int64(ttl),
 	}
 
-	return nil
+	return json.Unmarshal(b, out)
 }
 
 // Write adds a new item to the cache with the given TTL.

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -15,7 +15,9 @@
 package cache
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
 	"sync/atomic"
 	"time"
 )
@@ -44,7 +46,12 @@ func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Du
 	if err != nil {
 		return err
 	}
-	return readInto(val, out)
+
+	var b bytes.Buffer
+	if err := json.NewEncoder(&b).Encode(val); err != nil {
+		return err
+	}
+	return json.NewDecoder(&b).Decode(out)
 }
 
 // Write does nothing.

--- a/pkg/cache/redis.go
+++ b/pkg/cache/redis.go
@@ -17,9 +17,10 @@ package cache
 import (
 	"bytes"
 	"context"
-	"encoding/gob"
+	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
 	"strings"
 	"sync/atomic"
 	"time"
@@ -32,24 +33,22 @@ var _ Cacher = (*redis)(nil)
 // redis is an shared cache implementation backed by Redis. It's ideal for
 // production installations since the cache is shared among all services.
 type redis struct {
-	pool   *redigo.Pool
-	prefix string
+	pool    *redigo.Pool
+	keyFunc KeyFunc
 
 	stopped uint32
 	stopCh  chan struct{}
 }
 
 type RedisConfig struct {
-	// Prefix is a string to prepend to all cache keys before saving. This is
-	// useful on a shared service where you don't want to clash with the wrong
-	// cache values.
-	Prefix string
-
 	// Address is the redis address and port. The default value is 127.0.0.1:6379.
 	Address string
 
 	// Username and Password are used for authentication.
 	Username, Password string
+
+	// KeyFunc is the key function.
+	KeyFunc KeyFunc
 }
 
 // NewRedis creates a new in-memory cache.
@@ -79,8 +78,8 @@ func NewRedis(i *RedisConfig) (Cacher, error) {
 			MaxIdle:   0,
 			MaxActive: 0,
 		},
-		prefix: i.Prefix,
-		stopCh: make(chan struct{}),
+		keyFunc: i.KeyFunc,
+		stopCh:  make(chan struct{}),
 	}
 
 	return c, nil
@@ -90,77 +89,86 @@ func NewRedis(i *RedisConfig) (Cacher, error) {
 // returns the value. If the value does not exist, it calls f and caches the
 // result of f in the cache for ttl. The ttl is calculated from the time the
 // value is inserted, not the time the function is called.
-func (c *redis) Fetch(ctx context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) (retErr error) {
+func (c *redis) Fetch(ctx context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) error {
 	if c.isStopped() {
 		return ErrStopped
 	}
 
-	if c.prefix != "" {
-		key = c.prefix + key
+	if c.keyFunc != nil {
+		var err error
+		key, err = c.keyFunc(key)
+		if err != nil {
+			return fmt.Errorf("failed to execute keyFunc: %w", err)
+		}
 	}
 
-	fn := func(conn redigo.Conn) error {
-		cached, err := redigo.String(conn.Do("GET", key))
+	fn := func(conn redigo.Conn) (io.Reader, error) {
+		cached, err := redigo.Bytes(conn.Do("GET", key))
 		if err != nil && !errors.Is(err, redigo.ErrNil) {
-			return fmt.Errorf("failed to GET key: %w", err)
+			return nil, fmt.Errorf("failed to GET key: %w", err)
 		}
 
 		// Found a value
-		if cached != "" {
-			r := strings.NewReader(cached)
-			if err := gob.NewDecoder(r).Decode(out); err != nil {
-				return fmt.Errorf("failed to decode cached value: %w", err)
-			}
-			return nil
+		if len(cached) > 0 {
+			return bytes.NewReader(cached), nil
 		}
 
 		// No value found
 		if f == nil {
-			return ErrMissingFetchFunc
+			return nil, ErrMissingFetchFunc
 		}
 		val, err := f()
 		if err != nil {
-			return err
-		}
-		if err := readInto(val, out); err != nil {
-			return err
+			return nil, err
 		}
 
 		// Encode the value
 		var encoded bytes.Buffer
-		if err := gob.NewEncoder(&encoded).Encode(val); err != nil {
-			return fmt.Errorf("failed to encode value: %w", err)
+		if err := json.NewEncoder(&encoded).Encode(val); err != nil {
+			return nil, fmt.Errorf("failed to encode value: %w", err)
 		}
 
 		if _, err := conn.Do("WATCH", key); err != nil {
-			return fmt.Errorf("failed to WATCH key: %w", err)
+			return nil, fmt.Errorf("failed to WATCH key: %w", err)
 		}
 
 		if _, err := conn.Do("MULTI"); err != nil {
-			return fmt.Errorf("failed to MULTI: %w", err)
+			return nil, fmt.Errorf("failed to MULTI: %w", err)
 		}
 
-		if _, err := conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.String()); err != nil {
+		if _, err := conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.Bytes()); err != nil {
 			err = fmt.Errorf("failed to PSETEX: %w", err)
 
 			if _, derr := conn.Do("DISCARD"); derr != nil {
 				err = fmt.Errorf("failed to DISCARD: %v, original error: %w", derr, err)
 			}
 
-			return err
+			return nil, err
 		}
 
 		if _, err := conn.Do("EXEC"); err != nil {
-			return fmt.Errorf("failed to EXEC: %w", err)
+			return nil, fmt.Errorf("failed to EXEC: %w", err)
 		}
 
-		return nil
+		return &encoded, nil
 	}
 
 	// This is a CAS operation, so retry
 	var err error
 	for i := 0; i < 5; i++ {
-		err = c.withConn(fn)
+		err = c.withConn(func(c redigo.Conn) error {
+			r, err := fn(c)
+			if err != nil {
+				return err
+			}
+
+			// Decode the value into out.
+			if err := json.NewDecoder(r).Decode(out); err != nil {
+				return fmt.Errorf("failed to decode value")
+			}
+
+			return nil
+		})
 		if err == nil {
 			break
 		}
@@ -175,17 +183,21 @@ func (c *redis) Write(ctx context.Context, key string, value interface{}, ttl ti
 		return ErrStopped
 	}
 
-	if c.prefix != "" {
-		key = c.prefix + key
+	if c.keyFunc != nil {
+		var err error
+		key, err = c.keyFunc(key)
+		if err != nil {
+			return fmt.Errorf("failed to execute keyFunc: %w", err)
+		}
 	}
 
 	return c.withConn(func(conn redigo.Conn) error {
 		var encoded bytes.Buffer
-		if err := gob.NewEncoder(&encoded).Encode(value); err != nil {
+		if err := json.NewEncoder(&encoded).Encode(value); err != nil {
 			return fmt.Errorf("failed to encode value: %w", err)
 		}
 
-		if _, err := redigo.String(conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.String())); err != nil {
+		if _, err := redigo.String(conn.Do("PSETEX", key, int64(ttl.Milliseconds()), encoded.Bytes())); err != nil {
 			return fmt.Errorf("failed to PSETEX value: %w", err)
 		}
 		return nil
@@ -199,8 +211,12 @@ func (c *redis) Read(ctx context.Context, key string, out interface{}) error {
 		return ErrStopped
 	}
 
-	if c.prefix != "" {
-		key = c.prefix + key
+	if c.keyFunc != nil {
+		var err error
+		key, err = c.keyFunc(key)
+		if err != nil {
+			return fmt.Errorf("failed to execute keyFunc: %w", err)
+		}
 	}
 
 	return c.withConn(func(conn redigo.Conn) error {
@@ -213,7 +229,7 @@ func (c *redis) Read(ctx context.Context, key string, out interface{}) error {
 		}
 
 		r := strings.NewReader(val)
-		if err := gob.NewDecoder(r).Decode(out); err != nil {
+		if err := json.NewDecoder(r).Decode(out); err != nil {
 			return fmt.Errorf("failed to decode cached value: %w", err)
 		}
 		return nil
@@ -227,8 +243,12 @@ func (c *redis) Delete(ctx context.Context, key string) error {
 		return ErrStopped
 	}
 
-	if c.prefix != "" {
-		key = c.prefix + key
+	if c.keyFunc != nil {
+		var err error
+		key, err = c.keyFunc(key)
+		if err != nil {
+			return fmt.Errorf("failed to execute keyFunc: %w", err)
+		}
 	}
 
 	return c.withConn(func(conn redigo.Conn) error {
@@ -244,6 +264,7 @@ func (c *redis) Close() error {
 	if !atomic.CompareAndSwapUint32(&c.stopped, 0, 1) {
 		return nil
 	}
+
 	close(c.stopCh)
 	if err := c.pool.Close(); err != nil {
 		return fmt.Errorf("failed to close pool: %w", err)

--- a/pkg/controller/apikey/apikey.go
+++ b/pkg/controller/apikey/apikey.go
@@ -30,18 +30,18 @@ import (
 
 type Controller struct {
 	config *config.ServerConfig
-	cache  cache.Cacher
+	cacher cache.Cacher
 	db     *database.Database
 	h      *render.Renderer
 	logger *zap.SugaredLogger
 }
 
-func New(ctx context.Context, config *config.ServerConfig, cache cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
+func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx).Named("apikey")
 
 	return &Controller{
 		config: config,
-		cache:  cache,
+		cacher: cacher,
 		db:     db,
 		h:      h,
 		logger: logger,

--- a/pkg/controller/apikey/show.go
+++ b/pkg/controller/apikey/show.go
@@ -70,7 +70,7 @@ func (c *Controller) HandleShow() http.Handler {
 		// Get and cache the stats for this user.
 		var stats []*database.AuthorizedAppStats
 		cacheKey := fmt.Sprintf("stats:app:%d:%d", realm.ID, authApp.ID)
-		if err := c.cache.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
+		if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
 			now := time.Now().UTC()
 			past := now.Add(-14 * 24 * time.Hour)
 			return authApp.Stats(c.db, past, now)

--- a/pkg/controller/login/controller.go
+++ b/pkg/controller/login/controller.go
@@ -38,7 +38,7 @@ type Controller struct {
 
 // New creates a new login controller.
 func New(ctx context.Context, client *auth.Client, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).Named("login")
 
 	return &Controller{
 		client: client,

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -57,7 +57,7 @@ func (c *Controller) HandleShow() http.Handler {
 		// Get and cache the stats for this user.
 		var stats []*database.UserStats
 		cacheKey := fmt.Sprintf("stats:user:%d:%d", realm.ID, user.ID)
-		if err := c.cache.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
+		if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
 			now := time.Now().UTC()
 			past := now.Add(-14 * 24 * time.Hour)
 			return user.Stats(c.db, realm.ID, past, now)

--- a/pkg/controller/user/user.go
+++ b/pkg/controller/user/user.go
@@ -31,19 +31,19 @@ import (
 // Controller manages users
 type Controller struct {
 	config *config.ServerConfig
-	cache  cache.Cacher
+	cacher cache.Cacher
 	db     *database.Database
 	h      *render.Renderer
 	logger *zap.SugaredLogger
 }
 
 // New creates a new controller for managing users.
-func New(ctx context.Context, config *config.ServerConfig, cache cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
+func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx)
 
 	return &Controller{
 		config: config,
-		cache:  cache,
+		cacher: cacher,
 		db:     db,
 		h:      h,
 		logger: logger,

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -17,7 +17,6 @@ package database
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
@@ -40,10 +39,6 @@ type Config struct {
 	// Debug is a boolean that indicates whether the database should log SQL
 	// commands.
 	Debug bool `env:"DB_DEBUG,default=false"`
-
-	// CacheTTL is the amount of time to cache values. This is enabled on a
-	// per-query basis. Not all query results are cached.
-	CacheTTL time.Duration `env:"DB_CACHE_TTL, default=5m" json:",omitempty"`
 
 	// Keys is the key management configuration. This is used to resolve values
 	// that are encrypted via a KMS.

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -91,8 +91,6 @@ func NewTestDatabaseWithConfig(tb testing.TB) (*Database, *Config) {
 
 	// build database config.
 	config := Config{
-		CacheTTL: 30 * time.Second,
-
 		APIKeyDatabaseHMAC:  generateKey(tb, 128),
 		APIKeySignatureHMAC: generateKey(tb, 128),
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"context"
 	"fmt"
 	"strings"
 	"time"
@@ -196,7 +197,18 @@ func (r *Realm) SMSProvider(db *Database) (sms.Provider, error) {
 		}
 		return nil, err
 	}
-	return smsConfig.SMSProvider(db)
+
+	ctx := context.Background()
+	provider, err := sms.ProviderFor(ctx, &sms.Config{
+		ProviderType:     smsConfig.ProviderType,
+		TwilioAccountSid: smsConfig.TwilioAccountSid,
+		TwilioAuthToken:  smsConfig.TwilioAuthToken,
+		TwilioFromNumber: smsConfig.TwilioFromNumber,
+	})
+	if err != nil {
+		return nil, err
+	}
+	return provider, nil
 }
 
 // ListAuthorizedApps gets all the authorized apps for the realm.

--- a/pkg/database/sms_config.go
+++ b/pkg/database/sms_config.go
@@ -15,10 +15,6 @@
 package database
 
 import (
-	"context"
-	"fmt"
-	"time"
-
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 	"github.com/jinzhu/gorm"
 )
@@ -41,33 +37,9 @@ type SMSConfig struct {
 
 	// TwilioAuthToken is encrypted/decrypted automatically by callbacks. The
 	// cache fields exist as optimizations.
-	TwilioAuthToken                string `gorm:"type:varchar(250)" json:"-"`
-	TwilioAuthTokenPlaintextCache  string `gorm:"-" json:"-"`
-	TwilioAuthTokenCiphertextCache string `gorm:"-" json:"-"`
-}
-
-// SMSProvider gets the SMS provider for the given realm. The values are
-// cached.
-func (r *SMSConfig) SMSProvider(db *Database) (sms.Provider, error) {
-	ctx := context.Background()
-	key := fmt.Sprintf("sms_configs:provider:%v", r.ID)
-
-	var provider sms.Provider
-	if err := db.cacher.Fetch(ctx, key, &provider, 30*time.Minute, func() (interface{}, error) {
-		provider, err := sms.ProviderFor(ctx, &sms.Config{
-			ProviderType:     r.ProviderType,
-			TwilioAccountSid: r.TwilioAccountSid,
-			TwilioAuthToken:  r.TwilioAuthToken,
-			TwilioFromNumber: r.TwilioFromNumber,
-		})
-		if err != nil {
-			return nil, err
-		}
-		return provider, nil
-	}); err != nil {
-		return nil, err
-	}
-	return provider, nil
+	TwilioAuthToken                string `gorm:"type:varchar(250)"`
+	TwilioAuthTokenPlaintextCache  string `gorm:"-"`
+	TwilioAuthTokenCiphertextCache string `gorm:"-"`
 }
 
 // SaveSMSConfig creates or updates an SMS configuration record.


### PR DESCRIPTION
Switch to JSON encoding for the cacher. Gob is faster, but misconfigurations turn into runtime errors. It also decouples the cacher from the database.

This also introduces a KeyFunc type on the cacher to mutate keys before they are stored (e.g. to obfuscate or encrypt them), and fixes the SHA calculations on the rate limiter keys.

**Release Note**

```release-note
Switch to JSON encoding for cacher, decouple cacher from database
```

/assign @mikehelmick 
