### PR TITLE
Ensure Debugw always has the right number of fields

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -52,12 +52,12 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			Migrate: func(tx *gorm.DB) error {
 				// This is "out of order" as it were, but is needed to bootstrap fresh systems.
 				// Also in migration 8
-				logger.Debugw("db migrations: creating realms table")
+				logger.Debugw("creating realms table")
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
 					return err
 				}
 
-				logger.Debugw("db migrations: creating users table")
+				logger.Debugw("creating users table")
 				return tx.AutoMigrate(&User{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -70,7 +70,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00002-CreateVerificationCodes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: creating verification codes table")
+				logger.Debugw("creating verification codes table")
 				return tx.AutoMigrate(&VerificationCode{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -80,7 +80,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00003-CreateAuthorizedApps",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: creating authorized apps table")
+				logger.Debugw("creating authorized apps table")
 				return tx.AutoMigrate(&AuthorizedApp{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -90,7 +90,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00004-CreateTokens",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: creating tokens table")
+				logger.Debugw("creating tokens table")
 				return tx.AutoMigrate(&Token{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -100,7 +100,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00005-CreateCleanups",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: creating cleanup status table")
+				logger.Debugw("creating cleanup status table")
 				if err := tx.AutoMigrate(&CleanupStatus{}).Error; err != nil {
 					return err
 				}
@@ -117,30 +117,30 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00006-AddIndexes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: add users purge index")
+				logger.Debugw("add users purge index")
 				if err := tx.Model(&User{}).AddIndex("users_purge_index", "updated_at").Error; err != nil {
 					return err
 				}
-				logger.Debugw("db migrations: add verification code purge index")
+				logger.Debugw("add verification code purge index")
 				if err := tx.Model(&VerificationCode{}).AddIndex("ver_code_purge_index", "expires_at").Error; err != nil {
 					return err
 				}
-				logger.Debugw("db migrations: add tokens purge index")
+				logger.Debugw("add tokens purge index")
 				if err := tx.Model(&VerificationCode{}).AddIndex("token_purge_index", "expires_at").Error; err != nil {
 					return err
 				}
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: drop users purge index")
+				logger.Debugw("drop users purge index")
 				if err := tx.Model(&User{}).RemoveIndex("users_purge_index").Error; err != nil {
 					return err
 				}
-				logger.Debugw("db migrations: drop verification code purge index")
+				logger.Debugw("drop verification code purge index")
 				if err := tx.Model(&VerificationCode{}).RemoveIndex("ver_code_purge_index").Error; err != nil {
 					return err
 				}
-				logger.Debugw("db migrations: drop tokens purge index")
+				logger.Debugw("drop tokens purge index")
 				if err := tx.Model(&VerificationCode{}).RemoveIndex("token_purge_index").Error; err != nil {
 					return err
 				}
@@ -150,7 +150,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00007-AddSymptomOnset",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: rename test_date to symptom_date")
+				logger.Debugw("rename test_date to symptom_date")
 				// AutoMigrate will add missing fields.
 				if err := tx.AutoMigrate(&VerificationCode{}).Error; err != nil {
 					return err
@@ -174,7 +174,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: rename symptom_date to test_date")
+				logger.Debugw("rename symptom_date to test_date")
 				if err := tx.Model(&VerificationCode{}).DropColumn("symptom_date").Error; err != nil {
 					return err
 				}
@@ -187,7 +187,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00008-AddKeyTypes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: upgrading authorized_apps table.")
+				logger.Debugw("upgrading authorized_apps table.")
 				return tx.AutoMigrate(&AuthorizedApp{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -200,7 +200,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00009-AddIssuerColumns",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding issuer columns to issued codes")
+				logger.Debugw("adding issuer columns to issued codes")
 				return tx.AutoMigrate(&VerificationCode{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -216,7 +216,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00010-AddSMSConfig",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding sms_configs table")
+				logger.Debugw("adding sms_configs table")
 				return tx.AutoMigrate(&SMSConfig{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -226,12 +226,12 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00011-AddRealms",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: create realms table")
+				logger.Debugw("creating realms table")
 				// Add the realms table.
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
 					return err
 				}
-				logger.Debugw("Create the DEFAULT realm")
+				logger.Debugw("creating default realm")
 				// Create the default realm with all of the default settings.
 				defaultRealm := NewRealmWithDefaults("Default")
 				if err := tx.FirstOrCreate(defaultRealm).Error; err != nil {
@@ -239,17 +239,17 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				}
 
 				// Add realm relations to the rest of the tables.
-				logger.Debugw("Add RealmID to Users.")
+				logger.Debugw("adding RealmID to users")
 				if err := tx.AutoMigrate(&User{}).Error; err != nil {
 					return err
 				}
-				logger.Debugw("Join Users to Default Realm")
+				logger.Debugw("joining users to the default realm")
 				var users []*User
 				if err := tx.Find(&users).Error; err != nil {
 					return err
 				}
 				for _, u := range users {
-					logger.Debugw("added user: %v to default realm", u.ID)
+					logger.Debugw("adding user to default realm", "user", u.ID)
 
 					u.AddRealm(defaultRealm)
 					if u.Admin {
@@ -261,7 +261,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					}
 				}
 
-				logger.Debugw("Add RealmID to AuthorizedApps.")
+				logger.Debugw("adding RealmID to authorized_apps")
 				if err := tx.AutoMigrate(&AuthorizedApp{}).Error; err != nil {
 					return err
 				}
@@ -270,36 +270,36 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					return err
 				}
 				for _, a := range authApps {
-					logger.Debugw("added auth app: %v to default realm", a.Name)
+					logger.Debugw("added auth app to default realm", "app", a.Name)
 					a.RealmID = defaultRealm.ID
 					if err := tx.Save(a).Error; err != nil {
 						return err
 					}
 				}
 
-				logger.Debugw("Add RealmID to VerificationCodes.")
+				logger.Debugw("adding RealmID to VerificationCodes")
 				if err := tx.AutoMigrate(&VerificationCode{}).Error; err != nil {
 					return err
 				}
-				logger.Debugw("Join existing VerificationCodes to default realm")
+				logger.Debugw("joining existing VerificationCodes to default realm")
 				if err := tx.Exec("UPDATE verification_codes SET realm_id=?", defaultRealm.ID).Error; err != nil {
 					return err
 				}
 
-				logger.Debugw("Add RealmID to Tokens.")
+				logger.Debugw("adding RealmID to Tokens")
 				if err := tx.AutoMigrate(&Token{}).Error; err != nil {
 					return err
 				}
-				logger.Debugw("Join existing tokens to default realm")
+				logger.Debugw("joining existing tokens to default realm")
 				if err := tx.Exec("UPDATE tokens SET realm_id=?", defaultRealm.ID).Error; err != nil {
 					return err
 				}
 
-				logger.Debugw("Add RealmID to SMSConfig.")
+				logger.Debugw("adding RealmID to SMSConfig")
 				if err := tx.AutoMigrate(&SMSConfig{}).Error; err != nil {
 					return err
 				}
-				logger.Debugw("Join existing SMS config to default realm")
+				logger.Debugw("joining existing SMS config to default realm")
 				if err := tx.Exec("UPDATE sms_configs SET realm_id=?", defaultRealm.ID).Error; err != nil {
 					return err
 				}
@@ -354,7 +354,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00014-DropUserPurgeIndex",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: dropping user purge index=")
+				logger.Debugw("dropping user purge index")
 				sql := "DROP INDEX IF EXISTS users_purge_index"
 				return tx.Exec(sql).Error
 			},
@@ -365,7 +365,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00015-DropUserDisabled",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: dropping user disabled column")
+				logger.Debugw("dropping user disabled column")
 				sql := "ALTER TABLE users DROP COLUMN IF EXISTS disabled"
 				return tx.Exec(sql).Error
 			},
@@ -377,7 +377,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00016-MigrateSMSConfigs",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: migrating sms configs")
+				logger.Debugw("migrating sms configs")
 
 				var sms SMSConfig
 				rows, err := tx.Model(&SMSConfig{}).Rows()
@@ -417,7 +417,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00017-AddIssuerIDColumns",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding issuer id columns to verification codes")
+				logger.Debugw("adding issuer id columns to verification codes")
 				err := tx.AutoMigrate(&VerificationCode{}, &UserStats{}, &AuthorizedAppStats{}).Error
 				return err
 
