### PR TITLE
Add extra hosts flag to monitor

### DIFF
--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -1,5 +1,5 @@
 resource "google_monitoring_uptime_check_config" "https" {
-  for_each = toset([var.server-host, var.apiserver-host, var.adminapi-host])
+  for_each = toset(compact(concat([var.server-host, var.apiserver-host, var.adminapi-host], var.extra-hosts)))
 
   display_name = each.key
   timeout      = "3s"

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -5,7 +5,7 @@ variable "project" {
 variable "notification-email" {
   type        = string
   default     = "nobody@example.com"
-  description = "Email address for alerts"
+  description = "Email address for alerts to go to."
 }
 
 variable "server-host" {
@@ -24,6 +24,12 @@ variable "adminapi-host" {
   type        = string
   default     = ""
   description = "Domain adminapi is hosted on."
+}
+
+variable "extra-hosts" {
+  type        = list(string)
+  default     = []
+  description = "Extra hosts to probe and monitor."
 }
 
 terraform {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Let terraform alerting configs define extra hosts to monitor.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
extra-hosts variable added to alerting terraform to let people setup alerts for other hosts they care about.
```
