### PR TITLE
Require region codes are globally unique

### DIFF
--- a/cmd/server/assets/realmadmin/_form_abuse_prevention.html
+++ b/cmd/server/assets/realmadmin/_form_abuse_prevention.html
@@ -4,6 +4,7 @@
 
 <form method="POST" action="/realm/settings#abuse-prevention" class="floating-form">
   {{ .csrfField }}
+  <input type="hidden" name="abuse_prevention" value="1" />
 
   <p>
     Abuse prevention uses the historical record of your realm's past
@@ -18,9 +19,6 @@
   </p>
 
   <div class="form-group form-check">
-    <!-- This forces the form to send a value of false (instead of no value at
-    all), when abuse prevention is unchecked. -->
-    <input type="hidden" name="abuse_prevention_enabled" value="0" />
     <input type="checkbox" name="abuse_prevention_enabled" id="abuse-prevention-enabled" class="form-check-input" value="1" {{if $realm.AbusePreventionEnabled}} checked{{end}}>
     <label class="form-check-label" for="abuse-prevention-enabled">
       Enable abuse prevention

--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -10,6 +10,7 @@
 
 <form method="POST" action="/realm/settings#codes" class="floating-form">
   {{ .csrfField }}
+  <input type="hidden" name="codes" value="1" />
 
   <div class="form-group">
     <label>Allowed test types</label>

--- a/cmd/server/assets/realmadmin/_form_general.html
+++ b/cmd/server/assets/realmadmin/_form_general.html
@@ -9,6 +9,7 @@
 
 <form method="POST" action="/realm/settings#general" class="floating-form">
   {{ .csrfField }}
+  <input type="hidden" name="general" value="1" />
 
   <div class="form-label-group">
     <input type="text" name="name" id="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}"
@@ -22,11 +23,12 @@
     <small class="form-text text-muted">
       The realm name is displayed on the realm selection page and in the header
       when selected. Choose a descriptive name that your team will recognize.
+      This value must be globally unique in the system.
     </small>
   </div>
 
   <div class="form-label-group">
-    <input type="text" name="region_code" id="region-code" class="form-control{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}"
+    <input type="text" name="region_code" id="region-code" class="form-control text-uppercase{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}"
       value="{{$realm.RegionCode}}" placeholder="Region code" />
     <label for="region-code">Region code</label>
     {{if $realm.ErrorsFor "regionCode"}}
@@ -41,6 +43,7 @@
       <a href="https://en.wikipedia.org/wiki/List_of_ISO_3166_country_codes">ISO
       3166-1 country codes and ISO 3166-2 subdivision codes</a> where
       applicable. For example, Washington state would be <code>US-WA</code>.
+      This value must globally unique in the system.
     </small>
   </div>
 

--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -8,6 +8,7 @@
 
 <form method="POST" action="/realm/settings#security" class="floating-form">
   {{ .csrfField }}
+  <input type="hidden" name="security" value="1" />
 
   <div class="form-group">
     <label for="email-verified-mode">Email verification</label>

--- a/cmd/server/assets/realmadmin/_form_sms.html
+++ b/cmd/server/assets/realmadmin/_form_sms.html
@@ -11,7 +11,7 @@
 
 <form method="POST" action="/realm/settings#sms" class="floating-form">
   {{ .csrfField }}
-  <input type="hidden" name="twilio_sms_config" value="1" />
+  <input type="hidden" name="sms" value="1" />
 
   <div class="form-label-group">
     <input type="text" name="twilio_account_sid" id="twilio-account-sid" class="form-control text-monospace"

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -415,7 +415,7 @@ func callbackKMSEncrypt(ctx context.Context, keyManager keys.KeyManager, keyID, 
 	}
 }
 
-// callback HMAC alters HMACs the value with the given key before saving.
+// callbackHMAC alters HMACs the value with the given key before saving.
 func callbackHMAC(ctx context.Context, hashFunc func(string) (string, error), table, column string) func(scope *gorm.Scope) {
 	return func(scope *gorm.Scope) {
 		// Do nothing if not the target table
@@ -485,4 +485,20 @@ func withRetries(ctx context.Context, f retry.RetryFunc) error {
 	b = retry.WithCappedDuration(1*time.Second, b)
 
 	return retry.Do(ctx, b, f)
+}
+
+// stringValue gets the value of the string pointer, returning "" for nil.
+func stringValue(s *string) string {
+	if s == nil {
+		return ""
+	}
+	return *s
+}
+
+// stringPtr converts the string value to a pointer, returning nil for "".
+func stringPtr(s string) *string {
+	if s == "" {
+		return nil
+	}
+	return &s
 }


### PR DESCRIPTION
This is required for the ENX redirector, but we've also always made the
assumption that these need to be globally unique.

Note that this requires changing the column to citext (for
case-insensitive matching) and to NULL out the default of '', since ''
is a duplicate of ''.

It also handles any existing duplicates by appending -N to them before
applying the database-level unique constraint.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
**Potentially breaking** Require region codes be globally unique, add database constraint for realm name uniqueness
```

/cc @icco @mikehelmick 