### PR TITLE
Add session idle duration

### DIFF
--- a/cmd/server/assets/home.html
+++ b/cmd/server/assets/home.html
@@ -386,6 +386,12 @@
           }
         },
         error: function(xhr, resp, text) {
+          // On unauthorized, force a logout
+          if (xhr.status === 401 || xhr.status == 403) {
+            window.location.assign('/signout');
+            return;
+          }
+
           // Show reset button
           $buttonReset.removeClass('d-none');
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -182,7 +182,7 @@ func realMain(ctx context.Context) error {
 	r.Use(requireSession)
 
 	// Create common middleware
-	requireAuth := middleware.RequireAuth(ctx, cacher, auth, db, h, config.SessionDuration)
+	requireAuth := middleware.RequireAuth(ctx, cacher, auth, db, h, config.SessionIdleTimeout, config.SessionDuration)
 	requireVerified := middleware.RequireVerified(ctx, auth, db, h, config.SessionDuration)
 	requireAdmin := middleware.RequireRealmAdmin(ctx, h)
 	loadCurrentRealm := middleware.LoadCurrentRealm(ctx, cacher, db, h)

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -55,8 +55,9 @@ type ServerConfig struct {
 	Port string `env:"PORT,default=8080"`
 
 	// Login Config
-	SessionDuration   time.Duration `env:"SESSION_DURATION, default=20h"`
-	RevokeCheckPeriod time.Duration `env:"REVOKE_CHECK_DURATION,default=5m"`
+	SessionDuration    time.Duration `env:"SESSION_DURATION, default=20h"`
+	SessionIdleTimeout time.Duration `env:"SESSION_IDLE_TIMEOUT, default=20m"`
+	RevokeCheckPeriod  time.Duration `env:"REVOKE_CHECK_DURATION, default=5m"`
 
 	// Password Config
 	PasswordRequirements PasswordRequirementsConfig

--- a/pkg/controller/middleware/sessions.go
+++ b/pkg/controller/middleware/sessions.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -72,6 +73,7 @@ func RequireSession(ctx context.Context, store sessions.Store, h *render.Rendere
 				once.Do(func() {
 					session := controller.SessionFromContext(ctx)
 					if session != nil {
+						controller.StoreSessionLastActivity(session, time.Now())
 						err = session.Save(r, w)
 					}
 				})

--- a/pkg/controller/session.go
+++ b/pkg/controller/session.go
@@ -15,6 +15,8 @@
 package controller
 
 import (
+	"time"
+
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/sessions"
 )
@@ -25,11 +27,12 @@ import (
 type sessionKey string
 
 const (
-	sessionKeyFirebaseCookie  = sessionKey("firebaseCookie")
-	sessionKeyRealmID         = sessionKey("realmID")
+	emailVerificationPrompted = sessionKey("emailVerificationPrompted")
 	factorCount               = sessionKey("factorCount")
 	mfaPrompted               = sessionKey("mfaPrompted")
-	emailVerificationPrompted = sessionKey("emailVerificationPrompted")
+	sessionKeyFirebaseCookie  = sessionKey("firebaseCookie")
+	sessionKeyLastActivity    = sessionKey("lastActivity")
+	sessionKeyRealmID         = sessionKey("realmID")
 )
 
 // StoreSessionFirebaseCookie stores the firebase cookie in the session. If the
@@ -147,6 +150,36 @@ func MFAPromptedFromSession(session *sessions.Session) bool {
 	}
 
 	return f
+}
+
+// StoreSessionLastActivity stores the last time the user did something. This is
+// used to track idle session timeouts.
+func StoreSessionLastActivity(session *sessions.Session, t time.Time) {
+	if session == nil {
+		return
+	}
+	session.Values[sessionKeyLastActivity] = t.Unix()
+}
+
+// ClearLastActivity clears the session last activity time.
+func ClearLastActivity(session *sessions.Session) {
+	sessionClear(session, sessionKeyLastActivity)
+}
+
+// LastActivityFromSession extractsthe last time the user did something.
+func LastActivityFromSession(session *sessions.Session) time.Time {
+	v := sessionGet(session, sessionKeyLastActivity)
+	if v == nil {
+		return time.Time{}
+	}
+
+	i, ok := v.(int64)
+	if !ok || i == 0 {
+		delete(session.Values, sessionKeyLastActivity)
+		return time.Time{}
+	}
+
+	return time.Unix(i, 0)
 }
 
 // StoreSessionEmailVerificationPrompted stores if the user was prompted for email verification.


### PR DESCRIPTION
Fixes GH-574

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add session idle duration with a default of 20min
```
