### PR TITLE
Issue582

### DIFF
--- a/cmd/server/assets/realm.html
+++ b/cmd/server/assets/realm.html
@@ -1,0 +1,625 @@
+{{define "realm"}}
+
+{{$realm := .realm}}
+{{$smsConfig := .smsConfig}}
+{{$testTypes := .testTypes}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+  {{template "floatingform" .}}
+</head>
+
+<body class="bg-light">
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Realm settings</h1>
+    <p>
+      Find or edit the settings for <strong>{{$realm.Name}}</strong> below.
+    </p>
+
+    {{if not $realm.EnableENExpress}}
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          Exposure Notifications Express
+        </div>
+        <div class="card-body">
+          <p>
+            Click the button below to enable Exposure Notifications Express (EN
+            Express). You should only do this if you have confirmed
+            participation with Apple and Google.
+          </p>
+
+          <p class="text-danger">
+            This will override the settings and force the EN Express defaults.
+          </p>
+
+          <form method="POST" action="/realm/settings/enable-express">
+            {{ .csrfField }}
+            <a href="#" class="btn btn-primary btn-block" data-confirm="Are you sure you want to enable EN Express? You should only do this if you have confirmed participation with Apple and Google." data-submit-form>Enable EN Express</a>
+          </form>
+        </div>
+      </div>
+    {{end}}
+
+
+    <form method="POST" class="floating-form" action="/realm/settings/save">
+      {{ .csrfField }}
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          General settings
+        </div>
+        <div class="card-body">
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Name:</label>
+            <div class="col-sm-9">
+              <input type="text" id="name" name="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}" value="{{$realm.Name}}" />
+              {{if $realm.ErrorsFor "name"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "name") ", "}}
+              </div>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Region code:</label>
+            <div class="col-sm-9">
+              <input type="text" id="regionCode" name="regionCode" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}" value="{{$realm.RegionCode}}" />
+              {{if $realm.ErrorsFor "regionCode"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                Used in creating deep link SMS for multi-helath authority apps. Region should
+                be <a href="https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes">ISO 3166-1 country codes and ISO 3166-2 subdivision codes</a> where applicable.
+                For example, Washington State would be <code>US-WA</code>.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">Welcome message:</label>
+            <div class="col-sm-9">
+              <textarea id="welcome-message" name="welcomeMessage" class="form-control text-monospace{{if $realm.ErrorsFor "welcomeMessage"}} is-invalid{{end}}" rows="5">{{$realm.WelcomeMessage}}</textarea>
+              {{if $realm.ErrorsFor "welcomeMessage"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "welcomeMessage") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                Custom welcome message to display to users after selecting this
+                realm. Supports the common <a href="https://daringfireball.net/projects/markdown/syntax">markdown</a> stanard.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row mb-0">
+            <label class="col-sm-3">Allowed tests:</label>
+            <div class="col-sm-9">
+              {{if not $realm.EnableENExpress}}
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="allowedTestTypes" id="negative" value="{{$testTypes.negative}}"{{if eq $realm.AllowedTestTypes $testTypes.negative}} checked{{end}}/>
+                  <label class="form-check-label" for="negative">
+                    Positive + Likely + Negative
+                    <small class="form-text text-muted">
+                      Support confirmed positive tests from an official testing
+                      source, clinical diagnoses without a test, and confirmed
+                      negative test from an official testing source.
+                    </small>
+                  </label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="allowedTestTypes" id="likely" value="{{$testTypes.likely}}"{{if eq $realm.AllowedTestTypes $testTypes.likely}} checked{{end}} />
+                  <label class="form-check-label" for="likely">
+                    Positive + Likely
+                    <small class="form-text text-muted">
+                      Support confirmed positive tests from an official testing
+                      source and clinical diagnoses without a test.
+                    </small>
+                  </label>
+                </div>
+              </div>
+              {{end}}
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="allowedTestTypes" id="confirmed" value="{{$testTypes.confirmed}}"{{if eq $realm.AllowedTestTypes $testTypes.confirmed}} checked{{end}} />
+                  <label class="form-check-label" for="confirmed">
+                    Positive
+                    <small class="form-text text-muted">
+                      Only permit confirmed positive tests from an official
+                      testing source.
+                      {{if $realm.EnableENExpress}} <br/>
+                      You are enrolled in EN Express which only supports the sharing of
+                      positive tests.
+                      {{end}}
+                    </small>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="emailVerifiedMode" class="col-sm-3">Email verified:</label>
+            <div class="col-sm-9">
+              <select name="emailVerifiedMode" id="emailVerifiedMode" class="form-control">
+                <option value="1" {{if eq $realm.EmailVerifiedMode.String "required"}}selected{{end}}>Required</option>
+                <option value="0" {{if eq $realm.EmailVerifiedMode.String "prompt"}}selected{{end}}>Prompt after login</option>
+                <option value="2" {{if eq $realm.EmailVerifiedMode.String "optional"}}selected{{end}}>Optional</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="MFAMode" class="col-sm-3">Multi factor auth:</label>
+            <div class="col-sm-9">
+              <select name="MFAMode" id="MFAMode" class="form-control">
+                <option value="1" {{if eq $realm.MFAMode.String "required"}}selected{{end}}>Required</option>
+                <option value="0" {{if eq $realm.MFAMode.String "prompt"}}selected{{end}}>Prompt after login</option>
+                <option value="2" {{if eq $realm.MFAMode.String "optional"}}selected{{end}}>Optional</option>
+              </select>
+            </div>
+          </div>
+
+          <div class="form-group row mb-n3">
+            <label for="passwordRotate" class="col-sm-3">Password rotation every:</label>
+            <div class="col-sm-2">
+              <select class="form-control" name="passwordRotate" id="passwordRotate">
+                {{$current := $realm.PasswordRotationPeriodDays}}
+                {{range $prd := .passwordRotateDays}}
+                <option value="{{$prd}}" {{if (eq $prd $current)}}selected{{end}}>{{if (eq $prd 0)}}Off{{else}}{{$prd}}{{end}}</option>
+                {{end}}
+              </select>
+            </div>
+            <div class="input-group-append">
+              <label class="ml-1" for="passwordWarn">days</label>
+            </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-sm-3"></div>
+            <small class="form-text text-muted col">
+              The server will require the user to change their password after this number of
+              days elapse since their last password change.
+            </small>
+          </div>
+
+          <div class="form-group row  mb-n3">
+            <label for="passwordRotate" class="col-sm-3">Password rotation warning:</label>
+            <div class="col-sm-2">
+              <select class="custom-select{{if $realm.ErrorsFor "passwordWarn"}} is-invalid{{end}}" name="passwordWarn" id="passwordWarn">
+                {{$current := $realm.PasswordRotationWarningDays}}
+                {{range $pwd := .passwordWarnDays}}
+                <option value="{{$pwd }}" {{if (eq $pwd $current)}}selected{{end}}>{{if (eq $pwd 0)}}Off{{else}}{{$pwd}}{{end}}</option>
+                {{end}}
+              </select>
+             </div>
+              <div class="input-group-append">
+                <label class="ml-1" for="passwordWarn">days before rotation</label>
+              </div>
+          </div>
+          <div class="row mb-3">
+            <div class="col-sm-3"></div>
+            <small class="form-text text-muted col">
+              When the next password rotation is due in this many days, the server will warn the users
+              that their password will expire soon.
+            </small>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          Verification code configuration
+        </div>
+        <div class="card-body">
+          <div class="form-group row">
+            <label for="require_date" class="col-sm-3">Date configuration:</label>
+            <div class="col-sm-9">
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="requireDate" id="requireDateFalse" value="false"{{if not $realm.RequireDate }} checked{{end}}/>
+                  <label class="form-check-label" for="requireDateFalse">
+                    Optional date
+                    <small class="form-text text-muted">
+                      Do not require a test date when generating a verification
+                      code. Users and app can still optionally provide a date.
+                    </small>
+                  </label>
+                </div>
+              </div>
+
+              <div class="form-group">
+                <div class="form-check">
+                  <input class="form-check-input" type="radio" name="requireDate" id="requireDateTrue" value="true"{{if $realm.RequireDate }} checked{{end}} />
+                  <label class="form-check-label" for="requireDateTrue">
+                    Required date
+                    <small class="form-text text-muted">
+                      Require a symptom date or test date when generating a
+                      verification code. Attempting to generate a verification
+                      code without a date will return an error.
+                    </small>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Short code characters:</label>
+            <div class="col-sm-9">
+              {{if $realm.EnableENExpress}}
+                <input class="form-control{{if $realm.ErrorsFor "codeLength"}} is-invalid{{end}}" name="codeLength" id="codeLength" type="text" value="{{$realm.CodeLength}}" readonly />
+              {{else}}
+              <select class="form-control{{if $realm.ErrorsFor "codeLength"}} is-invalid{{end}}" name="codeLength" id="codeLength">
+                {{range $cl := .shortCodeLengths}}
+                <option value="{{$cl}}" {{if (eq $cl $realm.CodeLength)}}selected{{end}}>{{$cl}}</option>
+                {{end}}
+              </select>
+              <small class="form-text text-muted">
+                The short verification code is intended to be dictated over the phone to the
+                person and is <code>6</code>, <code>7</code>, or <code>8</code> digits in length.
+              </small>
+              {{end}}
+            </div>
+          </div>
+
+          <div class="form-group row mb-n1">
+            <label for="codeLength" class="col-sm-3">Code expires after:</label>
+            <div class="col-sm-2">
+              {{if $realm.EnableENExpress}}
+                <input class="form-control{{if $realm.ErrorsFor "CodeDurationSeconds"}} is-invalid{{end}}" name="codeDuration" id="codeDuration" type="text" value="{{$realm.GetCodeDurationMinutes}}" readonly />
+              {{else}}
+                <select class="form-control{{if $realm.ErrorsFor "CodeDurationSeconds"}} is-invalid{{end}}" name="codeDuration" id="codeDuration">
+                  {{$current := $realm.GetCodeDurationMinutes}}
+                  {{range $scm := .shortCodeMinutes}}
+                  <option value="{{$scm}}" {{if (eq $scm $current)}}selected{{end}}>{{$scm}}</option>
+                  {{end}}
+                </select>
+              {{end}}
+            </div>
+            <div class="input-group-append">
+              <label class="ml-1" for="passwordWarn">minutes</label>
+            </div>
+          </div>
+          {{if not $realm.EnableENExpress}}
+          <div class="row mb-3">
+            <div class="col-sm-3"></div>
+            <small class="form-text text-muted col">
+              The short code can be valid from anywhere between <code>5</code> and <code>60</code>
+              minutes. If you are using SMS deeplinks, it is recommended to keep this duration
+              short and let the long code be valid for a longer period (up to <code>24</code> hours).
+            </small>
+          </div>
+          {{end}}
+
+
+          <div class="form-group row">
+            <label for="codeLength" class="col-sm-3">Long code characters:</label>
+            <div class="col-sm-9">
+              {{if $realm.EnableENExpress}}
+                <input class="form-control{{if $realm.ErrorsFor "longCodeLength"}} is-invalid{{end}}" name="longCodeLength" id="longCodeLength" type="text" value="{{$realm.LongCodeLength}}" readonly />
+              {{else}}
+                <select class="form-control{{if $realm.ErrorsFor "longCodeLength"}} is-invalid{{end}}" name="longCodeLength" id="longCodeLength">
+                  {{range $cl := .longCodeLengths}}
+                  <option value="{{$cl}}" {{if (eq $cl $realm.LongCodeLength)}}selected{{end}}>{{$cl}}</option>
+                  {{end}}
+                </select>
+              {{end}}
+              <small class="form-text text-muted">
+                The 'long' verification code is only delivered over SMS{{if not $realm.EnableENExpress}}, is more complex with <code>12</code> -
+                <code>16</code> alphanumeric characters, and is never shown to a human. It is recommended
+                to leave this at the default of <code>16</code> digits{{end}}.
+              </small>
+            </div>
+          </div>
+
+          <div class="form-group row  mb-n3">
+            <label for="codeLength" class="col-sm-3">Long code expires after:</label>
+            <div class="col-sm-2">
+              {{if $realm.EnableENExpress}}
+                <input class="form-control{{if $realm.ErrorsFor "LongCodeDurationSeconds"}} is-invalid{{end}}" name="longCodeDuration" id="longCodeDuration" type="text" value="{{$realm.GetLongCodeDurationHours}}" readonly />
+              {{else}}
+                <select class="form-control{{if $realm.ErrorsFor "LongCodeDurationSeconds"}} is-invalid{{end}}" name="longCodeDuration" id="longCodeDuration">
+                  {{$current := $realm.GetLongCodeDurationHours}}
+                  {{range $lch := .longCodeHours}}
+                    <option value="{{$lch}}" {{if (eq $lch $current)}}selected{{end}}>{{$lch}}</option>
+                  {{end}}
+                </select>
+              {{end}}
+            </div>
+            <div class="input-group-append">
+              <label class="ml-1 col" for="passwordWarn">hours</label>
+            </div>
+          </div>
+          {{if not $realm.EnableENExpress}}
+          <div class="row mb-3">
+            <div class="col-sm-3"></div>
+            <small class="form-text text-muted col">
+              The long code can be valid between <code>1</code> and <code>24</code> hours.
+            </small>
+          </div>
+          {{end}}
+
+          <div class="form-group row">
+            <label for="name" class="col-sm-3">SMS text template:</label>
+            <div class="col-sm-9">
+              <textarea id="SMSTextTemplate" name="SMSTextTemplate" class="form-control{{if $realm.ErrorsFor "SMSTextTemplate"}} is-invalid{{end}}">{{$realm.SMSTextTemplate}}</textarea>
+              {{if $realm.ErrorsFor "SMSTextTemplate"}}
+              <div class="invalid-feedback">
+                {{joinStrings ($realm.ErrorsFor "SMSTextTemplate") ", "}}
+              </div>
+              {{end}}
+              <small class="form-text text-muted">
+                The SMS message will be constructed based on the template you provide. The overall
+                length of of the SMS message should not exceede 160 characters, or your message will need to be split
+                in transit and may not be joined correctly. There are some special strings that you can use
+                to substitute items.
+                {{if $realm.EnableENExpress}}
+                  Your SMS template <em>MUST</em> contain <code>[enslink]</code>.
+                  <ul>
+                    {{if eq "" .enxRedirectDomain}}
+                    <li><code>[enslink]</code> Inserts the required EN Express link of: <code>ens://v?r=[region]&c=[longcode]</code></li>
+                    {{else}}
+                    <li><code>[enslink]</code> Inserts the EN Express link of: <code>https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode]</code>
+                      <ul>
+                        <li>This domain should be registered as a universal link for both your Android and iOS applications.</li>
+                        <li>Contact your server operator to verify the the verification EN Express redirect service is running and configurd correctly.</li>
+                      </ul>
+                    </li>
+                    {{end}}
+                    <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+                  </ul>
+
+                  Here is an example SMS template using EN Express.
+
+                  <ul>
+                    <li>
+                      <p>Custom greeting before the EN Express link and showing expiration.</p>
+                      <p>
+                        <samp class="text-dark">
+                          State of Wonder DOH. Click to share anonymous data for exposure notifications [enslink] (mobile only) Expires in [longexpires] hours
+                        </samp>
+                      </p>
+                    </li>
+                    <li>
+                      <p>This results in a SMS message that looks like:</p>
+                      <p>
+                        <samp class="text-dark">
+                          {{if eq "" .enxRedirectDomain}}
+                          State of Wonder DOH. Click to share anonymous data for exposure notifications ens://v?r={{$realm.RegionCode}}&c=[longcode] (mobile only) Expires in 24 hours
+                          {{else}}
+                          State of Wonder DOH. Click to share anonymous data for exposure notifications https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode] (mobile only) Expires in 24 hours
+                          {{end}}
+                        </samp>
+                      </p>
+                    </li>
+                  </ul>
+
+                {{else}}
+                Your SMS template <em>MUST</em> contain either the <code>[code]</code> or
+                <code>[longcode]</code>.
+                <ul>
+                  <li><code>[region]</code>The region setting (set on this page).</li>
+                  <li><code>[code]</code>The 'short' verification code.</li>
+                  <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units).</li>
+                  <li><code>[longcode]</code>The 'long' verification code</li>
+                  <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+                </ul>
+
+                Here are some example SMS templates. The recommended usage is to include the long code in the SMS, and make
+                it clickable by registering a customer URI handler for your app.
+                <ul>
+                  <li>
+                    <p>Send short code in SMS (<code>104</code> characters with 8 digit codes and 60 minute expiration):</p>
+                    <p>
+                      <samp class="text-dark">
+                        State of Wonder Dept. of Health, your exposure
+                        notifications code is [code] and expires in [expires]
+                        minutes.
+                      </samp>
+                    </p>
+                  </li>
+                  <li>
+                    <p>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration).
+                       Here we assume that <code>verify.mypha.gov</code> is registred as a universal link for both your iOS
+                       and Android applications.
+                    </p>
+                    <p>
+                      <samp class="text-dark">
+                        You have tested positive for Covid-19. Click here to
+                        share anonymous data for exposure notifications
+                        https://verify.mypha.gov/v?c=[longcode] (Expires in [longexpires] hours)
+                      </samp>
+                    </p>
+                  </li>
+                </ul>
+                {{end}}
+              </small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          Abuse prevention
+        </div>
+        <div class="card-body">
+          {{template "beta-notice" .}}
+
+          <p>
+            Abuse prevention uses the historical record of your realm's past
+            daily code issuances to build a predictive model of future use,
+            rejecting requests that fall outside of the predicted model.
+          </p>
+
+          <p>
+            Without abuse protection, an attacker with a compromised credential
+            could generate many fake codes and then use those codes to
+            subsequently upload many fake keys to the system.
+          </p>
+
+          <div class="form-group form-check">
+            <input class="form-check-input" type="checkbox" name="abuse_prevention_enabled" id="abuse_prevention_enabled" value="1" {{if $realm.AbusePreventionEnabled}} checked{{end}}>
+            <label class="form-check-label" for="abuse_prevention_enabled">
+              Enable abuse prevention
+            </label>
+          </div>
+
+          <div id="abuse_prevention_configuration" class="{{if not $realm.AbusePreventionEnabled}}d-none{{end}}">
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_limit" name="abuse_prevention_limit" class="form-control" placeholder="Computed limit" value="{{$realm.AbusePreventionLimit}}" readonly />
+              <label for="abuse_prevention_limit">Computed limit</label>
+              <small class="form-text text-muted">
+                This value is computed by the historical daily model and applies
+                for the next 24h block of rolling UTC time.
+              </small>
+            </div>
+
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_limit_factor" name="abuse_prevention_limit_factor" class="form-control" placeholder="Limit factor" value="{{printf "%.3f" $realm.AbusePreventionLimitFactor}}" />
+              <label for="abuse_prevention_limit_factor">Limit factor</label>
+              <small class="form-text text-muted">
+                This value is factored against the predicted daily model to
+                determine the total number of codes that {{$realm.Name}} can issue
+                in a day. For example, to enable 25% more codes to be issued than
+                predicted by the model model, set this value to <code>1.25</code>.
+              </small>
+              <small class="form-text text-danger font-weight-bold">
+                Setting this value too low will prevent case workers from issuing
+                codes for legitimate uses!
+              </small>
+            </div>
+
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_effective_limit" class="form-control" placeholder="Effective limit" value="{{$realm.AbusePreventionEffectiveLimit}}" readonly />
+              <label for="abuse_prevention_effective_limit">Effective limit</label>
+              <small class="form-text text-muted">
+                This is the effective daily limit for {{$realm.Name}} after
+                applying your limit factor.
+              </small>
+            </div>
+
+            <div class="form-label-group">
+              <input type="text" id="abuse_prevention_burst" name="abuse_prevention_burst" class="form-control" placeholder="Temporary burst" value="0" />
+              <label for="abuse_prevention_burst">Temporary burst</label>
+              <small class="form-text text-muted">
+                Set this value to temporarily add quota to your realm. You
+                should only do this when you've exceeded your daily quota and
+                still need to issue new codes. After 00:00 UTC, the quota will
+                reset back to the predicted model automatically.
+              </small>
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          SMS configuration
+        </div>
+        <div class="card-body">
+          <div class="form-group row">
+            <label for="twilio_account_sid" class="col-sm-3">Twilio account:</label>
+            <div class="col-sm-9">
+              <input type="text" id="twilio_account_sid" name="twilio_account_sid" class="form-control" value="{{if $smsConfig}}{{$smsConfig.TwilioAccountSid}}{{end}}" />
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="twilio_auth_token" class="col-sm-3">Twilio auth token:</label>
+            <div class="input-group col-sm-9">
+              <input type="password" id="twilio_auth_token" name="twilio_auth_token" class="form-control" autocomplete="new-password" value="{{if $smsConfig}}{{$smsConfig.TwilioAuthToken}}{{end}}">
+              <div class="input-group-append">
+                <a class="input-group-text" data-toggle-password="twilio_auth_token">
+                  <span class="oi oi-lock-locked" aria-hidden="true"></span>
+                </a>
+              </div>
+            </div>
+          </div>
+
+          <div class="form-group row">
+            <label for="twilio_from_number" class="col-sm-3">Twilio number:</label>
+            <div class="col-sm-9">
+              <input type="tel" id="twilio_from_number" name="twilio_from_number" class="form-control" value="{{if $smsConfig}}{{$smsConfig.TwilioFromNumber}}{{end}}" />
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div class="form-group row">
+        <div class="col-sm-12">
+          <button type="submit" class="btn btn-primary btn-block">Update realm</button>
+        </div>
+      </div>
+    </form>
+
+    {{if $realm.EnableENExpress}}
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">
+        Exposure Notifications Express
+      </div>
+      <div class="card-body">
+        <p>
+          Click the button below to disable Exposure Notifications Express (EN
+          Express). This will enable you to control all the settings.
+        </p>
+
+        <p class="text-danger">
+          This could cause your iOS and Android integrations to stop working!
+        </p>
+
+        <form method="POST" action="/realm/settings/disable-express">
+          {{ .csrfField }}
+          <a href="#" class="btn btn-danger btn-block" data-confirm="Are you sure you want to disable EN Express? This could cause your iOS and Android integrations to stop working." data-submit-form>Disable EN Express</a>
+        </form>
+      </div>
+    </div>
+  {{end}}
+  </main>
+
+  {{template "scripts" .}}
+
+  <script type="text/javascript">
+    $(function() {
+      let $abusePreventionEnabled = $('#abuse_prevention_enabled');
+      let $abusePreventionConfiguration = $('#abuse_prevention_configuration');
+      let $abusePreventionLimit = $('#abuse_prevention_limit');
+      let $abusePreventionLimitFactor = $('#abuse_prevention_limit_factor');
+      let $abusePreventionEffectiveLimit = $('#abuse_prevention_effective_limit');
+
+      $abusePreventionEnabled.change(function(e) {
+        if (this.checked) {
+          $abusePreventionConfiguration.removeClass('d-none');
+        } else {
+          $abusePreventionConfiguration.addClass('d-none');
+        }
+      });
+
+      $abusePreventionLimitFactor.keyup(function(e){
+        let $this = $(e.currentTarget);
+        let current = $this.val();
+
+        if (current && current.length) {
+          let effective = parseFloat(current) * parseFloat($abusePreventionLimit.val());
+          effective = Math.ceil(effective);
+          $abusePreventionEffectiveLimit.val(effective);
+        }
+      });
+    });
+  </script>
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -180,7 +180,16 @@
       {{if $realm.EnableENExpress}}
         Your SMS template <em>MUST</em> contain <code>[enslink]</code>.
         <ul>
