### PR TITLE
Restore the old API key code

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,6 +61,11 @@ const (
 type ErrorReturn struct {
 	Error     string `json:"error"`
 	ErrorCode string `json:"errorCode"`
+
+	// ErrorCodeLegacy exists to populate the JSON with a deprecated error_code
+	// key. This will be removed in a future version. Consumers should use
+	// `errorCode` instead.
+	ErrorCodeLegacy string `json:"error_code"`
 }
 
 // InternalError constructs a generic internal error.
@@ -85,6 +90,7 @@ func Error(err error) *ErrorReturn {
 // WithCode adds an error code to an ErrorReturn
 func (e *ErrorReturn) WithCode(code string) *ErrorReturn {
 	e.ErrorCode = code
+	e.ErrorCodeLegacy = code
 	return e
 }
 


### PR DESCRIPTION
Semi-revert of GH-239. This adds two "error" fields to our responses, but it's the best interim solution I can think of.

/assign @mikehelmick 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Temporarily return `error_code` and `errorCode` in API JSON responses for backwards compatibility. `error_code` will be removed in a future version.
```
