### PR TITLE
Add dashboards to be managed by Terraform.

### DIFF
--- a/terraform/alerting/dashboards/e2e.yaml
+++ b/terraform/alerting/dashboards/e2e.yaml
@@ -34,5 +34,5 @@ gridLayout:
                 | [resource.job]
         timeshiftDuration: 0s
         yAxis:
-          label: "y1Axis"
-          scale: "LINEAR"
+          label: y1Axis
+          scale: LINEAR

--- a/terraform/alerting/dashboards/e2e.yaml
+++ b/terraform/alerting/dashboards/e2e.yaml
@@ -1,0 +1,38 @@
+displayName: e2e
+gridLayout:
+  columns: 2
+  widgets:
+    - title: /api/issue/code_issued_count rate by job
+      xyChart:
+        chartOptions:
+          mode: COLOR
+        dataSets:
+          - plotType: LINE
+            timeSeriesQuery:
+              timeSeriesQueryLanguage: >
+                generic_task ::
+                custom.googleapis.com/opencensus/en-verification-server/api/issue/codes_issued_count
+                | align rate()
+                | every 1m
+                | [resource.job]
+        timeshiftDuration: 0s
+        yAxis:
+          label: y1Axis
+          scale: LINEAR
+    - title: /api/verify/attempt_count rate by job
+      xyChart:
+        chartOptions:
+          mode: COLOR
+        dataSets:
+          - plotType: LINE
+            timeSeriesQuery:
+              timeSeriesQueryLanguage: >
+                generic_task ::
+                custom.googleapis.com/opencensus/en-verification-server/api/verify/attempt_count
+                | align rate()
+                | every 1m
+                | [resource.job]
+        timeshiftDuration: 0s
+        yAxis:
+          label: "y1Axis"
+          scale: "LINEAR"

--- a/terraform/alerting/dashboards/e2e.yaml
+++ b/terraform/alerting/dashboards/e2e.yaml
@@ -15,10 +15,6 @@ gridLayout:
                 | align rate()
                 | every 1m
                 | [resource.job]
-        timeshiftDuration: 0s
-        yAxis:
-          label: y1Axis
-          scale: LINEAR
     - title: /api/verify/attempt_count rate by job
       xyChart:
         chartOptions:
@@ -32,7 +28,3 @@ gridLayout:
                 | align rate()
                 | every 1m
                 | [resource.job]
-        timeshiftDuration: 0s
-        yAxis:
-          label: y1Axis
-          scale: LINEAR

--- a/terraform/alerting/dashboards/verification-server.yaml
+++ b/terraform/alerting/dashboards/verification-server.yaml
@@ -1,0 +1,38 @@
+displayName: Verification Server
+gridLayout:
+  columns: 2
+  widgets:
+    - title: Cloud Run Revision - Request Count (grouped) [SUM]
+      xyChart:
+        chartOptions:
+          mode: COLOR
+        dataSets:
+          - plotType: LINE
+            timeSeriesQuery:
+              timeSeriesQueryLanguage: >
+                cloud_run_revision ::
+                run.googleapis.com/request_count
+                | align rate()
+                | every 1m
+                | [resource.service_name, metric.response_code_class]
+        timeshiftDuration: 0s
+        yAxis:
+          label: y1Axis
+          scale: LINEAR
+    - title: OpenCensus/en-verification-server/api/issue/attempt_count by label.job [SUM]
+      xyChart:
+        chartOptions:
+          mode: COLOR
+        dataSets:
+          - plotType: LINE
+            timeSeriesQuery:
+              timeSeriesQueryLanguage: >
+                generic_task ::
+                custom.googleapis.com/opencensus/en-verification-server/api/issue/attempt_count
+                | align rate()
+                | every 1m
+                | [resource.job]
+        timeshiftDuration: 0s
+        yAxis:
+          label: y1Axis
+          scale: LINEAR

--- a/terraform/alerting/dashboards/verification-server.yaml
+++ b/terraform/alerting/dashboards/verification-server.yaml
@@ -15,10 +15,6 @@ gridLayout:
                 | align rate()
                 | every 1m
                 | [resource.service_name, metric.response_code_class]
-        timeshiftDuration: 0s
-        yAxis:
-          label: y1Axis
-          scale: LINEAR
     - title: OpenCensus/en-verification-server/api/issue/attempt_count by label.job [SUM]
       xyChart:
         chartOptions:
@@ -32,7 +28,3 @@ gridLayout:
                 | align rate()
                 | every 1m
                 | [resource.job]
-        timeshiftDuration: 0s
-        yAxis:
-          label: y1Axis
-          scale: LINEAR

--- a/terraform/alerting/monitoring.tf
+++ b/terraform/alerting/monitoring.tf
@@ -1,0 +1,29 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_monitoring_dashboard" "verification-server" {
+  project        = var.project
+  dashboard_json = jsonencode(yamldecode(file("${path.module}/dashboards/verification-server.yaml")))
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace
+  ]
+}
+
+resource "google_monitoring_dashboard" "e2e" {
+  project        = var.project
+  dashboard_json = jsonencode(yamldecode(file("${path.module}/dashboards/e2e.yaml")))
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace
+  ]
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,16 +45,16 @@ resource "google_project_service" "services" {
     "firebase.googleapis.com",
     "iam.googleapis.com",
     "identitytoolkit.googleapis.com",
+    "monitoring.googleapis.com",
     "redis.googleapis.com",
     "run.googleapis.com",
     "secretmanager.googleapis.com",
     "servicenetworking.googleapis.com",
     "sql-component.googleapis.com",
     "sqladmin.googleapis.com",
+    "stackdriver.googleapis.com",
     "storage.googleapis.com",
     "vpcaccess.googleapis.com",
-    "monitoring.googleapis.com",
-    "stackdriver.googleapis.com",
   ])
   service            = each.value
   disable_on_destroy = false

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,6 +53,8 @@ resource "google_project_service" "services" {
     "sqladmin.googleapis.com",
     "storage.googleapis.com",
     "vpcaccess.googleapis.com",
+    "monitoring.googleapis.com",
+    "stackdriver.googleapis.com",
   ])
   service            = each.value
   disable_on_destroy = false


### PR DESCRIPTION
NOTE: the chart on metric
custom.googleapis.com/opencensus/en-verification-server/ratelimit/limitware/rate_limited_count
was removed as it's no longer exported by the code.

The API requires JSON config but writing multi-line strings in JSON is PITA. I've decided to write it in YAML which is more compact and easier to write multi-line queries.

Related issue: #460 

**Release Note**


```release-note
NONE
```
