### PR TITLE
Redirect to show page after user-create

### DIFF
--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -8,9 +8,6 @@
 <head>
   {{template "head" .}}
   {{template "floatingform" .}}
-  {{if .created}}
-  {{template "firebase" .}}
-  {{end}}
 </head>
 
 <body class="bg-light">
@@ -34,26 +31,6 @@
   </main>
 
   {{template "scripts" .}}
-  {{if .created}}
-  <script type="text/javascript">
-  $(function() {
-    let $allUsers = $('#all-users');
-    let $submit = $('#submit-user');
-
-    let email = {{.user.Email}};
-
-    firebase.auth().sendPasswordResetEmail(email)
-      .then(function() {
-        flash.alert(`Successfully created user '{{.user.Name}}'.`);
-      }).catch(function(error) {
-        flash.error(error.message);
-      }).then(function() {
-        $submit.prop('disabled', false);
-        $allUsers.removeClass('disabled');
-      });
-  });
-  </script>
-  {{end}}
 </body>
 
 </html>

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -39,15 +39,13 @@
         </div>
 
         <strong>Admin</strong>
-        <div>
+        <div class="mb-3">
           {{$user.CanAdminRealm $currentRealm.ID}}
         </div>
 
-        {{if .currentUser.CanAdminRealm .currentRealm.ID}}
-        <button id="password-reset" class="btn btn-primary btn-block mt-3 disabled">
+        <button id="password-reset" class="btn btn-primary btn-block disabled">
           Send password reset
         </button>
-        {{end}}
       </div>
     </div>
 

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -8,6 +8,7 @@
 <html lang="en">
 <head>
   {{template "head" .}}
+  {{template "firebase" .}}
 </head>
 
 <body class="bg-light">
@@ -41,6 +42,12 @@
         <div>
           {{$user.CanAdminRealm $currentRealm.ID}}
         </div>
+
+        {{if .currentUser.CanAdminRealm .currentRealm.ID}}
+        <button id="password-reset" class="btn btn-primary btn-block mt-3 disabled">
+          Send password reset
+        </button>
+        {{end}}
       </div>
     </div>
 
@@ -106,6 +113,40 @@
     }
   </script>
   {{end}}
+
+  <script type="text/javascript">
+  $(function() {
+    $resetPassword = $('#password-reset');
+
+    {{if .created}}
+    sendReset(function() {
+      flash.alert(`Successfully created user '{{.user.Name}}'.`);
+    });
+    {{else}}
+    $resetPassword.removeClass('disabled');
+    {{end}}
+
+    $resetPassword.on('click', function(event) {
+      event.preventDefault();
+      sendReset(function() {
+        flash.alert(`Password reset email sent.`);
+      });
+    });
+
+    function sendReset(successFn) {
+      $resetPassword.addClass('disabled');
+      let email = {{$user.Email}};
+      return firebase.auth().sendPasswordResetEmail(email)
+      .then(function() {
+          setTimeout($resetPassword.addClass('disabled'), 10000);
+          successFn();
+      }).catch(function(error) {
+        $resetPassword.removeClass('disabled');
+        flash.error(error.message);
+      });
+    }
+  });
+  </script>
 </body>
 </html>
 {{end}}

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -79,6 +79,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			user.Name = form.Name
 		}
 
+		// Create firebase user first, if this fails we don't want a db.User entry
 		created, err := user.CreateFirebaseUser(ctx, c.client)
 		if err != nil {
 			flash.Alert("Failed to create user: %v", err)

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -106,6 +106,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		stats, err := c.getStats(ctx, user, realm)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 
 		c.renderShow(ctx, w, user, stats)

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -48,7 +48,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		// Requested form, stop processing.
 		if r.Method == http.MethodGet {
 			var user database.User
-			c.renderNew(ctx, w, &user, false)
+			c.renderNew(ctx, w, &user)
 			return
 		}
 
@@ -61,14 +61,13 @@ func (c *Controller) HandleCreate() http.Handler {
 			}
 
 			flash.Error("Failed to process form: %v", err)
-			c.renderNew(ctx, w, user, false)
+			c.renderNew(ctx, w, user)
 			return
 		}
 
 		// See if the user already exists by email - they may be a member of another
 		// realm.
 		user, err := c.db.FindUserByEmail(form.Email)
