### PR TITLE
Set 1m idle timeout on Redis connections

### DIFF
--- a/pkg/redis/config.go
+++ b/pkg/redis/config.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redis defines redis-specific configurations.
+package redis
+
+import (
+	"time"
+)
+
+// Config defines the default redis configuration and env processing.
+type Config struct {
+	Host     string `env:"REDIS_HOST, default=127.0.0.1"`
+	Port     string `env:"REDIS_PORT, default=6379"`
+	Username string `env:"REDIS_USERNAME"`
+	Password string `env:"REDIS_PASSWORD"`
+
+	IdleTimeout time.Duration `env:"REDIS_IDLE_TIMEOUT, default=1m"`
+	MaxIdle     int           `env:"REDIS_MAX_IDLE, default=16"`
+	MaxActive   int           `env:"REDIS_MAX_ACTIVE, default=64"`
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -164,11 +164,15 @@ export FIREBASE_MESSAGE_SENDER_ID="${data.google_firebase_web_app_config.default
 export FIREBASE_PROJECT_ID="${google_firebase_web_app.default.project}"
 export FIREBASE_STORAGE_BUCKET="${data.google_firebase_web_app_config.default.storage_bucket}"
 
+export CACHE_TYPE="REDIS"
+export CACHE_REDIS_HOST="${google_redis_instance.cache.host}"
+export CACHE_REDIS_PORT="${google_redis_instance.cache.port}"
+
 export RATE_LIMIT_TYPE="REDIS"
 export RATE_LIMIT_TOKENS="60"
 export RATE_LIMIT_INTERVAL="1m"
-export REDIS_HOST="${google_redis_instance.cache.host}"
-export REDIS_PORT="${google_redis_instance.cache.port}"
+export RATE_LIMIT_REDIS_HOST="${google_redis_instance.cache.host}"
+export RATE_LIMIT_REDIS_PORT="${google_redis_instance.cache.port}"
 
 export CERTIFICATE_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
 export TOKEN_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")}"

--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -106,7 +106,7 @@ resource "google_cloud_run_service" "adminapi" {
             local.cache_config,
             local.database_config,
             local.gcp_config,
-            local.redis_config,
+            local.rate_limit_config,
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "adminapi", {}),

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -113,7 +113,7 @@ resource "google_cloud_run_service" "apiserver" {
             local.database_config,
             local.firebase_config,
             local.gcp_config,
-            local.redis_config,
+            local.rate_limit_config,
             local.signing_config,
 
             // This MUST come last to allow overrides!

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -145,7 +145,7 @@ resource "google_cloud_run_service" "server" {
             local.database_config,
             local.firebase_config,
             local.gcp_config,
-            local.redis_config,
+            local.rate_limit_config,
             local.session_config,
             local.signing_config,
 

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -26,8 +26,9 @@ locals {
   }
 
   cache_config = {
-    CACHE_TYPE          = "REDIS"
-    CACHE_REDIS_ADDRESS = "${google_redis_instance.cache.host}:${google_redis_instance.cache.port}"
+    CACHE_TYPE       = "REDIS"
+    CACHE_REDIS_HOST = google_redis_instance.cache.host
+    CACHE_REDIS_PORT = google_redis_instance.cache.port
   }
 
   database_config = {
@@ -57,14 +58,12 @@ locals {
     FIREBASE_STORAGE_BUCKET    = lookup(data.google_firebase_web_app_config.default, "storage_bucket")
   }
 
-  redis_config = {
-    RATE_LIMIT_TYPE     = "REDIS"
-    RATE_LIMIT_TOKENS   = "60"
-    RATE_LIMIT_INTERVAL = "1m"
-    REDIS_HOST          = google_redis_instance.cache.host
-    REDIS_PORT          = google_redis_instance.cache.port
-    REDIS_MIN_POOL      = 32
-    REDIS_MAX_POOL      = 128
+  rate_limit_config = {
+    RATE_LIMIT_TYPE       = "REDIS"
+    RATE_LIMIT_TOKENS     = "60"
+    RATE_LIMIT_INTERVAL   = "1m"
+    RATE_LIMIT_REDIS_HOST = google_redis_instance.cache.host
+    RATE_LIMIT_REDIS_PORT = google_redis_instance.cache.port
   }
 
   signing_config = {


### PR DESCRIPTION
Centralize our Redis configuration and set a 1m idle timeout on all Redis connections

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set a 1m idle timeout on all Redis connections. `REDIS_HOST` and `REDIS_PORT` are now prefixed based on their scope (e.g. `CACHE_REDIS_HOST` and `RATE_LIMIT_REDIS_HOST`). This enables using a different Redis cluster or configuration for rate limiting vs caching.
```

/assign @mikehelmick 
/assign @icco 