-          <li><code>[enslink]</code> Inserts the required EN Express link of: <code>ens://v?r=[region]&c=[longcode]</code></li>
+          {{if eq "" .enxRedirectDomain}}
+          <li><code>[enslink]</code> Inserts the required EN Express link of: <code>ens://v?r=[region]&c=[longcode]</code></li>	                    <li><code>[enslink]</code> Inserts the required EN Express link of: <code>ens://v?r=[region]&c=[longcode]</code></li>
+          {{else}}
+          <li><code>[enslink]</code> Inserts the EN Express link of: <code>https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode]</code>
+            <ul>
+              <li>This domain should be registered as a universal link for both your Android and iOS applications.</li>
+              <li>Contact your server operator to verify the the verification EN Express redirect service is running and configurd correctly.</li>
+            </ul>
+          </li>
+          {{end}}
           <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
         </ul>
 
@@ -188,11 +197,10 @@
 
         <ul>
           <li>
-            <p>Custom greeting before the EN Express link and showing expiration.
-                This is <code>145</code> characters when expanded.</p>
+            <p>Custom greeting before the EN Express link and showing expiration.</p>
             <p>
               <samp class="text-dark">
-                State of Wonder Dept. of Health. Click to share anonymous data for exposure notifications [enslink] Expires in [longexpires] hours
+                State of Wonder DOH. Click to share anonymous data for exposure notifications [enslink] (mobile only) Expires in [longexpires] hours
               </samp>
             </p>
           </li>
