### PR TITLE
Support multiple custom domains

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -166,9 +166,10 @@ resource "google_compute_backend_service" "adminapi" {
 }
 
 resource "google_cloud_run_domain_mapping" "adminapi" {
-  count    = var.adminapi_custom_domain != "" ? 1 : 0
+  for_each = var.adminapi_custom_domains
+
   location = var.cloudrun_location
-  name     = var.adminapi_custom_domain
+  name     = each.key
 
   metadata {
     namespace = var.project

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -174,9 +174,10 @@ resource "google_compute_backend_service" "apiserver" {
 }
 
 resource "google_cloud_run_domain_mapping" "apiserver" {
-  count    = var.apiserver_custom_domain != "" ? 1 : 0
+  for_each = var.apiserver_custom_domains
+
   location = var.cloudrun_location
-  name     = var.apiserver_custom_domain
+  name     = each.key
 
   metadata {
     namespace = var.project

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -207,9 +207,10 @@ resource "google_compute_backend_service" "server" {
 }
 
 resource "google_cloud_run_domain_mapping" "server" {
-  count    = var.server_custom_domain != "" ? 1 : 0
+  for_each = var.server_custom_domains
+
   location = var.cloudrun_location
-  name     = var.server_custom_domain
+  name     = each.key
 
   metadata {
     namespace = var.project

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -134,25 +134,25 @@ variable "redis_cache_size" {
   description = "Size of the Redis instance in GB."
 }
 
-variable "adminapi_custom_domain" {
-  type    = string
-  default = ""
+variable "adminapi_custom_domains" {
+  type    = set(string)
+  default = []
 
-  description = "Custom domain to map for adminapi. This domain must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance. If not provided, no domain mapping is created."
+  description = "Custom domains to map for adminapi. These domains must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance."
 }
 
-variable "apiserver_custom_domain" {
-  type    = string
-  default = ""
+variable "apiserver_custom_domains" {
+  type    = set(string)
+  default = []
 
-  description = "Custom domain to map for apiserver. This domain must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance. If not provided, no domain mapping is created."
+  description = "Custom domains to map for apiserver. These domains must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance."
 }
 
-variable "server_custom_domain" {
-  type    = string
-  default = ""
+variable "server_custom_domains" {
+  type    = set(string)
+  default = []
 
-  description = "Custom domain to map for server. This domain must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance. If not provided, no domain mapping is created."
+  description = "Custom domains to map for server. These domains must already be verified by Google, and you must have a DNS CNAME record pointing to ghs.googlehosted.com in advance."
 }
 
 variable "server-host" {


### PR DESCRIPTION
This allows us to assign multiple domains to a single service.

**Release Note**

```release-note
BREAKING CHANGE! `*_custom_domain` are now `*_custom_domains` in Terraform and the type has changed from `string` to `set(string)` to support specifying multiple domains mapped to a single service.
```
