### PR TITLE
Reduce verification code save to 2 SQL statements.

### DIFF
--- a/pkg/controller/codestatus/logic.go
+++ b/pkg/controller/codestatus/logic.go
@@ -64,14 +64,14 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 	}
 
 	// The current user must have issued the code or be a realm admin.
-	if user != nil && !(code.IssuingUser != nil && code.IssuingUser.Email == user.Email || user.CanAdminRealm(realm.ID)) {
+	if user != nil && !(code.IssuingUserID == user.ID || user.CanAdminRealm(realm.ID)) {
 		logger.Errorw("failed to check otp code status", "error", "user email does not match issuing user")
 		return nil, http.StatusUnauthorized,
 			api.Errorf("failed to check otp code status: user does not match issuing user").WithCode(api.ErrVerifyCodeUserUnauth)
 	}
 
 	// The current app must have issued the code or be a realm admin.
-	if authApp != nil && !(code.IssuingApp.ID == authApp.ID || authApp.IsAdminType()) {
+	if authApp != nil && !(code.IssuingAppID == authApp.ID || authApp.IsAdminType()) {
 		logger.Errorw("failed to check otp code status", "error", "auth app does not match issuing app")
 		return nil, http.StatusUnauthorized,
 			api.Errorf("failed to check otp code status: auth app does not match issuing app").WithCode(api.ErrVerifyCodeUserUnauth)

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -58,10 +58,8 @@ type VerificationCode struct {
 	SymptomDate   *time.Time
 	ExpiresAt     time.Time
 	LongExpiresAt time.Time
-	IssuingUserID int
-	IssuingUser   *User
-	IssuingAppID  int
-	IssuingApp    *AuthorizedApp
+	IssuingUserID uint
+	IssuingAppID  uint
 }
 
 // TableName sets the VerificationCode table name

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -111,6 +111,16 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 				continue
 			}
 		}
+
+		issuingUserID := uint(0)
+		if o.IssuingUser != nil {
+			issuingUserID = o.IssuingUser.ID
+		}
+		issuingAppID := uint(0)
+		if o.IssuingApp != nil {
+			issuingAppID = o.IssuingApp.ID
+		}
+
 		verificationCode = database.VerificationCode{
 			RealmID:       o.RealmID,
 			Code:          code,
@@ -119,8 +129,8 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 			SymptomDate:   o.SymptomDate,
 			ExpiresAt:     o.ShortExpiresAt,
 			LongExpiresAt: o.LongExpiresAt,
-			IssuingUser:   o.IssuingUser,
-			IssuingApp:    o.IssuingApp,
+			IssuingUserID: issuingUserID,
+			IssuingAppID:  issuingAppID,
 		}
 		// If a verification code already exists, it will fail to save, and we retry.
 		if err := o.DB.SaveVerificationCode(&verificationCode, o.MaxSymptomAge); err != nil {


### PR DESCRIPTION
Fixes #359

## Proposed Changes

* Change foreign key to be just the ID and not the relationship on verification codes, reduce SQL overhead when saving verification code records.

**Release Note**

```release-note
Optimized SQL for issuing verification codes.
```
