### PR TITLE
Implement pagination for the Users page

### DIFF
--- a/cmd/server/assets/users/index.html
+++ b/cmd/server/assets/users/index.html
@@ -20,8 +20,7 @@
 
     <h1>Users</h1>
     <p>
-      These are the users of this realm. You can also <a
-      href="/users/new">create a new user</a>.
+      These are the users of this realm. You can also <a href="/users/new">create a new user</a>.
     </p>
 
     {{if $users}}
@@ -46,16 +45,14 @@
             </td>
             <td class="text-center">
               {{if .CanAdminRealm $currentRealm.ID}}
-                <span class="badge badge-pill badge-primary">Admin</span>
+              <span class="badge badge-pill badge-primary">Admin</span>
               {{end}}
             </td>
             <td class="text-center">
               {{- /* cannot delete yourself */ -}}
               {{if not (eq .ID $currentUser.ID)}}
-              <a href="/users/{{.ID}}" class="d-block text-danger"
-                data-method="DELETE"
-                data-confirm="Are you sure you want to remove '{{.Name}}'?"
-                data-toggle="tooltip"
+              <a href="/users/{{.ID}}" class="d-block text-danger" data-method="DELETE"
+                data-confirm="Are you sure you want to remove '{{.Name}}'?" data-toggle="tooltip"
                 title="Remove this user">
                 <span class="oi oi-trash" aria-hidden="true"></span>
               </a>
@@ -65,6 +62,22 @@
           {{end}}
         </tbody>
       </table>
+      {{if .pages}}
+      <nav>
+        {{$pages := .pages}}
+        <ul class="pagination">
+          <li class="page-item {{if eq $pages.Previous -1}}disabled{{end}}"><a class="page-link"
+              href="?offset={{$pages.Previous}}">Previous</a>
+          </li>
+          {{range $index, $pageOffset := $pages.Offsets}}
+          <li class="page-item {{if eq $pages.Current $pageOffset}}active{{end}}"><a class="page-link"
+              href="?offset={{$pageOffset}}">{{$index}}</a></li>
+          {{end}}
+          <li class="page-item {{if eq $pages.Next -1}}disabled{{end}}"><a class="page-link"
+              href="?offset={{$pages.Next}}">Next</a></li>
+        </ul>
+      </nav>
+      {{end}}
     </div>
     {{else}}
     <p>There are no users. Create one above.</p>
@@ -73,5 +86,6 @@
 
   {{template "scripts" .}}
 </body>
+
 </html>
 {{end}}

--- a/cmd/server/assets/users/index.html
+++ b/cmd/server/assets/users/index.html
@@ -69,9 +69,9 @@
           <li class="page-item {{if eq $pages.Previous -1}}disabled{{end}}"><a class="page-link"
               href="?offset={{$pages.Previous}}">Previous</a>
           </li>
-          {{range $index, $pageOffset := $pages.Offsets}}
-          <li class="page-item {{if eq $pages.Current $pageOffset}}active{{end}}"><a class="page-link"
-              href="?offset={{$pageOffset}}">{{$index}}</a></li>
+          {{range $pageOffset := $pages.Offsets}}
+          <li class="page-item {{if eq $pages.Current $pageOffset.Offset}}active{{end}}"><a class="page-link"
+              href="?offset={{$pageOffset.Offset}}">{{$pageOffset.Label}}</a></li>
           {{end}}
           <li class="page-item {{if eq $pages.Next -1}}disabled{{end}}"><a class="page-link"
               href="?offset={{$pages.Next}}">Next</a></li>

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -308,6 +308,7 @@ func realMain(ctx context.Context) error {
 
 		userController := user.New(ctx, cacher, config, db, h)
 		userSub.Handle("", userController.HandleIndex()).Methods("GET")
+		userSub.Handle("", userController.HandleIndex()).Queries("offset", "{[0-9]*?}").Methods("GET")
 		userSub.Handle("", userController.HandleCreate()).Methods("POST")
 		userSub.Handle("/new", userController.HandleCreate()).Methods("GET")
 		userSub.Handle("/{id}/edit", userController.HandleUpdate()).Methods("GET")

--- a/pkg/controller/user/index.go
+++ b/pkg/controller/user/index.go
@@ -24,7 +24,7 @@ import (
 )
 
 // pageSize is const for now, could provide options in UX
-const pageSize = 1
+const pageSize = 25
 
 type Pages struct {
 	Previous int

--- a/pkg/controller/user/index.go
+++ b/pkg/controller/user/index.go
@@ -17,14 +17,27 @@ package user
 import (
 	"context"
 	"net/http"
+	"strconv"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
+// pageSize is const for now, could provide options in UX
+const pageSize = 1
+
+type Pages struct {
+	Previous int
+	Current  int
+	Next     int
+	Offsets  []int
+}
+
 func (c *Controller) HandleIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		qvar := r.FormValue("offset")
+		offset, _ := strconv.Atoi(qvar)
 
 		realm := controller.RealmFromContext(ctx)
 		if realm == nil {
@@ -32,18 +45,50 @@ func (c *Controller) HandleIndex() http.Handler {
 			return
 		}
 
-		users, err := realm.ListUsers(c.db)
+		count, err := realm.CountUsers(c.db)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
 		}
 
-		c.renderIndex(ctx, w, users)
+		users, err := realm.ListUsers(c.db, offset, pageSize)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		var pages *Pages
+		if count > pageSize {
+			pages = &Pages{
+				Current:  offset,
+				Offsets:  []int{},
+				Previous: -1,
+				Next:     -1,
+			}
+			for i := 0; i < count; i += pageSize {
+				pages.Offsets = append(pages.Offsets, i)
+			}
+			if offset != 0 {
+				pages.Previous = offset - pageSize
+				if pages.Previous < 0 {
+					pages.Previous = 0
+				}
+			}
+			if offset != count-pageSize {
+				pages.Next = offset + pageSize
+				if pages.Next > count-pageSize {
+					pages.Next = count - pageSize
+				}
+			}
+		}
+
+		c.renderIndex(ctx, w, users, pages)
 	})
 }
 
-func (c *Controller) renderIndex(ctx context.Context, w http.ResponseWriter, users []*database.User) {
+func (c *Controller) renderIndex(ctx context.Context, w http.ResponseWriter, users []*database.User, pages *Pages) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["users"] = users
+	m["pages"] = pages
 	c.h.RenderHTML(w, "users/index", m)
 }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/538

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds pagination when there is a large number of users per realm
    * Still probably not ideal for order ~thousands

![pages](https://user-images.githubusercontent.com/36240966/93148345-6523b900-f6a8-11ea-970b-0c93f1fd1a5a.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pagination for Users page
```
