### PR TITLE
Populate cert as empty string on error

### DIFF
--- a/pkg/controller/realmkeys/render.go
+++ b/pkg/controller/realmkeys/render.go
@@ -79,6 +79,7 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 		// Download and PEM encode the public key.
 		publicKey, err := c.publicKeyCache.GetPublicKey(ctx, signing.CertificateSigningKey, c.systemCertificateKeyManager)
 		if err != nil {
+			m["systemCertPublicKey"] = ""
 			m["systemCertPublicKeyError"] = fmt.Sprintf("Failed to load public key: %v", err)
 		} else {
 			pem, err := keyutils.EncodePublicKey(publicKey)


### PR DESCRIPTION
This fixes a bug where trimSpace gets passed nil and the template fails to render

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix a rendering bug when retrieving a public key fails
```
