### PR TITLE
Load realm for system admin pages

### DIFF
--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -6,11 +6,7 @@
 
   <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     <div class="container">
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
-        aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
-
+      {{template "navtoggle" .}}
       <div class="collapse navbar-collapse" id="navbar">
         <ul class="navbar-nav mr-auto">
           {{if .currentRealm}}
@@ -19,26 +15,7 @@
           </li>
           {{end}}
         </ul>
-
-        <ul class="navbar-nav ml-auto">
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
-              aria-expanded="false">
-              {{.currentUser.Name}}
-            </a>
-
-            <div class="dropdown-menu" aria-labelledby="profile-menu">
-              <h6 class="dropdown-header">System admin</h6>
-              <a class="dropdown-item" href="/admin/realms">Realms</a>
-              <a class="dropdown-item" href="/admin/users">Admins</a>
-              <div class="dropdown-divider"></div>
-
-              <h6 class="dropdown-header">Actions</h6>
-              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
-              <a class="dropdown-item" href="/signout">Sign out</a>
-            </div>
-          </li>
-        </ul>
+        {{template "navdropdown" .}}
       </div>
     </div>
   </nav>

--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -8,13 +8,13 @@
     <div class="container">
       {{template "navtoggle" .}}
       <div class="collapse navbar-collapse" id="navbar">
+        {{if .currentRealm}}
         <ul class="navbar-nav mr-auto">
-          {{if .currentRealm}}
           <li class="nav-item">
             <a class="nav-link" href="/home">&larr; Back to {{.currentRealm.Name}} </a>
           </li>
-          {{end}}
         </ul>
+        {{end}}
         {{template "navdropdown" .}}
       </div>
     </div>

--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -1,4 +1,50 @@
 {{define "admin/navbar"}}
+<header class="mb-3">
+  <div href="/" class="d-block px-3 py-2 text-center text-bold text-white admin-header">
+    System Admin
+  </div>
+
+  <nav class="navbar navbar-expand-md navbar-dark bg-primary">
+    <div class="container">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
+        aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbar">
+        <ul class="navbar-nav mr-auto">
+          {{if .currentRealm}}
+          <li class="nav-item">
+            <a class="nav-link" href="/home">&larr; Back to {{.currentRealm.Name}} </a>
+          </li>
+          {{end}}
+        </ul>
+
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
+              aria-expanded="false">
+              {{.currentUser.Name}}
+            </a>
+
+            <div class="dropdown-menu" aria-labelledby="profile-menu">
+              <h6 class="dropdown-header">System admin</h6>
+              <a class="dropdown-item" href="/admin/realms">Realms</a>
+              <a class="dropdown-item" href="/admin/users">Admins</a>
+              <div class="dropdown-divider"></div>
+
+              <h6 class="dropdown-header">Actions</h6>
+              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
+              <a class="dropdown-item" href="/signout">Sign out</a>
+            </div>
+          </li>
+        </ul>
+      </div>
+    </div>
+  </nav>
+</header>
+
+
 <ul class="nav nav-pills justify-content-center mb-3">
   <li class="nav-item">
     <a class="nav-link{{if stringContains .currentPath "/admin/realms"}} active{{end}}" href="/admin/realms">Realms</a>

--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -1,7 +1,7 @@
 {{define "admin/navbar"}}
 <header class="mb-3">
   <div href="/" class="d-block px-3 py-2 text-center text-bold text-white admin-header">
-    System Admin
+    System admin
   </div>
 
   <nav class="navbar navbar-expand-md navbar-dark bg-primary">

--- a/cmd/server/assets/admin/info.html
+++ b/cmd/server/assets/admin/info.html
@@ -7,7 +7,6 @@
 </head>
 
 <body class="bg-light">
