### PR TITLE
Add admin/info page to display build info

### DIFF
--- a/cmd/server/assets/admin/info.html
+++ b/cmd/server/assets/admin/info.html
@@ -1,0 +1,33 @@
+{{define "admin/info"}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="bg-light">
+  {{template "navbar" .}}
+  {{template "admin/navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Info</div>
+      <div class="card-body">
+        <dl>
+          <dt>Build ID</dt>
+          <dd>{{.buildID}}</dd>
+
+          <dt>Build Tag</dt>
+          <dd>{{.buildTag}}</dd>
+        </dl>
+      </div>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -1,7 +1,7 @@
 {{define "head"}}
 <meta charset="utf-8">
 <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
-<meta data-build-id="{{.build_id}}" data-build-tag="{{.build_tag}}">
+<meta data-build-id="{{.buildID}}" data-build-tag="{{.buildTag}}">
 
 <link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
 <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
@@ -22,10 +22,6 @@
 <title>{{if .title}}{{.title}}{{else}}Diagnosis Verification Server{{end}}</title>
 
 <style type="text/css">
-  nav.navbar {
-    margin-bottom: 40px;
-  }
-
   div.realm-header {
     background-color: #0055b1;
   }
@@ -159,7 +155,7 @@
 {{end}}
 
 {{define "navbar"}}
-<header>
+<header class="mb-3">
   {{if .currentRealm}}
   <div href="/" class="d-block px-3 py-2 text-center text-bold text-white realm-header">
     {{.currentRealm.Name}}{{if .currentRealm.RegionCode}} - {{.currentRealm.RegionCode}}{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -372,6 +372,8 @@ func realMain(ctx context.Context) error {
 		adminSub.Handle("/realms", adminController.HandleIndex()).Methods("GET")
 		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("GET")
 		adminSub.Handle("/realms/create", adminController.HandleCreateRealm()).Methods("POST")
+
+		adminSub.Handle("/info", adminController.HandleInfoShow()).Methods("GET")
 	}
 
 	// Wrap the main router in the mutating middleware method. This cannot be

--- a/pkg/controller/admin/info.go
+++ b/pkg/controller/admin/info.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+)
+
+// HandleInfoShow renders the list of system admins.
+func (c *Controller) HandleInfoShow() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		m := controller.TemplateMapFromContext(ctx)
+		c.h.RenderHTML(w, "admin/info", m)
+	})
+}

--- a/pkg/controller/middleware/template.go
+++ b/pkg/controller/middleware/template.go
@@ -17,6 +17,7 @@ package middleware
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
@@ -36,8 +37,11 @@ func PopulateTemplateVariables(ctx context.Context, config *config.ServerConfig)
 			m := controller.TemplateMapFromContext(ctx)
 			m["server"] = config.ServerName
 			m["title"] = config.ServerName
-			m["build_id"] = buildinfo.BuildID
-			m["build_tag"] = buildinfo.BuildTag
+			m["buildID"] = buildinfo.BuildID
+			m["buildTag"] = buildinfo.BuildTag
+
+			// Current page variables.
+			m["currentPath"] = "/" + strings.Trim(r.URL.Path, "/")
 
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -130,8 +130,9 @@ func loadTemplates(tmpl *template.Template, root string) error {
 
 func templateFuncs() template.FuncMap {
 	return map[string]interface{}{
-		"joinStrings": strings.Join,
-		"trimSpace":   strings.TrimSpace,
+		"joinStrings":    strings.Join,
+		"trimSpace":      strings.TrimSpace,
+		"stringContains": strings.Contains,
 	}
 }
 


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add info page for admins to see build info
```