@@ -438,7 +438,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00018-IncreaseAPIKeySize",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: increasing API key size")
+				logger.Debugw("increasing API key size")
 				sql := "ALTER TABLE authorized_apps ALTER COLUMN api_key TYPE varchar(512)"
 				return tx.Exec(sql).Error
 			},
@@ -450,7 +450,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00019-AddAPIKeyPreviewAuthApp",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: migrating authapp")
+				logger.Debugw("migrating authapp")
 				return tx.AutoMigrate(AuthorizedApp{}).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -460,7 +460,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00020-HMACAPIKeys",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: HMACing existing api keys")
+				logger.Debugw("HMACing existing api keys")
 
 				var apps []AuthorizedApp
 				if err := tx.Model(AuthorizedApp{}).Find(&apps).Error; err != nil {
@@ -495,7 +495,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00021-AddUUIDExtension",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding uuid extension")
+				logger.Debugw("adding uuid extension")
 				return tx.Exec("CREATE EXTENSION IF NOT EXISTS \"uuid-ossp\"").Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -505,7 +505,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00022-AddUUIDToVerificationCodes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: migrating verification code uuid")
+				logger.Debugw("migrating verification code uuid")
 
 				if err := tx.AutoMigrate(VerificationCode{}).Error; err != nil {
 					return fmt.Errorf("failed to auto migrate: %w", err)
@@ -532,7 +532,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00023-MakeUUIDVerificationCodesNotNull",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: making verification code uuid not null")
+				logger.Debugw("making verification code uuid not null")
 
 				if err := tx.Exec("ALTER TABLE verification_codes ALTER COLUMN uuid SET NOT NULL").Error; err != nil {
 					return fmt.Errorf("failed to set null: %w", err)
@@ -551,7 +551,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00024-AddTestTypesToRealms",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding test types to realm")
+				logger.Debugw("adding test types to realm")
 
 				sql := fmt.Sprintf("ALTER TABLE realms ADD COLUMN IF NOT EXISTS allowed_test_types INTEGER DEFAULT %d",
 					TestTypeConfirmed|TestTypeLikely|TestTypeNegative)
