### PR TITLE
Make default session duration 20h

### DIFF
--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -41,7 +41,7 @@ type ServerConfig struct {
 	Port string `env:"PORT,default=8080"`
 
 	// Login Config
-	SessionDuration   time.Duration `env:"SESSION_DURATION,default=24h"`
+	SessionDuration   time.Duration `env:"SESSION_DURATION, default=20h"`
 	RevokeCheckPeriod time.Duration `env:"REVOKE_CHECK_DURATION,default=5m"`
 
 	// CookieKeys is a slice of bytes. The first is 64 bytes, the second is 32.


### PR DESCRIPTION
Part of GH-574

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change default session duration from 24h to 20h
```
