### PR TITLE
OTP entry form instead of window alert

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -36,9 +36,9 @@
   }
 
   a.disabled {
-  color: lightgray;
-  pointer-events: none;
-}
+    color: lightgray;
+    pointer-events: none;
+  }
 </style>
 {{end}}
 
@@ -234,7 +234,7 @@
 {{end}}
 
 {{define "flash"}}
-<div id="alerts">
+<div id="alerts-container">
   {{range $msg := .flash.Errors}}
   <div class="alert alert-danger" role="alert">
     {{$msg}}
@@ -366,7 +366,7 @@
     });
   });
 
-  var $alerts = $('#alerts');
+  var $alerts = $('#alerts-container');
 
   function clearExistingFlash() {
     $alerts.empty();

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -234,24 +234,26 @@
 {{end}}
 
 {{define "flash"}}
-{{range $msg := .flash.Errors}}
-<div class="alert alert-danger" role="alert">
-  {{$msg}}
+<div id="alerts">
+  {{range $msg := .flash.Errors}}
+  <div class="alert alert-danger" role="alert">
+    {{$msg}}
+  </div>
+  {{end}}
+  {{range $msg := .flash.Warnings}}
+  <div class="alert alert-warning" role="alert">
+    {{$msg}}
+  </div>
+  {{end}}
+  {{range $msg := .flash.Alerts}}
+  <div class="alert alert-success alert-dismissible fade show" role="alert">
+    {{$msg}}
+    <button type="button" class="close" data-dismiss="alert" aria-label="Close">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  {{end}}
 </div>
-{{end}}
-{{range $msg := .flash.Warnings}}
-<div class="alert alert-warning" role="alert">
-  {{$msg}}
-</div>
-{{end}}
-{{range $msg := .flash.Alerts}}
-<div class="alert alert-success alert-dismissible fade show" role="alert">
-  {{$msg}}
-  <button type="button" class="close" data-dismiss="alert" aria-label="Close">
-    <span aria-hidden="true">&times;</span>
-  </button>
-</div>
-{{end}}
 {{end}}
 
 {{define "scripts"}}
@@ -364,10 +366,10 @@
     });
   });
 
-  var $main = $('main');
+  var $alerts = $('#alerts');
 
   function clearExistingFlash() {
-    $main.find('div.alert').remove();
+    $alerts.empty();
   }
 
   function flash(message, errLevel, dismissible = undefined) {
@@ -385,7 +387,7 @@
     }
 
     let $div = $('<div class="alert alert-' + errLevel + '" role="alert">');
-    $div.text(message);
+    $div.html(message);
 
     if (dismissible) {
       $div.addClass("alert-dismissible fade show");
@@ -395,7 +397,7 @@
       </button>');
     }
 
-    $main.prepend($div);
+    $alerts.append($div);
   }
 </script>
 {{end}}

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -34,6 +34,11 @@
     cursor: pointer;
     text-decoration: none;
   }
+
+  a.disabled {
+  color: lightgray;
+  pointer-events: none;
+}
 </style>
 {{end}}
 

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -40,25 +40,25 @@
 {{end}}
 
 {{define "login/pindiv"}}
-<div class="card shadow-sm" style="display:none;" id="pin-div">
+<div class="card shadow-sm" style="display:none;" id="sms-code-div">
   <div class="card-header">
-    SMS PIN
-    <button type="button" class="close" aria-label="Close" id="pin-close">
+    SMS Confirmation Code
+    <button type="button" class="close" aria-label="Close" id="sms-code-close">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <div class="card-body">
-    <form id="pin-form" class="floating-form" action="/" method="POST">
+    <form id="sms-code-form" class="floating-form" action="/" method="POST">
       <div class="form-label-group">
