### PR TITLE
Add per realm stats

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -184,6 +184,7 @@
               <a class="dropdown-item" href="/apikeys">API keys</a>
               <a class="dropdown-item" href="/realm/keys">Signing keys</a>
               <a class="dropdown-item" href="/users">Users</a>
+              <a class="dropdown-item" href="/realm/stats">Statistics</a>
               <a class="dropdown-item" href="/realm/settings">Settings</a>
               <div class="dropdown-divider"></div>
               {{end}}

--- a/cmd/server/assets/realmstats.html
+++ b/cmd/server/assets/realmstats.html
@@ -1,0 +1,64 @@
+{{define "realmstats"}}
+
+{{$realm := .realm}}
+{{$stats := .stats}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Realm stats</h1>
+
+    <div class="card mb-3">
+      <div class="card-header">Statistics</div>
+      <div class="card-body table-responsive">
+        {{if $stats}}
+        <div id="chart" style="height: 300px;">
+          <span>Loading chart...</span>
+        </div>
+        {{else}}
+          <p>No codes have been issued in this realm.</p>
+        {{end}}
+      </div>
+    </div>
+
+  </main>
+
+  {{template "scripts" .}}
+
+  {{if $stats}}
+  <script src="https://www.gstatic.com/charts/loader.js"></script>
+  <script>
+    google.charts.load('current', {packages: ['line']});
+    google.charts.setOnLoadCallback(drawChart)
+
+    function drawChart() {
+      var data = google.visualization.arrayToDataTable([
+        ['Date', 'Issued', "Claimed"],
+        {{range $stat := $stats}}
+        ['{{$stat.Date.Format "Jan 2"}}', {{$stat.CodesIssued}}, {{$stat.CodesClaimed}}],
+        {{end}}
+      ]);
+
+      var options = {
+        colors: ['#007bff', '#ff7b00'],
+        legend: {position: 'left'},
+        tooltip: {trigger: 'focus'},
+      };
+
+      var chart = new google.charts.Line(document.getElementById('chart'));
+      chart.draw(data, options);
+    }
+  </script>
+  {{end}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -37,6 +37,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realm"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmstats"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit/limitware"
@@ -316,6 +317,9 @@ func realMain(ctx context.Context) error {
 		realmSub.Handle("/settings/save", realmadminController.HandleSave()).Methods("POST")
 		realmSub.Handle("/settings/enable-express", realmadminController.HandleEnableExpress()).Methods("POST")
 		realmSub.Handle("/settings/disable-express", realmadminController.HandleDisableExpress()).Methods("POST")
+
+		realmStatsController := realmstats.New(ctx, db, h)
+		realmSub.Handle("/stats", realmStatsController.HandleIndex()).Methods("GET")
 
 		realmKeysController, err := realmkeys.New(ctx, config, db, certificateSigner, h)
 		if err != nil {

--- a/pkg/controller/realmstats/index.go
+++ b/pkg/controller/realmstats/index.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realmstats
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func (c *Controller) HandleIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		today := time.Now().Truncate(24 * time.Hour)
+		nago := today.Add(-30 * 24 * time.Hour).Truncate(24 * time.Hour)
+		stats, err := realm.Stats(c.db, nago, today)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.renderShow(ctx, w, realm, stats)
+	})
+}
+
+func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, realm *database.Realm, stats []*database.RealmStats) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["realm"] = realm
+	m["stats"] = stats
+
+	// Valid settings for code parameters.
+	c.h.RenderHTML(w, "realmstats", m)
+}

--- a/pkg/controller/realmstats/realmstats.go
+++ b/pkg/controller/realmstats/realmstats.go
@@ -1,0 +1,43 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package realmstats contains web controllers for changing realm stats.
+package realmstats
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	db     *database.Database
+	h      *render.Renderer
+	logger *zap.SugaredLogger
+}
+
+func New(ctx context.Context, db *database.Database, h *render.Renderer) *Controller {
+	logger := logging.FromContext(ctx).Named("realmstats")
+
+	return &Controller{
+		db:     db,
+		h:      h,
+		logger: logger,
+	}
+}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -863,6 +863,31 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00035-AddRealmStats",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("db migrations: adding realm stats")
+				if err := tx.AutoMigrate(&RealmStats{}).Error; err != nil {
+					return err
+				}
+				statements := []string{
+					"CREATE UNIQUE INDEX IF NOT EXISTS idx_realm_stats_stats_date_realm_id ON realm_stats (date, realm_id)",
+					"CREATE INDEX IF NOT EXISTS idx_realm_stats_date ON realm_stats (date)",
+				}
+				for _, sql := range statements {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				if err := tx.DropTable(&RealmStats{}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+		},
 	})
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -608,3 +608,27 @@ func (r *Realm) DestroySigningKeyVersion(ctx context.Context, db *Database, id i
 
 	return nil
 }
+
+// Stats returns the usage statistics for this realm. If no stats exist,
+// returns an empty array.
+func (r *Realm) Stats(db *Database, start, stop time.Time) ([]*RealmStats, error) {
+	var stats []*RealmStats
+
+	start = start.Truncate(24 * time.Hour)
+	stop = stop.Truncate(24 * time.Hour)
+
+	if err := db.db.
+		Model(&RealmStats{}).
+		Where("realm_id = ?", r.ID).
+		Where("(date >= ? AND date <= ?)", start, stop).
+		Order("date ASC").
+		Find(&stats).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return stats, nil
+		}
+		return nil, err
+	}
+
+	return stats, nil
+}

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -1,0 +1,32 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+)
+
+// RealmStats represents statistics related to a user in the database.
+type RealmStats struct {
+	Date         time.Time `gorm:"date; not null"`
+	RealmID      uint      `gorm:"realm_id; not null"`
+	CodesIssued  uint      `gorm:"codes_issued; default: 0"`
+	CodesClaimed uint      `gorm:"codes_claimed; default: 0"`
+}
+
+// TableName sets the RealmStats table name
+func (RealmStats) TableName() string {
+	return "realm_stats"
+}

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -183,23 +183,16 @@ func (db *Database) VerifyCodeAndIssueToken(realmID uint, verCode string, accept
 			return err
 		}
 
-		if expired, err := db.IsCodeExpired(&vc, verCode); err != nil {
-			db.logger.Debugw("error checking code expiration", "error", err)
-			return ErrVerificationCodeExpired
-		} else if expired {
-			return ErrVerificationCodeExpired
-		}
-
-		if vc.Claimed {
-			return ErrVerificationCodeUsed
-		}
-
 		if _, ok := acceptTypes[vc.TestType]; !ok {
 			return ErrUnsupportedTestType
 		}
 
+		// And mark as claimed.
+		if err := vc.claim(db, tx, verCode, realmID); err != nil {
+			return err
+		}
+
 		// Mark claimed. Transactional update.
-		vc.Claimed = true
 		if err := tx.Save(&vc).Error; err != nil {
 			return err
 		}


### PR DESCRIPTION
Adds per realm stats, and a simple visualization of the codes issued and
claimed for the past month.

Fixes #410

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds per-realm stats, and a simple visualization of the last 30 days of issued and claimed codes.
```
