### PR TITLE
HMAC instead of hash keys in the cacher

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -85,9 +85,10 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	// TODO(sethvargo): switch to HMAC
 	cacher, err := cache.CacherFor(ctx, &config.Cache, cache.MultiKeyFunc(
-		cache.HashKeyFunc(sha1.New), cache.PrefixKeyFunc("adminapi:")))
+		cache.HMACKeyFunc(sha1.New, config.Cache.HMACKey),
+		cache.PrefixKeyFunc("adminapi:"),
+	))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -88,9 +88,10 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	// TODO(sethvargo): switch to HMAC
 	cacher, err := cache.CacherFor(ctx, &config.Cache, cache.MultiKeyFunc(
-		cache.HashKeyFunc(sha1.New), cache.PrefixKeyFunc("apiserver:")))
+		cache.HMACKeyFunc(sha1.New, config.Cache.HMACKey),
+		cache.PrefixKeyFunc("apiserver:"),
+	))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -104,9 +104,10 @@ func realMain(ctx context.Context) error {
 	sessions.Options.SameSite = http.SameSiteStrictMode
 
 	// Setup cacher
-	// TODO(sethvargo): switch to HMAC
 	cacher, err := cache.CacherFor(ctx, &config.Cache, cache.MultiKeyFunc(
-		cache.HashKeyFunc(sha1.New), cache.PrefixKeyFunc("server:")))
+		cache.HMACKeyFunc(sha1.New, config.Cache.HMACKey),
+		cache.PrefixKeyFunc("server:"),
+	))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/docs/development.md
+++ b/docs/development.md
@@ -91,6 +91,13 @@ represent best practices.
     # where NUM is 32 or 64, respectively.
     export COOKIE_KEYS="ARLaFwAqBGIkm5pLjAveJuahtCnX2NLoAUz2kCZKrScUaUkEaxHSvJLVYb5yAPCc441Cho5n5yp8jdEmy6hyig==,RLjcRZeqc07s6dh3OK4CM1POjHDZHC+usNU1w/XNTjM="
 
+    # Configure cache and cache HMAC. Create your own values with:
+    #
+    #     openssl rand -base64 128
+    #
+    export CACHE_TYPE="IN_MEMORY"
+    export CACHE_HMAC_KEY="/wC2dki5Z+To9iFwUamINtHIMOH/dME7e5Gy+9h3WTDBhqeeSYkqduZRjcZWwG3kPMdiWAdBxxop5wB+BHTBnSlfVVmy8qKVNv+Wf5ywgxV7SbB8bjNQBHSpn7aC5RxR6nkEsZ2w2fUhTJwD9q+MDo6TQvf+8OXEPrV1SXWNHrs="
+
     # Configure certificate key management. The CERTIFICATE_SIGNING_KEY should
     # be the value output in the previous step.
     export CERTIFICATE_KEY_MANAGER="FILESYSTEM"

