### PR TITLE
Allow auth app to check code status

### DIFF
--- a/pkg/controller/codestatus/logic.go
+++ b/pkg/controller/codestatus/logic.go
@@ -32,11 +32,6 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 	if err != nil {
 		return nil, http.StatusUnauthorized, api.Error(err)
 	}
-	if user == nil {
-		logger.Errorw("failed to check otp code status", "error", "no user found")
-		return nil, http.StatusUnauthorized,
-			api.Errorf("failed to check otp code status: no user found").WithCode(api.ErrVerifyCodeUserUnauth)
-	}
 
 	var realm *database.Realm
 	if authApp != nil {
@@ -69,10 +64,17 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 	}
 
 	// The current user must have issued the code or be a realm admin.
-	if !(code.IssuingUser != nil && code.IssuingUser.Email == user.Email || user.CanAdminRealm(realm.ID)) {
+	if user != nil && !(code.IssuingUser != nil && code.IssuingUser.Email == user.Email || user.CanAdminRealm(realm.ID)) {
 		logger.Errorw("failed to check otp code status", "error", "user email does not match issuing user")
 		return nil, http.StatusUnauthorized,
 			api.Errorf("failed to check otp code status: user does not match issuing user").WithCode(api.ErrVerifyCodeUserUnauth)
+	}
+
+	// The current user must have issued the code or be a realm admin.
+	if authApp != nil && !(code.IssuingApp.ID == authApp.ID || authApp.IsAdminType()) {
+		logger.Errorw("failed to check otp code status", "error", "auth app does not match issuing app")
+		return nil, http.StatusUnauthorized,
+			api.Errorf("failed to check otp code status: auth app does not match issuing app").WithCode(api.ErrVerifyCodeUserUnauth)
 	}
 
 	if code.RealmID != realm.ID {

--- a/pkg/controller/codestatus/logic.go
+++ b/pkg/controller/codestatus/logic.go
@@ -70,7 +70,7 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 			api.Errorf("failed to check otp code status: user does not match issuing user").WithCode(api.ErrVerifyCodeUserUnauth)
 	}
 
-	// The current user must have issued the code or be a realm admin.
+	// The current app must have issued the code or be a realm admin.
 	if authApp != nil && !(code.IssuingApp.ID == authApp.ID || authApp.IsAdminType()) {
 		logger.Errorw("failed to check otp code status", "error", "auth app does not match issuing app")
 		return nil, http.StatusUnauthorized,


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/341

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allow both users and authorized apps to check code status

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow authorized apps to check code status
```