@@ -572,7 +572,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00025-SetTestTypesNotNull",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: setting test types to not-null")
+				logger.Debugw("setting test types to not-null")
 
 				if err := tx.Exec("ALTER TABLE realms ALTER COLUMN allowed_test_types SET NOT NULL").Error; err != nil {
 					return err
@@ -591,7 +591,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00026-EnableExtension_citext",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: enabling citext extension")
+				logger.Debugw("enabling citext extension")
 				return tx.Exec("CREATE EXTENSION citext").Error
 			},
 			Rollback: func(tx *gorm.DB) error {
@@ -601,7 +601,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00027-AlterColumns_citext",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: setting columns to case insensitive")
+				logger.Debugw("setting columns to case insensitive")
 				sqls := []string{
 					"ALTER TABLE authorized_apps ALTER COLUMN name TYPE CITEXT",
 					"ALTER TABLE realms ALTER COLUMN name TYPE CITEXT",
@@ -633,7 +633,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00028-AddSMSDeeplinkFields",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding long_code and SMS deeplink settings")
+				logger.Debugw("adding long_code and SMS deeplink settings")
 				// long_code cannot be auto migrated because of unique index.
 				// manually create long_code and long_expires_at and backfill with existing data.
 				sqls := []string{
@@ -657,7 +657,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					return err
 				}
 
