### PR TITLE
fix db connection var

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -45,7 +45,7 @@ locals {
     DB_SSLROOTCERT                    = "secret://${google_secret_manager_secret_version.db-secret-version["sslrootcert"].id}?target=file"
     DB_USER                           = google_sql_user.user.name
     DB_VERIFICATION_CODE_DATABASE_KEY = "secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
-    DB_CONNECTION_KEEPALIVE_TIME      = "1m"
+    DB_MAX_CONN_IDLE_TIME             = "1m"
   }
 
   firebase_config = {


### PR DESCRIPTION
**Release Note**

removes unused one, and sets another (although this is currently the default value)

```release-note
NONE
```
