### PR TITLE
Terraform smoke test

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 *.tfvars
 terraform/state.tf
 terraform-e2e/state.tf
+*/crash.log
 
 # Local things
 bin/

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -20,6 +20,10 @@ set -eEuo pipefail
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 
 # TODO: use project pool for this
-export PROJECT_ID=poetic-inkwell-287516
+# PROW_JOB_ID is an env var set by prow, use project for prow when it's in prow
+if [[ -z "${PROJECT_ID:-}" && -n "${PROW_JOB_ID:-}" ]]; then
+    echo "Using project for prow since"
+    export PROJECT_ID=poetic-inkwell-287516
+fi
 
 ${ROOT}/scripts/terraform.sh smoke

--- a/scripts/e2e-test.sh
+++ b/scripts/e2e-test.sh
@@ -1,0 +1,25 @@
+
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eEuo pipefail
+
+ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+
+# TODO: use project pool for this
+export PROJECT_ID=poetic-inkwell-287516
+
+${ROOT}/scripts/terraform.sh smoke

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -eEuo pipefail
+
+PROGNAME="$(basename $0)"
+ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
+
+if [[ -z "${PROJECT_ID:-}" ]]; then
+  echo "✋ PROJECT_ID must be set"
+fi
+
+if [[ -z "${GOOGLE_APPLICATION_CREDENTIALS:-}" ]]; then
+  if [[ ! -f "${HOME}/.config/gcloud/application_default_credentials.json" ]]; then
+    echo "This is local development, authenticate using gcloud"
+    gcloud auth login
+    gcloud auth application-default login
+    gcloud auth application-default set-quota-project "${PROJECT_ID}"
+  fi
+else
+  echo "GOOGLE_APPLCIATION_CREDENTIALS defined, use it for authentication."
+  echo "For local development, run 'unset GOOGLE_APPLCIATION_CREDENTIALS', "
+  echo "then rerun this script"
+fi
+
+function deploy() {
+  pushd "${ROOT}/terraform-e2e" > /dev/null
+
+  # Preparing for deployment
+  echo "project = \"${PROJECT_ID}\"" > ./terraform.tfvars
+  # Don't fail if it already exists
+  gsutil mb -p ${PROJECT_ID} gs://${PROJECT_ID}-tf-state 2>/dev/null || true
+  cat <<EOF > "${ROOT}/terraform-e2e/state.tf"
+terraform {
+  backend "gcs" {
+    bucket = "${PROJECT_ID}-tf-state"
+  }
+}
+EOF
+
+  # google_app_engine_application.app is global, cannot be deleted once created,
+  # if this project already has it created then terraform apply will fail,
+  # importing it can solve this problem
+  terraform init
+  terraform import module.en.google_app_engine_application.app ${PROJECT_ID} || true
+  terraform import module.en.google_firebase_project.default ${PROJECT_ID} || true
+  # Terraform deployment might fail intermittently with certain cloud run 
+  # services not up, retry to make it more resilient
+  local failed=1
+  for i in 1 2 3; do
+    if [[ "${failed}" == "0" ]]; then
+      break
+    fi
+    if terraform apply -auto-approve; then
+      failed=0
+    fi
+  done
+  popd > /dev/null
+  return $failed
+}
+
+function destroy() {
+  pushd "${ROOT}/terraform-e2e" > /dev/null
+  local db_inst_name
+  db_inst_name="$(terraform output 'db_inst_name')"
+  # DB often failed to be destroyed by terraform due to "used by other process",
+  # so delete it manually
+  gcloud sql instances delete ${db_inst_name} -q --project=chao-en-e2e-exp
+  # Clean up states after manual DB delete
+  terraform state rm google_sql_user.user
+  terraform state rm google_sql_ssl_cert.db-cert
+  terraform destroy -auto-approve
+  popd > /dev/null
+}
+
+function smoke() {
+  # Best effort destroy before applying
+  destroy 2>/dev/null || true
+  deploy
+  trap "destroy || true" EXIT
+}
+
+# help prints help.
+function help() {
+  echo 1>&2 "Usage: ${PROGNAME} <command>"
+  echo 1>&2 ""
+  echo 1>&2 "Commands:"
+  echo 1>&2 "  deploy       deploy server"
+  echo 1>&2 "  destroy      destroy server"
+  echo 1>&2 "  smoke        deploy then destroy server"
+}
+
+case "${1:-}" in
+  "" | "help" | "-h" | "--help" )
+    help
+    ;;
+
+  "deploy" | "destroy" | "smoke" )
+    $1
+    ;;
+
+  *)
+    help
+    exit 1
+    ;;
+esac

