### PR TITLE
Add middleware for debug headers

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -124,6 +124,10 @@ func realMain(ctx context.Context) error {
 	// Install common security headers
 	r.Use(middleware.SecureHeaders(ctx, config.DevMode, "json"))
 
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug(ctx)
+	r.Use(processDebug)
+
 	// Create the renderer
 	h, err := render.New(ctx, "", config.DevMode)
 	if err != nil {

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -137,6 +137,10 @@ func realMain(ctx context.Context) error {
 	// Install common security headers
 	r.Use(middleware.SecureHeaders(ctx, config.DevMode, "json"))
 
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug(ctx)
+	r.Use(processDebug)
+
 	// Create the renderer
 	h, err := render.New(ctx, "", config.DevMode)
 	if err != nil {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -169,6 +169,10 @@ func realMain(ctx context.Context) error {
 	// Install common security headers
 	r.Use(middleware.SecureHeaders(ctx, config.DevMode, "html"))
 
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug(ctx)
+	r.Use(processDebug)
+
 	// Install the CSRF protection middleware.
 	configureCSRF := middleware.ConfigureCSRF(ctx, config, h)
 	r.Use(configureCSRF)

--- a/pkg/controller/middleware/debug.go
+++ b/pkg/controller/middleware/debug.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
+	"github.com/gorilla/mux"
+)
+
+// ProcessDebug adds additional debugging information to the response if the
+// request included the "X-Debug" header with any value.
+func ProcessDebug(ctx context.Context) mux.MiddlewareFunc {
+	header := "x-debug"
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if r.Header.Get(header) != "" {
+				w.Header().Set("x-build-id", buildinfo.BuildID)
+				w.Header().Set("x-build-tag", buildinfo.BuildTag)
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/debug.go
+++ b/pkg/controller/middleware/debug.go
@@ -22,14 +22,14 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const HeaderDebug = "x-debug"
+
 // ProcessDebug adds additional debugging information to the response if the
 // request included the "X-Debug" header with any value.
 func ProcessDebug(ctx context.Context) mux.MiddlewareFunc {
-	header := "x-debug"
-
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-			if r.Header.Get(header) != "" {
+			if r.Header.Get(HeaderDebug) != "" {
 				w.Header().Set("x-build-id", buildinfo.BuildID)
 				w.Header().Set("x-build-tag", buildinfo.BuildTag)
 			}

--- a/pkg/controller/middleware/debug.go
+++ b/pkg/controller/middleware/debug.go
@@ -22,7 +22,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
-const HeaderDebug = "x-debug"
+const (
+	HeaderDebug         = "x-debug"
+	HeaderDebugBuildID  = "x-build-id"
+	HeaderDebugBuildTag = "x-build-tag"
+)
 
 // ProcessDebug adds additional debugging information to the response if the
 // request included the "X-Debug" header with any value.
@@ -30,8 +34,8 @@ func ProcessDebug(ctx context.Context) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			if r.Header.Get(HeaderDebug) != "" {
-				w.Header().Set("x-build-id", buildinfo.BuildID)
-				w.Header().Set("x-build-tag", buildinfo.BuildTag)
+				w.Header().Set(HeaderDebugBuildID, buildinfo.BuildID)
+				w.Header().Set(HeaderDebugBuildTag, buildinfo.BuildTag)
 			}
 
 			next.ServeHTTP(w, r)


### PR DESCRIPTION
If the request sends an x-debug header with any value, the response headers will be populated with the build ID and tag.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return build information in response headers if `X-Debug` is supplied as a request header
```

/cc @icco 