### PR TITLE
Use a form (not ajax) for invalidating codes

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -142,7 +142,7 @@ func realMain(ctx context.Context) error {
 
 	codeStatusController := codestatus.NewAPI(ctx, config, db, h)
 	r.Handle("/api/checkcodestatus", codeStatusController.HandleCheckCodeStatus()).Methods("POST")
-	r.Handle("/api/expirecode", codeStatusController.HandleExpire()).Methods("POST")
+	r.Handle("/api/expirecode", codeStatusController.HandleExpireAPI()).Methods("POST")
 
 	srv, err := server.New(config.Port)
 	if err != nil {

--- a/cmd/server/assets/codestatus/_codescripts.html
+++ b/cmd/server/assets/codestatus/_codescripts.html
@@ -2,7 +2,7 @@
 <script type="text/javascript">
   // element is expected to be a jquery element or dom query selector, ts is
   // the number of seconds since epoch, UTC.
-  function countdown(element, ts) {
+  function countdown(element, ts, expiredCallback) {
     if (typeof (ts) === 'undefined') {
       return;
     }
@@ -49,7 +49,7 @@
     };
 
     // Fire once so the time is displayed immediately.
-    setTimeOrExpired($element, formattedTime())
+    setTimeOrExpired($element, formattedTime(), expiredCallback);
 
     // Set timer.
     const fn = setInterval(function() {
@@ -57,20 +57,22 @@
       if (!time) {
         clearInterval(fn);
       }
-      setTimeOrExpired($element, time)
+      setTimeOrExpired($element, time, expiredCallback);
     }, 1000);
 
-    return fn
+    return fn;
   }
 
-  function setTimeOrExpired(element, time) {
-    if (!time) {
-      element.html('<strong>EXPIRED</strong>');
-      return
-    }
+  const countdownExpired = '<strong>EXPIRED</strong>';
 
-    let text = `Expires in ${time}`.trim();
-    element.html(text);
+  function setTimeOrExpired(element, time, expiredCallback) {
+    if (!time) {
+      if (typeof expiredCallback === 'function') {
+        expiredCallback();
+      }
+      return element.html(countdownExpired);
+    }
+    return element.html(`Expires in ${time}`.trim());
   }
 </script>
 {{end}}

--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -42,6 +42,10 @@
         <h5 class="mb-1">Expiry</h5>
         <span id="code-expires-at" class="sm text-danger"></span>
       </div>
+      <form id="expireForm" action="/expire" method="POST">
+        <input type="hidden" name="uuid" value="{{.code.UUID}}" />
+        <button type="submit" id="invalidate" class="btn btn-danger btn-sm">Invalidate code now</button>
+      </form>
     </div>
 
     <div>

--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -42,28 +42,32 @@
         <h5 class="mb-1">Expiry</h5>
         <span id="code-expires-at" class="sm text-danger"></span>
       </div>
-      <form id="expireForm" action="/expire" method="POST">
-        <input type="hidden" name="uuid" value="{{.code.UUID}}" />
-        <button type="submit" id="invalidate" class="btn btn-danger btn-sm">Invalidate code now</button>
-      </form>
+      <div class="card-body">
+        <form action="/code/expire" method="POST">
+          {{ .csrfField }}
+          <input type="hidden" id="uuid" name="uuid" value="{{.code.UUID}}" />
+          <button type="submit" id="invalidate" class="btn btn-danger btn-sm">Invalidate code now</button>
+        </form>
+      </div>
     </div>
 
-    <div>
-      <a href="/code/status">&larr; Enter another code</a>
-    </div>
+    <a href="/code/status" class="card-link">&larr; Enter another code</a>
   </main>
 
   {{template "scripts" .}}
   {{template "codescripts" .}}
 
   <script type="text/javascript">
-    let $codeExpiresAt;
+    let $buttonInvalidate = $('button#invalidate');
     let expires = {{ .code.Expires }};
 
     $(function() {
-      $codeExpiresAt = $('#code-expires-at');
+      let $codeExpiresAt = $('#code-expires-at');
       // Start countdown
-      countdown($codeExpiresAt, expires);
+      countdown($codeExpiresAt, expires, function() {
+        // Disable the submit if already expired.
+        $buttonInvalidate.prop('disabled', true);
+      });
     });
   </script>
 </body>

--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -43,9 +43,9 @@
         <span id="code-expires-at" class="sm text-danger"></span>
       </div>
       <div class="card-body">
-        <form action="/code/expire" method="POST">
+        <form action="/code/{{.code.UUID}}/expire" method="POST">
+          <input type="hidden" name="_method" value="PATCH">
           {{ .csrfField }}
-          <input type="hidden" id="uuid" name="uuid" value="{{.code.UUID}}" />
           <button type="submit" id="invalidate" class="btn btn-danger btn-sm">Invalidate code now</button>
         </form>
       </div>

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -242,6 +242,7 @@ func realMain(ctx context.Context) error {
 		codeStatusController := codestatus.NewServer(ctx, config, db, h)
 		sub.Handle("/status", codeStatusController.HandleIndex()).Methods("GET")
 		sub.Handle("/show", codeStatusController.HandleShow()).Methods("POST")
+		sub.Handle("/expire", codeStatusController.HandleExpirePage()).Methods("POST")
 	}
 
 	// apikeys

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -242,7 +242,7 @@ func realMain(ctx context.Context) error {
 		codeStatusController := codestatus.NewServer(ctx, config, db, h)
 		sub.Handle("/status", codeStatusController.HandleIndex()).Methods("GET")
 		sub.Handle("/show", codeStatusController.HandleShow()).Methods("POST")
-		sub.Handle("/expire", codeStatusController.HandleExpirePage()).Methods("POST")
+		sub.Handle("/{uuid}/expire", codeStatusController.HandleExpirePage()).Methods("PATCH")
 	}
 
 	// apikeys

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -21,9 +21,10 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-func (c *Controller) HandleExpire() http.Handler {
+func (c *Controller) HandleExpireAPI() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		var request api.ExpireCodeRequest
 		if err := controller.BindJSON(w, r, &request); err != nil {
@@ -49,5 +50,48 @@ func (c *Controller) HandleExpire() http.Handler {
 				ExpiresAtTimestamp:     code.ExpiresAt.UTC().Unix(),
 				LongExpiresAtTimestamp: code.ExpiresAt.UTC().Unix(),
 			})
+	})
+}
+
+func (c *Controller) HandleExpirePage() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		var code *database.VerificationCode
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		retCode := Code{}
+
+		var form FormData
+		if err := controller.BindForm(w, r, &form); err != nil {
+			flash.Error("Failed to process form: %v.", err)
+			c.renderStatus(ctx, w, code)
+			return
+		}
+
+		// Retrieve once to check permissions.
+
+		code, _, apiErr := c.CheckCodeStatus(r, form.UUID)
+		if apiErr != nil {
+			flash.Error("failed to expire code", apiErr.Error)
+			c.renderStatus(ctx, w, code)
+			return
+		}
+
+		expiredCode, err := c.db.ExpireCode(form.UUID)
+		if err != nil {
+			flash.Error("Failed to process form: %v.", err)
+			expiredCode = code
+		} else {
+			flash.Alert("Expired code.")
+		}
+
+		c.responseCode(ctx, r, expiredCode, &retCode)
+		c.renderShow(ctx, w, retCode)
 	})
 }

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -56,7 +56,7 @@ func (c *Controller) HandleExpireAPI() http.Handler {
 func (c *Controller) HandleExpirePage() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		var code *database.VerificationCode
+		var code database.VerificationCode
 
 		session := controller.SessionFromContext(ctx)
 		if session == nil {
@@ -70,7 +70,7 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error("Failed to process form: %v.", err)
-			c.renderStatus(ctx, w, code)
+			c.renderStatus(ctx, w, &code)
 			return
 		}
 
@@ -79,14 +79,14 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		code, _, apiErr := c.CheckCodeStatus(r, form.UUID)
 		if apiErr != nil {
 			flash.Error("failed to expire code", apiErr.Error)
-			c.renderStatus(ctx, w, code)
+			c.renderStatus(ctx, w, &code)
 			return
 		}
 
 		expiredCode, err := c.db.ExpireCode(form.UUID)
 		if err != nil {
 			flash.Error("Failed to process form: %v.", err)
-			expiredCode = code
+			expiredCode = &code
 		} else {
 			flash.Alert("Expired code.")
 		}

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -21,7 +21,6 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 )
 
