### PR TITLE
Rename bucket_policy_only -> uniform_bucket_level_access

### DIFF
--- a/terraform/build.tf
+++ b/terraform/build.tf
@@ -17,8 +17,8 @@ resource "google_storage_bucket" "cloudbuild-cache" {
   name     = "${var.project}-cloudbuild-cache"
   location = var.storage_location
 
-  force_destroy      = true
-  bucket_policy_only = true
+  force_destroy               = true
+  uniform_bucket_level_access = true
 
   // Automatically expire cached objects after 14 days.
   lifecycle_rule {


### PR DESCRIPTION
Terraform deprecation

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Rename Terraform `bucket_policy_only` to `uniform_bucket_level_access` to handle depreaction
```
