### PR TITLE
Make KMS key ring name configurable

### DIFF
--- a/terraform/keys.tf
+++ b/terraform/keys.tf
@@ -14,7 +14,7 @@
 
 resource "google_kms_key_ring" "verification" {
   project  = var.project
-  name     = "verification"
+  name     = var.kms_key_ring_name
   location = var.kms_location
 
   depends_on = [

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -91,6 +91,13 @@ variable "kms_location" {
   description = "Location in which to create KMS keys"
 }
 
+variable "kms_key_ring_name" {
+  type    = string
+  default = "verification"
+
+  description = "Name of the KMS key ring to create"
+}
+
 variable "redis_location" {
   type    = string
   default = "us-central1-a"


### PR DESCRIPTION
Make KMS key ring name configurable

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make KMS key ring name configurable in Terraform
```
