### PR TITLE
Fix cleanup failure logic

### DIFF
--- a/pkg/database/cleanup.go
+++ b/pkg/database/cleanup.go
@@ -47,8 +47,8 @@ func (db *Database) CreateCleanup(cType string) (*CleanupStatus, error) {
 		NotBefore:  time.Now().UTC(),
 	}
 	if err := db.db.
-		Set("gorm:insert_option", "ON CONFLICT (uix_cleanup_statuses_type) DO NOTHING RETURNING *").
-		Create(cstat).
+		Set("gorm:insert_option", "ON CONFLICT (type) DO NOTHING").
+		FirstOrCreate(cstat).
 		Error; err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Fixes GH-401

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix SQL error in cleanup logic
```
