### PR TITLE
Use local time when issuing codes

### DIFF
--- a/cmd/get-code/main.go
+++ b/cmd/get-code/main.go
@@ -31,11 +31,12 @@ import (
 )
 
 var (
-	testFlag    = flag.String("type", "", "diagnosis test type: confirmed, likely, negative")
-	onsetFlag   = flag.String("onset", "", "Symptom onset date, YYYY-MM-DD format")
-	apikeyFlag  = flag.String("apikey", "", "API Key to use")
-	addrFlag    = flag.String("addr", "http://localhost:8080", "protocol, address and port on which to make the API call")
-	timeoutFlag = flag.Duration("timeout", 5*time.Second, "request time out duration in the format: 0h0m0s")
+	testFlag     = flag.String("type", "", "diagnosis test type: confirmed, likely, negative")
+	onsetFlag    = flag.String("onset", "", "Symptom onset date, YYYY-MM-DD format")
+	tzOffsetFlag = flag.Int("tzOffset", 0, "timezone adjustment (minutes) from UTC for request")
+	apikeyFlag   = flag.String("apikey", "", "API Key to use")
+	addrFlag     = flag.String("addr", "http://localhost:8080", "protocol, address and port on which to make the API call")
+	timeoutFlag  = flag.Duration("timeout", 5*time.Second, "request time out duration in the format: 0h0m0s")
 )
 
 func main() {
@@ -58,7 +59,7 @@ func main() {
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	request, response, err := clients.IssueCode(ctx, *addrFlag, *apikeyFlag, *testFlag, *onsetFlag, *timeoutFlag)
+	request, response, err := clients.IssueCode(ctx, *addrFlag, *apikeyFlag, *testFlag, *onsetFlag, *tzOffsetFlag, *timeoutFlag)
 	logger.Infow("sent request", "request", request)
 	if err != nil {
 		return fmt.Errorf("failed to get token: %w", err)

--- a/cmd/server/assets/home.html
+++ b/cmd/server/assets/home.html
@@ -98,25 +98,15 @@
         <div class="card-body">
           <div class="form-row">
             <div class="form-group col-md-6">
-              <label for="testDate">Testing date</label>
+              <label for="testDate">Testing date (local time)</label>
               <input type="date" id="testDate" name="testDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" />
-              <small class="form-text text-muted">
-                <strong>Recommended.</strong>
-                This is the <a href="https://www.timeanddate.com/worldclock/timezone/utc" target="_blank">UTC date</a> when the test was performed.
-                Click here to <a href="#" data-fill-target="testDate" data-fill-value="{{.maxDate}}">use today's UTC date</a>.
-              </small>
             </div>
 
             <div class="form-group col-md-6">
-              <label for="symptomDate">Symptoms onset</label>
+              <label for="symptomDate">Symptoms onset (local time)</label>
               <div class="input-group">
                 <input type="date" id="symptomDate" name="symptomDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" />
               </div>
-              <small class="form-text text-muted">
-                <strong>Recommended.</strong>
-                This is the <a href="https://www.timeanddate.com/worldclock/timezone/utc" target="_blank">UTC date</a> when symptoms began. It cannot be more than {{.maxSymptomDays}} days ago.
-                Click here to <a href="#" data-fill-target="symptomDate" data-fill-value="{{.maxDate}}">use today's UTC date</a>.
-              </small>
             </div>
           </div>
         </div>
@@ -199,6 +189,7 @@
         $($('#issueForm').serializeArray()).each(function(index, obj){
           data[obj.name] = obj.value;
         });
+        data.tzOffset = new Date().getTimezoneOffset();
 
         getCode(data);
       });

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -102,6 +102,7 @@ type IssueCodeRequest struct {
 	SymptomDate string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
 	TestDate    string `json:"testDate"`
 	TestType    string `json:"testType"`
+	TZOffset    int    `json:"tzOffset"` // offset in minutes of the user's timezone.
 	Phone       string `json:"phone"`
 }
 

--- a/pkg/clients/apis.go
+++ b/pkg/clients/apis.go
@@ -26,11 +26,12 @@ import (
 
 // IssueCode uses the ADMIN API to issue a verification code.
 // Currently does not accept the SMS param.
-func IssueCode(ctx context.Context, hostname string, apiKey, testType, symptomDate string, timeout time.Duration) (*api.IssueCodeRequest, *api.IssueCodeResponse, error) {
+func IssueCode(ctx context.Context, hostname string, apiKey, testType, symptomDate string, tzMinOffset int, timeout time.Duration) (*api.IssueCodeRequest, *api.IssueCodeResponse, error) {
 	url := hostname + "/api/issue"
 	request := api.IssueCodeRequest{
 		TestType:    testType,
 		SymptomDate: symptomDate,
+		TZOffset:    tzMinOffset,
 	}
 	client := &http.Client{
 		Timeout: timeout,

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -96,8 +96,8 @@ func (c *Controller) HandleIssue() http.Handler {
 			return
 		}
 
-		// Max date is today (local time) and min date is AllowedTestAge ago, truncated.
-		maxDate := time.Now().Local()
+		// Max date is today (UTC time) and min date is AllowedTestAge ago, truncated.
+		maxDate := time.Now().UTC()
 		minDate := maxDate.Add(-1 * c.config.GetAllowedSymptomAge()).Truncate(24 * time.Hour)
 
 		var symptomDate *time.Time
@@ -107,6 +107,7 @@ func (c *Controller) HandleIssue() http.Handler {
 				return
 			} else {
 				parsed = parsed.Local()
+				parsed = parsed.Add(time.Duration(request.TZOffset) * time.Minute) // adjust to UTC
 				if minDate.After(parsed) || parsed.After(maxDate) {
 					err := fmt.Errorf("symptom onset date must be on/after %v and on/before %v",
 						minDate.Format("2006-01-02"),


### PR DESCRIPTION
Rather than requiring a user to adjust their dates to UTC, use the
browser's idea of what timezone the client is in.

Fixes #63

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Use the browser's local TZ setting, and include it in the code issuance api.
* Requires browsers to have an accurate TZ setting.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```Requires users to have an accurate timezone setting in their client.

```
