### PR TITLE
Add initial scaffolding for abuse prevention

### DIFF
--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -8,6 +8,7 @@
 <html lang="en">
 <head>
   {{template "head" .}}
+  {{template "floatingform" .}}
 </head>
 
 <body class="bg-light">
@@ -46,7 +47,7 @@
     {{end}}
 
 
-    <form method="POST" action="/realm/settings/save">
+    <form method="POST" class="floating-form" action="/realm/settings/save">
       {{ .csrfField }}
 
       <div class="card mb-3 shadow-sm">
@@ -347,7 +348,66 @@
               </small>
             </div>
           </div>
+        </div>
+      </div>
 
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          Abuse prevention
+        </div>
+        <div class="card-body">
+          <div class="alert alert-warning">
+            <span class="oi oi-beaker"></span> This feature is still under
+            active development.
+          </div>
+
+          <p>
+            Abuse prevention uses the historical record of your realm's past
+            daily code issuances to build a predictive model of future use,
+            rejecting requests that fall outside of the predicted model.
+          </p>
+
+          <div class="form-group form-check">
+            <input class="form-check-input" type="checkbox" name="abuse_prevention_enabled" id="abuse_prevention_enabled" value="1" {{if $realm.AbusePreventionEnabled}} checked{{end}}>
+            <label class="form-check-label" for="abuse_prevention_enabled">
+              Enable abuse prevention
+            </label>
+          </div>
+
+          <div id="abuse_prevention_configuration" class="{{if not $realm.AbusePreventionEnabled}}d-none{{end}}">
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_limit" name="abuse_prevention_limit" class="form-control" placeholder="Computed limit" value="{{$realm.AbusePreventionLimit}}" readonly />
+              <label for="abuse_prevention_limit">Computed limit</label>
+              <small class="form-text text-muted">
+                This value is computed by the historical daily model and applies
+                for the next 24h block of rolling UTC time.
+              </small>
+            </div>
+
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_limit_factor" name="abuse_prevention_limit_factor" class="form-control" placeholder="Limit factor" value="{{printf "%.3f" $realm.AbusePreventionLimitFactor}}" />
+              <label for="abuse_prevention_limit_factor">Limit factor</label>
+              <small class="form-text text-muted">
+                This value is factored against the predicted daily model to
+                determine the total number of codes that {{$realm.Name}} can issue
+                in a day. For example, to enable 25% more codes to be issued than
+                predicted by the model model, set this value to <code>1.25</code>.
+              </small>
+              <small class="form-text text-danger font-weight-bold">
+                Setting this value too low will prevent case workers from issuing
+                codes for legitimate uses!
+              </small>
+            </div>
+
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_effective_limit" class="form-control" placeholder="Effective limit" value="{{$realm.AbusePreventionEffectiveLimit}}" readonly />
+              <label for="abuse_prevention_effective_limit">Effective limit</label>
+              <small class="form-text text-muted">
+                This is the effective daily limit for {{$realm.Name}} after
+                applying your limit factor.
+              </small>
+            </div>
+          </div>
         </div>
       </div>
 
@@ -416,6 +476,35 @@
   </main>
 
   {{template "scripts" .}}
+
+  <script type="text/javascript">
+    $(function() {
+      let $abusePreventionEnabled = $('#abuse_prevention_enabled');
+      let $abusePreventionConfiguration = $('#abuse_prevention_configuration');
+      let $abusePreventionLimit = $('#abuse_prevention_limit');
+      let $abusePreventionLimitFactor = $('#abuse_prevention_limit_factor');
+      let $abusePreventionEffectiveLimit = $('#abuse_prevention_effective_limit');
+
+      $abusePreventionEnabled.change(function(e) {
+        if (this.checked) {
+          $abusePreventionConfiguration.removeClass('d-none');
+        } else {
+          $abusePreventionConfiguration.addClass('d-none');
+        }
+      });
+
+      $abusePreventionLimitFactor.keyup(function(e){
+        let $this = $(e.currentTarget);
+        let current = $this.val();
+
+        if (current && current.length) {
+          let effective = parseFloat(current) * parseFloat($abusePreventionLimit.val());
+          effective = Math.ceil(effective);
+          $abusePreventionEffectiveLimit.val(effective);
+        }
+      });
+    });
+  </script>
 </body>
 </html>
 {{end}}

--- a/pkg/controller/realmadmin/save.go
+++ b/pkg/controller/realmadmin/save.go
@@ -57,6 +57,9 @@ func (c *Controller) HandleSave() http.Handler {
 		TwilioAccountSid string `form:"twilio_account_sid"`
 		TwilioAuthToken  string `form:"twilio_auth_token"`
 		TwilioFromNumber string `form:"twilio_from_number"`
+
+		AbusePreventionEnabled     bool    `form:"abuse_prevention_enabled"`
+		AbusePreventionLimitFactor float32 `form:"abuse_prevention_limit_factor"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -101,6 +104,8 @@ func (c *Controller) HandleSave() http.Handler {
 		realm.LongCodeDuration.Duration = time.Hour * time.Duration(form.LongCodeHours)
 		realm.SMSTextTemplate = form.SMSTextTemplate
 		realm.MFAMode = database.MFAMode(form.MFAMode)
+		realm.AbusePreventionEnabled = form.AbusePreventionEnabled
+		realm.AbusePreventionLimitFactor = form.AbusePreventionLimitFactor
 		if err := c.db.SaveRealm(realm); err != nil {
 			flash.Error("Failed to update realm: %v", err)
 			c.renderShow(ctx, w, r, realm, nil)

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -964,6 +964,39 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00041-AddRealmAbuseProtection",
+			Migrate: func(tx *gorm.DB) error {
+				sqls := []string{
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS abuse_prevention_enabled bool NOT NULL DEFAULT false`,
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS abuse_prevention_limit integer NOT NULL DEFAULT 100`,
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS abuse_prevention_limit_factor numeric(8, 5) NOT NULL DEFAULT 1.0`,
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				sqls := []string{
+					`ALTER TABLE realms DROP COLUMN IF EXISTS abuse_prevention_enabled`,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS abuse_prevention_limit`,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS abuse_prevention_limit_factor`,
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
This adds the new realm fields and UI elements. The form is wired up to save and persist them in the database, but there's no enforcement or historical calculations yet.

Part of GH-534

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add database fields and UI structure for abuse prevention
```
