### PR TITLE
Add realm configuration for requiring dates

### DIFF
--- a/cmd/server/assets/home.html
+++ b/cmd/server/assets/home.html
@@ -103,16 +103,27 @@
             <div class="form-row">
               <div class="form-group col-md-6">
                 <label for="testDate">Testing date (local time)</label>
-                <input type="date" id="test-date" name="testDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" />
+                <input type="date" id="test-date" name="testDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" {{if $currentRealm.RequireDate}}required{{end}} />
               </div>
 
               <div class="form-group col-md-6">
                 <label for="symptomDate">Symptoms onset (local time)</label>
                 <div class="input-group">
-                  <input type="date" id="symptom-date" name="symptomDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" />
+                  <input type="date" id="symptom-date" name="symptomDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control" {{if $currentRealm.RequireDate}}required{{end}} />
                 </div>
               </div>
             </div>
+
+            {{if $currentRealm.RequireDate}}
+            <div class="form-row">
+              <div class="col">
+                <small class="form-text text-muted">
+                  {{$currentRealm.Name}} requires at least one date to be
+                  provided.
+                </small>
+              </div>
+            </div>
+            {{end}}
           </div>
         </div>
 
@@ -307,6 +318,13 @@
         // Show form
         $formArea.removeClass('d-none');
       });
+
+      {{if $currentRealm.RequireDate}}
+      let $dates = $('input#test-date,input#symptom-date');
+      $dates.on('input', function() {
+        $dates.not(this).prop('required', !$(this).val().length);
+      });
+      {{end}}
     });
 
     function getCode(data) {

--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -87,7 +87,7 @@
             <label class="col-sm-3">Allowed tests:</label>
             <div class="col-sm-9">
               {{if not $realm.EnableENExpress}}
-              <div class="form-group mb-0">
+              <div class="form-group">
                 <div class="form-check">
                   <input class="form-check-input" type="radio" name="allowedTestTypes" id="negative" value="{{$testTypes.negative}}"{{if eq $realm.AllowedTestTypes $testTypes.negative}} checked{{end}}/>
                   <label class="form-check-label" for="negative">
@@ -152,6 +152,38 @@
           Verification code configuration
         </div>
         <div class="card-body">
+          <div class="form-group row">
+            <label for="require_date" class="col-sm-3">Date configuration:</label>
+            <div class="col-sm-9">
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="requireDate" id="requireDateFalse" value="false"{{if not $realm.RequireDate }} checked{{end}}/>
+                  <label class="form-check-label" for="requireDateFalse">
+                    Optional date
+                    <small class="form-text text-muted">
+                      Do not require a test date when generating a verification
+                      code. Users and app can still optionally provide a date.
+                    </small>
+                  </label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="requireDate" id="requireDateTrue" value="true"{{if $realm.RequireDate }} checked{{end}} />
+                  <label class="form-check-label" for="requireDateTrue">
+                    Required date
+                    <small class="form-text text-muted">
+                      Require a symptom date or test date when generating a
+                      verification code. Attempting to generate a verification
+                      code without a date will return an error.
+                    </small>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
           <div class="form-group row">
             <label for="codeLength" class="col-sm-3">Short code characters:</label>
             <div class="col-sm-9">

--- a/docs/api.md
+++ b/docs/api.md
@@ -95,6 +95,7 @@ Possible error code responses. New error codes may be added in future releases.
 | `code_expired`          | 400         | No    | Code has expired, user may need to obtain a new code. |
 | `code_not_found`        | 400         | No    | The server has no record of that code. |
 | `invalid_test_type`     | 400         | No    | The client sent an accept of an unrecgonized test type |
+| `missing_date`          | 400         | No    | The realm requires either a test or symptom date, but none was provided. |
 | `unsupported_test_type` | 412         | No    | The code may be valid, but represents a test type the client cannot process. User may need to upgrade software. |
 |                         | 500         | Yes   | Internal processing error, may be successful on retry. |
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -52,6 +52,8 @@ const (
 	// ErrInvalidTestType indicates the client says it supports a test type this server doesn't
 	// know about.
 	ErrInvalidTestType = "invalid_test_type"
+	// ErrMissingDate indicates the realm requires a date, but none was supplied.
+	ErrMissingDate = "missing_date"
 
 	// Certificate API responses
 	// ErrTokenInvalid indicates the token provided is unknown or already used

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -118,6 +118,13 @@ func (c *Controller) HandleIssue() http.Handler {
 			return
 		}
 
+		// If this realm requires a date but no date was specified, return an error.
+		if request.SymptomDate == "" && realm.RequireDate {
+			stats.Record(ctx, c.metrics.IssueAttempts.M(1), c.metrics.CodeIssueErrors.M(1))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("missing either test or symptom date").WithCode(api.ErrMissingDate))
+			return
+		}
+
 		// Add realm so that metrics are groupable on a per-realm basis.
 		ctx, err = tag.New(ctx,
 			tag.Upsert(observability.RealmTagKey, realm.Name))

--- a/pkg/controller/realmadmin/save.go
+++ b/pkg/controller/realmadmin/save.go
@@ -46,6 +46,7 @@ func (c *Controller) HandleSave() http.Handler {
 		RegionCode       string            `form:"regionCode"`
 		AllowedTestTypes database.TestType `form:"allowedTestTypes"`
 		MFAMode          int16             `form:"MFAMode"`
+		RequireDate      bool              `form:"requireDate"`
 
 		CodeLength          uint   `form:"codeLength"`
 		CodeDurationMinutes int64  `form:"codeDuration"`
@@ -93,6 +94,7 @@ func (c *Controller) HandleSave() http.Handler {
 		realm.Name = form.Name
 		realm.RegionCode = form.RegionCode
 		realm.AllowedTestTypes = form.AllowedTestTypes
+		realm.RequireDate = form.RequireDate
 		realm.CodeLength = form.CodeLength
 		realm.CodeDuration.Duration = time.Duration(form.CodeDurationMinutes) * time.Minute
 		realm.LongCodeLength = form.LongCodeLength

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -893,6 +893,26 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00037-AddRealmRequireDate",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("db migrations: adding require_date to realms")
+				return tx.Exec("ALTER TABLE realms ADD COLUMN IF NOT EXISTS require_date bool DEFAULT false").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE realms DROP COLUMN IF EXISTS require_date").Error
+			},
+		},
+		{
+			ID: "00038-AddRealmRequireDateNotNull",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("db migrations: adding not null requirement to require_date on realms")
+				return tx.Exec("ALTER TABLE realms ALTER COLUMN require_date SET NOT NULL").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE realms ALTER COLUMN require_date SET NULL").Error
+			},
+		},
 	})
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -90,6 +90,10 @@ type Realm struct {
 	// value is to allow all test types.
 	AllowedTestTypes TestType `gorm:"type:smallint; not null; default: 14"`
 
+	// RequireDate requires that verifications on this realm require a test or
+	// symptom date (either). The default behavior is to not require a date.
+	RequireDate bool `gorm:"type:boolean; not null; default:false"`
+
 	// Signing Key Settings
 	UseRealmCertificateKey bool            `gorm:"type:boolean; default: false"`
 	CertificateIssuer      string          `gorm:"type:varchar(150); default: ''"`


### PR DESCRIPTION
Fixes GH-519

This adds a new realm-specific configuration for requiring a date. The default is false and backfilled as false.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add realm configuration for requiring a date when generating a verification code. This includes a new `missing_date` error code in the issue API.
```
