### PR TITLE
Use the same cacher for public key and signing caches

### DIFF
--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -176,7 +176,7 @@ func realMain(ctx context.Context) error {
 		// POST /api/certificate
 		certChaff := chaff.New()
 		defer certChaff.Close()
-		certapiController, err := certapi.New(ctx, config, db, h, certificateSigner)
+		certapiController, err := certapi.New(ctx, config, db, cacher, certificateSigner, h)
 		if err != nil {
 			return fmt.Errorf("failed to create certapi controller: %w", err)
 		}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -338,7 +338,7 @@ func realMain(ctx context.Context) error {
 		realmSub.Handle("/settings/disable-express", realmadminController.HandleDisableExpress()).Methods("POST")
 		realmSub.Handle("/stats", realmadminController.HandleShow()).Methods("GET")
 
-		realmKeysController, err := realmkeys.New(ctx, config, db, certificateSigner, h)
+		realmKeysController, err := realmkeys.New(ctx, config, db, certificateSigner, cacher, h)
 		if err != nil {
 			return fmt.Errorf("failed to create realmkeys controller: %w", err)
 		}

--- a/go.sum
+++ b/go.sum
@@ -595,6 +595,7 @@ github.com/grpc-ecosystem/grpc-gateway v1.14.8 h1:hXClj+iFpmLM8i3lkO6i4Psli4P2qO
 github.com/grpc-ecosystem/grpc-gateway v1.14.8/go.mod h1:NZE8t6vs6TnwLL/ITkaK8W3ecMLGAbh2jXTclvpiwYo=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed h1:5upAirOpQc1Q53c0bnx2ufif5kANL7bfZWcc6VJWJd8=
 github.com/hailocab/go-hostpool v0.0.0-20160125115350-e80d13ce29ed/go.mod h1:tMWxXQ9wFIaZeTI9F+hmhFiGpFmhOHzyShyFUhRm0H4=
+github.com/hashicorp/consul-template v0.25.0 h1:wsnv4jSqBIVzlg6U0wNg+ePzfrsF3Vi9MqIqDEUrg9U=
 github.com/hashicorp/consul-template v0.25.0/go.mod h1:/vUsrJvDuuQHcxEw0zik+YXTS7ZKWZjQeaQhshBmfH0=
 github.com/hashicorp/consul/api v1.3.0/go.mod h1:MmDNSzIMUjNpY/mQ398R4bk2FnqQLoPndWW5VkKPlCE=
 github.com/hashicorp/consul/api v1.4.0 h1:jfESivXnO5uLdH650JU/6AnjRoHrLhULq0FnC3Kp9EY=

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -20,6 +20,7 @@ import (
 	"crypto"
 	"fmt"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
@@ -27,7 +28,6 @@ import (
 	"go.opencensus.io/stats"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
-	"github.com/google/exposure-notifications-server/pkg/cache"
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -41,24 +41,21 @@ type Controller struct {
 	h           *render.Renderer
 	logger      *zap.SugaredLogger
 	pubKeyCache *keyutils.PublicKeyCache // Cache of public keys for verification token verification.
-	signerCache *cache.Cache             // Cache signers on a per-realm basis.
+	signerCache cache.Cacher             // Cache signers on a per-realm basis.
 	kms         keys.KeyManager
 
 	metrics *Metrics
 }
 
-func New(ctx context.Context, config *config.APIServerConfig, db *database.Database, h *render.Renderer, kms keys.KeyManager) (*Controller, error) {
+func New(ctx context.Context, config *config.APIServerConfig, db *database.Database, cacher cache.Cacher, kms keys.KeyManager, h *render.Renderer) (*Controller, error) {
 	logger := logging.FromContext(ctx)
 
-	pubKeyCache, err := keyutils.NewPublicKeyCache(config.CertificateSigning.PublicKeyCacheDuration)
+	pubKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, config.CertificateSigning.PublicKeyCacheDuration)
 	if err != nil {
 		return nil, fmt.Errorf("cannot create public key cache, likely invalid duration: %w", err)
 	}
 
-	signerCache, err := cache.New(config.CertificateSigning.SignerCacheDuration)
-	if err != nil {
-		return nil, fmt.Errorf("cannot create signer cache, likely invalid duration: %w", err)
-	}
+	signerCache := cacher
 
 	metrics, err := registerMetrics()
 	if err != nil {

--- a/pkg/controller/certapi/signers.go
+++ b/pkg/controller/certapi/signers.go
@@ -32,54 +32,52 @@ type SignerInfo struct {
 }
 
 func (c *Controller) getSignerForRealm(ctx context.Context, authApp *database.AuthorizedApp) (*SignerInfo, error) {
-	sRealmID := fmt.Sprintf("%d", authApp.RealmID)
-	signerCache, err := c.signerCache.WriteThruLookup(sRealmID,
-		func() (interface{}, error) {
-			realm, err := authApp.Realm(c.db)
+	ttl := c.config.CertificateSigning.SignerCacheDuration
+	key := fmt.Sprintf("signer:realm:%d", authApp.RealmID)
+
+	var signerInfo SignerInfo
+	if err := c.signerCache.Fetch(ctx, key, &signerInfo, ttl, func() (interface{}, error) {
+		realm, err := authApp.Realm(c.db)
+		if err != nil {
+			return nil, fmt.Errorf("unable to load realm settings: %w", err)
+		}
+
+		if !realm.UseRealmCertificateKey {
+			// This realm is using the system key.
+			signer, err := c.kms.NewSigner(ctx, c.config.CertificateSigning.CertificateSigningKey)
 			if err != nil {
-				return nil, fmt.Errorf("unable to load realm settings: %w", err)
-			}
-
-			if !realm.UseRealmCertificateKey {
-				// This realm is using the system key.
-				signer, err := c.kms.NewSigner(ctx, c.config.CertificateSigning.CertificateSigningKey)
-				if err != nil {
-					return nil, fmt.Errorf("unable to get signing key from key manager: realmId: %v: %w", sRealmID, err)
-				}
-				return &SignerInfo{
-					Signer:   signer,
-					KeyID:    c.config.CertificateSigning.CertificateSigningKeyID,
-					Issuer:   c.config.CertificateSigning.CertificateIssuer,
-					Audience: c.config.CertificateSigning.CertificateAudience,
-					Duration: c.config.CertificateSigning.CertificateDuration,
-				}, nil
-			}
-
-			// Relam has custom signing keys.
-			signingKey, err := realm.GetCurrentSigningKey(c.db)
-			if err != nil || signingKey == nil {
-				return nil, fmt.Errorf("unable to find current signing key for realm: %v: %w", realm.Model.ID, err)
-			}
-
-			// load the crypto.Signer for this keyID
-			signer, err := c.kms.NewSigner(ctx, signingKey.KeyID)
-			if err != nil {
-				return nil, fmt.Errorf("unable to get signing key from key manager: realmId: %v: %w", sRealmID, err)
+				return nil, fmt.Errorf("unable to get signing key from key manager: %w", err)
 			}
 			return &SignerInfo{
 				Signer:   signer,
-				KeyID:    signingKey.GetKID(),
-				Issuer:   realm.CertificateIssuer,
-				Audience: realm.CertificateAudience,
-				Duration: realm.CertificateDuration.Duration,
+				KeyID:    c.config.CertificateSigning.CertificateSigningKeyID,
+				Issuer:   c.config.CertificateSigning.CertificateIssuer,
+				Audience: c.config.CertificateSigning.CertificateAudience,
+				Duration: c.config.CertificateSigning.CertificateDuration,
 			}, nil
-		})
-	if err != nil {
-		return nil, fmt.Errorf("unable to get signer for realmID: %v: %w", sRealmID, err)
+		}
+
+		// Realm has custom signing keys.
+		signingKey, err := realm.GetCurrentSigningKey(c.db)
+		if err != nil || signingKey == nil {
+			return nil, fmt.Errorf("unable to find current signing key: %w", err)
+		}
+
+		// load the crypto.Signer for this keyID
+		signer, err := c.kms.NewSigner(ctx, signingKey.KeyID)
+		if err != nil {
+			return nil, fmt.Errorf("unable to get signing key from key manager: %w", err)
+		}
+		return &SignerInfo{
+			Signer:   signer,
+			KeyID:    signingKey.GetKID(),
+			Issuer:   realm.CertificateIssuer,
+			Audience: realm.CertificateAudience,
+			Duration: realm.CertificateDuration.Duration,
+		}, nil
+	}); err != nil {
+		return nil, fmt.Errorf("failed to get signer for realm %d: %w", authApp.RealmID, err)
 	}
-	signer, ok := signerCache.(*SignerInfo)
-	if !ok {
-		return nil, fmt.Errorf("certificate signer in wrong format for realmID: %v: %w", sRealmID, err)
-	}
-	return signer, nil
+
+	return &signerInfo, nil
 }

--- a/pkg/controller/realmkeys/realmkeys.go
+++ b/pkg/controller/realmkeys/realmkeys.go
@@ -17,10 +17,10 @@ package realmkeys
 
 import (
 	"context"
-	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
@@ -40,10 +40,10 @@ type Controller struct {
 	systemCertificateKeyManager keys.KeyManager
 }
 
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, h *render.Renderer) (*Controller, error) {
+func New(ctx context.Context, config *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, cacher cache.Cacher, h *render.Renderer) (*Controller, error) {
 	logger := logging.FromContext(ctx)
 
-	publicKeyCache, err := keyutils.NewPublicKeyCache(time.Minute)
+	publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, config.CertificateSigning.PublicKeyCacheDuration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/realmkeys/render.go
+++ b/pkg/controller/realmkeys/render.go
@@ -84,6 +84,7 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 		} else {
 			pem, err := keyutils.EncodePublicKey(publicKey)
 			if err != nil {
+				m["systemCertPublicKey"] = ""
 				m["systemCertPublicKeyError"] = fmt.Sprintf("Failed to encode public key: %v", err)
 			} else {
 				m["systemCertPublicKey"] = pem


### PR DESCRIPTION
Fixes GH-346

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use the configured cacher for public key and signing key caches
```

/assign @jeremyfaller 