### PR TITLE
don't show expiry countdown if claimed

### DIFF
--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -43,7 +43,7 @@
         <div class="list-group-item">
           <h5 class="mb-1">Expiry</h5>
           <span id="code-expires-at" class="sm text-danger">&nbsp;</span>
-        </div>        
+        </div>
         {{if .code.HasLongExpires}}
         <div class="list-group-item">
           <h5 class="mb-1">SMS link expiry</h5>

--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -39,15 +39,17 @@
           <h5 class="mb-1">Status</h5>
           <p class="mb-1">{{.code.Status}}</p>
         </div>
+        {{if not .code.Claimed}}
         <div class="list-group-item">
           <h5 class="mb-1">Expiry</h5>
           <span id="code-expires-at" class="sm text-danger">&nbsp;</span>
-        </div>
+        </div>        
         {{if .code.HasLongExpires}}
         <div class="list-group-item">
           <h5 class="mb-1">SMS link expiry</h5>
           <span id="long-code-expires-at" class="sm text-danger">&nbsp;</span>
         </div>
+        {{end}}
         {{end}}
         {{if .code.Expires}}
         <div class="list-group-item">
@@ -65,6 +67,7 @@
   {{template "scripts" .}}
   {{template "codescripts" .}}
 
+  {{if not .code.Claimed}}
   <script type="text/javascript">
     let $buttonInvalidate = $('button#invalidate');
     let expires = {{ .code.Expires }};
@@ -80,6 +83,7 @@
       {{end}}
     });
   </script>
+  {{end}}
 </body>
 
 </html>

--- a/pkg/controller/codestatus/show.go
+++ b/pkg/controller/codestatus/show.go
@@ -84,12 +84,13 @@ func (c *Controller) responseCode(ctx context.Context, r *http.Request, code *da
 		retCode.Issuer = c.getAuthAppName(ctx, r, code.IssuingAppID)
 	}
 
+	retCode.Claimed = code.Claimed
 	if code.Claimed {
 		retCode.Status = "Claimed by user"
 	} else {
 		retCode.Status = "Not yet claimed"
 	}
-	if !code.IsExpired() {
+	if !code.IsExpired() && !code.Claimed {
 		retCode.Expires = code.ExpiresAt.UTC().Unix()
 		retCode.LongExpires = code.LongExpiresAt.UTC().Unix()
 		retCode.HasLongExpires = retCode.LongExpires > retCode.Expires
@@ -152,6 +153,7 @@ func (c *Controller) getAuthAppName(ctx context.Context, r *http.Request, id uin
 
 type Code struct {
 	UUID           string `json:"uuid"`
+	Claimed        bool   `json:"claimed"`
 	Status         string `json:"status"`
 	TestType       string `json:"testType"`
 	IssuerType     string `json:"issuerType"`


### PR DESCRIPTION
## Proposed Changes

* Don't show the expiration countdown if a code is already claimed. Previously you would see the red countdown clock for a code that has already been redeemed.

**Release Note**

```release-note
NONE
```
