### PR TITLE
Create separate key manager instances for certs, tokens, and db

### DIFF
--- a/pkg/config/api_server_config.go
+++ b/pkg/config/api_server_config.go
@@ -44,12 +44,12 @@ type APIServerConfig struct {
 	// Verification Token Config
 	// Currently this does not easily support rotation. TODO(mikehelmick) - add support.
 	VerificationTokenDuration time.Duration `env:"VERIFICATION_TOKEN_DURATION,default=24h"`
-	TokenSigningKey           string        `env:"TOKEN_SIGNING_KEY,required"`
-	TokenSigningKeyID         string        `env:"TOKEN_SIGNING_KEY_ID,default=v1"`
-	TokenIssuer               string        `env:"TOKEN_ISSUER,default=diagnosis-verification-example"`
 
-	// Verification certificate config
-	VerificationSettings CertificateSigningConfig
+	// Token signing
+	TokenSigning TokenSigningConfig
+
+	// Certificate signing
+	CertificateSigning CertificateSigningConfig
 
 	// Rate limiting configuration
 	RateLimit ratelimit.Config

--- a/pkg/config/certificate_signing_config.go
+++ b/pkg/config/certificate_signing_config.go
@@ -14,11 +14,19 @@
 
 package config
 
-import "time"
+import (
+	"time"
 
-// CertificateSigningConfig represents the settinsg for system wide certificate signing.
-// these should be used if you are managing certifiate keys externally.
+	"github.com/google/exposure-notifications-server/pkg/keys"
+)
+
+// CertificateSigningConfig represents the settings for system-wide certificate
+// signing. These should be used if you are managing certifiate keys externally.
 type CertificateSigningConfig struct {
+	// Keys determines the key manager configuration for this certificate signing
+	// configuration.
+	Keys keys.Config `env:",prefix=CERTIFICATE_"`
+
 	PublicKeyCacheDuration  time.Duration `env:"PUBLIC_KEY_CACHE_DURATION, default=15m"`
 	SignerCacheDuration     time.Duration `env:"CERTIFICATE_SIGNER_CACHE_DURATION, default=1m"`
 	CertificateSigningKey   string        `env:"CERTIFICATE_SIGNING_KEY, required"`

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -64,7 +64,7 @@ type ServerConfig struct {
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
 
 	// Certificate signing key settings, needed for public key / settings display.
-	VerificationSettings CertificateSigningConfig
+	CertificateSigning CertificateSigningConfig
 
 	// If Dev mode is true, cookies aren't required to be sent over secure channels.
 	// This includes CSRF protection base cookie. You want this false in production (the default).

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -1,0 +1,31 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"github.com/google/exposure-notifications-server/pkg/keys"
+)
+
+// TokenSigningConfig represents the settings for system-wide certificate
+// signing. These should be used if you are managing certifiate keys externally.
+type TokenSigningConfig struct {
+	// Keys determines the key manager configuration for this token signing
+	// configuration.
+	Keys keys.Config `env:",prefix=TOKEN_"`
+
+	TokenSigningKey   string `env:"TOKEN_SIGNING_KEY, required"`
+	TokenSigningKeyID string `env:"TOKEN_SIGNING_KEY_ID, default=v1"`
+	TokenIssuer       string `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
+}

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -41,7 +41,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		}
 
 		// Get the public key for the token.
-		publicKey, err := c.pubKeyCache.GetPublicKey(ctx, c.config.TokenSigningKey, c.kms)
+		publicKey, err := c.pubKeyCache.GetPublicKey(ctx, c.config.TokenSigning.TokenSigningKey, c.kms)
 		if err != nil {
 			c.logger.Errorw("failed to get public key", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())

--- a/pkg/controller/certapi/signers.go
+++ b/pkg/controller/certapi/signers.go
@@ -42,16 +42,16 @@ func (c *Controller) getSignerForRealm(ctx context.Context, authApp *database.Au
 
 			if !realm.UseRealmCertificateKey {
 				// This realm is using the system key.
-				signer, err := c.kms.NewSigner(ctx, c.config.VerificationSettings.CertificateSigningKey)
+				signer, err := c.kms.NewSigner(ctx, c.config.CertificateSigning.CertificateSigningKey)
 				if err != nil {
 					return nil, fmt.Errorf("unable to get signing key from key manager: realmId: %v: %w", sRealmID, err)
 				}
 				return &SignerInfo{
 					Signer:   signer,
-					KeyID:    c.config.VerificationSettings.CertificateSigningKeyID,
-					Issuer:   c.config.VerificationSettings.CertificateIssuer,
-					Audience: c.config.VerificationSettings.CertificateAudience,
-					Duration: c.config.VerificationSettings.CertificateDuration,
+					KeyID:    c.config.CertificateSigning.CertificateSigningKeyID,
+					Issuer:   c.config.CertificateSigning.CertificateIssuer,
+					Audience: c.config.CertificateSigning.CertificateAudience,
+					Duration: c.config.CertificateSigning.CertificateDuration,
 				}, nil
 			}
 

--- a/pkg/controller/realmkeys/render.go
+++ b/pkg/controller/realmkeys/render.go
@@ -69,12 +69,12 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 
 	if !realm.UseRealmCertificateKey {
 		// load the system information.
-		m["certIssuer"] = c.config.VerificationSettings.CertificateIssuer
-		m["certAudience"] = c.config.VerificationSettings.CertificateAudience
-		m["certDuration"] = c.config.VerificationSettings.CertificateDuration
-		m["certKeyID"] = c.config.VerificationSettings.CertificateSigningKeyID
+		m["certIssuer"] = c.config.CertificateSigning.CertificateIssuer
+		m["certAudience"] = c.config.CertificateSigning.CertificateAudience
+		m["certDuration"] = c.config.CertificateSigning.CertificateDuration
+		m["certKeyID"] = c.config.CertificateSigning.CertificateSigningKeyID
 		// Download and PEM encode the public key.
-		publicKey, err := c.publicKeyCache.GetPublicKey(ctx, c.config.VerificationSettings.CertificateSigningKey, c.db.KeyManager())
+		publicKey, err := c.publicKeyCache.GetPublicKey(ctx, c.config.CertificateSigning.CertificateSigningKey, c.db.KeyManager())
 		if err != nil {
 			m["certPublicKeyError"] = fmt.Sprintf("Error loading public key: %v", err)
 		} else {

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -80,7 +80,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		}
 
 		// Get the signer based on Key configuration.
-		signer, err := c.kms.NewSigner(ctx, c.config.TokenSigningKey)
+		signer, err := c.kms.NewSigner(ctx, c.config.TokenSigning.TokenSigningKey)
 		if err != nil {
 			c.logger.Errorw("failed to get signer", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
@@ -118,15 +118,15 @@ func (c *Controller) HandleVerify() http.Handler {
 		subject := verificationToken.Subject()
 		now := time.Now().UTC()
 		claims := &jwt.StandardClaims{
-			Audience:  c.config.TokenIssuer,
+			Audience:  c.config.TokenSigning.TokenIssuer,
 			ExpiresAt: now.Add(c.config.VerificationTokenDuration).Unix(),
 			Id:        verificationToken.TokenID,
 			IssuedAt:  now.Unix(),
-			Issuer:    c.config.TokenIssuer,
+			Issuer:    c.config.TokenSigning.TokenIssuer,
 			Subject:   subject.String(),
 		}
 		token := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
-		token.Header[verifyapi.KeyIDHeader] = c.config.TokenSigningKeyID
+		token.Header[verifyapi.KeyIDHeader] = c.config.TokenSigning.TokenSigningKeyID
 		signedJWT, err := jwthelper.SignJWT(token, signer)
 		if err != nil {
 			c.logger.Errorw("failed to sign token", "error", err)

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -42,7 +42,7 @@ type Config struct {
 
 	// Keys is the key management configuration. This is used to resolve values
 	// that are encrypted via a KMS.
-	Keys keys.Config
+	Keys keys.Config `env:",prefix=DB_"`
 
 	// The KMS managed KeyRing that per-realm certificate signing keys are
 	// created on.

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -31,6 +31,7 @@ locals {
   }
 
   database_config = {
+    DB_KEY_MANAGER                    = "GOOGLE_CLOUD_KMS"
     DB_APIKEY_DATABASE_KEY            = "secret://${google_secret_manager_secret_version.db-apikey-db-hmac.id}"
     DB_APIKEY_SIGNATURE_KEY           = "secret://${google_secret_manager_secret_version.db-apikey-sig-hmac.id}"
     DB_ENCRYPTION_KEY                 = google_kms_crypto_key.database-encrypter.self_link
@@ -67,9 +68,12 @@ locals {
   }
 
   signing_config = {
+    CERTIFICATE_KEY_MANAGER     = "GOOGLE_CLOUD_KMS"
     CERTIFICATE_SIGNING_KEY     = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")
-    TOKEN_SIGNING_KEY           = trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")
     CERTIFICATE_SIGNING_KEYRING = google_kms_key_ring.verification.self_link
+
+    TOKEN_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
+    TOKEN_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")
   }
 }
 


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Create separate key manager instances instead of using a shared pool. This changes the configuration to require a prefix on the key managers (e.g. TOKEN_KEY_MANAGER and CERTIFICATE_KEY_MANAGER) if you are overriding the defaults.
```

/assign @mikehelmick 