### PR TITLE
Add middleware for setting HSTS headers

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -117,6 +117,12 @@ func realMain(ctx context.Context) error {
 	}
 	rateLimit := httplimiter.Handle
 
+	// Install HSTS headers in production
+	if !config.DevMode {
+		addHSTS := middleware.AddHSTS(ctx)
+		r.Use(addHSTS)
+	}
+
 	// Create the renderer
 	h, err := render.New(ctx, "", config.DevMode)
 	if err != nil {

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -130,6 +130,12 @@ func realMain(ctx context.Context) error {
 	}
 	rateLimit := httplimiter.Handle
 
+	// Install HSTS headers in production
+	if !config.DevMode {
+		addHSTS := middleware.AddHSTS(ctx)
+		r.Use(addHSTS)
+	}
+
 	// Create the renderer
 	h, err := render.New(ctx, "", config.DevMode)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -152,6 +152,12 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create limiter middleware: %w", err)
 	}
 
+	// Install HSTS headers in production
+	if !config.DevMode {
+		addHSTS := middleware.AddHSTS(ctx)
+		r.Use(addHSTS)
+	}
+
 	// Install the CSRF protection middleware.
 	configureCSRF := middleware.ConfigureCSRF(ctx, config, h)
 	r.Use(configureCSRF)

--- a/pkg/controller/middleware/hsts.go
+++ b/pkg/controller/middleware/hsts.go
@@ -1,0 +1,53 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"github.com/gorilla/mux"
+)
+
+// AddHSTS adds the required HSTS headers to the response. You should only
+// enable this middlware in production systems.
+func AddHSTS(ctx context.Context) mux.MiddlewareFunc {
+	logger := logging.FromContext(ctx).Named("middleware.AddHSTS")
+
+	writeHeader := func(w http.ResponseWriter) {
+		w.Header().Add("Strict-Transport-Security", "max-age=63072000; includeSubDomains; preload")
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Add the HSTS header before sending the first byte
+			bfbw := &beforeFirstByteWriter{
+				w: w,
+				before: func() error {
+					writeHeader(w)
+					return nil
+				},
+				logger: logger,
+			}
+
+			next.ServeHTTP(bfbw, r)
+
+			// Ensure the header is written on empty responses
+			writeHeader(w)
+		})
+	}
+}


### PR DESCRIPTION
Fixes GH-381

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set HSTS headers in production service
```
