### PR TITLE
Use js to groom uuid formatting

### DIFF
--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -28,10 +28,9 @@
           {{ .csrfField }}
           <div class="form-group">
             <div class="form-label-group ">
-              <input type="text" id="uuid" name="uuid" class="form-control text-monospace{{if $code.ErrorsFor "uuid"}} is-invalid{{end}}" value="{{$code.UUID}}"
-                placeholder="xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx"
-                autocomplete="off">
-                <label for="uuid">xxxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxxx</label>
+              <input type="text" id="uuid" name="uuid" class='form-control text-monospace{{if $code.ErrorsFor "uuid"}} is-invalid{{end}}' value="{{$code.UUID}}"
+                placeholder="UUID" maxlength="36"autocomplete="off">
+                <label for="uuid">UUID</label>
               {{if $code.ErrorsFor "uuid"}}
               <div class="invalid-feedback">
                 {{joinStrings ($code.ErrorsFor "uuid") ", "}}
@@ -54,6 +53,30 @@
   </main>
 
   {{template "scripts" .}}
+  <script type="text/javascript">
+
+    $(function () {
+      let $uuid = $('#uuid');
+      let allowedChars = new RegExp("[0-9a-fA-F]")
+      let dashLocations = [8, 13, 18, 23];
+
+      $uuid.on('keyup', function(){
+        let s = $uuid.val();
+        let r = ""
+        for (i = 0; i < s.length && i <= 36; i++) {
+          let c = s.charAt(i)
+          if (dashLocations.includes(i)) {
+            r += '-'
+          }
+
+          if (allowedChars.test(c)) {
+            r += c
+          }
+        }
+        $uuid.val(r);
+      });
+    });
+  </script>
 </body>
 
 </html>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Change the label for uuid input to 'UUID' instead of xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxxxx
* Enforce GUID-valid characters and dashes vs javascript as the user types