@@ -66,11 +65,7 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		}
 		flash := controller.Flash(session)
 
-		code := &database.VerificationCode{}
-		retCode := Code{}
-
 		// Retrieve once to check permissions.
-
 		code, _, apiErr := c.CheckCodeStatus(r, vars["uuid"])
 		if apiErr != nil {
 			flash.Error("failed to expire code", apiErr.Error)
@@ -86,6 +81,7 @@ func (c *Controller) HandleExpirePage() http.Handler {
 			flash.Alert("Expired code.")
 		}
 
+		retCode := Code{}
 		c.responseCode(ctx, r, expiredCode, &retCode)
 		c.renderShow(ctx, w, retCode)
 	})

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -68,7 +68,7 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		// Retrieve once to check permissions.
 		code, _, apiErr := c.CheckCodeStatus(r, vars["uuid"])
 		if apiErr != nil {
-			flash.Error("failed to expire code", apiErr.Error)
+			flash.Error("Failed to expire code: %v.", apiErr.Error)
 			c.renderStatus(ctx, w, code)
 			return
 		}

--- a/pkg/controller/codestatus/expire.go
+++ b/pkg/controller/codestatus/expire.go
@@ -54,9 +54,13 @@ func (c *Controller) HandleExpireAPI() http.Handler {
 }
 
 func (c *Controller) HandleExpirePage() http.Handler {
+	type FormData struct {
+		UUID string `form:"uuid"`
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		var code database.VerificationCode
+		var code *database.VerificationCode = &database.VerificationCode{}
 
 		session := controller.SessionFromContext(ctx)
 		if session == nil {
@@ -70,7 +74,7 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error("Failed to process form: %v.", err)
-			c.renderStatus(ctx, w, &code)
+			c.renderStatus(ctx, w, code)
 			return
 		}
 
@@ -79,14 +83,14 @@ func (c *Controller) HandleExpirePage() http.Handler {
 		code, _, apiErr := c.CheckCodeStatus(r, form.UUID)
 		if apiErr != nil {
 			flash.Error("failed to expire code", apiErr.Error)
-			c.renderStatus(ctx, w, &code)
+			c.renderStatus(ctx, w, code)
 			return
 		}
 
 		expiredCode, err := c.db.ExpireCode(form.UUID)
 		if err != nil {
 			flash.Error("Failed to process form: %v.", err)
-			expiredCode = &code
+			expiredCode = code
 		} else {
 			flash.Alert("Expired code.")
 		}

--- a/pkg/controller/codestatus/show.go
+++ b/pkg/controller/codestatus/show.go
@@ -25,11 +25,11 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-type FormData struct {
-	UUID string `form:"uuid"`
-}
-
 func (c *Controller) HandleShow() http.Handler {
+	type FormData struct {
+		UUID string `form:"uuid"`
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a button to an invalidate endpoint that sets the code to expire now
* Alternative to ajax https://github.com/google/exposure-notifications-verification-server/pull/373 
* @sethvargo may have suggestions to make this look nicer

![Screenshot from 2020-08-26 17-50-16](https://user-images.githubusercontent.com/36240966/91370974-ad943900-e7c4-11ea-9ef2-fdd16a55cef3.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow users to expire a code
```