-        <input type="text" id="pin" name="pin" class="form-control" placeholder="Code" autocomplete="one-time-code" required autofocus />
-        <label for="pin">Code</label>
+        <input type="text" id="sms-code" name="sms-code" class="form-control" placeholder="Code" autocomplete="one-time-code" required autofocus />
+        <label for="sms-code">Code</label>
         <small class="form-text text-muted">
           Please enter the numerical code that was sent via SMS.
         </small>
       </div>
 
-      <button type="submit" id="submit-pin" class="btn btn-primary btn-block">Confirm code</button>
-      <a id="resend-pin" class="card-link btn-block disabled" disabled>Resend SMS</a>
+      <button type="submit" id="sms-code-submit" class="btn btn-primary btn-block">Confirm code</button>
+      <a id="sms-code-resend" class="card-link btn-block disabled" disabled>Resend SMS</a>
     </form>
   </div>
 </div>

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -50,7 +50,7 @@
   <div class="card-body">
     <form id="pinForm" class="floating-form" action="/" method="POST">
       <div class="form-label-group">
-        <input type="text" id="pin" name="pin" class="form-control" placeholder="Pin" required autofocus />
+        <input type="text" id="pin" name="pin" class="form-control" placeholder="Pin" autocomplete="one-time-code" required autofocus />
         <label for="pin">Pin</label>
         <small class="form-text text-muted">
           Please enter the numerical pin that was sent via SMS.

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -38,3 +38,28 @@
   }
 </script>
 {{end}}
+
+{{define "pindiv"}}
+<div class="card mb-3 shadow-sm" style="display:none;" id="pinDiv">
+  <div class="card-header">
+    SMS Pin
+    <button type="button" class="close" aria-label="Close" id="pinClose">
+      <span aria-hidden="true">&times;</span>
+    </button>
+  </div>
+  <div class="card-body">
+    <form id="pinForm" class="floating-form" action="/" method="POST">
+      <div class="form-label-group">
+        <input type="text" id="pin" name="pin" class="form-control" placeholder="Pin" required autofocus />
+        <label for="pin">Pin</label>
+        <small class="form-text text-muted">
+          Please enter the numerical pin that was sent via SMS.
+        </small>
+      </div>
+
+      <button type="submit" id="submitPin" class="btn btn-primary btn-block">Confirm pin</button>
+      <button id="resendPin" class="btn btn-primary btn-block" disabled>Resend SMS</button>
+    </form>
+  </div>
+</div>
+{{end}}

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -39,26 +39,26 @@
 </script>
 {{end}}
 
-{{define "pindiv"}}
-<div class="card shadow-sm" style="display:none;" id="pinDiv">
+{{define "login/pindiv"}}
+<div class="card shadow-sm" style="display:none;" id="pin-div">
   <div class="card-header">
-    SMS Pin
-    <button type="button" class="close" aria-label="Close" id="pinClose">
+    SMS PIN
+    <button type="button" class="close" aria-label="Close" id="pin-close">
       <span aria-hidden="true">&times;</span>
     </button>
   </div>
   <div class="card-body">
-    <form id="pinForm" class="floating-form" action="/" method="POST">
+    <form id="pin-form" class="floating-form" action="/" method="POST">
       <div class="form-label-group">
-        <input type="text" id="pin" name="pin" class="form-control" placeholder="Pin" autocomplete="one-time-code" required autofocus />
-        <label for="pin">Pin</label>
+        <input type="text" id="pin" name="pin" class="form-control" placeholder="Code" autocomplete="one-time-code" required autofocus />
+        <label for="pin">Code</label>
         <small class="form-text text-muted">
-          Please enter the numerical pin that was sent via SMS.
+          Please enter the numerical code that was sent via SMS.
         </small>
       </div>
 
-      <button type="submit" id="submitPin" class="btn btn-primary btn-block">Confirm pin</button>
-      <a id="resendPin" class="card-link btn-block disabled" disabled>Resend SMS</a>
+      <button type="submit" id="submit-pin" class="btn btn-primary btn-block">Confirm code</button>
+      <a id="resend-pin" class="card-link btn-block disabled" disabled>Resend SMS</a>
     </form>
   </div>
 </div>

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -58,7 +58,7 @@
       </div>
 
       <button type="submit" id="submitPin" class="btn btn-primary btn-block">Confirm pin</button>
