### PR TITLE
Upgrade to Go 1.15.1

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -44,7 +44,7 @@ steps:
   - '-allow-failure'
 
 - id: 'download-modules'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'mod'
@@ -66,7 +66,7 @@ steps:
 # adminapi
 #
 - id: 'build-adminapi'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -92,7 +92,7 @@ steps:
 # apiserver
 #
 - id: 'build-apiserver'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -118,7 +118,7 @@ steps:
 # cleanup
 #
 - id: 'build-cleanup'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -144,7 +144,7 @@ steps:
 # e2e-runner
 #
 - id: 'build-e2e-runner'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -170,7 +170,7 @@ steps:
 # migrate
 #
 - id: 'build-migrate'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'
@@ -196,7 +196,7 @@ steps:
 # server
 #
 - id: 'build-server'
-  name: 'golang:1.15'
+  name: 'golang:1.15.1'
   args:
   - 'go'
   - 'build'

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/google/exposure-notifications-verification-server
 
-go 1.14
+go 1.15
 
 require (
 	cloud.google.com/go v0.65.0


### PR DESCRIPTION
Fixes GH-441

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Upgrade to Go 1.15.1
```