--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -52,7 +52,7 @@ EOF
   # google_app_engine_application.app is global, cannot be deleted once created,
   # if this project already has it created then terraform apply will fail,
   # importing it can solve this problem
-  terraform init
+  terraform init -upgrade
   terraform get --update
   terraform import module.en.google_app_engine_application.app ${PROJECT_ID} || true
   terraform import module.en.google_firebase_project.default ${PROJECT_ID} || true

--- a/terraform-e2e/README.md
+++ b/terraform-e2e/README.md
@@ -4,6 +4,8 @@ This directory contains terraform configuration to be used for deploying verific
 
 ## Prerequisite
 
+Terraform version > 1.13.1
+
 Follow steps from [Terrafrom instructions](https://github.com/google/exposure-notifications-verification-server/tree/main/terraform), going through from top until finishing `Instructions` section, then change into `terraform-e2e` directory:
 
 ```shell

--- a/terraform-e2e/README.md
+++ b/terraform-e2e/README.md
@@ -47,7 +47,7 @@ This can be mitigated by updating terraform to version equal or greater than 1.1
 
 ## Terraform Destroy
 
-Terraform destroy often fails while trying to delete db instance. To be reliably successfully destroy, run these ahead:
+Terraform destroy always fails while trying to delete db instance. To be reliably successfully destroy, run these ahead:
 
 ```shell
 db_inst_name="$(terraform output 'db_inst_name')"

--- a/terraform-e2e/main.tf
+++ b/terraform-e2e/main.tf
@@ -35,8 +35,23 @@ module "en" {
 
   service_environment = {
     server = {
-      FIREBASE_PRIVACY_POLICY_URL   = "TODO"
-      FIREBASE_TERMS_OF_SERVICE_URL = "TODO"
+      FIREBASE_PRIVACY_POLICY_URL   = "https://policies.google.com/privacy"
+      FIREBASE_TERMS_OF_SERVICE_URL = "https://policies.google.com/terms"
+      LOG_DEBUG = "true"
+    }
+
+    apiserver = {
+      LOG_DEBUG = "true"
+    }
+
+    adminapi = {
+      LOG_DEBUG = "true"
+    }
+
+    e2e-runner = {
+      HEALTH_AUTHORITY_CODE = "e2e-test-only"
+      KEY_SERVER = "TODO"
+      LOG_DEBUG = "true"
     }
   }
 }

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -271,6 +271,7 @@ resource "null_resource" "migrate" {
       DB_USER                           = google_sql_user.user.name
       DB_VERIFICATION_CODE_DATABASE_KEY = "secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
       LOG_DEBUG                         = true
+      TAG                               = "initial"
     }
 
     command = "${path.module}/../scripts/migrate"
@@ -291,6 +292,10 @@ output "db_conn" {
 
 output "db_host" {
   value = google_sql_database_instance.db-inst.private_ip_address
+}
+
+output "db_inst_name" {
+  value = google_sql_database_instance.db-inst.name
 }
 
 output "db_name" {


### PR DESCRIPTION
Production code change
- Tag "migrate" image as "initial` just like the other images
- output `db_inst_name`

Test related changes:
- Add  a script for terraform smoke test
- Bring terraform-e2e module closer to the module used in prod

Note for code reviewer:
This PR overlaps a lot with it's peer PR in key server https://github.com/google/exposure-notifications-server/pull/948

/hold
Let's resolve https://github.com/google/exposure-notifications-server/pull/948 first