### PR TITLE
Enforce password  rotation

### DIFF
--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -9,6 +9,9 @@
 </head>
 
 <body class="bg-light">
+  {{if .currentUser}}
+  {{template "navbar" .}}
+  {{end}}
   <main role="main" class="container">
     {{template "flash" .}}
 
@@ -43,7 +46,6 @@
   </main>
 
   {{template "scripts" .}}
-  {{template "loginscripts" .}}
 
   <script type="text/javascript">
     $(function() {

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -221,6 +221,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
 			sub.Handle("/login/select-realm", loginController.HandleSelectRealm()).Methods("GET", "POST")
+			sub.Handle("/login/change-password", loginController.HandleResetPassword()).Methods("GET")
 
 			// Verifying email requires the user is logged in
 			sub = r.PathPrefix("").Subrouter()

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,6 +120,11 @@ func RedirectToMFA(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
 	http.Redirect(w, r, "/login/register-phone", http.StatusSeeOther)
 }
 
+// RedirectToResetPassword redirects to the password reset page.
+func RedirectToResetPassword(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
+	http.Redirect(w, r, "/login/reset-password", http.StatusSeeOther)
+}
+
 func prefixInList(list []string, prefix string) bool {
 	for _, v := range list {
 		if strings.HasPrefix(v, prefix) {

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -120,9 +120,9 @@ func RedirectToMFA(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
 	http.Redirect(w, r, "/login/register-phone", http.StatusSeeOther)
 }
 
-// RedirectToResetPassword redirects to the password reset page.
-func RedirectToResetPassword(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
-	http.Redirect(w, r, "/login/reset-password", http.StatusSeeOther)
+// RedirectToChangePassword redirects to the password reset page.
+func RedirectToChangePassword(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
+	http.Redirect(w, r, "/login/change-password", http.StatusSeeOther)
 }
 
 func prefixInList(list []string, prefix string) bool {

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -26,7 +26,6 @@ func (c *Controller) HandleResetPassword() http.Handler {
 		ctx := r.Context()
 
 		m := controller.TemplateMapFromContext(ctx)
-
 		m["firebase"] = c.config.Firebase
 		c.h.RenderHTML(w, "login/reset-password", m)
 	})

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -26,6 +26,7 @@ func (c *Controller) HandleResetPassword() http.Handler {
 		ctx := r.Context()
 
 		m := controller.TemplateMapFromContext(ctx)
+
 		m["firebase"] = c.config.Firebase
 		c.h.RenderHTML(w, "login/reset-password", m)
 	})

--- a/pkg/controller/middleware/realm.go
+++ b/pkg/controller/middleware/realm.go
@@ -16,8 +16,10 @@ package middleware
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"net/http"
+	"strings"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
@@ -115,6 +117,10 @@ func RequireRealm(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 				return
 			}
 
+			if passwordRedirectRequired(ctx, user, realm) {
+				controller.RedirectToResetPassword(w, r, h)
+			}
+
 			next.ServeHTTP(w, r)
 		})
 	}
@@ -152,7 +158,59 @@ func RequireRealmAdmin(ctx context.Context, h *render.Renderer) mux.MiddlewareFu
 				return
 			}
 
+			if passwordRedirectRequired(ctx, user, realm) {
+				controller.RedirectToResetPassword(w, r, h)
+			}
+
 			next.ServeHTTP(w, r)
 		})
 	}
+}
+
+func passwordRedirectRequired(ctx context.Context, user *database.User, realm *database.Realm) bool {
+	switch checkRealmPasswordAge(user, realm) {
+	case nil:
+		return false
+	case errPasswordChangeRequired:
+		return true
+	default:
+		if session := controller.SessionFromContext(ctx); !controller.
+			PasswordExpireWarnedFromSession(session) {
+			controller.StorePasswordExpireWarned(session, true)
+			flash := controller.Flash(session)
+			flash.Alert(strings.Title(err.Error()) + ".")
+		}
+		return false
+	}
+}
+
+var errPasswordChangeRequired = errors.New("password change required")
+
+func checkRealmPasswordAge(user *database.User, realm *database.Realm) error {
+	if realm.PasswordRotationPeriodDays <= 0 {
+		return nil
+	}
+
+	now := time.Now().UTC()
+	nextPasswordChange := user.LastPasswordChange.Add(
+		time.Hour * 24 * time.Duration(realm.PasswordRotationPeriodDays))
+
+	if nextPasswordChange.After(now) {
+		return errPasswordChangeRequired
+	}
+
+	if nextPasswordChange.Add(
+		time.Hour * 24 * time.Duration(realm.PasswordRotationWarningDays)).
+		After(now) {
+		untilChange := nextPasswordChange.Sub(now).Hours()
+		if daysUntilChange := int(untilChange / 24); daysUntilChange > 1 {
+			return fmt.Errorf("password change required in %d days", daysUntilChange)
+		}
+		if hoursUntilChange := int(untilChange); hoursUntilChange > 1 {
+			return fmt.Errorf("password change required in %d hours", hoursUntilChange)
+		}
+		return fmt.Errorf("password change required soon")
+	}
+
+	return nil
 }

--- a/pkg/controller/session.go
+++ b/pkg/controller/session.go
@@ -34,6 +34,7 @@ const (
 	sessionKeyLastActivity            = sessionKey("lastActivity")
 	sessionKeyRealmID                 = sessionKey("realmID")
 	sessionKeyWelcomeMessageDisplayed = sessionKey("welcomeMessageDisplayed")
+	passwordExpireWarned              = sessionKey("passwordExpireWarned")
 )
 
 // StoreSessionFirebaseCookie stores the firebase cookie in the session. If the
@@ -238,6 +239,37 @@ func WelcomeMessageDisplayedFromSession(session *sessions.Session) bool {
 	f, ok := v.(bool)
 	if !ok {
 		delete(session.Values, sessionKeyWelcomeMessageDisplayed)
+		return false
+	}
+
+	return f
+}
+
+// StorePasswordExpireWarned stores if the user was displayed the
+// realm welcome message.
+func StorePasswordExpireWarned(session *sessions.Session, prompted bool) {
+	if session == nil {
+		return
+	}
+	session.Values[passwordExpireWarned] = prompted
+}
+
+// ClearPasswordExpireWarned clears the welcome message prompt bit.
+func ClearPasswordExpireWarned(session *sessions.Session) {
+	sessionClear(session, passwordExpireWarned)
+}
+
+// PasswordExpireWarnedFromSession extracts if the user was displayed the
+// realm welcome message.
+func PasswordExpireWarnedFromSession(session *sessions.Session) bool {
+	v := sessionGet(session, passwordExpireWarned)
+	if v == nil {
+		return false
+	}
+
+	f, ok := v.(bool)
+	if !ok {
+		delete(session.Values, passwordExpireWarned)
 		return false
 	}
 


### PR DESCRIPTION
Fixes #https://github.com/google/exposure-notifications-verification-server/issues/575

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Enforce password age per realm setting
    * Currently redirects to a change-password page that is the same as reset-password.
    * We should create a real password change page so an authed user nearing the deadline doesn't need the full email re-verification.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Enforce password rotation
```
