### PR TITLE
add sys admin screen for creating realms

### DIFF
--- a/cmd/server/assets/admin/new.html
+++ b/cmd/server/assets/admin/new.html
@@ -14,7 +14,7 @@
   <main role="main" class="container">
     {{template "flash" .}}
 
-    <h1>New Realm</h1>
+    <h1>New realm</h1>
     <p>
       Use the form below to create a new realm.
     </p>
@@ -38,7 +38,7 @@
           </div>
 
           <div class="form-group row">
-            <label for="name" class="col-sm-3">Region Code:</label>
+            <label for="name" class="col-sm-3">Region code:</label>
             <div class="col-sm-9">
               <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}">
               {{if $realm.ErrorsFor "regionCode"}}
@@ -46,11 +46,17 @@
                 {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
               </div>
               {{end}}
+              <small class="form-text text-muted">
+                Used in creating deep link SMS for multi-helath authority apps. Region should
+                be <a href="https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes">ISO 3166-1 country codes and ISO 3166-2 subdivision codes</a> where applicable.
+                For example, Washington State would be <code>US-WA</code>.
+              </small>
             </div>
           </div>
 
+          {{if .supportsPerRealmSigning}}
           <div class="form-group row">
-            <label for="type" class="col-sm-3">Certificate Signing Keys:</label>
+            <label for="type" class="col-sm-3">Certificate signing keys:</label>
             <div class="col-sm-9">
               <select class="form-control{{if $realm.ErrorsFor "UseRealmCertificateKey"}} is-invalid{{end}}" name="useRealmCertificateKey" id="useRealmCertificateKey">
                 <option value="true" {{if $realm.UseRealmCertificateKey}}selected{{end}}>Create realm specific signing key</option>
@@ -61,8 +67,14 @@
                 {{joinStrings ($realm.ErrorsFor "UseRealmCertificateKey") ", "}}
               </div>
               {{end}}
+              <small class="form-text text-muted">
+                It is recommended that you create a realm specific signing key when creating a new realm. However, it
+                is important to note that this once a realm is created, you cannot switch back to using the system
+                signing key.
+              </small>
             </div>
           </div>
+          {{end}}
 
           <div class="form-group row">
             <label for="name" class="col-sm-3">Issuer (iss):</label>

--- a/cmd/server/assets/admin/new.html
+++ b/cmd/server/assets/admin/new.html
@@ -28,7 +28,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-3">Name:</label>
             <div class="col-sm-9">
-              <input type="text" id="name" name="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}" value="{{$realm.Name}}">
+              <input type="text" id="name" name="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}" value="{{$realm.Name}}" />
               {{if $realm.ErrorsFor "name"}}
               <div class="invalid-feedback">
                 {{joinStrings ($realm.ErrorsFor "name") ", "}}
@@ -40,7 +40,7 @@
           <div class="form-group row">
             <label for="name" class="col-sm-3">Region code:</label>
             <div class="col-sm-9">
-              <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}">
+              <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}" />
               {{if $realm.ErrorsFor "regionCode"}}
               <div class="invalid-feedback">
                 {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
@@ -74,30 +74,37 @@
               </small>
             </div>
           </div>
-          {{end}}
-
+          
           <div class="form-group row">
             <label for="name" class="col-sm-3">Issuer (iss):</label>
-            <div class="input-group col-sm-9">
-              <input type="text" id="certificateIssuer" name="certificateIssuer" class="form-control text-monospace" value="{{$realm.CertificateIssuer}}" />
+            <div class="col-sm-9">
+              <input type="text" id="certificateIssuer" name="certificateIssuer" class="form-control{{if $realm.ErrorsFor "certificateIssuer"}} is-invalid{{end}}" value="{{$realm.CertificateIssuer}}" />
               {{if $realm.ErrorsFor "certificateIssuer"}}
                 <div class="invalid-feedback">
                   {{joinStrings ($realm.ErrorsFor "certificateIssuer") ", "}}
                 </div>
               {{end}}
+              <small class="form-text text-muted">
+                This value is specific to the health authority.<br/>After created using realm specific keys, this field cannot be changed.
+              </small>
             </div>
           </div>
           <div class="form-group row">
             <label for="name" class="col-sm-3">Audience (aud):</label>
-            <div class="input-group col-sm-9">
-              <input type="text" id="certificateAudiance" name="certificateAudiance" class="form-control text-monospace" value="{{$realm.CertificateAudience}}" />
+            <div class="col-sm-9">
+              <input type="text" id="certificateAudiance" name="certificateAudiance" class="form-control{{if $realm.ErrorsFor "certificateAudience"}} is-invalid{{end}}" value="{{$realm.CertificateAudience}}" />
               {{if $realm.ErrorsFor "certificateAudience"}}
                 <div class="invalid-feedback">
                   {{joinStrings ($realm.ErrorsFor "certificateAudience") ", "}}
                 </div>
               {{end}}
+              <small class="form-text text-muted">
+                The audience (<tt>aud</tt>) value is provided the <em>key server</em> operator.<br/>
+                After upgrading to use realm specific keys, this field cannot be changed.
+              </small>
             </div>
           </div>
+          {{end}}
 
           <div class="form-group row">
             <div class="offset-sm-3 col-sm-9">

--- a/cmd/server/assets/admin/new.html
+++ b/cmd/server/assets/admin/new.html
@@ -1,0 +1,103 @@
+{{define "admin/newrealm"}}
+
+{{$realm := .realm}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>New Realm</h1>
+    <p>
+      Use the form below to create a new realm.
+    </p>
+
+    <div class="card mb-3">
+      <div class="card-header">Details</div>
+      <div class="card-body">
+        <form method="POST" action="/admin/realms/create">
+          {{ .csrfField }}
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Name:</label>
+            <div class="col-sm-9">
+              <input type="text" id="name" name="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}" value="{{$realm.Name}}">
+              {{if $realm.ErrorsFor "name"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "name") ", "}}
+              </div>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Region Code:</label>
+            <div class="col-sm-9">
+              <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}">
+              {{if $realm.ErrorsFor "regionCode"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
+              </div>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="type" class="col-sm-3">Certificate Signing Keys:</label>
+            <div class="col-sm-9">
+              <select class="form-control{{if $realm.ErrorsFor "UseRealmCertificateKey"}} is-invalid{{end}}" name="useRealmCertificateKey" id="useRealmCertificateKey">
+                <option value="true" {{if $realm.UseRealmCertificateKey}}selected{{end}}>Create realm specific signing key</option>
+                <option value="false" {{if not $realm.UseRealmCertificateKey}}selected{{end}}>Use system signing key</option>
+              </select>
+              {{if $realm.ErrorsFor "UseRealmCertificateKey"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "UseRealmCertificateKey") ", "}}
+              </div>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Issuer (iss):</label>
+            <div class="input-group col-sm-9">
+              <input type="text" id="certificateIssuer" name="certificateIssuer" class="form-control text-monospace" value="{{$realm.CertificateIssuer}}" />
+              {{if $realm.ErrorsFor "certificateIssuer"}}
+                <div class="invalid-feedback">
+                  {{joinStrings ($realm.ErrorsFor "certificateIssuer") ", "}}
+                </div>
+              {{end}}
+            </div>
+          </div>
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Audience (aud):</label>
+            <div class="input-group col-sm-9">
+              <input type="text" id="certificateAudiance" name="certificateAudiance" class="form-control text-monospace" value="{{$realm.CertificateAudience}}" />
+              {{if $realm.ErrorsFor "certificateAudience"}}
+                <div class="invalid-feedback">
+                  {{joinStrings ($realm.ErrorsFor "certificateAudience") ", "}}
+                </div>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <div class="offset-sm-3 col-sm-9">
+              <button type="submit" class="btn btn-primary btn-block">Create realm</button>
+            </div>
+          </div>
+        </form>
+      </div>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/admin/realms.html
+++ b/cmd/server/assets/admin/realms.html
@@ -1,0 +1,53 @@
+{{define "admin/realms"}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Realms</h1>
+    <p>
+       These are the currently available realms. You can also <a href="/admin/realms/create">create a new realm</a>.
+    </p>
+    
+    {{if .realms}}
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped">
+        <thead>
+          <tr>
+            <th scope="col">Name</th>
+            <th scope="col" width="25">Region Code</th>
+            <th scope="col" width="50">Signing Key</th>
+          </tr>
+        </thead>
+        <tbody>
+        {{range .realms}}
+          <tr>
+              <td>{{.Name}}</td>
+              <td>{{.RegionCode}}</td>
+              <td>
+                  {{if .UseRealmCertificateKey}}Realm{{else}}System{{end}}
+              </td>
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <p class="text-center">
+      <em>There are no realms.</em>
+    </p>
+    {{end}}
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/admin/realms.html
+++ b/cmd/server/assets/admin/realms.html
@@ -23,8 +23,8 @@
         <thead>
           <tr>
             <th scope="col">Name</th>
-            <th scope="col" width="25">Region Code</th>
-            <th scope="col" width="50">Signing Key</th>
+            <th scope="col" width="25">Region code</th>
+            <th scope="col" width="50">Signing key</th>
           </tr>
         </thead>
         <tbody>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -189,6 +189,12 @@
               {{end}}
               {{end}}
 
+              {{if .currentUser.Admin}}
+              <h6 class="dropdown-header">System Admin</h6>
+              <a class="dropdown-item" href="/admin/realms">Realms</a>
+              <div class="dropdown-divider"></div>
+              {{end}}
+              
               <h6 class="dropdown-header">Actions</h6>
               {{if gt (len .currentUser.Realms) 1}}
               <a class="dropdown-item" href="/realm">Change realm</a>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -190,7 +190,7 @@
               {{end}}
 
               {{if .currentUser.Admin}}
-              <h6 class="dropdown-header">System Admin</h6>
+              <h6 class="dropdown-header">System admin</h6>
               <a class="dropdown-item" href="/admin/realms">Realms</a>
               <div class="dropdown-divider"></div>
               {{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -346,7 +346,7 @@ func realMain(ctx context.Context) error {
 		adminSub.Use(requireSystemAdmin)
 		adminSub.Use(rateLimit)
 
-		adminController := admin.New(ctx, config, cacher, db, h)
+		adminController := admin.New(ctx, config, db, h)
 		adminSub.Handle("/realms", adminController.HandleIndex()).Methods("GET")
 		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("GET")
 		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("POST")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codestatus"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/home"
@@ -180,6 +181,7 @@ func realMain(ctx context.Context) error {
 	requireVerified := middleware.RequireVerified(ctx, auth, db, h, config.SessionDuration)
 	requireAdmin := middleware.RequireRealmAdmin(ctx, h)
 	requireRealm := middleware.RequireRealm(ctx, cacher, db, h)
+	requireSystemAdmin := middleware.RequireAdmin(ctx, h)
 	rateLimit := httplimiter.Handle
 
 	{
@@ -334,6 +336,20 @@ func realMain(ctx context.Context) error {
 			return fmt.Errorf("failed to create jwks controller: %w", err)
 		}
 		jwksSub.Handle("/{realm}", jwksController.HandleIndex()).Methods("GET")
+	}
+
+	// System admin.
+	{
+		adminSub := r.PathPrefix("/admin").Subrouter()
+		adminSub.Use(requireAuth)
+		adminSub.Use(requireVerified)
+		adminSub.Use(requireSystemAdmin)
+		adminSub.Use(rateLimit)
+
+		adminController := admin.New(ctx, config, cacher, db, h)
+		adminSub.Handle("/realms", adminController.HandleIndex()).Methods("GET")
+		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("GET")
+		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("POST")
 	}
 
 	// Wrap the main router in the mutating middleware method. This cannot be

--- a/pkg/controller/admin/admin.go
+++ b/pkg/controller/admin/admin.go
@@ -37,7 +37,7 @@ type Controller struct {
 }
 
 func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).Named("admin")
 
 	return &Controller{
 		config: config,

--- a/pkg/controller/admin/admin.go
+++ b/pkg/controller/admin/admin.go
@@ -1,0 +1,49 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package admin contains controllers for system wide administrative actions.
+package admin
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	config *config.ServerConfig
+	cacher cache.Cacher
+	db     *database.Database
+	h      *render.Renderer
+	logger *zap.SugaredLogger
+}
+
+func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
+	logger := logging.FromContext(ctx)
+
+	return &Controller{
+		config: config,
+		cacher: cacher,
+		db:     db,
+		h:      h,
+		logger: logger,
+	}
+}

--- a/pkg/controller/admin/admin.go
+++ b/pkg/controller/admin/admin.go
@@ -18,7 +18,6 @@ package admin
 import (
 	"context"
 
-	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -30,18 +29,16 @@ import (
 
 type Controller struct {
 	config *config.ServerConfig
-	cacher cache.Cacher
 	db     *database.Database
 	h      *render.Renderer
 	logger *zap.SugaredLogger
 }
 
-func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
+func New(ctx context.Context, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx).Named("admin")
 
 	return &Controller{
 		config: config,
-		cacher: cacher,
 		db:     db,
 		h:      h,
 		logger: logger,

--- a/pkg/controller/admin/create_realm.go
+++ b/pkg/controller/admin/create_realm.go
@@ -102,5 +102,6 @@ func (c *Controller) HandleCreateRealm() http.Handler {
 func (c *Controller) renderNew(ctx context.Context, w http.ResponseWriter, realm *database.Realm) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["realm"] = realm
+	m["supportsPerRealmSigning"] = c.db.SupportsPerRealmSigning()
 	c.h.RenderHTML(w, "admin/newrealm", m)
 }

--- a/pkg/controller/admin/create_realm.go
+++ b/pkg/controller/admin/create_realm.go
@@ -1,0 +1,106 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func (c *Controller) HandleCreateRealm() http.Handler {
+	type FormData struct {
+		Name                   string `form:"name"`
+		RegionCode             string `form:"regionCode"`
+		UseRealmCertificateKey bool   `form:"useRealmCertificateKey"`
+		CertificateIssuer      string `form:"certificateIssuer"`
+		CertificateAudience    string `form:"certificateAudiance"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+
+		user := controller.UserFromContext(ctx)
+		if user == nil {
+			controller.MissingUser(w, r, c.h)
+			return
+		}
+
+		flash := controller.Flash(session)
+
+		// Requested form, stop processing.
+		if r.Method == http.MethodGet {
+			var realm database.Realm
+			realm.UseRealmCertificateKey = true
+			c.renderNew(ctx, w, &realm)
+			return
+		}
+
+		var form FormData
+		if err := controller.BindForm(w, r, &form); err != nil {
+			var realm database.Realm
+			realm.UseRealmCertificateKey = true
+			flash.Error("Failed to process form: %v", err)
+			c.renderNew(ctx, w, &realm)
+			return
+		}
+
+		realm := database.NewRealmWithDefaults(form.Name)
+		realm.RegionCode = form.RegionCode
+		realm.UseRealmCertificateKey = form.UseRealmCertificateKey
+		realm.CertificateIssuer = form.CertificateIssuer
+		realm.CertificateAudience = form.CertificateAudience
+
+		user.Realms = append(user.Realms, realm)
+		user.AdminRealms = append(user.AdminRealms, realm)
+
+		if err := c.db.SaveUser(user); err != nil {
+			flash.Error("Failed to create realm: %v", err)
+			c.renderNew(ctx, w, realm)
+			return
+		}
+		flash.Alert("Created realm: %q. You have been made an admin of the realm.", realm.Name)
+
+		// Remove this user from the cache so that the allowed realms will be reloaded.
+		c.cacher.Delete(ctx, user.CacheKey())
+
+		if realm.UseRealmCertificateKey {
+			// If we are using realm specific keys - we need to create the first one.
+			keyID, err := realm.CreateSigningKeyVersion(ctx, c.db)
+			if err != nil {
+				flash.Error("Failed to create signing keys for realm. This can be done from the realm's admin screens.")
+				http.Redirect(w, r, "/admin/realms", http.StatusSeeOther)
+				return
+			}
+			flash.Alert("Created initial signing key for realm, id: %q", keyID)
+		}
+
+		http.Redirect(w, r, "/admin/realms", http.StatusSeeOther)
+	})
+}
+
+func (c *Controller) renderNew(ctx context.Context, w http.ResponseWriter, realm *database.Realm) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["realm"] = realm
+	c.h.RenderHTML(w, "admin/newrealm", m)
+}

--- a/pkg/controller/admin/index.go
+++ b/pkg/controller/admin/index.go
@@ -1,0 +1,37 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+func (c *Controller) HandleIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		realms, err := c.db.GetRealms()
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		m := controller.TemplateMapFromContext(ctx)
+		m["realms"] = realms
+		c.h.RenderHTML(w, "admin/realms", m)
+	})
+}

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -95,7 +95,6 @@ func (c *Controller) HandleCreate() http.Handler {
 			c.renderNew(ctx, w, user)
 			return
 		}
-		c.cacher.Delete(ctx, user.CacheKey())
 
 		flash.Alert("Successfully created user '%v'", form.Name)
 		http.Redirect(w, r, "/users", http.StatusSeeOther)

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -68,6 +68,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		// See if the user already exists by email - they may be a member of another
 		// realm.
 		user, err := c.db.FindUserByEmail(form.Email)
+		alreadyExists := true
 		if err != nil {
 			if !database.IsNotFound(err) {
 				controller.InternalError(w, r, c.h, err)
@@ -75,11 +76,14 @@ func (c *Controller) HandleCreate() http.Handler {
 			}
 
 			user = new(database.User)
+			alreadyExists = false
 		}
 
-		// Build the user struct
-		user.Email = form.Email
-		user.Name = form.Name
+		// Build the user struct - keeping email and name if user already exists in another realm.
+		if !alreadyExists {
+			user.Email = form.Email
+			user.Name = form.Name
+		}
 		user.Realms = append(user.Realms, realm)
 
 		if form.Admin {
@@ -91,6 +95,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			c.renderNew(ctx, w, user)
 			return
 		}
+		c.cacher.Delete(ctx, user.CacheKey())
 
 		flash.Alert("Successfully created user '%v'", form.Name)
 		http.Redirect(w, r, "/users", http.StatusSeeOther)

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -440,9 +440,6 @@ func (db *Database) GetRealms() ([]*Realm, error) {
 }
 
 func (db *Database) SaveRealm(r *Realm) error {
-	if r.Model.ID == 0 {
-		return db.db.Create(r).Error
-	}
 	return db.db.Save(r).Error
 }
 

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -35,6 +35,11 @@ type User struct {
 	AdminRealms     []*Realm `gorm:"many2many:admin_realms"`
 }
 
+// CacheKey returns the key for this user in the distributed cache.
+func (u *User) CacheKey() string {
+	return fmt.Sprintf("users:by_email:%s", u.Email)
+}
+
 // BeforeSave runs validations. If there are errors, the save fails.
 func (u *User) BeforeSave(tx *gorm.DB) error {
 	u.Email = strings.TrimSpace(u.Email)

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -35,11 +35,6 @@ type User struct {
 	AdminRealms     []*Realm `gorm:"many2many:admin_realms"`
 }
 
-// CacheKey returns the key for this user in the distributed cache.
-func (u *User) CacheKey() string {
-	return fmt.Sprintf("users:by_email:%s", u.Email)
-}
-
 // BeforeSave runs validations. If there are errors, the save fails.
 func (u *User) BeforeSave(tx *gorm.DB) error {
 	u.Email = strings.TrimSpace(u.Email)


### PR DESCRIPTION

## Proposed Changes

* System admins can create new realms (very basic)
* clear user from cache when realms change - otherwise you can't select the new realm until record expires.

**Release Note**

```release-note
System admin page to create realms from the UI instead of command line tools.
```