-				logger.Debugw("db migrations: add verification code purge index")
+				logger.Debugw("add verification code purge index")
 				if err := tx.Model(&VerificationCode{}).AddIndex("ver_code_long_purge_index", "long_expires_at").Error; err != nil {
 					return err
 				}
@@ -685,7 +685,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00029-IncreaseVerificationCodeSizes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: increasing verification code sizes")
+				logger.Debugw("increasing verification code sizes")
 				sqls := []string{
 					"ALTER TABLE verification_codes ALTER COLUMN code TYPE varchar(512)",
 					"ALTER TABLE verification_codes ALTER COLUMN long_code TYPE varchar(512)",
@@ -715,7 +715,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00030-HMACCodes",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: HMACing existing tokens")
+				logger.Debugw("HMACing existing tokens")
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
 					return err
 				}
@@ -763,7 +763,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00031-AlterStatsColumns",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: changing stats columns")
+				logger.Debugw("changing stats columns")
 
 				sqls := []string{
 					// AuthorizedApps
@@ -815,7 +815,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00032-RegionCodeSize",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: increasing region code sizes")
+				logger.Debugw("increasing region code sizes")
 				sqls := []string{
 					"ALTER TABLE realms ALTER COLUMN region_code TYPE varchar(10)",
 				}
@@ -834,7 +834,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00033-PerlRealmSigningKeys",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding signing_keys table")
+				logger.Debugw("adding signing_keys table")
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
 					return err
 				}
@@ -852,7 +852,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 		{
 			ID: "00034-AddENExpressSettings",
 			Migrate: func(tx *gorm.DB) error {
-				logger.Debugw("db migrations: adding EN Express settings")
+				logger.Debugw("adding EN Express settings")
 				if err := tx.AutoMigrate(&Realm{}).Error; err != nil {
 					return err
 				}
@@ -868,9 +868,11 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 
 // MigrateTo migrates the database to a specific target migration ID.
 func (db *Database) MigrateTo(ctx context.Context, target string, rollback bool) error {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).Named("migrate")
+	ctx = logging.WithLogger(ctx, logger)
+
 	m := db.getMigrations(ctx)
-	logger.Debugw("database migrations started")
+	logger.Debugw("migrations starting")
 
 	var err error
 	if target == "" {
@@ -888,22 +890,24 @@ func (db *Database) MigrateTo(ctx context.Context, target string, rollback bool)
 	}
 
 	if err != nil {
-		logger.Errorf("database migrations failed: %v", err)
+		logger.Errorw("failed to migrate", "error", err)
 		return nil
 	}
-	logger.Debugw("database migrations completed")
+	logger.Debugw("migrations complete")
 	return nil
 }
 
 // RunMigrations will apply sequential, transactional migrations to the database
 func (db *Database) RunMigrations(ctx context.Context) error {
-	logger := logging.FromContext(ctx)
+	logger := logging.FromContext(ctx).Named("migrate")
+	ctx = logging.WithLogger(ctx, logger)
+
 	m := db.getMigrations(ctx)
-	logger.Debugw("database migrations started")
+	logger.Debugw("migrations starting")
 	if err := m.Migrate(); err != nil {
-		logger.Errorf("migrations failed: %v", err)
+		logger.Errorf("failed to migrate", "error", err)
 		return err
 	}
-	logger.Debugw("database migrations completed")
+	logger.Debugw("migrations complete")
 	return nil
 }


### PR DESCRIPTION
Apparently this turned into a panic instead of a silent failure in a recent version.

**Release Note**

```release-note
Fix migration logging
```

/cc @chaodaiG 