### PR TITLE
Acquire a lock before registering callbacks

### DIFF
--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -89,7 +89,7 @@ func NewTestDatabaseWithConfig(tb testing.TB) (*Database, *Config) {
 	port := container.GetPort("5432/tcp")
 
 	// build database config.
-	config := Config{
+	config := &Config{
 		APIKeyDatabaseHMAC:           generateKeys(tb, 3, 128),
 		APIKeySignatureHMAC:          generateKeys(tb, 3, 128),
 		VerificationCodeDatabaseHMAC: generateKeys(tb, 3, 128),
@@ -136,7 +136,7 @@ func NewTestDatabaseWithConfig(tb testing.TB) (*Database, *Config) {
 		db.db.Close()
 	})
 
-	return db, &config
+	return db, config
 }
 
 func NewTestDatabase(tb testing.TB) *Database {


### PR DESCRIPTION
This should fix the sporadic data race issues we see in CI, at the expense of increasing the test suite by ~3s.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
