### PR TITLE
Add redis opencensus metrics to the server

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,6 @@ require (
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/gomodule/redigo v1.8.2
 	github.com/google/exposure-notifications-server v0.5.0
 	github.com/google/go-cmp v0.5.1
@@ -39,6 +38,7 @@ require (
 	github.com/mikehelmick/go-chaff v0.3.0
 	github.com/mitchellh/mapstructure v1.3.3 // indirect
 	github.com/onsi/ginkgo v1.13.0 // indirect
+	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/prometheus/common v0.12.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -19,7 +19,7 @@ require (
 	github.com/containerd/continuity v0.0.0-20200710164510-efbc4488d8fe // indirect
 	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
-	github.com/gomodule/redigo v1.8.2
+	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/google/exposure-notifications-server v0.5.0
 	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.1 // indirect
@@ -44,7 +44,7 @@ require (
 	github.com/prometheus/statsd_exporter v0.17.0 // indirect
 	github.com/sethvargo/go-envconfig v0.3.1
 	github.com/sethvargo/go-limiter v0.4.0
-	github.com/sethvargo/go-redisstore v0.1.0
+	github.com/sethvargo/go-redisstore v0.1.1-opencensus
 	github.com/sethvargo/go-retry v0.1.0
 	github.com/sethvargo/go-signalcontext v0.1.0
 	github.com/stretchr/objx v0.3.0 // indirect

--- a/go.mod
+++ b/go.mod
@@ -20,6 +20,7 @@ require (
 	github.com/denisenkom/go-mssqldb v0.0.0-20200620013148-b91950f658ec // indirect
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
 	github.com/opencensus-integrations/redigo v2.0.1+incompatible
+	github.com/gomodule/redigo v1.8.2
 	github.com/google/exposure-notifications-server v0.5.0
 	github.com/google/go-cmp v0.5.1
 	github.com/google/uuid v1.1.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1216,11 +1216,8 @@ github.com/sethvargo/go-envconfig v0.3.1 h1:OUnL02SWTz+t8XtxTO6YQuLMi3StljJHzmtP
 github.com/sethvargo/go-envconfig v0.3.1/go.mod h1:XZ2JRR7vhlBEO5zMmOpLgUhgYltqYqq4d4tKagtPUv0=
 github.com/sethvargo/go-gcpkms v0.1.0 h1:pyjDLqLwpk9pMjDSTilPpaUjgP1AfSjX9WGzitZwGUY=
 github.com/sethvargo/go-gcpkms v0.1.0/go.mod h1:33BuvqUjsYk0bpMgn+WCclCYtMLOyaqtn5j0fCo4vvk=
-github.com/sethvargo/go-limiter v0.3.2-0.20200818185929-f9ab9053588b/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
 github.com/sethvargo/go-limiter v0.4.0 h1:YrMxUpjFx3osTFT+8Yg7L7IVQJbUzHUorbEDkUO+JHE=
 github.com/sethvargo/go-limiter v0.4.0/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
-github.com/sethvargo/go-redisstore v0.1.0 h1:N5771Hwi6H2sPvxT/aBqF7wa3U32T0mRY985zCz+IUo=
-github.com/sethvargo/go-redisstore v0.1.0/go.mod h1:PQJ9OHIjpYQ/atam4JS0rFdd/8CjdBbW6F+mVhiLxXg=
 github.com/sethvargo/go-redisstore v0.1.1-opencensus h1:MlYmIQpUIxcAD9SmOfrG0AwT4cZSZBXG1mXgwas4bUE=
 github.com/sethvargo/go-redisstore v0.1.1-opencensus/go.mod h1:jHUXCIJOsmsGy4/xRg8DnZ5+0437NZ3X9bhYP8B/jGM=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=

--- a/go.sum
+++ b/go.sum
@@ -1071,6 +1071,8 @@ github.com/onsi/gomega v1.9.0/go.mod h1:Ho0h+IUsWyvy1OpqCwxlQ/21gkhVunqlU8fDGcoT
 github.com/onsi/gomega v1.10.1 h1:o0+MgICZLuZ7xjH7Vx6zS/zcu93/BEp1VwkIW1mEXCE=
 github.com/onsi/gomega v1.10.1/go.mod h1:iN09h71vgCQne3DLsj+A5owkum+a2tYe+TOCB1ybHNo=
 github.com/op/go-logging v0.0.0-20160315200505-970db520ece7/go.mod h1:HzydrMdWErDVzsI23lYNej1Htcns9BCg93Dk0bBINWk=
+github.com/opencensus-integrations/redigo v2.0.1+incompatible h1:1EbXlxudNBcuUYZk5EMvSswbu8jwZbxLO241AThg8xk=
+github.com/opencensus-integrations/redigo v2.0.1+incompatible/go.mod h1:iH5qq3BZppLeyPZP0Hy2qffpbcppAl58otmaERGeJaQ=
 github.com/opencontainers/go-digest v1.0.0-rc1 h1:WzifXhOVOEOuFYOJAW6aQqW0TooG2iki3E3Ii+WN7gQ=
 github.com/opencontainers/go-digest v1.0.0-rc1/go.mod h1:cMLVZDEM3+U2I4VmLI6N8jQYUd2OVphdqWwCJHrFt2s=
 github.com/opencontainers/go-digest v1.0.0 h1:apOUWs51W5PlhuyGyz9FCeeBIOUDA/6nW8Oi/yOhh5U=
@@ -1219,6 +1221,8 @@ github.com/sethvargo/go-limiter v0.4.0 h1:YrMxUpjFx3osTFT+8Yg7L7IVQJbUzHUorbEDkU
 github.com/sethvargo/go-limiter v0.4.0/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
 github.com/sethvargo/go-redisstore v0.1.0 h1:N5771Hwi6H2sPvxT/aBqF7wa3U32T0mRY985zCz+IUo=
 github.com/sethvargo/go-redisstore v0.1.0/go.mod h1:PQJ9OHIjpYQ/atam4JS0rFdd/8CjdBbW6F+mVhiLxXg=
+github.com/sethvargo/go-redisstore v0.1.1-opencensus h1:MlYmIQpUIxcAD9SmOfrG0AwT4cZSZBXG1mXgwas4bUE=
+github.com/sethvargo/go-redisstore v0.1.1-opencensus/go.mod h1:jHUXCIJOsmsGy4/xRg8DnZ5+0437NZ3X9bhYP8B/jGM=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=
 github.com/sethvargo/go-signalcontext v0.1.0 h1:3IU7HOlmRXF0PSDf85C4nJ/zjYDjF+DS+LufcKfLvyk=

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -20,7 +20,7 @@ import (
 	"fmt"
 	"time"
 
-	"github.com/gomodule/redigo/redis"
+	"github.com/opencensus-integrations/redigo/redis"
 	"github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/memorystore"
 	"github.com/sethvargo/go-limiter/noopstore"
@@ -71,9 +71,8 @@ func RateLimiterFor(ctx context.Context, c *Config) (limiter.Store, error) {
 		}
 
 		return redisstore.NewWithPool(config, &redis.Pool{
-			DialContext: func(ctx context.Context) (redis.Conn, error) {
-				return redis.DialContext(ctx, "tcp", addr,
-					redis.DialUsername(c.RedisUsername),
+			Dial: func() (redis.Conn, error) {
+				return redis.Dial("tcp", addr,
 					redis.DialPassword(c.RedisPassword),
 				)
 			},

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -25,6 +25,7 @@ import (
 	"github.com/sethvargo/go-limiter/memorystore"
 	"github.com/sethvargo/go-limiter/noopstore"
 	"github.com/sethvargo/go-redisstore"
+	"go.opencensus.io/trace"
 )
 
 // RateLimitType represents a type of rate limiter.
@@ -72,8 +73,13 @@ func RateLimiterFor(ctx context.Context, c *Config) (limiter.Store, error) {
 
 		return redisstore.NewWithPool(config, &redis.Pool{
 			Dial: func() (redis.Conn, error) {
+				options := redis.TraceOptions{}
+				// set default attributes
+				redis.WithDefaultAttributes(trace.StringAttribute("span.type", "DB"))(&options)
+
 				return redis.DialWithContext(ctx, "tcp", addr,
 					redis.DialPassword(c.RedisPassword),
+					redis.DialTraceOptions(options),
 				)
 			},
 			TestOnBorrow: func(conn redis.Conn, _ time.Time) error {

--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -72,7 +72,7 @@ func RateLimiterFor(ctx context.Context, c *Config) (limiter.Store, error) {
 
 		return redisstore.NewWithPool(config, &redis.Pool{
 			Dial: func() (redis.Conn, error) {
-				return redis.Dial("tcp", addr,
+				return redis.DialWithContext(ctx, "tcp", addr,
 					redis.DialPassword(c.RedisPassword),
 				)
 			},

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -14,6 +14,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+	"github.com/opencensus-integrations/redigo/redis"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -108,6 +109,10 @@ func NewMiddleware(ctx context.Context, s limiter.Store, f httplimit.KeyFunc, op
 		TagKeys:     []tag.Key{},
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
+	}
+
+	if err := view.Register(redis.ObservabilityMetricViews...); err != nil {
+		return nil, fmt.Errorf("redis view registration failure: %w", err)
 	}
 
 	m := &Middleware{

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -14,10 +14,10 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
-	"github.com/opencensus-integrations/redigo/redis"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
+	"github.com/opencensus-integrations/redigo/redis"
 	"github.com/sethvargo/go-limiter"
 	"github.com/sethvargo/go-limiter/httplimit"
 	"go.opencensus.io/stats"


### PR DESCRIPTION
Fixes #266

## Proposed Changes

* Change redigo to opencensus/redigo
* Change redisstore to instrumented redisstore

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add redis opencensus metrics to the verification server, this will enable to monitor problems with redis connections itself.
```
