### PR TITLE
Adding a fast-forward for very-long lists

### DIFF
--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -62,6 +62,8 @@ const (
 	MFARequired
 	// MFAOptional will not prompt users to enable MFA.
 	MFAOptional
+	// MaxPageSize is the maximum allowed page size for a list query.
+	MaxPageSize = 1000
 )
 
 // Realm represents a tenant in the system. Typically this corresponds to a
@@ -449,8 +451,8 @@ func (r *Realm) CountUsers(db *Database) (int, error) {
 
 // ListUsers returns the list of users on this realm.
 func (r *Realm) ListUsers(db *Database, offset, limit int) ([]*User, error) {
-	if limit > 100 {
-		limit = 100
+	if limit > MaxPageSize {
+		limit = MaxPageSize
 	}
 
 	var users []*User


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/538

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Some follow-up on https://github.com/google/exposure-notifications-verification-server/pull/541
* Adds a fast-forward and backward button to skip many pages if the set is long
* Fix a constant
* Handle atoi err
