### PR TITLE
Add terraform module for smoke test terraform configuration

### DIFF
--- a/terraform-e2e/README.md
+++ b/terraform-e2e/README.md
@@ -1,0 +1,55 @@
+# terraform-e2e
+
+This directory contains terraform configuration to be used for deploying verification servers with terraform, while being able to reuse a project to deploy repeatedly.
+
+## Prerequisite
+
+Follow steps from [Terrafrom instructions](https://github.com/google/exposure-notifications-verification-server/tree/main/terraform), going through from top until finishing `Instructions` section, then change into `terraform-e2e` directory:
+
+```shell
+cd terraform-e2e/
+echo "project = \"${PROJECT_ID}\"" >> ./terraform.tfvars
+```
+
+## Terraform Apply
+
+### Fresh GCP project
+
+If it's a fresh GCP project, just run `terraform init; terrform apply` under current directory.
+
+### Existing GCP project
+
+If it's a project that had verification server deployed before, run these before `terraform apply`:
+
+```shell
+terraform import module.en.google_app_engine_application.app ${PROJECT_ID}
+terraform import module.en.google_firebase_project.default ${PROJECT_ID}
+```
+
+#### Troubleshooting: `terraform import` failure
+
+If you ran `terraform import` and see the error of invalid provider configuration like:
+
+```text
+Error: Invalid provider configuration
+
+  on ../terraform/main.tf line 15:
+  15: provider "google" {
+
+The configuration for
+module.en.provider["registry.terraform.io/hashicorp/google"] depends on values
+that cannot be determined until apply.
+```
+
+This can be mitigated by commenting out [project = var.project](https://github.com/google/exposure-notifications-verification-server/blob/86a05f09dabfeddbce73c9d628ec01d3738782ed/terraform/main.tf#L16), as well as [project = var.project](https://github.com/google/exposure-notifications-verification-server/blob/86a05f09dabfeddbce73c9d628ec01d3738782ed/terraform/main.tf#L23). This is similar to the issue described in https://github.com/hashicorp/terraform/issues/25816, and might be fixed in 0.13.1 release of terraform.
+
+## Terraform Destroy
+
+Terraform destroy often fails while trying to delete db instance. To be reliably successfully destroy, run these ahead:
+
+```shell
+db_inst_name="$(terraform output 'db_inst_name')"
+gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID}
+terraform state rm module.en.google_sql_user.user
+terraform state rm module.en.google_sql_ssl_cert.db-cert
+```

--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+resource "random_string" "suffix" {
+  length  = 5
+  special = false
+  number  = false
+  upper   = false
+}
+
+module "en" {
+  source = "../terraform"
+
+  project = var.project
+  database_name = "en-verification-${random_string.suffix.result}"
+  kms_key_ring_name = "verification-${random_string.suffix.result}"
+
+  create_env_file = true
+
+  service_environment = {
+    server = {
+      FIREBASE_PRIVACY_POLICY_URL   = "TODO"
+      FIREBASE_TERMS_OF_SERVICE_URL = "TODO"
+    }
+  }
+}
+
+output "en" {
+  value = module.en
+}


### PR DESCRIPTION
This new module contains some random prefix/suffix for GCP resources that can not be deleted by terraform, so that the same GCP project can be used for smoke testing terraform deployment repeatedly

/assign @sethvargo 
/cc @yegle 