@@ -200,7 +208,11 @@
             <p>This results in a SMS message that looks like:</p>
             <p>
               <samp class="text-dark">
-                State of Wonder Dept. of Health. Click to share anonymous data for exposure notifications ens://v?r=US-XX&c=12345678abcd1234 Expires in 24 hours
+                {{if eq "" .enxRedirectDomain}}
+                State of Wonder DOH. Click to share anonymous data for exposure notifications ens://v?r={{$realm.RegionCode}}&c=[longcode] (mobile only) Expires in 24 hours
+                {{else}}
+                State of Wonder DOH. Click to share anonymous data for exposure notifications https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode] (mobile only) Expires in 24 hours
+                {{end}}
               </samp>
             </p>
           </li>
@@ -231,12 +243,15 @@
           </p>
         </li>
         <li>
-          <p>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration):</p>
+          <p>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration).
+            Here we assume that <code>verify.mypha.gov</code> is registred as a universal link for both your iOS
+            and Android applications.
+         </p>
           <p>
             <samp class="text-dark">
-              You have tested positive for Covid-19. Click here to
+              You have tested positive for COVID-19. Click here to
               share anonymous data for exposure notifications
-              dohen://v?c=[longcode] (Expires in [longexpires] hours)
+              https://verify.mypha.gov/v?c=[longcode] (Expires in [longexpires] hours)
             </samp>
           </p>
         </li>

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
@@ -48,6 +49,11 @@ type AdminAPIServerConfig struct {
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=false"`
+
+	// For EN Express, the link will be
+	// https://[realm-region].[ENX_REDIRECT_DOMAIN]/v?c=[longcode]
+	// This repository contains a redirect service that can be used for this purpose.
+	ENExpressRedirectDomain string `env:"ENX_REDIRECT_DOMAIN"`
 }
 
 // NewAdminAPIServerConfig returns the environment config for the Admin API server.