-      <button id="resendPin" class="btn btn-primary btn-block" disabled>Resend SMS</button>
+      <a id="resendPin" class="card-link btn-block disabled" disabled>Resend SMS</a>
     </form>
   </div>
 </div>

--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -40,7 +40,7 @@
 {{end}}
 
 {{define "pindiv"}}
-<div class="card mb-3 shadow-sm" style="display:none;" id="pinDiv">
+<div class="card shadow-sm" style="display:none;" id="pinDiv">
   <div class="card-header">
     SMS Pin
     <button type="button" class="close" aria-label="Close" id="pinClose">

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -16,10 +16,10 @@
       <div class="d-flex w-100 justify-content-center align-self-center">
         <div class="col-sm-6">
 
-          <div class="card shadow-sm" id="loginDiv">
+          <div class="card shadow-sm" id="login-div">
             <div class="card-header">COVID-19 test verification</div>
             <div class="card-body">
-              <form id="loginForm" class="floating-form" action="/" method="POST">
+              <form id="login-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">
                   <input type="email" id="email" name="email" class="form-control" placeholder="Email address" required
                     autofocus />
@@ -38,7 +38,7 @@
             </div>
           </div>
 
-          {{template "pindiv" .}}
+          {{template "login/pindiv" .}}
 
         </div>
       </div>
