### PR TITLE
https -> ens protocol redirect service

### DIFF
--- a/cmd/enx-redirect/assets/404.html
+++ b/cmd/enx-redirect/assets/404.html
@@ -1,0 +1,21 @@
+{{define "404"}}
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  <main role="main" class="container mt-5">
+    <h1>Not found.</h1>
+    <p>
+      <code>{{.requestURI}}</code> was not found on this server.
+    </p>
+    <p>
+      If you are trying to submit your anonymous data for exposure notifications,
+      please contact the public health authority that issued your verification code.
+    </p>
+  </main>
+</body>
+</html>
+{{end}}

--- a/cmd/enx-redirect/assets/500.html
+++ b/cmd/enx-redirect/assets/500.html
@@ -1,0 +1,17 @@
+{{define "500"}}
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  <main role="main" class="container mt-5">
+    <h1>Internal server error</h1>
+    <p>
+      {{.error}}
+    </p>
+  </main>
+</body>
+</html>
+{{end}}

--- a/cmd/enx-redirect/assets/header.html
+++ b/cmd/enx-redirect/assets/header.html
@@ -1,0 +1,39 @@
+{{define "head"}}
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
+<meta data-build-id="{{.build_id}}" data-build-tag="{{.build_tag}}">
+
+<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
+<link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
+<link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
+<link rel="manifest" href="/static/site.webmanifest">
+<link rel="mask-icon" href="/static/safari-pinned-tab.svg" color="#5bbad5">
+<link rel="shortcut icon" href="/static/favicon.ico">
+<meta name="msapplication-TileColor" content="#ff0554">
+<meta name="msapplication-config" content="/static/browserconfig.xml">
+<meta name="theme-color" content="#ffffff">
+
+<link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
+  integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">
+<link rel="stylesheet"
+  href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css"
+  integrity="sha256-BJ/G+e+y7bQdrYkS2RBTyNfBHpA9IuGaPmf9htub5MQ=" crossorigin="anonymous">
+
+<title>Exposure Notifications Express Redirect Service</title>
+
+<style type="text/css">
+  nav.navbar {
+    margin-bottom: 40px;
+  }
+
+  div.realm-header {
+    background-color: #0055b1;
+  }
+
+  a.input-group-text:hover {
+    cursor: pointer;
+    text-decoration: none;
+  }
+
+</style>
+{{end}}