-		alreadyExists := true
 		if err != nil {
 			if !database.IsNotFound(err) {
 				controller.InternalError(w, r, c.h, err)
@@ -76,42 +75,45 @@ func (c *Controller) HandleCreate() http.Handler {
 			}
 
 			user = new(database.User)
-			alreadyExists = false
-		}
-
-		// Build the user struct - keeping email and name if user already exists in another realm.
-		if !alreadyExists {
 			user.Email = form.Email
 			user.Name = form.Name
 		}
-		user.Realms = append(user.Realms, realm)
 
+		created, err := user.CreateFirebaseUser(ctx, c.client)
+		if err != nil {
+			flash.Alert("Failed to create user: %v", err)
+			c.renderNew(ctx, w, user)
+			return
+		}
+
+		// Build the user struct - keeping email and name if user already exists in another realm.
+		user.Realms = append(user.Realms, realm)
 		if form.Admin {
 			user.AdminRealms = append(user.AdminRealms, realm)
 		}
 
 		if err := c.db.SaveUser(user); err != nil {
 			flash.Error("Failed to create user: %v", err)
-			c.renderNew(ctx, w, user, false)
+			c.renderNew(ctx, w, user)
 			return
 		}
 
-		created, err := user.CreateFirebaseUser(ctx, c.client)
-		if err != nil {
-			flash.Alert("Failed to create user: %v", err)
-			c.renderNew(ctx, w, user, false)
+		if created {
+			m := controller.TemplateMapFromContext(ctx)
+			m["created"] = true
 		}
 
-		c.renderNew(ctx, w, user, created)
+		stats, err := c.getStats(ctx, user, realm)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+		}
+
+		c.renderShow(ctx, w, user, stats)
 	})
 }
 
-func (c *Controller) renderNew(ctx context.Context, w http.ResponseWriter, user *database.User, createdNewUser bool) {
+func (c *Controller) renderNew(ctx context.Context, w http.ResponseWriter, user *database.User) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["user"] = user
-	if createdNewUser {
-		m["firebase"] = c.config.Firebase
-	}
-	m["created"] = createdNewUser
 	c.h.RenderHTML(w, "users/new", m)
 }

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -54,25 +54,33 @@ func (c *Controller) HandleShow() http.Handler {
 			return
 		}
 
-		// Get and cache the stats for this user.
-		var stats []*database.UserStats
-		cacheKey := fmt.Sprintf("stats:user:%d:%d", realm.ID, user.ID)
-		if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
-			now := time.Now().UTC()
-			past := now.Add(-14 * 24 * time.Hour)
-			return user.Stats(c.db, realm.ID, past, now)
-		}); err != nil {
+		stats, err := c.getStats(ctx, user, realm)
+		if err != nil {
 			controller.InternalError(w, r, c.h, err)
-			return
 		}
 
 		c.renderShow(ctx, w, user, stats)
 	})
 }
 
+// Get and cache the stats for this user.
+func (c *Controller) getStats(ctx context.Context, user *database.User, realm *database.Realm) ([]*database.UserStats, error) {
+	var stats []*database.UserStats
+	cacheKey := fmt.Sprintf("stats:user:%d:%d", realm.ID, user.ID)
+	if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
+		now := time.Now().UTC()
+		past := now.Add(-14 * 24 * time.Hour)
+		return user.Stats(c.db, realm.ID, past, now)
+	}); err != nil {
+		return nil, err
+	}
+	return stats, nil
+}
+
 func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, user *database.User, stats []*database.UserStats) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["user"] = user
 	m["stats"] = stats
+	m["firebase"] = c.config.Firebase
 	c.h.RenderHTML(w, "users/show", m)
 }

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -57,6 +57,7 @@ func (c *Controller) HandleShow() http.Handler {
 		stats, err := c.getStats(ctx, user, realm)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 
 		c.renderShow(ctx, w, user, stats)

--- a/pkg/controller/user/update.go
+++ b/pkg/controller/user/update.go
@@ -94,7 +94,7 @@ func (c *Controller) HandleUpdate() http.Handler {
 
 		if err := c.db.SaveUser(user); err != nil {
 			flash.Error("Failed to update user: %v", err)
-			c.renderNew(ctx, w, user, false)
+			c.renderNew(ctx, w, user)
 			return
 		}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Redirect the user to the show-user page after creation
    * The current experience is potentially confusing as the user winds up back at the new-user page (despite the flash alert). This makes it more clear that the user is created.
* Adds a send-password reset button to the user page so admins can resend the reset if need-be.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add password-reset button for admins
Change new-user redirect to show-user
```