@@ -75,7 +81,13 @@ func (c *AdminAPIServerConfig) Validate() error {
 		}
 	}
 
+	c.ENExpressRedirectDomain = strings.ToLower(c.ENExpressRedirectDomain)
+
 	return nil
+}
+
+func (c *AdminAPIServerConfig) GetENXRedirectDomain() string {
+	return c.ENExpressRedirectDomain
 }
 
 func (c *AdminAPIServerConfig) GetCollisionRetryCount() uint {

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -27,4 +27,5 @@ type IssueAPIConfig interface {
 	GetAllowedSymptomAge() time.Duration
 	GetEnforceRealmQuotas() bool
 	GetRateLimitConfig() *ratelimit.Config
+	GetENXRedirectDomain() string
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -81,6 +81,11 @@ type ServerConfig struct {
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
 
+	// For EN Express, the link will be
+	// https://[realm-region].[ENX_REDIRECT_DOMAIN]/v?c=[longcode]
+	// This repository contains a redirect service that can be used for this purpose.
+	ENExpressRedirectDomain string `env:"ENX_REDIRECT_DOMAIN"`
+
 	// Certificate signing key settings, needed for public key / settings display.
 	CertificateSigning CertificateSigningConfig
 
@@ -119,7 +124,13 @@ func (c *ServerConfig) Validate() error {
 		}
 	}
 
+	c.ENExpressRedirectDomain = strings.ToLower(c.ENExpressRedirectDomain)
+
 	return nil
+}
+
+func (c *ServerConfig) GetENXRedirectDomain() string {
+	return c.ENExpressRedirectDomain
 }
 
 func (c *ServerConfig) GetCollisionRetryCount() uint {

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -255,7 +255,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		}
 
 		if request.Phone != "" && smsProvider != nil {
-			message := realm.BuildSMSText(code, longCode)
+			message := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain())
 			if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
 				// Delete the token
 				if err := c.db.DeleteVerificationCode(code); err != nil {

--- a/pkg/controller/realmadmin/express.go
+++ b/pkg/controller/realmadmin/express.go
@@ -89,7 +89,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		realm.CodeDuration = enxSettings.CodeDuration
 		realm.LongCodeLength = enxSettings.LongCodeLength
 		realm.LongCodeDuration = enxSettings.LongCodeDuration
-		realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
+		realm.SMSTextTemplate = "You Exposure Notifications Verification link: [enslink] Expires in [longexpires] hours (click for mobile device only)"
 		// Confirmed is the only allowed test type for EN Express.
 		realm.AllowedTestTypes = database.TestTypeConfirmed
 

--- a/pkg/controller/realmadmin/express.go
+++ b/pkg/controller/realmadmin/express.go
@@ -89,7 +89,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		realm.CodeDuration = enxSettings.CodeDuration
 		realm.LongCodeLength = enxSettings.LongCodeLength
 		realm.LongCodeDuration = enxSettings.LongCodeDuration
-		realm.SMSTextTemplate = "You Exposure Notifications Verification link: [enslink] Expires in [longexpires] hours (click for mobile device only)"
+		realm.SMSTextTemplate = "Your Exposure Notifications verification link: [enslink]. Expires in [longexpires] hours (click for mobile device only)"
 		// Confirmed is the only allowed test type for EN Express.
 		realm.AllowedTestTypes = database.TestTypeConfirmed
 

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -263,11 +263,11 @@ func (c *Controller) renderSettings(ctx context.Context, w http.ResponseWriter, 
 	// Valid settings for pwd rotation.
 	m["passwordRotateDays"] = passwordRotationPeriodDays
 	m["passwordWarnDays"] = passwordRotationWarningDays
-
 	// Valid settings for code parameters.
 	m["shortCodeLengths"] = shortCodeLengths
 	m["shortCodeMinutes"] = shortCodeMinutes
 	m["longCodeLengths"] = longCodeLengths
 	m["longCodeHours"] = longCodeHours
+	m["enxRedirectDomain"] = c.config.GetENXRedirectDomain()
 	c.h.RenderHTML(w, "realmadmin/edit", m)
 }

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -29,9 +29,9 @@ func TestSMS(t *testing.T) {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 
-	realm.SMSTextTemplate = "State of Wonder, Covid-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
+	realm.SMSTextTemplate = "State of Wonder, COVID-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
 	got = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "")
-	want = "State of Wonder, Covid-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
+	want = "State of Wonder, COVID-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
 	if got != want {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -14,26 +14,25 @@
 
 package database
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestSMS(t *testing.T) {
 	realm := NewRealmWithDefaults("test")
+	realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
 	realm.RegionCode = "US-WA"
 
-	{
-		got := realm.BuildSMSText("12345678", "abcdefgh12345678")
-		want := "This is your Exposure Notifications Verification code: ens://v?r=US-WA&c=abcdefgh12345678 Expires in 24 hours"
-		if got != want {
-			t.Errorf("SMS text wrong, want: %q got %q", want, got)
-		}
+	got := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express")
+	want := "This is your Exposure Notifications Verification code: https://us-wa.en.express/v?c=abcdefgh12345678 Expires in 24 hours"
+	if got != want {
+		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 
-	{
-		realm.SMSTextTemplate = "State of Wonder, Covid-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
-		got := realm.BuildSMSText("654321", "asdflkjasdlkfjl")
-		want := "State of Wonder, Covid-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
-		if got != want {
-			t.Errorf("SMS text wrong, want: %q got %q", want, got)
-		}
+	realm.SMSTextTemplate = "State of Wonder, Covid-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
+	got = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "")
+	want = "State of Wonder, Covid-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
+	if got != want {
+		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 }

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -133,6 +133,8 @@ func templateFuncs() template.FuncMap {
 		"joinStrings":    strings.Join,
 		"trimSpace":      strings.TrimSpace,
 		"stringContains": strings.Contains,
+		"toLower":        strings.ToLower,
+		"toUpper":        strings.ToUpper,
 	}
 }
 

--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -119,6 +119,7 @@ resource "google_cloud_run_service" "adminapi" {
             local.database_config,
             local.gcp_config,
             local.rate_limit_config,
+            local.issue_config,
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "adminapi", {}),

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -160,6 +160,7 @@ resource "google_cloud_run_service" "server" {
             local.rate_limit_config,
             local.session_config,
             local.signing_config,
+            local.issue_config,
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "server", {}),

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -84,6 +84,10 @@ locals {
     VERIFICATION_SERVER_API = google_cloud_run_service.apiserver.status.0.url
   }
 
+  issue_config = {
+    ENX_REDIRECT_DOMAIN = var.enx_redirect_domain
+  }
+
   enx_redirect_config = {
     ASSETS_PATH        = "/assets"
     HOSTNAME_TO_REGION = join(",", [for o in var.enx_redirect_domain_map : format("%s=%s", o.host, o.region)])

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -178,6 +178,12 @@ variable "adminapi-host" {
   description = "Domain adminapi is hosted on."
 }
 
+variable "enx_redirect_domain" {
+  type        = string
+  default     = ""
+  description = "TLD for enx-redirect service links."
+}
+
 variable "enx_redirect_domain_map" {
   type = list(object({
     region = string


### PR DESCRIPTION
Fixes #536 
Fixes #582

## Proposed Changes

* EN Express links will use the enx-redirect service when possible. If the redirect domain isn't configured, the legacy `ens://` links are preserved
* suggest links are for mobile (we're really character constrained) // feels like perf 

**Release Note**


```release-note
For ENX enabled domains, take advantage of the enx-redirect service for https:// clickable links / universal links / ens:// redirect.
```
