### PR TITLE
Add existing alerts to terraform

### DIFF
--- a/terraform/alerting/notifications.tf
+++ b/terraform/alerting/notifications.tf
@@ -1,0 +1,9 @@
+resource "google_monitoring_notification_channel" "email" {
+  provider     = google-beta
+  project      = var.project
+  display_name = "Email Notification Channel"
+  type         = "email"
+  labels = {
+    email_address = var.notification-email
+  }
+}

--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -1,0 +1,66 @@
+resource "google_monitoring_uptime_check_config" "https" {
+  for_each = toset([var.server-host, var.apiserver-host, var.adminapi-host])
+
+  display_name = each.key
+  timeout      = "3s"
+  project      = var.project
+  period       = "60s"
+
+  http_check {
+    path         = "/health"
+    port         = "443"
+    use_ssl      = true
+    validate_ssl = true
+  }
+
+  monitored_resource {
+    type = "uptime_url"
+    labels = {
+      project_id = var.project
+      host       = each.key
+    }
+  }
+}
+
+resource "google_monitoring_alert_policy" "probers" {
+  project      = var.project
+  display_name = "Host Down"
+  combiner     = "OR"
+  conditions {
+    display_name = "Host is unreachable"
+    condition_threshold {
+      duration        = "300s"
+      threshold_value = 0.2
+      comparison      = "COMPARISON_LT"
+      filter          = "metric.type=\"monitoring.googleapis.com/uptime_check/check_passed\" resource.type=\"uptime_url\""
+
+      aggregations {
+        alignment_period     = "60s"
+        cross_series_reducer = "REDUCE_FRACTION_TRUE"
+        group_by_fields = [
+          "resource.label.host",
+        ]
+        per_series_aligner = "ALIGN_NEXT_OLDER"
+      }
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = <<-EOT
+## $${policy.display_name}
+
+[$${resource.label.host}](https://$${resource.label.host}/health) is being reported unreachable.
+
+See [docs/hosts.md](https://github.com/sethvargo/exposure-notifications-server-infra/blob/main/docs/hosts.md) for information about hosts.
+EOT
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [
+    google_monitoring_notification_channel.email.id
+  ]
+}

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -1,0 +1,42 @@
+variable "project" {
+  type = string
+}
+
+variable "notification-email" {
+  type        = string
+  default     = "nobody@example.com"
+  description = "Email address for alerts"
+}
+
+variable "server-host" {
+  type        = string
+  default     = ""
+  description = "Domain web ui is hosted on."
+}
+
+variable "apiserver-host" {
+  type        = string
+  default     = ""
+  description = "Domain apiserver is hosted on."
+}
+
+variable "adminapi-host" {
+  type        = string
+  default     = ""
+  description = "Domain adminapi is hosted on."
+}
+
+terraform {
+  required_version = ">= 0.13"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.36"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.36"
+    }
+  }
+}


### PR DESCRIPTION
Begins #461

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a new terraform module you can include to get alerts

Example:
```
module "en-alerting" {
  source  = "github.com/google/exposure-notifications-verification-server/terraform/alerting"
  project = "example"

  adminapi-host  = "adminapi.example.org"
  apiserver-host = "apiserver.example.org"
  server-host    = "example.org"

  notification-email = "example+alert@google.com"
}
```

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
There is now an alerting module you can initialize to get alerts for server health.
```
