### PR TITLE
implement token signing key rotation

### DIFF
--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -15,6 +15,8 @@
 package config
 
 import (
+	"fmt"
+
 	"github.com/google/exposure-notifications-server/pkg/keys"
 )
 
@@ -25,7 +27,22 @@ type TokenSigningConfig struct {
 	// configuration.
 	Keys keys.Config `env:",prefix=TOKEN_"`
 
-	TokenSigningKey   string `env:"TOKEN_SIGNING_KEY, required"`
-	TokenSigningKeyID string `env:"TOKEN_SIGNING_KEY_ID, default=v1"`
-	TokenIssuer       string `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
+	TokenSigningKey   []string `env:"TOKEN_SIGNING_KEY, required"`
+	TokenSigningKeyID []string `env:"TOKEN_SIGNING_KEY_ID, default=v1"`
+	TokenIssuer       string   `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
+}
+
+func (t *TokenSigningConfig) ActiveKey() string {
+	return t.TokenSigningKey[0]
+}
+
+func (t *TokenSigningConfig) ActiveKeyID() string {
+	return t.TokenSigningKeyID[0]
+}
+
+func (t *TokenSigningConfig) Validate() error {
+	if len(t.TokenSigningKey) != len(t.TokenSigningKeyID) {
+		return fmt.Errorf("TOKEN_SIGNING_KEY and TOKEN_SIGNING_KEY_ID must be lists of the same length")
+	}
+	return nil
 }

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -70,7 +70,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		}
 
 		// Get the signer based on Key configuration.
-		signer, err := c.kms.NewSigner(ctx, c.config.TokenSigning.TokenSigningKey)
+		signer, err := c.kms.NewSigner(ctx, c.config.TokenSigning.ActiveKey())
 		if err != nil {
 			c.logger.Errorw("failed to get signer", "error", err)
 			stats.Record(ctx, c.metrics.CodeVerificationError.M(1))
@@ -123,7 +123,7 @@ func (c *Controller) HandleVerify() http.Handler {
 			Subject:   subject.String(),
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-		token.Header[verifyapi.KeyIDHeader] = c.config.TokenSigning.TokenSigningKeyID
+		token.Header[verifyapi.KeyIDHeader] = c.config.TokenSigning.ActiveKeyID()
 		signedJWT, err := jwthelper.SignJWT(token, signer)
 		if err != nil {
 			stats.Record(ctx, c.metrics.CodeVerificationError.M(1))


### PR DESCRIPTION
Fixes #94

## Proposed Changes

* Allow the token signing key to be rotated by the server operator. This is totally independent from the certificate signing keys

**Release Note**

```release-note
Verification server operators can rotate their token signing key. `TOKEN_SIGNING_KEY` and `TOKEN_SIGNING_KEY_ID` are now array based env vars. They must be the same length. The first items in the lists represents the active key/kid and the remaining entries are allowed to validate.
```
