### PR TITLE
Add default envvar values to e2e-runner service

### DIFF
--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -76,6 +76,8 @@ locals {
   }
 
   e2e_runner_config = {
+    HEALTH_AUTHORITY_CODE = "com.example"
+    KEY_SERVER = "https://example.com/v1/publish"
     VERIFICATION_ADMIN_API = google_cloud_run_service.adminapi.status.0.url
     VERIFICATION_SERVER_API = google_cloud_run_service.apiserver.status.0.url
   }


### PR DESCRIPTION
This allows `terraform apply` to proceed without error.

**Release Note**

```release-note
NONE
```
