### PR TITLE
Don't mount migrations on the verification server

### DIFF
--- a/builders/migrate.dockerfile
+++ b/builders/migrate.dockerfile
@@ -18,7 +18,6 @@ RUN apk add --no-cache bash
 ADD https://storage.googleapis.com/cloudsql-proxy/v1.18.0/cloud_sql_proxy.linux.amd64 /cloud-sql-proxy
 COPY ./bin/migrate /migrate
 COPY ./builders/cloud-sql-exec /cloud-sql-exec
-COPY ./migrations /migrations
 
 RUN chown $(whoami):$(whoami) /cloud-sql-proxy /cloud-sql-exec /migrate
 RUN chmod +x /cloud-sql-proxy /cloud-sql-exec /migrate


### PR DESCRIPTION

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
