### PR TITLE
Configure max lifetime idle timeout too

### DIFF
--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -26,16 +26,21 @@ import (
 
 // Config represents the env var based configuration for database connections.
 type Config struct {
-	Name                  string        `env:"DB_NAME" json:",omitempty"`
-	User                  string        `env:"DB_USER" json:",omitempty"`
-	Host                  string        `env:"DB_HOST, default=localhost" json:",omitempty"`
-	Port                  string        `env:"DB_PORT, default=5432" json:",omitempty"`
-	SSLMode               string        `env:"DB_SSLMODE, default=require" json:",omitempty"`
-	ConnectionTimeout     uint          `env:"DB_CONNECT_TIMEOUT" json:",omitempty"`
-	Password              string        `env:"DB_PASSWORD" json:"-"` // ignored by zap's JSON formatter
-	SSLCertPath           string        `env:"DB_SSLCERT" json:",omitempty"`
-	SSLKeyPath            string        `env:"DB_SSLKEY" json:",omitempty"`
-	SSLRootCertPath       string        `env:"DB_SSLROOTCERT" json:",omitempty"`
+	Name              string `env:"DB_NAME" json:",omitempty"`
+	User              string `env:"DB_USER" json:",omitempty"`
+	Host              string `env:"DB_HOST, default=localhost" json:",omitempty"`
+	Port              string `env:"DB_PORT, default=5432" json:",omitempty"`
+	SSLMode           string `env:"DB_SSLMODE, default=require" json:",omitempty"`
+	ConnectionTimeout uint   `env:"DB_CONNECT_TIMEOUT" json:",omitempty"`
+	Password          string `env:"DB_PASSWORD" json:"-"` // ignored by zap's JSON formatter
+	SSLCertPath       string `env:"DB_SSLCERT" json:",omitempty"`
+	SSLKeyPath        string `env:"DB_SSLKEY" json:",omitempty"`
+	SSLRootCertPath   string `env:"DB_SSLROOTCERT" json:",omitempty"`
+
+	// MaxConnectionLifetime and MaxConnectionIdleTime determine the connection
+	// configuration. Note that MaxConnectionIdleTime must be less than
+	// MaxConnectionLifetime.
+	MaxConnectionLifetime time.Duration `env:"DB_MAX_CONN_LIFETIME, default=5m" json:",omitempty"`
 	MaxConnectionIdleTime time.Duration `env:"DB_MAX_CONN_IDLE_TIME, default=1m" json:",omitempty"`
 
 	// Debug is a boolean that indicates whether the database should log SQL

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -45,7 +45,6 @@ locals {
     DB_SSLROOTCERT                    = "secret://${google_secret_manager_secret_version.db-secret-version["sslrootcert"].id}?target=file"
     DB_USER                           = google_sql_user.user.name
     DB_VERIFICATION_CODE_DATABASE_KEY = "secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
-    DB_MAX_CONN_IDLE_TIME             = "1m"
   }
 
   firebase_config = {


### PR DESCRIPTION
Per https://golang.org/src/database/sql/sql.go?s=24445:25000#L871, the
idle conn timeout is only observed if the max conn timeout is also set.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow configuring database max lifetime idle timeout
```

/assign @mikehelmick 