### PR TITLE
Add code expire endpoint

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -139,6 +139,7 @@ func realMain(ctx context.Context) error {
 
 	codeStatusController := codestatus.NewAPI(ctx, config, db, h)
 	r.Handle("/api/checkcodestatus", codeStatusController.HandleCheckCodeStatus()).Methods("POST")
+	r.Handle("/api/expirecode", codeStatusController.HandleExpire()).Methods("POST")
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -151,7 +151,29 @@ type CheckCodeStatusResponse struct {
 	// UTC seconds since epoch.
 	LongExpiresAtTimestamp int64 `json:"longExpiresAtTimestamp,omitempty"`
 
-	Error     string `json:"error"`
+	Error     string `json:"error,omitempty"`
+	ErrorCode string `json:"errorCode,omitempty"`
+}
+
+// ExpireCodeRequest defines the parameters to request that a code be expired now.
+// This is called by the Web frontend.
+// API is served at /api/expirecode
+type ExpireCodeRequest struct {
+	// UUID is a handle which allows the issuer to track status of the issued verification code.
+	UUID string `json:"uuid"`
+}
+
+// ExpireCodeResponse defines the response type for ExpireCodeRequest.
+type ExpireCodeResponse struct {
+	// ExpiresAtTimestamp represents Unix, seconds since the epoch. Still UTC.
+	// After this time the code will no longer be accepted and is eligible for deletion.
+	ExpiresAtTimestamp int64 `json:"expiresAtTimestamp"`
+
+	// LongExpiresAtTimestamp repesents the time when the long code expires, in
+	// UTC seconds since epoch.
+	LongExpiresAtTimestamp int64 `json:"longExpiresAtTimestamp,omitempty"`
+
+	Error     string `json:"error,omitempty"`
 	ErrorCode string `json:"errorCode,omitempty"`
 }
 

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -38,8 +38,7 @@ func (c *Controller) HandleExpire() http.Handler {
 			return
 		}
 
-		// Re-retrieve in transaction for write.
-		code, err := c.db.ExpireCode(request.UUID)
+		expiredAt, err := c.db.ExpireCode(request.UUID)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
@@ -47,8 +46,8 @@ func (c *Controller) HandleExpire() http.Handler {
 
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.ExpireCodeResponse{
-				ExpiresAtTimestamp:     code.ExpiresAt.UTC().Unix(),
-				LongExpiresAtTimestamp: code.LongExpiresAt.UTC().Unix(),
+				ExpiresAtTimestamp:     expiredAt.UTC().Unix(),
+				LongExpiresAtTimestamp: expiredAt.UTC().Unix(),
 			})
 	})
 }

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package codestatus defines a web controller for the code status page of the verification
+// server. This view allows users to view the status of previously-issued OTP codes.
+package codestatus
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+func (c *Controller) HandleExpire() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var request api.ExpireCodeRequest
+		if err := controller.BindJSON(w, r, &request); err != nil {
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			return
+		}
+
+		// Retrieve once to check permissions.
+		_, errCode, apiErr := c.CheckCodeStatus(r, request.UUID)
+		if apiErr != nil {
+			c.h.RenderJSON(w, errCode, apiErr)
+			return
+		}
+
+		// Re-retrieve in transaction for write.
+		code, err := c.db.ExpireCode(request.UUID)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.h.RenderJSON(w, http.StatusOK,
+			&api.ExpireCodeResponse{
+				ExpiresAtTimestamp:     code.ExpiresAt.UTC().Unix(),
+				LongExpiresAtTimestamp: code.LongExpiresAt.UTC().Unix(),
+			})
+	})
+}

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -38,7 +38,7 @@ func (c *Controller) HandleExpire() http.Handler {
 			return
 		}
 
-		expiredAt, err := c.db.ExpireCode(request.UUID)
+		code, err := c.db.ExpireCode(request.UUID)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
@@ -46,8 +46,8 @@ func (c *Controller) HandleExpire() http.Handler {
 
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.ExpireCodeResponse{
-				ExpiresAtTimestamp:     expiredAt.UTC().Unix(),
-				LongExpiresAtTimestamp: expiredAt.UTC().Unix(),
+				ExpiresAtTimestamp:     code.ExpiresAt.UTC().Unix(),
+				LongExpiresAtTimestamp: code.ExpiresAt.UTC().Unix(),
 			})
 	})
 }

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -202,7 +202,7 @@ func (db *Database) ExpireCode(uuid string) (time.Time, error) {
 		ExpiresAt:     now,
 		LongExpiresAt: now,
 	}
-	return now, db.db.Model(&vc).Where("uuid = ?", uuid).Debug().Update(&vc).Error
+	return now, db.db.Model(&vc).Where("uuid = ?", uuid).Update(&vc).Error
 }
 
 // SaveVerificationCode created or updates a verification code in the database.

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -196,13 +196,30 @@ func (db *Database) FindVerificationCodeByUUID(uuid string) (*VerificationCode, 
 }
 
 // ExpireCode saves a verification code as expired.
-func (db *Database) ExpireCode(uuid string) (time.Time, error) {
-	now := time.Now().UTC()
-	vc := VerificationCode{
-		ExpiresAt:     now,
-		LongExpiresAt: now,
+func (db *Database) ExpireCode(uuid string) (*VerificationCode, error) {
+	var vc VerificationCode
+	err := db.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.
+			Set("gorm:query_option", "FOR UPDATE").
+			Where("uuid = ?", uuid).
+			Find(&vc).Error; err != nil {
+			return err
+		}
+		if vc.IsExpired() {
+			return errors.New("code already expired")
+		}
+		if vc.Claimed {
+			return errors.New("code already caimed")
+		}
+
+		vc.ExpiresAt = time.Now()
+		vc.LongExpiresAt = vc.ExpiresAt
+		return tx.Save(&vc).Error
+	})
+	if err != nil {
+		return nil, err
 	}
-	return now, db.db.Model(&vc).Where("uuid = ?", uuid).Update(&vc).Error
+	return &vc, nil
 }
 
 // SaveVerificationCode created or updates a verification code in the database.

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -128,8 +128,7 @@ func TestVerificationCode_ExpireVerificationCode(t *testing.T) {
 	}
 
 	{
-		db.ExpireCode(uuid)
-		got, err := db.FindVerificationCodeByUUID(uuid)
+		got, err := db.ExpireCode(uuid)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,6 +138,10 @@ func TestVerificationCode_ExpireVerificationCode(t *testing.T) {
 		if got.ExpiresAt.After(time.Now()) {
 			t.Errorf("expected expired, got %v", got.ExpiresAt)
 		}
+	}
+
+	if _, err := db.ExpireCode(uuid); err == nil {
+		t.Errorf("Expected code already expired, got %v", err)
 	}
 }
 

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -128,7 +128,8 @@ func TestVerificationCode_ExpireVerificationCode(t *testing.T) {
 	}
 
 	{
-		got, err := db.ExpireCode(uuid)
+		db.ExpireCode(uuid)
+		got, err := db.FindVerificationCodeByUUID(uuid)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add the expire code API to allow users to invalidate a code (set expiry time to now)
    * Spinning the logic out of: https://github.com/google/exposure-notifications-verification-server/pull/373 so I can focus on UX separately

