### PR TITLE
Render inline codestatus responses

### DIFF
--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -1,5 +1,7 @@
 {{define "code/status"}}
 
+{{$code := .code}}
+
 <!doctype html>
 <html lang="en">
 
@@ -7,7 +9,7 @@
   {{template "head" .}}
 </head>
 
-<body>
+<body class="bg-light">
   {{template "navbar" .}}
 
   <main role="main" class="container">
@@ -23,12 +25,16 @@
         <form method="POST" action="show">
           {{ .csrfField }}
           <div class="row form-group">
-            <label for="uuid" class="col-sm-3">Code Identifier</label>
+            <label for="uuid" class="col-sm-3">Code identifier</label>
             <div class="col-sm-9">
-              <div class="input-group p-0 shadow-sm">
-                <input type="text" id="uuid" name="uuid" class="form-control text-monospace"
-                  placeholder="xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx" />
+              <input type="text" id="uuid" name="uuid" class="form-control text-monospace{{if $code.ErrorsFor "uuid"}} is-invalid{{end}}" value="{{$code.UUID}}"
+                placeholder="xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
+                autocomplete="off">
+              {{if $code.ErrorsFor "uuid"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($code.ErrorsFor "uuid") ", "}}
               </div>
+              {{end}}
               <small class="form-text text-muted">
                 Identifier given from the Issue Code form.
               </small>

--- a/cmd/server/assets/home.html
+++ b/cmd/server/assets/home.html
@@ -134,7 +134,7 @@
               <label for="symptomDate" class="col-sm-3">Patient phone</label>
               <div class="col-sm-9">
                 <div class="input-group">
-                  <input type="tel" id="phone" name="phone" class="form-control" placeholder="+1 (555) 555-5555" />
+                  <input type="tel" id="phone" name="phone" class="form-control" placeholder="+1 (555) 555-5555" autocomplete="off" />
                 </div>
                 <small class="form-text text-muted">
                   If provided, the system will send text containing the code to the

--- a/pkg/controller/codestatus/index.go
+++ b/pkg/controller/codestatus/index.go
@@ -17,18 +17,26 @@
 package codestatus
 
 import (
+	"context"
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 func (c *Controller) HandleIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		m := controller.TemplateMapFromContext(ctx)
 		// TODO(whaught): load a list of recent codes to show
 
-		c.h.RenderHTML(w, "code/status", m)
+		var code database.VerificationCode
+		c.renderStatus(ctx, w, &code)
 	})
+}
+
+func (c *Controller) renderStatus(ctx context.Context, w http.ResponseWriter, code *database.VerificationCode) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["code"] = code
+	c.h.RenderHTML(w, "code/status", m)
 }

--- a/pkg/controller/codestatus/show.go
+++ b/pkg/controller/codestatus/show.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 func (c *Controller) HandleShow() http.Handler {
@@ -52,10 +53,21 @@ func (c *Controller) HandleShow() http.Handler {
 			return
 		}
 
+		if form.UUID == "" {
+			var code database.VerificationCode
+			code.AddError("uuid", "cannot be blank")
+
+			c.renderStatus(ctx, w, &code)
+			return
+		}
+
 		code, _, apiErr := c.CheckCodeStatus(r, form.UUID)
 		if apiErr != nil {
-			flash.Error("Failed to process form: %v", apiErr.Error)
-			c.renderShow(ctx, w, form.UUID, "", "")
+			var code database.VerificationCode
+			code.UUID = form.UUID
+			code.AddError("uuid", apiErr.Error)
+
+			c.renderStatus(ctx, w, &code)
 			return
 		}
 

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -49,6 +49,8 @@ var (
 // VerificationCode represents a verification code in the database.
 type VerificationCode struct {
 	gorm.Model
+	Errorable
+
 	RealmID       uint   // VerificationCodes belong to exactly one realm when issued.
 	Code          string `gorm:"type:varchar(512);unique_index"`
 	LongCode      string `gorm:"type:varchar(512);unique_index"`


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
