### PR TITLE
pkg/controller/issueapi: fix json parsing of tzOffset

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -104,8 +104,8 @@ type IssueCodeRequest struct {
 	TestType    string `json:"testType"`
 	// Offset in minutes of the user's timezone. Positive, negative, 0, or omitted
 	// (using the default of 0) are all valid. 0 is considered to be UTC.
-	TZOffset int    `json:"tzOffset"`
-	Phone    string `json:"phone"`
+	TZOffset float32 `json:"tzOffset"`
+	Phone    string  `json:"phone"`
 }
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.

--- a/pkg/clients/apis.go
+++ b/pkg/clients/apis.go
@@ -31,7 +31,7 @@ func IssueCode(ctx context.Context, hostname string, apiKey, testType, symptomDa
 	request := api.IssueCodeRequest{
 		TestType:    testType,
 		SymptomDate: symptomDate,
-		TZOffset:    tzMinOffset,
+		TZOffset:    float32(tzMinOffset),
 	}
 	client := &http.Client{
 		Timeout: timeout,

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -172,7 +172,7 @@ func (c *Controller) HandleIssue() http.Handler {
 				maxDate := time.Now().UTC().Truncate(24 * time.Hour)
 				minDate := maxDate.Add(-1 * c.config.GetAllowedSymptomAge()).Truncate(24 * time.Hour)
 
-				symptomDate, err = validateDate(parsed, minDate, maxDate, request.TZOffset)
+				symptomDate, err = validateDate(parsed, minDate, maxDate, int(request.TZOffset))
 				if err != nil {
 					err := fmt.Errorf("symptom onset date must be on/after %v and on/before %v %v",
 						minDate.Format("2006-01-02"),


### PR DESCRIPTION
Not all browsers send timezone offsets as integers.

Updates #63

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fix tzoffset parsing by changing the type to float, and passing it correctly around.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE

```