--- a/docs/production.md
+++ b/docs/production.md
@@ -322,8 +322,8 @@ CACHE_HMAC_KEY="RBwXRppIqscSWxSsP/e52AsPsab4jW7lL5DJSw3uZfTbwgGXj3IV/iWx0ZGjyvY0
 ```
 
 Note: Changing this value will invalidate any existing caches. Most caches are
-small and are automatically re-built on demand, so occassional rotation is
-likely fine for this system.
+small and are automatically re-built on demand, so occasional rotation is likely
+fine for this system.
 
 
 [gcp-kms]: https://cloud.google.com/kms

--- a/docs/production.md
+++ b/docs/production.md
@@ -296,4 +296,34 @@ lifetime is short, it is probably safe to remove the key beyond 30 days.
 If you are using system keys, the system administrator will handle rotation. If
 you are using realm keys, you can generate new keys in the UI.
 
+
+### Cacher HMAC keys
+
+**Recommended frequency:** 90 days, on breach
+
+This key is used as the HMAC key to named values in the cacher. For example, API
+keys are cached in the cacher for a few minutes to reduce load on the database.
+We do not want the cacher to have plaintext API keys, so the values are HMACed
+before being written (and HMACed on lookup). This prevents a server operator
+with access to the cacher (e.g. Redis) from seeing plaintext data about the
+system. The data is hashed instead of encrypted because we only need a
+deterministic value to lookup.
+
+To generate a new key:
+
+```sh
+openssl rand -base64 128 | tr -d "\n"
+```
+
+Use this value as of the `CACHE_HMAC_KEY` environment variable:
+
+```sh
+CACHE_HMAC_KEY="RBwXRppIqscSWxSsP/e52AsPsab4jW7lL5DJSw3uZfTbwgGXj3IV/iWx0ZGjyvY0GB3kupK7qbaDZBGsxxqABT4thujJkx6kAiAabH4kz5qPwoPNGK2M9KW9TX5jM3dnX7smPzlL+Hg8ijxczceDCeQF44cys+3rdWaDdC6kHec="
+```
+
+Note: Changing this value will invalidate any existing caches. Most caches are
+small and are automatically re-built on demand, so occassional rotation is
+likely fine for this system.
+
+
 [gcp-kms]: https://cloud.google.com/kms

--- a/pkg/cache/cacher.go
+++ b/pkg/cache/cacher.go
@@ -17,6 +17,7 @@ package cache
 
 import (
 	"context"
+	"crypto/hmac"
 	"fmt"
 	"hash"
 	"io"
@@ -68,8 +69,8 @@ func PrefixKeyFunc(prefix string) KeyFunc {
 	}
 }
 
-// HashKeyFunc returns a KeyFunc that hashes or HMACs the provided key before
-// passing it to the cacher for storage.
+// HashKeyFunc returns a KeyFunc that hashes the provided key before passing it
+// to the cacher for storage.
 func HashKeyFunc(hasher func() hash.Hash) KeyFunc {
 	return func(in string) (string, error) {
 		h := hasher()
@@ -83,6 +84,14 @@ func HashKeyFunc(hasher func() hash.Hash) KeyFunc {
 		dig := h.Sum(nil)
 		return fmt.Sprintf("%x", dig), nil
 	}
+}
+
+// HMACKeyFunc returns a KeyFunc that HMACs the provided key before passing it
+// to the cacher for storage.
+func HMACKeyFunc(hasher func() hash.Hash, key []byte) KeyFunc {
+	return HashKeyFunc(func() hash.Hash {
+		return hmac.New(hasher, key)
+	})
 }
 
 // Cacher is an interface that defines caching.

--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/redis"
+	"github.com/sethvargo/go-envconfig"
 )
 
 // CacherType represents a type of cacher.
@@ -34,8 +35,11 @@ const (
 type Config struct {
 	Type CacherType `env:"TYPE, default=IN_MEMORY"`
 
+	// HMACKey is the hash key to use when for keys in the cacher.
+	HMACKey envconfig.Base64Bytes `env:"CACHE_HMAC_KEY, required"`
+
 	// Redis configuration
-	Redis redis.Config `env:",prefix=CACHE_"`
+	Redis redis.Config `env:", prefix=CACHE_"`
 }
 
 func CacherFor(ctx context.Context, c *Config, keyFunc KeyFunc) (Cacher, error) {

--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -30,6 +30,28 @@ resource "google_redis_instance" "cache" {
   ]
 }
 
+# Create secret for the HMAC cache keys
+resource "random_id" "cache-hmac-key" {
+  byte_length = 128
+}
+
+resource "google_secret_manager_secret" "cache-hmac-key" {
+  secret_id = "cache-hmac-key"
+
+  replication {
+    automatic = true
+  }
+
+  depends_on = [
+    google_project_service.services["secretmanager.googleapis.com"],
+  ]
+}
+
+resource "google_secret_manager_secret_version" "cache-hmac-key" {
+  secret      = google_secret_manager_secret.cache-hmac-key.id
+  secret_data = random_id.cache-hmac-key.b64_std
+}
+
 output "redis_host" {
   value = google_redis_instance.cache.host
 }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -27,6 +27,7 @@ locals {
 
   cache_config = {
     CACHE_TYPE       = "REDIS"
+    CACHE_HMAC_KEY   = "secret://${google_secret_manager_secret_version.cache-hmac-key.id}"
     CACHE_REDIS_HOST = google_redis_instance.cache.host
     CACHE_REDIS_PORT = google_redis_instance.cache.port
   }


### PR DESCRIPTION
Fixes GH-429 (most of it is done, this was the last remaining bit)

**Release Note**

```release-note
Use HMAC instead of hashes in cacher keys
```
