### PR TITLE
Fix intial container images path in terraform services

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -91,7 +91,7 @@ resource "google_cloud_run_service" "adminapi" {
       timeout_seconds      = 25
 
       containers {
-        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cmd/adminapi:initial"
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/adminapi:initial"
 
         resources {
           limits = {

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -97,7 +97,7 @@ resource "google_cloud_run_service" "apiserver" {
       timeout_seconds      = 25
 
       containers {
-        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cmd/apiserver:initial"
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/apiserver:initial"
 
         resources {
           limits = {

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -90,7 +90,7 @@ resource "google_cloud_run_service" "cleanup" {
       service_account_name = google_service_account.cleanup.email
 
       containers {
-        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cmd/cleanup:initial"
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cleanup:initial"
 
         resources {
           limits = {

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -128,7 +128,7 @@ resource "google_cloud_run_service" "server" {
       timeout_seconds      = 25
 
       containers {
-        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cmd/server:initial"
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/server:initial"
 
         resources {
           limits = {


### PR DESCRIPTION
Fixes #
Container images are not in sync with changes in builder scripts

Container images in terraform scripts are pointing towards an older path which was recently changed in cloud builders.

Old Path : gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/cmd/SERVICE-NAME:initial

New Path : Old Path : gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/SERVICE-NAME:initial




