### PR TITLE
Include auth factor count in session

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -371,6 +371,7 @@
     switch (errLevel) {
       case "warning":
       case "danger":
+        break;
       case "success":
         if (dismissible === undefined) {
           dismissible = true

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -16,7 +16,6 @@
         url: '/session',
         data: {
           idToken: idToken,
-          email: user.email,
           factorCount: factorCount,
         },
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -1,7 +1,7 @@
 {{define "loginscripts"}}
 <script type="text/javascript">
 
-  firebase.auth().onAuthStateChanged(function (user) {
+  firebase.auth().onAuthStateChanged(function(user) {
     if (!user) {
       return
     }
@@ -9,25 +9,30 @@
   });
 
   function setSession(user) {
+    let factorCount = user.multiFactor.enrolledFactors.length;
     user.getIdToken().then(idToken => {
       $.ajax({
         type: 'POST',
         url: '/session',
-        data: { idToken: idToken },
+        data: {
+          idToken: idToken,
+          email: user.email,
+          factorCount: factorCount,
+        },
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/x-www-form-urlencoded',
-        success: function (returnData) {
-          if (user.multiFactor.enrolledFactors.length > 0) {
+        success: function(returnData) {
+          if (factorCount > 0) {
             // The user successfully signed in, redirect to realm selection.
             window.location.assign('/realm');
           } else {
-            // The user successfully signed in, ask for multiauth.
+            // The user successfully signed in, ask for multi-auth.
             window.location.assign('/login/registerphone');
           }
         },
-        error: function (xhr, status, e) {
+        error: function(xhr, status, e) {
           // There was an error finding the user. Redirect to the
-          // signout page to clear the firebase cookie and any session
+          // sign-out page to clear the firebase cookie and any session
           // data.
           //
           // The flash data may have more detailed error messages, which

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -197,7 +197,7 @@ func realMain(ctx context.Context) error {
 	}
 
 	{
-		loginController := login.New(ctx, auth, config, db, h)
+		loginController := login.New(ctx, cacher, auth, config, db, h)
 		{
 			sub := r.PathPrefix("").Subrouter()
 			sub.Use(rateLimit)

--- a/pkg/controller/login/controller.go
+++ b/pkg/controller/login/controller.go
@@ -18,6 +18,7 @@ package login
 import (
 	"context"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -29,6 +30,7 @@ import (
 )
 
 type Controller struct {
+	cacher cache.Cacher
 	client *auth.Client
 	config *config.ServerConfig
 	db     *database.Database
@@ -37,10 +39,11 @@ type Controller struct {
 }
 
 // New creates a new login controller.
-func New(ctx context.Context, client *auth.Client, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
+func New(ctx context.Context, cacher cache.Cacher, client *auth.Client, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx).Named("login")
 
 	return &Controller{
+		cacher: cacher,
 		client: client,
 		config: config,
 		db:     db,

--- a/pkg/controller/login/session.go
+++ b/pkg/controller/login/session.go
@@ -22,13 +22,13 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 func (c *Controller) HandleCreateSession() http.Handler {
 	type FormData struct {
 		IDToken     string `form:"idToken,required"`
-		Email       string `form:"email"`
 		FactorCount int    `form:"factorCount"`
 	}
 
@@ -52,31 +52,39 @@ func (c *Controller) HandleCreateSession() http.Handler {
 			return
 		}
 
-		// Require user to exist for login session.
-		var user database.User
-		cacheKey := fmt.Sprintf("users:by_email:%s", form.Email)
-		if err := c.cacher.Fetch(ctx, cacheKey, &user, cacheTTL, func() (interface{}, error) {
-			return c.db.FindUserByEmail(form.Email)
-		}); err != nil {
-			if database.IsNotFound(err) {
-				logger.Debugw("user does not exist")
-				flash.Error("User does not exist: %v", form.Email)
-				c.h.RenderJSON(w, http.StatusUnauthorized, nil)
-				return
-			}
-
-			logger.Errorw("failed to lookup user", "error", err)
-			flash.Error("Failed to look up user: %v", form.Email)
-			c.h.RenderJSON(w, http.StatusUnauthorized, nil)
-			return
-		}
-
 		// Get the session cookie from firebase.
 		ttl := c.config.SessionDuration
 		cookie, err := c.client.SessionCookie(ctx, form.IDToken, ttl)
 		if err != nil {
 			flash.Error("Failed to create session: %v", err)
 			c.h.RenderJSON(w, http.StatusUnauthorized, api.Error(err))
+			return
+		}
+
+		// Verify the cookie and extract email.
+		email, err := middleware.EmailFromFirebaseCookie(ctx, c.client, cookie)
+		if err != nil {
+			logger.Debugw("failed to verify cookie and extract email")
+			flash.Error("Failed to verify session for user: %v", email)
+			c.h.RenderJSON(w, http.StatusUnauthorized, nil)
+		}
+
+		// Require user to exist for login session.
+		var user database.User
+		cacheKey := fmt.Sprintf("users:by_email:%s", email)
+		if err := c.cacher.Fetch(ctx, cacheKey, &user, cacheTTL, func() (interface{}, error) {
+			return c.db.FindUserByEmail(email)
+		}); err != nil {
+			if database.IsNotFound(err) {
+				logger.Debugw("user does not exist")
+				flash.Error("User does not exist: %v", email)
+				c.h.RenderJSON(w, http.StatusUnauthorized, nil)
+				return
+			}
+
+			logger.Errorw("failed to lookup user", "error", err)
+			flash.Error("Failed to look up user: %v", email)
+			c.h.RenderJSON(w, http.StatusUnauthorized, nil)
 			return
 		}
 


### PR DESCRIPTION
Issue #https://github.com/google/exposure-notifications-verification-server/issues/506

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Here we verify the token and retrieve the user from cache as we create the auth session
    * Similar logic was removed with https://github.com/google/exposure-notifications-verification-server/pull/355 so looking to see if this was intended @sethvargo 

Next this is going to store the MFA state of the user if they have other factors. This will be used to require mfa per-realm. This solution isn't ideal but firebase doesn't provide a go client for managing mfa yet.