### PR TITLE
Add enforcement mechanism for realm quotas

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -150,7 +150,7 @@ func realMain(ctx context.Context) error {
 		// Install the APIKey Auth Middleware
 		sub.Use(requireAPIKey)
 
-		issueapiController, err := issueapi.New(ctx, config, db, h)
+		issueapiController, err := issueapi.New(ctx, config, db, limiterStore, h)
 		if err != nil {
 			return fmt.Errorf("issueapi.New: %w", err)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -252,7 +252,7 @@ func realMain(ctx context.Context) error {
 		sub.Handle("", homeController.HandleHome()).Methods("GET")
 
 		// API for creating new verification codes. Called via AJAX.
-		issueapiController, err := issueapi.New(ctx, config, db, h)
+		issueapiController, err := issueapi.New(ctx, config, db, limiterStore, h)
 		if err != nil {
 			return fmt.Errorf("issueapi.New: %w", err)
 		}

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -47,6 +47,7 @@ type AdminAPIServerConfig struct {
 
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
+	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=false"`
 }
 
 // NewAdminAPIServerConfig returns the environment config for the Admin API server.
@@ -83,6 +84,14 @@ func (c *AdminAPIServerConfig) GetCollisionRetryCount() uint {
 
 func (c *AdminAPIServerConfig) GetAllowedSymptomAge() time.Duration {
 	return c.AllowedSymptomAge
+}
+
+func (c *AdminAPIServerConfig) GetEnforceRealmQuotas() bool {
+	return c.EnforceRealmQuotas
+}
+
+func (c *AdminAPIServerConfig) GetRateLimitConfig() *ratelimit.Config {
+	return &c.RateLimit
 }
 
 func (c *AdminAPIServerConfig) ObservabilityExporterConfig() *observability.Config {

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -14,11 +14,17 @@
 
 package config
 
-import "time"
+import (
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
+)
 
 // IssueAPIConfig is an interface that represents what is needed of the verification
 // code issue API.
 type IssueAPIConfig interface {
 	GetCollisionRetryCount() uint
 	GetAllowedSymptomAge() time.Duration
+	GetEnforceRealmQuotas() bool
+	GetRateLimitConfig() *ratelimit.Config
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -59,6 +59,7 @@ type ServerConfig struct {
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
+	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=false"`
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
 
@@ -109,6 +110,14 @@ func (c *ServerConfig) GetCollisionRetryCount() uint {
 
 func (c *ServerConfig) GetAllowedSymptomAge() time.Duration {
 	return c.AllowedSymptomAge
+}
+
+func (c *ServerConfig) GetEnforceRealmQuotas() bool {
+	return c.EnforceRealmQuotas
+}
+
+func (c *ServerConfig) GetRateLimitConfig() *ratelimit.Config {
+	return &c.RateLimit
 }
 
 func (c *ServerConfig) ObservabilityExporterConfig() *observability.Config {

--- a/pkg/controller/issueapi/issueapi.go
+++ b/pkg/controller/issueapi/issueapi.go
@@ -27,14 +27,16 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
+	"github.com/sethvargo/go-limiter"
 	"go.uber.org/zap"
 )
 
 type Controller struct {
-	config config.IssueAPIConfig
-	db     *database.Database
-	h      *render.Renderer
-	logger *zap.SugaredLogger
+	config  config.IssueAPIConfig
+	db      *database.Database
+	h       *render.Renderer
+	limiter limiter.Store
+	logger  *zap.SugaredLogger
 
 	validTestType map[string]struct{}
 
@@ -42,17 +44,18 @@ type Controller struct {
 }
 
 // New creates a new IssueAPI controller.
-func New(ctx context.Context, config config.IssueAPIConfig, db *database.Database, h *render.Renderer) (*Controller, error) {
+func New(ctx context.Context, config config.IssueAPIConfig, db *database.Database, limiter limiter.Store, h *render.Renderer) (*Controller, error) {
 	metrics, err := registerMetrics()
 	if err != nil {
 		return nil, err
 	}
 
 	return &Controller{
-		config: config,
-		db:     db,
-		h:      h,
-		logger: logging.FromContext(ctx),
+		config:  config,
+		db:      db,
+		h:       h,
+		limiter: limiter,
+		logger:  logging.FromContext(ctx),
 		validTestType: map[string]struct{}{
 			api.TestTypeConfirmed: {},
 			api.TestTypeLikely:    {},


### PR DESCRIPTION
Fixes GH-534

This adds an optional (off by default) enforcement mechanism for per-realm daily quota enforcement.

**Release Note**

```release-note
Add enforcement mechanism for realm quotas
```