@@ -62,18 +62,18 @@
       });
 
     $(function() {
-      let $loginDiv = $('#loginDiv');
-      let $form = $('#loginForm');
+      let $loginDiv = $('#login-div');
+      let $form = $('#login-form');
       let $submit = $('#submit');
       let $email = $('#email');
       let $password = $('#password');
 
-      let $pinDiv = $('#pinDiv');
-      let $pinClose = $('#pinClose');
-      let $pinForm = $('#pinForm');
+      let $pinDiv = $('#pin-div');
+      let $pinClose = $('#pin-close');
+      let $pinForm = $('#pin-form');
       let $pin = $('#pin');
-      let $submitPin = $('#submitPin');
-      let $resendPin = $('#resendPin');
+      let $submitPin = $('#submit-pin');
+      let $resendPin = $('#resend-pin');
 
       let verId = "";
 

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -68,12 +68,12 @@
       let $email = $('#email');
       let $password = $('#password');
 
-      let $pinDiv = $('#pin-div');
-      let $pinClose = $('#pin-close');
-      let $pinForm = $('#pin-form');
-      let $pin = $('#pin');
-      let $submitPin = $('#submit-pin');
-      let $resendPin = $('#resend-pin');
+      let $pinDiv = $('#sms-code-div');
+      let $pinClose = $('#sms-code-close');
+      let $pinForm = $('#sms-code-form');
+      let $pin = $('#sms-code');
+      let $submitPin = $('#sms-code-submit');
+      let $resendPin = $('#sms-code-resend');
 
       let verId = "";
 

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -33,10 +33,8 @@
                 </div>
 
                 <button type="submit" id="submit" class="btn btn-primary btn-block">Login</button>
+                <a class="card-link btn-block" href="login/reset-password">Forgot password</a>
               </form>
-              <div class="card-body">
-                <a class="card-link" href="login/reset-password">Forgot password</a>
-              </div>
             </div>
           </div>
 
@@ -103,7 +101,7 @@
                   .then(function(verificationId) {
                     verId = verificationId;
 
-                    setTimeout(function() { $resendPin.prop('disabled', false); }, 15000);
+                    setTimeout(function() { $resendPin.removeClass('disabled'); }, 15000);
 
                     $submitPin.prop('disabled', false);
                     $loginDiv.hide();
@@ -150,8 +148,8 @@
       });
 
       $resendPin.on('click', function(event) {
-        $resendPin.prop('disabled', true);
-        setTimeout(function() { $resendPin.prop('disabled', false); }, 15000);
+        $resendPin.addClass('disabled');
+        setTimeout(function() { $resendPin.removeClass('disabled'); }, 15000);
 
         let phoneInfoOptions = {
           multiFactorHint: resolver.hints[0],

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -100,9 +100,7 @@
                 return phoneAuthProvider.verifyPhoneNumber(phoneInfoOptions, recaptchaVerifier)
                   .then(function(verificationId) {
                     verId = verificationId;
-
                     setTimeout(function() { $resendPin.removeClass('disabled'); }, 15000);
-
                     $submitPin.prop('disabled', false);
                     $loginDiv.hide();
                     $pinDiv.show();

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -15,7 +15,8 @@
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center align-self-center">
         <div class="col-sm-6">
-          <div class="card shadow-sm">
+
+          <div class="card shadow-sm" id="loginDiv">
             <div class="card-header">COVID-19 test verification</div>
             <div class="card-body">
               <form id="loginForm" class="floating-form" action="/" method="POST">
@@ -38,6 +39,9 @@
               </div>
             </div>
           </div>
+
+          {{template "pindiv" .}}
+
         </div>
       </div>
     </div>
@@ -60,10 +64,20 @@
       });
 
     $(function() {
+      let $loginDiv = $('#loginDiv');
       let $form = $('#loginForm');
       let $submit = $('#submit');
       let $email = $('#email');
       let $password = $('#password');
+
+      let $pinDiv = $('#pinDiv');
+      let $pinClose = $('#pinClose');
+      let $pinForm = $('#pinForm');
+      let $pin = $('#pin');
+      let $submitPin = $('#submitPin');
+      let $resendPin = $('#resendPin');
+
+      let verId = "";
 
       $form.on('submit', function(event) {
         event.preventDefault();
@@ -80,7 +94,6 @@
               resolver = error.resolver;
               let selectedIndex = 0 // TODO: show list of factors
               if (resolver.hints[selectedIndex].factorId === firebase.auth.PhoneMultiFactorGenerator.FACTOR_ID) {
-
                 let phoneInfoOptions = {
                   multiFactorHint: resolver.hints[selectedIndex],
                   session: resolver.session
@@ -88,16 +101,13 @@
                 let phoneAuthProvider = new firebase.auth.PhoneAuthProvider();
                 return phoneAuthProvider.verifyPhoneNumber(phoneInfoOptions, recaptchaVerifier)
                   .then(function(verificationId) {
-                    let verificationCode = window.prompt('Please enter the verification ' +
-                      'code that was sent to your mobile device.');
+                    verId = verificationId;
 
-                    // Ask user for the SMS verification code.
-                    let cred = firebase.auth.PhoneAuthProvider.credential(
-                      verificationId, verificationCode);
-                    let multiFactorAssertion =
-                      firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
-                    // Complete sign-in.
-                    return resolver.resolveSignIn(multiFactorAssertion)
+                    setTimeout(function() { $resendPin.prop('disabled', false); }, 15000);
+
+                    $submitPin.prop('disabled', false);
+                    $loginDiv.hide();
+                    $pinDiv.show();
                   }).catch(function(error) {
                     clearExistingFlash();
                     flash(error.message, "danger");
@@ -112,6 +122,49 @@
               flash(error.message, "danger");
               $submit.prop('disabled', false);
             }
+          });
+      });
+
+      $pinForm.on('submit', function(event) {
+        event.preventDefault();
+
+        // Disable the submit button so we only attempt once.
+        $submitPin.prop('disabled', true);
+
+        // Ask user for the SMS verification code.
+        let cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
+        let multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+        // Complete sign-in.
+        resolver.resolveSignIn(multiFactorAssertion)
+          .catch(function(err) {
+            clearExistingFlash();
+            flash(err.message, "danger");
+            $submit.prop('disabled', false);
+          });
+      });
+
+      $pinClose.on('click', function(event) {
+        $submit.prop('disabled', false);
+        $loginDiv.show();
+        $pinDiv.hide();
+      });
+
+      $resendPin.on('click', function(event) {
+        $resendPin.prop('disabled', true);
+        setTimeout(function() { $resendPin.prop('disabled', false); }, 15000);
+
+        let phoneInfoOptions = {
+          multiFactorHint: resolver.hints[0],
+          session: resolver.session
+        };
+        let phoneAuthProvider = new firebase.auth.PhoneAuthProvider();
+        phoneAuthProvider.verifyPhoneNumber(phoneInfoOptions, recaptchaVerifier)
+          .then(function(verificationId) {
+            verId = verificationId;
+          }).catch(function(error) {
+            clearExistingFlash();
+            flash(error.message, "danger");
+            $submit.prop('disabled', false);
           });
       });
     });

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -23,6 +23,12 @@
           <div class="card shadow-sm" id="registerDiv">
             <div class="card-header">Multi-factor authentication</div>
             <div class="card-body">
+              {{if eq .currentRealm.MFAModeString "required"}}
+              <div class="alert alert-warning">
+                <span class="oi oi-warning"></span> This realm <strong>requires</strong> multi-factor authorization.
+              </div>
+              {{end}}
+
               <p>
                 <strong>{{$currentRealm.Name}}</strong>
                 {{if eq .currentRealm.MFAModeString "required"}}requires{{else}}recommends{{end}}
@@ -68,10 +74,6 @@
 
   {{template "scripts" .}}
   <script>
-    {{if eq .currentRealm.MFAModeString "required"}}
-    flash("This realm <strong>requires</strong> multi-factor authorization.", "warning")
-    {{end}}
-
     window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
       'recaptcha-container',
       { 'size': 'invisible' }

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -13,48 +13,53 @@
 
 <body class="bg-light">
   {{template "navbar" .}}
-
   <main role="main" class="container">
     {{template "flash" .}}
 
-    <h1>Configure enhanced security</h1>
-    <p class="mb-3">
-      Use the form below to configure advanced security settings for your
-      account on {{$currentRealm.Name}}.
-    </p>
+    <div class="d-flex vh-100">
+      <div class="d-flex w-100 justify-content-center">
+        <div class="col-sm-6">
 
-    <div class="card mb-3 shadow-sm">
-      <div class="card-header">Multi-factor authentication</div>
-      <div class="card-body">
-        <p class="mb-3">
-          {{$currentRealm.Name}} {{if eq .currentRealm.MFAModeString "required"}}requires{{else}}recommends{{end}}
-          enhanced security via SMS-based 2-factor authentication. Please
-          provide your information below.
-        </p>
+          <div class="card shadow-sm" id="registerDiv">
+            <div class="card-header">Multi-factor authentication</div>
+            <div class="card-body">
+              <p>
+                <strong>{{$currentRealm.Name}}</strong>
+                {{if eq .currentRealm.MFAModeString "required"}}requires{{else}}recommends{{end}}
+                enhanced security via SMS-based 2-factor authentication. Please
+                provide your information below.
+              </p>
 
-        <form id="registerForm" class="floating-form" action="/" method="POST">
-          <div class="form-label-group">
-            <input type="tel" id="phone" name="phone" class="form-control" placeholder="Phone number" required autofocus />
-            <label for="phone">Phone number</label>
-            <small class="form-text text-muted">
-              Fully qualified phone number beginning with '+'. Standard SMS rates may apply.
-            </small>
+              <form id="registerForm" class="floating-form" action="/" method="POST">
+                <div class="form-label-group">
+                  <input type="tel" id="phone" name="phone" class="form-control" placeholder="Phone number" required
+                    autofocus />
+                  <label for="phone">Phone number</label>
+                  <small class="form-text text-muted">
+                    Fully qualified phone number beginning with '+'. Standard SMS rates may apply.
+                  </small>
+                </div>
+
+                <div class="form-label-group">
+                  <input type="text" id="display" name="display" class="form-control" placeholder="Display name" />
+                  <label for="display">Display name</label>
+                  <small class="form-text text-muted">
+                    Name for this phone.
+                  </small>
+                </div>
+
+                <button type="submit" id="submitRegister" class="btn btn-primary btn-block">Register</button>
+              </form>
+
+              {{if ne .currentRealm.MFAModeString "required"}}
+              <a id="skip" class="float-right mt-3 text-muted" href="/home">Skip for now</a>
+              {{end}}
+            </div>
           </div>
 
-          <div class="form-label-group">
-            <input type="text" id="display" name="display" class="form-control" placeholder="Display name" />
-            <label for="display">Display name</label>
-            <small class="form-text text-muted">
-              Name for this phone.
-            </small>
-          </div>
+          {{template "pindiv" .}}
 
-          <button type="submit" id="register" class="btn btn-primary btn-block">Register</button>
-        </form>
-
-        {{if ne .currentRealm.MFAModeString "required"}}
-          <a id="skip" class="float-right mt-3 text-muted" href="/home">Skip for now</a>
-        {{end}}
+        </div>
       </div>
     </div>
 
@@ -62,10 +67,9 @@
   </main>
 
   {{template "scripts" .}}
-
   <script>
     {{if eq .currentRealm.MFAModeString "required"}}
-    flash("This realm requires multi-factor authorization.","warning")
+    flash("This realm requires multi-factor authorization.", "warning")
     {{end}}
 
     window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
@@ -74,25 +78,35 @@
     );
 
     recaptchaVerifier.render()
-      .then(function (widgetId) {
+      .then(function(widgetId) {
         window.recaptchaWidgetId = widgetId;
       });
 
-    $(function () {
+    $(function() {
+      let $registerDiv = $('#registerDiv');
       let $displayName = $('#display');
-      let $submit = $('#register');
+      let $submit = $('#submitRegister');
       let $phone = $('#phone');
-      let $form = $('#registerForm');
+      let $registerForm = $('#registerForm');
       let $skip = $('#skip');
 
-      $form.on('submit', function (event) {
+      let $pinDiv = $('#pinDiv');
+      let $pinClose = $('#pinClose');
+      let $pinForm = $('#pinForm');
+      let $pin = $('#pin');
+      let $submitPin = $('#submitPin');
+      let $resendPin = $('#resendPin');
+
+      let verId = ""
+
+      $registerForm.on('submit', function(event) {
         event.preventDefault();
 
         // Disable the submit button so we only attempt once.
         $submit.prop('disabled', true);
 
         let user = firebase.auth().currentUser
-        user.multiFactor.getSession().then(function (multiFactorSession) {
+        user.multiFactor.getSession().then(function(multiFactorSession) {
           // Specify the phone number and pass the MFA session.
           var phoneInfoOptions = {
             phoneNumber: $phone.val(),
@@ -102,23 +116,63 @@
           // Send SMS verification code.
           return phoneAuthProvider.verifyPhoneNumber(
             phoneInfoOptions, window.recaptchaVerifier);
-        }).then(function (verificationId) {
-          var verificationCode = window.prompt('Please enter the verification ' +
-            'code that was sent to your mobile device.');
-          var cred = firebase.auth.PhoneAuthProvider.credential(verificationId, verificationCode);
-          var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
-          // Complete enrollment.
-          return user.multiFactor.enroll(multiFactorAssertion, $displayName.val());
-        }).then(function () {
-          clearExistingFlash();
-          flash("SMS authentication enrolled successfully.", "success");
-          $skip.text("Continue")
-        }).catch(function (err) {
+        }).then(function(verificationId) {
+          verId = verificationId
+          setTimeout(function() { $resendPin.removeClass('disabled'); }, 15000);
+          $registerDiv.hide();
+          $pinDiv.show();
+        }).catch(function(err) {
           clearExistingFlash();
           flash(err.message, "danger");
           $submit.prop('disabled', false);
-        }
-        );
+        });
+      });
+
+      $pinForm.on('submit', function(event) {
+        event.preventDefault();
+
+        // Disable the submit button so we only attempt once.
+        $submitPin.prop('disabled', true);
+
+        var cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
+        var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
+
+        // Complete enrollment.
+        let user = firebase.auth().currentUser
+        user.multiFactor.enroll(multiFactorAssertion, $displayName.val()).then(function() {
+          clearExistingFlash();
+          flash("SMS authentication enrolled successfully.", "success");
+          $skip.text("Continue")
+        }).catch(function(err) {
+          clearExistingFlash();
+          flash(err.message, "danger");
+          $submit.prop('disabled', false);
+        });
+      });
+
+      $pinClose.on('click', function(event) {
+        $submit.prop('disabled', false);
+        $registerDiv.show();
+        $pinDiv.hide();
+      });
+
+      $resendPin.on('click', function(event) {
+        $resendPin.addClass('disabled');
+        setTimeout(function() { $resendPin.removeClass('disabled'); }, 15000);
+
+        let phoneInfoOptions = {
+          multiFactorHint: resolver.hints[0],
+          session: resolver.session
+        };
+        let phoneAuthProvider = new firebase.auth.PhoneAuthProvider();
+        phoneAuthProvider.verifyPhoneNumber(phoneInfoOptions, recaptchaVerifier)
+          .then(function(verificationId) {
+            verId = verificationId;
+          }).catch(function(error) {
+            clearExistingFlash();
+            flash(error.message, "danger");
+            $submit.prop('disabled', false);
+          });
       });
     });
   </script>

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -20,7 +20,7 @@
       <div class="d-flex w-100 justify-content-center">
         <div class="col-sm-6">
 
-          <div class="card shadow-sm" id="registerDiv">
+          <div class="card shadow-sm" id="register-div">
             <div class="card-header">Multi-factor authentication</div>
             <div class="card-body">
               {{if eq .currentRealm.MFAModeString "required"}}
@@ -36,7 +36,7 @@
                 provide your information below.
               </p>
 
-              <form id="registerForm" class="floating-form" action="/" method="POST">
+              <form id="register-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">
                   <input type="tel" id="phone" name="phone" class="form-control" placeholder="Phone number" required
                     autofocus />
@@ -54,7 +54,7 @@
                   </small>
                 </div>
 
-                <button type="submit" id="submitRegister" class="btn btn-primary btn-block">Register</button>
+                <button type="submit" id="submit-register" class="btn btn-primary btn-block">Register</button>
               </form>
 
               {{if ne .currentRealm.MFAModeString "required"}}
@@ -63,7 +63,7 @@
             </div>
           </div>
 
-          {{template "pindiv" .}}
+          {{template "login/pindiv" .}}
 
         </div>
       </div>
@@ -85,19 +85,19 @@
       });
 
     $(function() {
-      let $registerDiv = $('#registerDiv');
+      let $registerDiv = $('#register-div');
       let $displayName = $('#display');
-      let $submit = $('#submitRegister');
+      let $submit = $('#submit-register');
       let $phone = $('#phone');
-      let $registerForm = $('#registerForm');
+      let $registerForm = $('#register-form');
       let $skip = $('#skip');
 
-      let $pinDiv = $('#pinDiv');
-      let $pinClose = $('#pinClose');
-      let $pinForm = $('#pinForm');
+      let $pinDiv = $('#pin-div');
+      let $pinClose = $('#pin-close');
+      let $pinForm = $('#pin-form');
       let $pin = $('#pin');
-      let $submitPin = $('#submitPin');
-      let $resendPin = $('#resendPin');
+      let $submitPin = $('#submit-pin');
+      let $resendPin = $('#resend-pin');
 
       let verId = ""
 

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -107,10 +107,6 @@
         // Disable the submit button so we only attempt once.
         $submit.prop('disabled', true);
 
-        $registerDiv.hide();
-        $pinDiv.show();
-        return // for testing
-
         let user = firebase.auth().currentUser
         user.multiFactor.getSession().then(function(multiFactorSession) {
           // Specify the phone number and pass the MFA session.
@@ -139,8 +135,6 @@
 
         // Disable the submit button so we only attempt once.
         $submitPin.prop('disabled', true);
-
-        return // for testing
 
         var cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
         var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -92,12 +92,12 @@
       let $registerForm = $('#register-form');
       let $skip = $('#skip');
 
-      let $pinDiv = $('#pin-div');
-      let $pinClose = $('#pin-close');
-      let $pinForm = $('#pin-form');
-      let $pin = $('#pin');
-      let $submitPin = $('#submit-pin');
-      let $resendPin = $('#resend-pin');
+      let $pinDiv = $('#sms-code-div');
+      let $pinClose = $('#sms-code-close');
+      let $pinForm = $('#sms-code-form');
+      let $pin = $('#sms-code');
+      let $submitPin = $('#sms-code-submit');
+      let $resendPin = $('#sms-code-resend');
 
       let verId = ""
 

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -69,7 +69,7 @@
   {{template "scripts" .}}
   <script>
     {{if eq .currentRealm.MFAModeString "required"}}
-    flash("This realm requires multi-factor authorization.", "warning")
+    flash("This realm <strong>requires</strong> multi-factor authorization.", "warning")
     {{end}}
 
     window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
@@ -105,6 +105,10 @@
         // Disable the submit button so we only attempt once.
         $submit.prop('disabled', true);
 
+        $registerDiv.hide();
+        $pinDiv.show();
+        return // for testing
+
         let user = firebase.auth().currentUser
         user.multiFactor.getSession().then(function(multiFactorSession) {
           // Specify the phone number and pass the MFA session.
@@ -133,6 +137,8 @@
 
         // Disable the submit button so we only attempt once.
         $submitPin.prop('disabled', true);
+
+        return // for testing
 
         var cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
         var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -16,20 +16,25 @@
       <div class="d-flex w-100 justify-content-center align-self-center">
         <div class="col-sm-6">
           <div class="card shadow-sm">
-            <div class="card-header">Reset password</div>
+            <div class="card-header">
+              Reset password
+              <a href="/" type="button" class="close" aria-label="Close" id="pinClose">
+                <span aria-hidden="true">&times;</span>
+              </a>
+            </div>
             <div class="card-body">
               <form id="loginForm" class="floating-form" action="/" method="POST">
                 <div class="form-label-group mb-2">
                   <input type="email" id="email" name="email" class="form-control" placeholder="Email address" required
                     autofocus />
                   <label for="email">Email address</label>
+                  <small class="form-text text-muted">
+                    A reset link will be sent to this address.
+                  </small>
                 </div>
 
                 <button type="submit" id="submit" class="btn btn-primary btn-block">Send reset email</button>
               </form>
-            </div>
-            <div class="card-body">
-              <a class="card-link" href="/">&larr; Login</a>
             </div>
           </div>
         </div>

--- a/pkg/controller/login/select.go
+++ b/pkg/controller/login/select.go
@@ -94,7 +94,6 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 		}
 
 		controller.StoreSessionRealm(session, realm)
-		flash.Alert("Successfully selected realm '%s'", realm.Name)
 		http.Redirect(w, r, "/home", http.StatusSeeOther)
 	})
 }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/545

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Create a custom html pin form for login and registerphone
* Resend SMS link is disabled and enables on a 15s timer.
* Use the close-icon to return to previous
* Some css tweaks

![pinform](https://user-images.githubusercontent.com/36240966/93428674-bbddee00-f874-11ea-9ad5-fc8e3c54f606.png)

![register](https://user-images.githubusercontent.com/36240966/93476589-d2a13680-f8ae-11ea-80c0-3d47a4cb3fc2.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use custom html for entering SMS pin
```
