### PR TITLE
Suppress user-not-found error

### DIFF
--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -70,8 +70,12 @@
           flash.alert('Password reset email sent.');
         }).catch(function(error) {
           flash.clear();
-          flash.error(error.message);
-          $submit.prop('disabled', false);
+          if (error.code = "auth/user-not-found") {
+            flash.alert('Password reset email sent.');
+          } else {
+            flash.error(error.message);
+            $submit.prop('disabled', false);
+          }
         });
       });
     });


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Respond the same for users who's emails are not found
* This won't fool anyone savvy - we need to be either:
1) sending these from our own SMTP server
2) find a firebase toggle that disables this response
2) run all firebase from node.js in a function as a proxy, filter server side, keep the firebase api key secret