-  {{template "navbar" .}}
   {{template "admin/navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/admin/realms/index.html
+++ b/cmd/server/assets/admin/realms/index.html
@@ -9,7 +9,6 @@
 </head>
 
 <body class="bg-light">
-  {{template "navbar" .}}
   {{template "admin/navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/admin/realms/new.html
+++ b/cmd/server/assets/admin/realms/new.html
@@ -10,7 +10,6 @@
 </head>
 
 <body class="bg-light">
-  {{template "navbar" .}}
   {{template "admin/navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -10,7 +10,6 @@
 </head>
 
 <body class="bg-light">
-  {{template "navbar" .}}
   {{template "admin/navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/admin/users/new.html
+++ b/cmd/server/assets/admin/users/new.html
@@ -11,7 +11,6 @@
 </head>
 
 <body class="bg-light">
-  {{template "navbar" .}}
   {{template "admin/navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -236,7 +236,7 @@
 
               <h6 class="dropdown-header">Actions</h6>
               {{if gt (len .currentUser.Realms) 1}}
-              <a class="dropdown-item" href="/login/select-realm">Change realm</a>
+              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
               {{end}}
               <a class="dropdown-item" href="/signout">Sign out</a>
             </div>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -33,6 +33,10 @@
     background-color: #0055b1;
   }
 
+  div.admin-header {
+    background-color:#D66402
+  }
+
   a.input-group-text:hover {
     cursor: pointer;
     text-decoration: none;
@@ -180,6 +184,82 @@
 {{end}}
 
 {{define "navbar"}}
+<header class="mb-3">
+  {{if .currentRealm}}
+  <div href="/" class="d-block px-3 py-2 text-center text-bold text-white realm-header">
+    {{.currentRealm.Name}}{{if .currentRealm.RegionCode}} - {{.currentRealm.RegionCode}}{{end}}
+  </div>
+  {{end}}
+
+  <nav class="navbar navbar-expand-md navbar-dark bg-primary">
+    <div class="container">
+      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
+        aria-expanded="false" aria-label="Toggle navigation">
+        <span class="navbar-toggler-icon"></span>
+      </button>
+
+      <div class="collapse navbar-collapse" id="navbar">
+        {{if .currentUser}}
+        <ul class="navbar-nav mr-auto">
+          {{if .currentRealm}}
+          <li class="nav-item">
+            <a class="nav-link" href="/home">Issue code</a>
+          </li>
+          <li class="nav-item">
+            <a class="nav-link" href="/code/status">Check code status</a>
+          </li>
+          {{end}}
+        </ul>
+
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item dropdown">
+            <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
+              aria-expanded="false">
+              {{.currentUser.Name}}
+            </a>
+
+            <div class="dropdown-menu" aria-labelledby="profile-menu">
+              {{if .currentRealm }}
+              {{if .currentUser.CanAdminRealm .currentRealm.ID}}
+              <h6 class="dropdown-header">Manage realm</h6>
+              <a class="dropdown-item" href="/apikeys">API keys</a>
+              <a class="dropdown-item" href="/realm/keys">Signing keys</a>
+              <a class="dropdown-item" href="/realm/stats">Statistics</a>
+              <a class="dropdown-item" href="/users">Users</a>
+              <a class="dropdown-item" href="/realm/settings#general">Settings</a>
+              <div class="dropdown-divider"></div>
+              {{end}}
+              {{end}}
+
+              {{if .currentUser.Admin}}
+              <h6 class="dropdown-header">System admin</h6>
+              <a class="dropdown-item" href="/admin/realms">Realms</a>
+              <a class="dropdown-item" href="/admin/users">Admins</a>
+              <div class="dropdown-divider"></div>
+              {{end}}
+
+              <h6 class="dropdown-header">Actions</h6>
+              {{if gt (len .currentUser.Realms) 1}}
+              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
+              {{end}}
+              <a class="dropdown-item" href="/signout">Sign out</a>
+            </div>
+          </li>
+        </ul>
+        {{else}}
+        <ul class="navbar-nav ml-auto">
+          <li class="nav-item">
+            <a class="nav-link" href="/">Sign in</a>
+          </li>
+        </ul>
+        {{end}}
+      </div>
+    </div>
+  </nav>
+</header>
+{{end}}
+
+{{define "admin-navbar"}}
 <header class="mb-3">
   {{if .currentRealm}}
   <div href="/" class="d-block px-3 py-2 text-center text-bold text-white realm-header">

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -197,8 +197,7 @@
       {{template "navtoggle" .}}
 
       <div class="collapse navbar-collapse" id="navbar">
-        {{if .currentUser}}
-        {{if .currentRealm}}
+        {{if and .currentUser .currentRealm}}
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
             <a class="nav-link" href="/home">Issue code</a>
@@ -207,7 +206,6 @@
             <a class="nav-link" href="/code/status">Check code status</a>
           </li>
         </ul>
-        {{end}}
         {{end}}
         {{template "navdropdown" .}}
       </div>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -197,7 +197,7 @@
       {{template "navtoggle" .}}
 
       <div class="collapse navbar-collapse" id="navbar">
-        {{if and .currentUser .currentRealm}}
+        {{if .currentRealm}}
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
             <a class="nav-link" href="/home">Issue code</a>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -183,6 +183,7 @@
 </style>
 {{end}}
 
+{{/* defines the top navigation bar */}}
 {{define "navbar"}}
 <header class="mb-3">
   {{if .currentRealm}}
@@ -193,146 +194,79 @@
 
   <nav class="navbar navbar-expand-md navbar-dark bg-primary">
     <div class="container">
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
-        aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
+      {{template "navtoggle" .}}
 
       <div class="collapse navbar-collapse" id="navbar">
         {{if .currentUser}}
+        {{if .currentRealm}}
         <ul class="navbar-nav mr-auto">
-          {{if .currentRealm}}
           <li class="nav-item">
             <a class="nav-link" href="/home">Issue code</a>
           </li>
           <li class="nav-item">
             <a class="nav-link" href="/code/status">Check code status</a>
           </li>
-          {{end}}
-        </ul>
-
-        <ul class="navbar-nav ml-auto">
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
-              aria-expanded="false">
-              {{.currentUser.Name}}
-            </a>
-
-            <div class="dropdown-menu" aria-labelledby="profile-menu">
-              {{if .currentRealm }}
-              {{if .currentUser.CanAdminRealm .currentRealm.ID}}
-              <h6 class="dropdown-header">Manage realm</h6>
-              <a class="dropdown-item" href="/apikeys">API keys</a>
-              <a class="dropdown-item" href="/realm/keys">Signing keys</a>
-              <a class="dropdown-item" href="/realm/stats">Statistics</a>
-              <a class="dropdown-item" href="/users">Users</a>
-              <a class="dropdown-item" href="/realm/settings#general">Settings</a>
-              <div class="dropdown-divider"></div>
-              {{end}}
-              {{end}}
-
-              {{if .currentUser.Admin}}
-              <h6 class="dropdown-header">System admin</h6>
-              <a class="dropdown-item" href="/admin/realms">Realms</a>
-              <a class="dropdown-item" href="/admin/users">Admins</a>
-              <div class="dropdown-divider"></div>
-              {{end}}
-
-              <h6 class="dropdown-header">Actions</h6>
-              {{if gt (len .currentUser.Realms) 1}}
-              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
-              {{end}}
-              <a class="dropdown-item" href="/signout">Sign out</a>
-            </div>
-          </li>
-        </ul>
-        {{else}}
-        <ul class="navbar-nav ml-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="/">Sign in</a>
-          </li>
         </ul>
         {{end}}
+        {{end}}
+        {{template "navdropdown" .}}
       </div>
     </div>
   </nav>
 </header>
 {{end}}
 
-{{define "admin-navbar"}}
-<header class="mb-3">
-  {{if .currentRealm}}
-  <div href="/" class="d-block px-3 py-2 text-center text-bold text-white realm-header">
-    {{.currentRealm.Name}}{{if .currentRealm.RegionCode}} - {{.currentRealm.RegionCode}}{{end}}
-  </div>
-  {{end}}
+{{/* defines the hamburger menu toggle for mobile */}}
+{{define "navtoggle"}}
+<button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
+aria-expanded="false" aria-label="Toggle navigation">
+  <span class="navbar-toggler-icon"></span>
+</button>
+{{end}}
 
-  <nav class="navbar navbar-expand-md navbar-dark bg-primary">
-    <div class="container">
-      <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbar" aria-controls="navbar"
-        aria-expanded="false" aria-label="Toggle navigation">
-        <span class="navbar-toggler-icon"></span>
-      </button>
+{{/* defines the dropdown menu */}}
+{{define "navdropdown"}}
+<ul class="navbar-nav ml-auto">
+  {{if .currentUser}}
+  <li class="nav-item dropdown">
+    <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
+      aria-expanded="false">
+      {{.currentUser.Name}}
+    </a>
 
-      <div class="collapse navbar-collapse" id="navbar">
-        {{if .currentUser}}
-        <ul class="navbar-nav mr-auto">
-          {{if .currentRealm}}
-          <li class="nav-item">
-            <a class="nav-link" href="/home">Issue code</a>
-          </li>
-          <li class="nav-item">
-            <a class="nav-link" href="/code/status">Check code status</a>
-          </li>
-          {{end}}
-        </ul>
+    <div class="dropdown-menu" aria-labelledby="profile-menu">
+      {{if .currentRealm }}
+      {{if .currentUser.CanAdminRealm .currentRealm.ID}}
+      <h6 class="dropdown-header">Manage realm</h6>
+      <a class="dropdown-item" href="/apikeys">API keys</a>
+      <a class="dropdown-item" href="/realm/keys">Signing keys</a>
+      <a class="dropdown-item" href="/realm/stats">Statistics</a>
+      <a class="dropdown-item" href="/users">Users</a>
+      <a class="dropdown-item" href="/realm/settings#general">Settings</a>
+      <div class="dropdown-divider"></div>
+      {{end}}
+      {{end}}
 
-        <ul class="navbar-nav ml-auto">
-          <li class="nav-item dropdown">
-            <a class="nav-link dropdown-toggle" href="#" id="profile-menu" data-toggle="dropdown" aria-haspopup="true"
-              aria-expanded="false">
-              {{.currentUser.Name}}
-            </a>
+      {{if .currentUser.Admin}}
+      <h6 class="dropdown-header">System admin</h6>
+      <a class="dropdown-item" href="/admin/realms">Realms</a>
+      <a class="dropdown-item" href="/admin/users">Admins</a>
+      <div class="dropdown-divider"></div>
+      {{end}}
 
-            <div class="dropdown-menu" aria-labelledby="profile-menu">
-              {{if .currentRealm }}
-              {{if .currentUser.CanAdminRealm .currentRealm.ID}}
-              <h6 class="dropdown-header">Manage realm</h6>
-              <a class="dropdown-item" href="/apikeys">API keys</a>
-              <a class="dropdown-item" href="/realm/keys">Signing keys</a>
-              <a class="dropdown-item" href="/realm/stats">Statistics</a>
-              <a class="dropdown-item" href="/users">Users</a>
-              <a class="dropdown-item" href="/realm/settings#general">Settings</a>
-              <div class="dropdown-divider"></div>
-              {{end}}
-              {{end}}
-
-              {{if .currentUser.Admin}}
-              <h6 class="dropdown-header">System admin</h6>
-              <a class="dropdown-item" href="/admin/realms">Realms</a>
-              <a class="dropdown-item" href="/admin/users">Admins</a>
-              <div class="dropdown-divider"></div>
-              {{end}}
-
-              <h6 class="dropdown-header">Actions</h6>
-              {{if gt (len .currentUser.Realms) 1}}
-              <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
-              {{end}}
-              <a class="dropdown-item" href="/signout">Sign out</a>
-            </div>
-          </li>
-        </ul>
-        {{else}}
-        <ul class="navbar-nav ml-auto">
-          <li class="nav-item">
-            <a class="nav-link" href="/">Sign in</a>
-          </li>
-        </ul>
-        {{end}}
-      </div>
+      <h6 class="dropdown-header">Actions</h6>
+      {{if gt (len .currentUser.Realms) 1}}
+      <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
+      {{end}}
+      <a class="dropdown-item" href="/signout">Sign out</a>
     </div>
-  </nav>
-</header>
+  </li>
+  {{else}}
+  <li class="nav-item">
+    <a class="nav-link" href="/">Sign in</a>
+  </li>
+  {{end}}
+</ul>
 {{end}}
 
 {{define "scripts"}}

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -224,7 +224,7 @@ aria-expanded="false" aria-label="Toggle navigation">
 </button>
 {{end}}
 
-{{/* defines the dropdown menu */}}
+{{/* defines the user dropdown menu */}}
 {{define "navdropdown"}}
 <ul class="navbar-nav ml-auto">
   {{if .currentUser}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -365,6 +365,7 @@ func realMain(ctx context.Context) error {
 	{
 		adminSub := r.PathPrefix("/admin").Subrouter()
 		adminSub.Use(requireAuth)
+		adminSub.Use(loadCurrentRealm)
 		adminSub.Use(requireVerified)
 		adminSub.Use(requireSystemAdmin)
 		adminSub.Use(rateLimit)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Load the current realm for admin pages
    * Currently if you navigate to an admin page, the rest of the nav menu is lost which is a weird UX dead-end. This is cruft from when we only had RequireRealm (you can still get to this page if no particular realm is selected)
* Differentiated coloring and navigation for admin pages reinforces that this is a different experience.

![newadminwhodis](https://user-images.githubusercontent.com/36240966/93691242-62a1d480-fa97-11ea-92f7-6186ae301589.png)

**Release Note**

```release-note
Differentiated nav bar for System Admin
```