### PR TITLE
Generate new user account on the server-side

### DIFF
--- a/cmd/server/assets/users/_form.html
+++ b/cmd/server/assets/users/_form.html
@@ -41,7 +41,7 @@
       </div>
     </div>
 
-    <button type="submit" class="btn btn-primary btn-block">
+    <button type="submit" id="submit-user" class="btn btn-primary btn-block" {{if .created}}disabled{{end}}>
       {{if $user.ID}}
       Update user
       {{else}}

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -37,9 +37,10 @@
   {{if .created}}
   <script type="text/javascript">
   $(function() {
-    let email = {{.user.Email}};
     let $allUsers = $('#all-users');
     let $submit = $('#submit-user');
+
+    let email = {{.user.Email}};
 
     firebase.auth().sendPasswordResetEmail(email)
       .then(function() {

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -46,7 +46,7 @@
       .then(function() {
         flash("Successfully created user '" + {{.user.Name}} + "'.", "success");
       }).catch(function(error) {
-        flash(error.message, "danger")
+        flash(error.message, "danger");
       }).then(function() {
         $submit.prop('disabled', false);
         $allUsers.removeClass('disabled');

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -37,15 +37,10 @@
   {{if .created}}
   <script type="text/javascript">
     let email = {{.user.Email }};
-    let pwd = Math.random().toString(36).substring(2, 15) + Math.random().toString(36).substring(2, 15);
-
-    firebase.auth().createUserWithEmailAndPassword(email, pwd)
-      .then(function(userCredential) {
-        return firebase.auth().sendPasswordResetEmail(email);
-      }).then(function() {
+    firebase.auth().sendPasswordResetEmail(email)
+      .then(function() {
         flash("New user invite sent.", "success");
-      })
-      .catch(function(error) {
+      }).catch(function(error) {
         flash(error.message, "danger")
         $submit.prop('disabled', false);
       });

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -36,6 +36,7 @@
   {{template "scripts" .}}
   {{if .created}}
   <script type="text/javascript">
+  $(function() {
     let email = {{.user.Email}};
     let $allUsers = $('#all-users');
     let $submit = $('#submit-user');
@@ -49,6 +50,7 @@
         $submit.prop('disabled', false);
         $allUsers.removeClass('disabled');
       });
+  });
   </script>
   {{end}}
 </body>

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -30,19 +30,24 @@
         {{template "users/_form" .}}
       </div>
     </div>
-    <a class="card-link" href="/users">&larr; All users</a>
+    <a class="card-link {{if .created}}disabled{{end}}" href="/users" id="all-users">&larr; All users</a>
   </main>
 
   {{template "scripts" .}}
   {{if .created}}
   <script type="text/javascript">
-    let email = {{.user.Email }};
+    let email = {{.user.Email}};
+    let $allUsers = $('#all-users');
+    let $submit = $('#submit-user');
+
     firebase.auth().sendPasswordResetEmail(email)
       .then(function() {
-        flash("New user invite sent.", "success");
+        flash("Successfully created user '" + {{.user.Name}} + "'.", "success");
       }).catch(function(error) {
         flash(error.message, "danger")
+      }).then(function() {
         $submit.prop('disabled', false);
+        $allUsers.removeClass('disabled');
       });
   </script>
   {{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -306,7 +306,7 @@ func realMain(ctx context.Context) error {
 		userSub.Use(requireMFA)
 		userSub.Use(rateLimit)
 
-		userController := user.New(ctx, cacher, config, db, h)
+		userController := user.New(ctx, auth, cacher, config, db, h)
 		userSub.Handle("", userController.HandleIndex()).Methods("GET")
 		userSub.Handle("", userController.HandleIndex()).Queries("offset", "{[0-9]*?}").Methods("GET")
 		userSub.Handle("", userController.HandleCreate()).Methods("POST")

--- a/go.mod
+++ b/go.mod
@@ -32,6 +32,7 @@ require (
 	github.com/rakutentech/jwk-go v1.0.1
 	github.com/sethvargo/go-envconfig v0.3.1
 	github.com/sethvargo/go-limiter v0.5.1
+	github.com/sethvargo/go-password v0.2.0
 	github.com/sethvargo/go-redisstore v0.2.0-opencensus
 	github.com/sethvargo/go-retry v0.1.0
 	github.com/sethvargo/go-signalcontext v0.1.0

--- a/go.sum
+++ b/go.sum
@@ -1166,6 +1166,8 @@ github.com/sethvargo/go-gcpkms v0.1.0 h1:pyjDLqLwpk9pMjDSTilPpaUjgP1AfSjX9WGzitZ
 github.com/sethvargo/go-gcpkms v0.1.0/go.mod h1:33BuvqUjsYk0bpMgn+WCclCYtMLOyaqtn5j0fCo4vvk=
 github.com/sethvargo/go-limiter v0.5.1 h1:3Ss4/AC1hXrHwQv75xMjGYJDCeMGeHv8B5tqKIi5+Pc=
 github.com/sethvargo/go-limiter v0.5.1/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
+github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
+github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
 github.com/sethvargo/go-redisstore v0.2.0-opencensus h1:GoKpIA/d0KDotrHhk18syOoDthgbBMzdhe0iguvyXbQ=
 github.com/sethvargo/go-redisstore v0.2.0-opencensus/go.mod h1:ovmJaSVc9yhiG+7is6gf3uSTC92kzAbrJsx6L0vnPZU=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -21,7 +21,7 @@ import (
 	"firebase.google.com/go/auth"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
-	"github.com/google/exposure-notifications-verification-server/pkg/otp"
+	"github.com/sethvargo/go-password/password"
 )
 
 func (c *Controller) HandleCreate() http.Handler {
@@ -99,7 +99,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		}
 
 		if !alreadyExists {
-			pwd, err := otp.GenerateAlphanumericCode(24)
+			pwd, err := password.Generate(24, 8, 8, false, true)
 			if err != nil {
 				flash.Alert("Failed to generate password for '%v'", form.Email)
 				c.renderNew(ctx, w, user, false)
@@ -108,8 +108,7 @@ func (c *Controller) HandleCreate() http.Handler {
 
 			fbUser := &auth.UserToCreate{}
 			fbUser.Email(user.Email).DisplayName(user.Name).Password(pwd)
-			_, err = c.client.CreateUser(ctx, fbUser)
-			if err != nil {
+			if _, err = c.client.CreateUser(ctx, fbUser); err != nil {
 				flash.Alert("Error creating user '%v'", form.Email)
 				c.renderNew(ctx, w, user, false)
 				return

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -101,7 +101,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		if !alreadyExists {
 			pwd, err := otp.GenerateAlphanumericCode(24)
 			if err != nil {
-				flash.Alert("Error generating password for '%v'", form.Email)
+				flash.Alert("Failed to generate password for '%v'", form.Email)
 				c.renderNew(ctx, w, user, false)
 				return
 			}

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -114,7 +114,6 @@ func (c *Controller) HandleCreate() http.Handler {
 				return
 			}
 
-			flash.Alert("Successfully created user '%v'", form.Name)
 			c.renderNew(ctx, w, user, true)
 			return
 		}

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -98,7 +98,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			return
 		}
 
-		if !alreadyExists {
+		if _, err := c.client.GetUserByEmail(ctx, user.Email); auth.IsUserNotFound(err) {
 			pwd, err := password.Generate(24, 8, 8, false, true)
 			if err != nil {
 				flash.Alert("Failed to generate password for '%v'", form.Email)
@@ -113,10 +113,13 @@ func (c *Controller) HandleCreate() http.Handler {
 				c.renderNew(ctx, w, user, false)
 				return
 			}
+
+			flash.Alert("Successfully created user '%v'", form.Name)
+			c.renderNew(ctx, w, user, true)
+			return
 		}
 
-		flash.Alert("Successfully created user '%v'", form.Name)
-		c.renderNew(ctx, w, user, !alreadyExists)
+		c.renderNew(ctx, w, user, false)
 	})
 }
 

--- a/pkg/controller/user/user.go
+++ b/pkg/controller/user/user.go
@@ -18,6 +18,7 @@ package user
 import (
 	"context"
 
+	"firebase.google.com/go/auth"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -31,6 +32,7 @@ import (
 // Controller manages users
 type Controller struct {
 	cacher cache.Cacher
+	client *auth.Client
 	config *config.ServerConfig
 	db     *database.Database
 	h      *render.Renderer
@@ -38,11 +40,12 @@ type Controller struct {
 }
 
 // New creates a new controller for managing users.
-func New(ctx context.Context, cacher cache.Cacher, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
+func New(ctx context.Context, client *auth.Client, cacher cache.Cacher, config *config.ServerConfig, db *database.Database, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx)
 
 	return &Controller{
 		cacher: cacher,
+		client: client,
 		config: config,
 		db:     db,
 		h:      h,


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We currently generate new user accounts on the client, this moves it to the server.
    * Ideally we'd send an email from the server too, but we don't have and email service.
    * Someday I'd love to restrict the public firebase APIKey from creating accounts and only allow the server to do it (and rotate a private/secret key)