--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -1,0 +1,112 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"strconv"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/redirect"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-server/pkg/server"
+
+	"github.com/gorilla/handlers"
+	"github.com/gorilla/mux"
+	"github.com/sethvargo/go-signalcontext"
+)
+
+func main() {
+	ctx, done := signalcontext.OnInterrupt()
+
+	debug, _ := strconv.ParseBool(os.Getenv("LOG_DEBUG"))
+	logger := logging.NewLogger(debug)
+	logger = logger.With("build_id", buildinfo.BuildID)
+	logger = logger.With("build_tag", buildinfo.BuildTag)
+
+	ctx = logging.WithLogger(ctx, logger)
+
+	err := realMain(ctx)
+	done()
+
+	if err != nil {
+		logger.Fatal(err)
+	}
+	logger.Info("successful shutdown")
+}
+
+func realMain(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+
+	config, err := config.NewRedirectConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to process config: %w", err)
+	}
+
+	// Setup monitoring
+	logger.Info("configuring observability exporter")
+	oeConfig := config.ObservabilityExporterConfig()
+	oe, err := observability.NewFromEnv(ctx, oeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create ObservabilityExporter provider: %w", err)
+	}
+	if err := oe.StartExporter(); err != nil {
+		return fmt.Errorf("error initializing observability exporter: %w", err)
+	}
+	defer oe.Close()
+	logger.Infow("observability exporter", "config", oeConfig)
+
+	// Create the router
+	r := mux.NewRouter()
+
+	// Create the renderer
+	h, err := render.New(ctx, config.AssetsPath, config.DevMode)
+	if err != nil {
+		return fmt.Errorf("failed to create renderer: %w", err)
+	}
+
+	// Install common security headers
+	r.Use(middleware.SecureHeaders(ctx, config.DevMode, "html"))
+
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug(ctx)
+	r.Use(processDebug)
+
+	{
+		redirectController := redirect.New(ctx, config, h)
+		r.Handle("/v", redirectController.HandleIndex()).Methods("GET")
+	}
+
+	// Wrap the main router in the mutating middleware method. This cannot be
+	// inserted as middleware because gorilla processes the method before
+	// middleware.
+	mux := http.NewServeMux()
+	mux.Handle("/", middleware.MutateMethod(ctx)(r))
+
+	srv, err := server.New(config.Port)
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+	logger.Infow("server listening", "port", config.Port)
+	return srv.ServeHTTPHandler(ctx, handlers.CombinedLoggingHandler(os.Stdout, mux))
+}

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -34,7 +34,7 @@ type RedirectConfig struct {
 
 	AssetsPath string `env:"ASSETS_PATH, default=./cmd/enx-redirect/assets"`
 
-	// If Dev mode is true, extended logging is enabled and tempalte
+	// If Dev mode is true, extended logging is enabled and template
 	// auto-reload is enabled.
 	DevMode bool `env:"DEV_MODE"`
 

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -1,0 +1,57 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
+
+	"github.com/google/exposure-notifications-server/pkg/observability"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+// RedirectConfig represents the environment based config for the redirect server.
+type RedirectConfig struct {
+	Observability observability.Config
+
+	Port string `env:"PORT,default=8080"`
+
+	AssetsPath string `env:"KO_DATA_PATH"`
+
+	// If Dev mode is true, cookies aren't required to be sent over secure channels.
+	// This includes CSRF protection base cookie. You want this false in production (the default).
+	DevMode bool `env:"DEV_MODE"`
+
+	RedirectFrom []string `env:"REDIRECT_FROM"`
+	RedirectTo   []string `env:"REDIRECT_TO"`
+
+	// Rate limiting configuration
+	RateLimit ratelimit.Config
+}
+
+// NewRedirectConfig initializes and validates a RedirectConfig struct.
+func NewRedirectConfig(ctx context.Context) (*RedirectConfig, error) {
+	var config RedirectConfig
+	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (c *RedirectConfig) ObservabilityExporterConfig() *observability.Config {
+	return &c.Observability
+}

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -30,9 +30,9 @@ import (
 type RedirectConfig struct {
 	Observability observability.Config
 
-	Port string `env:"PORT,default=8080"`
+	Port string `env:"PORT, default=8080"`
 
-	AssetsPath string `env:"ASSETS_PATH,default=./cmd/enx-redirect/assets"`
+	AssetsPath string `env:"ASSETS_PATH, default=./cmd/enx-redirect/assets"`
 
 	// If Dev mode is true, extended logging is enabled and tempalte
 	// auto-reload is enabled.

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -1,0 +1,38 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package redirect
+
+import (
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+func (c *Controller) HandleIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		//ctx := r.Context()
+
+		idx := strings.Index(r.RequestURI, "/v?")
+		if idx < 0 {
+			controller.InternalError(w, r, c.h, fmt.Errorf("don't do that."))
+			return
+		}
+		keep := r.RequestURI[idx:]
+		sendTo := fmt.Sprintf("ens:/%s", keep)
+
+		http.Redirect(w, r, sendTo, http.StatusSeeOther)
+	})
+}

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -11,6 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 package redirect
 
 import (

--- a/pkg/controller/redirect/redirect.go
+++ b/pkg/controller/redirect/redirect.go
@@ -17,6 +17,7 @@ package redirect
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -27,18 +28,25 @@ import (
 )
 
 type Controller struct {
-	config *config.RedirectConfig
-	h      *render.Renderer
-	logger *zap.SugaredLogger
+	config           *config.RedirectConfig
+	h                *render.Renderer
+	logger           *zap.SugaredLogger
+	hostnameToRegion map[string]string
 }
 
 // New creates a new login controller.
-func New(ctx context.Context, config *config.RedirectConfig, h *render.Renderer) *Controller {
+func New(ctx context.Context, config *config.RedirectConfig, h *render.Renderer) (*Controller, error) {
 	logger := logging.FromContext(ctx).Named("login")
 
-	return &Controller{
-		config: config,
-		h:      h,
-		logger: logger,
+	cfgMap, err := config.HostnameToRegion()
+	if err != nil {
+		return nil, fmt.Errorf("invalid config: %w", err)
 	}
+
+	return &Controller{
+		config:           config,
+		h:                h,
+		logger:           logger,
+		hostnameToRegion: cfgMap,
+	}, nil
 }

--- a/pkg/controller/redirect/redirect.go
+++ b/pkg/controller/redirect/redirect.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package redirect defines the controller for the deep link redirector.
+package redirect
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	config *config.RedirectConfig
+	h      *render.Renderer
+	logger *zap.SugaredLogger
+}
+
+// New creates a new login controller.
+func New(ctx context.Context, config *config.RedirectConfig, h *render.Renderer) *Controller {
+	logger := logging.FromContext(ctx).Named("login")
+
+	return &Controller{
+		config: config,
+		h:      h,
+		logger: logger,
+	}
+}


### PR DESCRIPTION
First towards #549 

## Proposed Changes

* Standalone service to redirect https:// links to ens:// for mobile 

**Release Note**

```release-note
Introduce deep link redirect service to support exposure notification express.
```
