### PR TITLE
Add redirect support for iOS and Android.

### DIFF
--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -16,14 +16,17 @@ package main
 
 import (
 	"context"
+	"crypto/sha1"
 	"fmt"
 	"net/http"
 	"os"
 	"strconv"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/associated"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/redirect"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -58,14 +61,14 @@ func main() {
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	config, err := config.NewRedirectConfig(ctx)
+	cfg, err := config.NewRedirectConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to process config: %w", err)
 	}
 
 	// Setup monitoring
 	logger.Info("configuring observability exporter")
-	oeConfig := config.ObservabilityExporterConfig()
+	oeConfig := cfg.ObservabilityExporterConfig()
 	oe, err := observability.NewFromEnv(ctx, oeConfig)
 	if err != nil {
 		return fmt.Errorf("unable to create ObservabilityExporter provider: %w", err)
@@ -76,25 +79,69 @@ func realMain(ctx context.Context) error {
 	defer oe.Close()
 	logger.Infow("observability exporter", "config", oeConfig)
 
+	// Setup cacher
+	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.MultiKeyFunc(
+		cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey),
+		cache.PrefixKeyFunc("cache:"),
+	))
+	if err != nil {
+		return fmt.Errorf("failed to create cacher: %w", err)
+	}
+	defer cacher.Close()
+
+	// Setup database
+	db, err := cfg.Database.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.OpenWithCacher(ctx, cacher); err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+
 	// Create the router
 	r := mux.NewRouter()
 
 	// Create the renderer
-	h, err := render.New(ctx, config.AssetsPath, config.DevMode)
+	h, err := render.New(ctx, cfg.AssetsPath, cfg.DevMode)
 	if err != nil {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
 
 	// Install common security headers
-	r.Use(middleware.SecureHeaders(ctx, config.DevMode, "html"))
+	r.Use(middleware.SecureHeaders(ctx, cfg.DevMode, "html"))
 
 	// Enable debug headers
 	processDebug := middleware.ProcessDebug(ctx)
 	r.Use(processDebug)
 
+	// iOS and Android include functionality to associate data between web-apps
+	// and device apps. Things like handoff between websites and apps, or
+	// shared credentials are the common usecases. The redirect server
+	// publishes the metadata needed to share data between the two domains to
+	// offer a more seemless experience between the website and apps. iOS and
+	// Android publish specs as to what this format looks like, and both live
+	// under the /.well-known directory on the server.
+	//
+	//   Android Specs:
+	//     https://developer.android.com/training/app-links/verify-site-associations
+	//   iOS Specs:
+	//     https://developer.apple.com/documentation/safariservices/supporting_associated_domains
+	{ // .well-known directory
+		wk := r.PathPrefix("/.well-known").Subrouter()
+
+		// Enable the iOS and Android redirect handler.
+		assocHandler, err := associated.New(ctx, db, cacher, h)
+		if err != nil {
+			return fmt.Errorf("failed to create associated links handler %w", err)
+		}
+		wk.PathPrefix("/apple-app-site-association").Handler(assocHandler.HandleIos()).Methods("GET")
+		wk.PathPrefix("/assetlinks.json").Handler(assocHandler.HandleAndroid()).Methods("GET")
+	}
+
 	r.Handle("/health", controller.HandleHealthz(ctx, nil, h)).Methods("GET")
 
-	redirectController, err := redirect.New(ctx, config, h)
+	redirectController, err := redirect.New(ctx, cfg, h)
 	if err != nil {
 		return err
 	}
@@ -103,10 +150,10 @@ func realMain(ctx context.Context) error {
 	mux := http.NewServeMux()
 	mux.Handle("/", r)
 
-	srv, err := server.New(config.Port)
+	srv, err := server.New(cfg.Port)
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
-	logger.Infow("server listening", "port", config.Port)
+	logger.Infow("server listening", "port", cfg.Port)
 	return srv.ServeHTTPHandler(ctx, mux)
 }

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -238,6 +238,7 @@ aria-expanded="false" aria-label="Toggle navigation">
       {{if .currentUser.CanAdminRealm .currentRealm.ID}}
       <h6 class="dropdown-header">Manage realm</h6>
       <a class="dropdown-item" href="/apikeys">API keys</a>
+      <a class="dropdown-item" href="/mobileapp">Mobile apps</a>
       <a class="dropdown-item" href="/realm/keys">Signing keys</a>
       <a class="dropdown-item" href="/realm/stats">Statistics</a>
       <a class="dropdown-item" href="/users">Users</a>

--- a/cmd/server/assets/mobileapp/_app.html
+++ b/cmd/server/assets/mobileapp/_app.html
@@ -1,0 +1,56 @@
+{{define "app"}}
+
+{{$app := .app}}
+
+  <div class="form-group">
+    <select class="form-control{{if $app.ErrorsFor "os"}} is-invalid{{end}}" name="os" id="os" onchange="osSelect()">
+      <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS</option>
+      <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android</option>
+    </select>
+    {{if $app.ErrorsFor "os"}}
+    <div class="invalid-feedback">
+      {{joinStrings ($app.ErrorsFor "os") ", "}}
+    </div>
+    {{end}}
+  </div>
+
+  <div class="form-label-group" id="appID">
+    <input type="text" id="appID" name="appID" class="form-control{{if $app.ErrorsFor "appID"}} is-invalid{{end}}" value="{{$app.AppID}}" placeholder="Application ID" autofocus>
+    <label for="appID" id="idDIV">FILLIN</label>
+    {{if $app.ErrorsFor "appID"}}
+    <div class="invalid-feedback">
+      {{joinStrings ($app.ErrorsFor "appID") ", "}}
+    </div>
+    {{end}}
+  </div>
+
+    <label for="sha">SHAs (One Per Line)</label>
+    {{if $app.ErrorsFor "sha"}}
+    <div class="invalid-feedback">
+      {{joinStrings ($app.ErrorsFor "sha") ", "}}
+    </div>
+    {{end}}
+  <div class="form-label-group" id="shaDIV">
+    <textarea type="text" id="sha" name="sha" class="form-control{{if $app.ErrorsFor "sha"}} is-invalid{{end}}" rows=5 autofocus>{{$app.SHA}}</textarea>
+  </div>
+
+  <script>
+    function osSelect() {
+      selection = document.getElementById("os").value;
+      id = document.getElementById("idDIV")
+      sha = document.getElementById("shaDIV");
+      switch(selection) {
+		default:
+        case "{{.iOS}}":
+            id.innerText = "Application ID"
+            sha.style.display = "none";
+          break;
+        case "{{.android}}":
+            id.innerHTML = "Bundle Identifier"
+            sha.style.display = "block";
+          break;
+      }
+    }
+  </script>
+
+{{end}}

--- a/cmd/server/assets/mobileapp/edit.html
+++ b/cmd/server/assets/mobileapp/edit.html
@@ -1,0 +1,57 @@
+{{define "mobileapp/edit"}}
+
+{{$app := .app}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+  {{template "floatingform" .}}
+</head>
+
+<body class="tab-content" onload="osSelect()">
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Edit Mobile App</h1>
+    <p>
+      Use the form below to edit the app.
+    </p>
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Details</div>
+      <div class="card-body">
+        <form method="POST" action="/mobileapp/{{$app.ID}}">
+          <input type="hidden" name="_method" value="PATCH">
+          {{ .csrfField }}
+
+          <div class="form-label-group">
+            <input type="text" id="name" name="name" class="form-control{{if $app.ErrorsFor "name"}} is-invalid{{end}}" value="{{$app.Name}}" placeholder="Application name" autofocus>
+            <label for="name">Application name</label>
+            {{if $app.ErrorsFor "name"}}
+            <div class="invalid-feedback">
+              {{joinStrings ($app.ErrorsFor "name") ", "}}
+            </div>
+            {{end}}
+          </div>
+
+		  {{template "app" .}}
+
+          <button type="submit" class="btn btn-primary btn-block">Update Mobile App</button>
+        </form>
+      </div>
+    </div>
+
+    <div>
+      <p>
+        <a href="/mobileapp">&larr; Back to all mobile apps</a>
+      </p>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/mobileapp/index.html
+++ b/cmd/server/assets/mobileapp/index.html
@@ -1,0 +1,84 @@
+{{define "mobileapp/index"}}
+
+{{$apps := .apps}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Mobile Apps</h1>
+    <p>
+      These are the mobile apps for this realm. You
+      can also <a href="/mobileapp/new">create a new mobile app</a>.
+    </p>
+
+    {{if .apps}}
+    <div class="table-responsive">
+      <table class="table table-bordered table-striped bg-white">
+        <thead>
+          <tr>
+            <th scope="col">App</th>
+            <th scope="col" width="95">Enabled</th>
+            <th scope="col" width="40"></th>
+          </tr>
+        </thead>
+        <tbody>
+        {{range .apps}}
+          <tr>
+
+            <td>
+              <a href="/mobileapp/{{.ID}}" class="text-truncate">{{.Name}}</a>
+            </td>
+
+            <td>
+              {{if .DeletedAt}}
+                <span class="badge badge-pill badge-danger">Deleted</span>
+              {{else}}
+                <span class="badge badge-pill badge-success">Enabled</span>
+              {{end}}
+            </td>
+
+            <td class="text-center">
+              {{if .DeletedAt}}
+              <a href="/mobileapp/{{.ID}}/enable" class="d-block text-danger"
+                data-method="patch"
+                data-confirm="Are you sure you want to restore '{{.Name}}'?"
+                data-toggle="tooltip"
+                title="Restore this mobile app">
+                <span class="oi oi-loop-circular" aria-hidden="true"></span>
+              </a>
+              {{else}}
+              <a href="/mobileapp/{{.ID}}/disable" class="d-block text-danger"
+                data-method="patch"
+                data-confirm="Are you sure you want to disable '{{.Name}}'?"
+                data-toggle="tooltip"
+                title="Disable this mobile app">
+                <span class="oi oi-trash" aria-hidden="true"></span>
+              </a>
+              {{end}}
+            </td>
+
+          </tr>
+        {{end}}
+        </tbody>
+      </table>
+    </div>
+    {{else}}
+    <p class="text-center">
+      <em>There are no mobile apps.</em>
+    </p>
+    {{end}}
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/mobileapp/new.html
+++ b/cmd/server/assets/mobileapp/new.html
@@ -1,0 +1,50 @@
+{{define "mobileapp/new"}}
+
+{{$app := .app}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+  {{template "floatingform" .}}
+</head>
+
+<body class="tab-content" onload="osSelect()">>
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>New Mobile App</h1>
+    <p>
+      Use the form below to create a new mobile app.
+    </p>
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Details</div>
+      <div class="card-body">
+        <form method="POST" action="/mobileapp">
+          {{ .csrfField }}
+
+          <div class="form-label-group">
+            <input type="text" id="name" name="name" class="form-control{{if $app.ErrorsFor "name"}} is-invalid{{end}}" value="{{$app.Name}}" placeholder="Application name" autofocus>
+            <label for="name">Application name</label>
+            {{if $app.ErrorsFor "name"}}
+            <div class="invalid-feedback">
+              {{joinStrings ($app.ErrorsFor "name") ", "}}
+            </div>
+            {{end}}
+          </div>
+
+		  {{template "app" .}}
+
+          <button type="submit" class="btn btn-primary btn-block">Create mobile app</button>
+        </form>
+      </div>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/mobileapp/show.html
+++ b/cmd/server/assets/mobileapp/show.html
@@ -1,0 +1,76 @@
+
+{{define "mobileapp/show"}}
+
+{{$app := .app}}
+
+<!doctype html>
+<html lang="en">
+
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>{{$app.Name}}</h1>
+    <p class="float-right">
+      <a href="/mobileapp/{{$app.ID}}/edit">Edit</a>
+    </p>
+    <p>
+      Here is information about the Mobile App.
+    </p>
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Details</div>
+      <div class="card-body">
+        <strong>App name</strong>
+        <div class="mb-3">
+          {{$app.Name}}
+        </div>
+        <strong>OS</strong>
+        <div>
+          {{if (eq $app.OS .iOS)}}
+          iOS
+          {{else if (eq $app.OS .android)}}
+          Android
+          {{end}}
+        </div>
+
+		{{if (eq $app.OS .iOS)}}
+          <strong>iOS App ID:</strong>
+          <div>
+          {{$app.AppID}}
+          </div>
+        {{end}}
+
+		{{if (eq $app.OS .android)}}
+          <strong>Android Bundle Identifier:</strong>
+          <div>
+          {{$app.AppID}}
+          </div>
+
+          <strong>SHA:</strong>
+          <div>
+          {{$app.SHA}}
+          </div>
+        {{end}}
+      </div>
+	</div>
+
+    <div>
+      <p>
+        <a href="/mobileapp">&larr; Back to all mobile apps</a>
+      </p>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+
+</body>
+
+</html>
+{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -36,6 +36,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/jwks"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapp"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/user"
@@ -299,6 +300,29 @@ func realMain(ctx context.Context) error {
 		sub.Handle("/status", codeStatusController.HandleIndex()).Methods("GET")
 		sub.Handle("/show", codeStatusController.HandleShow()).Methods("POST")
 		sub.Handle("/{uuid}/expire", codeStatusController.HandleExpirePage()).Methods("PATCH")
+	}
+
+	// mobileapp
+	{
+		sub := r.PathPrefix("/mobileapp").Subrouter()
+		sub.Use(requireAuth)
+		sub.Use(loadCurrentRealm)
+		sub.Use(requireRealm)
+		sub.Use(processFirewall)
+		sub.Use(requireAdmin)
+		sub.Use(requireVerified)
+		sub.Use(requireMFA)
+		sub.Use(rateLimit)
+
+		mobileController := mobileapp.New(ctx, config, cacher, db, h)
+		sub.Handle("", mobileController.HandleIndex()).Methods("GET")
+		sub.Handle("", mobileController.HandleCreate()).Methods("POST")
+		sub.Handle("/new", mobileController.HandleCreate()).Methods("GET")
+		sub.Handle("/{id}/edit", mobileController.HandleUpdate()).Methods("GET")
+		sub.Handle("/{id}", mobileController.HandleShow()).Methods("GET")
+		sub.Handle("/{id}", mobileController.HandleUpdate()).Methods("PATCH")
+		sub.Handle("/{id}/disable", mobileController.HandleDisable()).Methods("PATCH")
+		sub.Handle("/{id}/enable", mobileController.HandleEnable()).Methods("PATCH")
 	}
 
 	// apikeys

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -20,13 +20,17 @@ import (
 	"strings"
 
 	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/sethvargo/go-envconfig"
 )
 
 // RedirectConfig represents the environment based config for the redirect server.
 type RedirectConfig struct {
+	Database      database.Config
 	Observability observability.Config
+	Cache         cache.Config
 
 	Port string `env:"PORT, default=8080"`
 
@@ -61,6 +65,10 @@ func NewRedirectConfig(ctx context.Context) (*RedirectConfig, error) {
 
 func (c *RedirectConfig) ObservabilityExporterConfig() *observability.Config {
 	return &c.Observability
+}
+
+func (c *RedirectConfig) DatabaseConfig() *database.Config {
+	return &c.Database
 }
 
 // HostnameToRegion returns a normalized map of the HOSTNAME_TO_REGION config value.

--- a/pkg/controller/associated/android.go
+++ b/pkg/controller/associated/android.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associated
+
+import (
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+type AndroidData struct {
+	Relation []string `json:"relation,omitempty"`
+	Target   Target   `json:"target,omitempty"`
+}
+
+type Target struct {
+	Namespace    string   `json:"namespace,omitempty"`
+	PackageName  string   `json:"package_name,omitempty"`
+	Fingerprints []string `json:"sha256_cert_fingerprints,omitempty"`
+}
+
+// getAndroidData finds all the android data apps.
+func (c *Controller) getAndroidData() ([]AndroidData, error) {
+	apps, err := c.db.ListActiveAppsByOS(database.OSTypeAndroid)
+	if err != nil {
+		return nil, err
+	}
+
+	ret := make([]AndroidData, 0, len(apps))
+	for i := range apps {
+		ret = append(ret, AndroidData{
+			Relation: []string{"delegate_permission/common.handle_all_urls"},
+			Target: Target{
+				Namespace:    "android_app",
+				PackageName:  apps[i].AppID,
+				Fingerprints: strings.Split(apps[i].SHA, "\n"),
+			},
+		})
+	}
+
+	return ret, nil
+}

--- a/pkg/controller/associated/index.go
+++ b/pkg/controller/associated/index.go
@@ -1,0 +1,116 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package associated handles the iOS and Android associated app handler
+// protocols. For more discussion of these protocols, please see:
+//
+// Android:
+//   https://developer.android.com/training/app-links/verify-site-associations
+// iOS:
+//   https://developer.apple.com/documentation/safariservices/supporting_associated_domains
+package associated
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+type Controller struct {
+	ctxt   context.Context
+	db     *database.Database
+	cacher cache.Cacher
+	h      *render.Renderer
+}
+
+var ttl = 30 * time.Minute
+
+func (c *Controller) HandleIos() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.String()
+
+		// Check the cache.
+		{
+			var data IOSData
+			if err := c.cacher.Read(c.ctxt, key, &data); err == nil {
+				c.h.RenderJSON(w, http.StatusOK, data)
+				return
+			} else if err != cache.ErrNotFound {
+				controller.InternalError(w, r, c.h, err)
+				return
+			}
+		}
+
+		// Not in cache, go get it.
+		data, err := c.getIosData()
+		if err != nil {
+			c.h.RenderJSON(w, http.StatusOK, api.Error(err))
+			return
+		}
+
+		// Cache the data.
+		if err := c.cacher.Fetch(c.ctxt, key, &data, ttl, func() (interface{}, error) {
+			return data, nil
+		}); err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.h.RenderJSON(w, http.StatusOK, data)
+	})
+}
+
+func (c *Controller) HandleAndroid() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		key := r.URL.String()
+
+		// Check the cache
+		var data []AndroidData
+		if err := c.cacher.Read(c.ctxt, r.URL.String(), &data); err == nil {
+			c.h.RenderJSON(w, http.StatusOK, data)
+			return
+		} else if err != cache.ErrNotFound {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		// Not in cache, get the data.
+		var err error
+		data, err = c.getAndroidData()
+		if err != nil {
+			c.h.RenderJSON(w, http.StatusOK, api.Error(err))
+			return
+		}
+
+		// And save to the cache.
+		if err := c.cacher.Fetch(c.ctxt, key, &data, ttl, func() (interface{}, error) {
+			return data, nil
+		}); err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.h.RenderJSON(w, http.StatusOK, data)
+	})
+}
+
+func New(ctxt context.Context, db *database.Database, cacher cache.Cacher, h *render.Renderer) (*Controller, error) {
+	return &Controller{ctxt: ctxt, db: db, cacher: cacher, h: h}, nil
+}

--- a/pkg/controller/associated/ios.go
+++ b/pkg/controller/associated/ios.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package associated
+
+// The iOS format is specified by:
+//   https://developer.apple.com/documentation/safariservices/supporting_associated_domains
+
+import "github.com/google/exposure-notifications-verification-server/pkg/database"
+
+type IOSData struct {
+	Applinks Applinks `json:"applinks"`
+
+	// The following two fields are included for completeness' sake, but are not
+	// currently populated/used by the system.
+	Webcredentials *Appstrings `json:"webcredentials,omitempty"`
+	Appclips       *Appstrings `json:"appclips,omitempty"`
+}
+
+type Applinks struct {
+	Details []Detail `json:"details,omitempty"`
+}
+
+type Detail struct {
+	AppIds     []string    `json:"appIDs,omitempty"`
+	Components []Component `json:"components,omitempty"`
+}
+
+type Component struct {
+	Path    string `json:"/,omitempty"`
+	Param   string `json:"?,omitempty"`
+	Exclude *bool  `json:"exclude,omitempty"`
+	Comment string `json:"comment,omitempty"`
+}
+
+type Appstrings struct {
+	Apps []string `json:"apps,omitempty"`
+}
+
+// getAppIds finds all the iOS app ids we know about.
+func (c *Controller) getAppIds() ([]string, error) {
+	apps, err := c.db.ListActiveAppsByOS(database.OSTypeIOS)
+	if err != nil {
+		return nil, err
+	}
+	ret := make([]string, 0, len(apps))
+	for i := range apps {
+		ret = append(ret, apps[i].AppID)
+	}
+	return ret, nil
+}
+
+// getIosData gets the iOS app data.
+func (c *Controller) getIosData() (*IOSData, error) {
+	var ids []string
+	var err error
+
+	ids, err = c.getAppIds()
+	if err != nil {
+		return nil, err
+	}
+
+	return &IOSData{
+		Applinks: Applinks{
+			Details: []Detail{{
+				AppIds: ids,
+				Components: []Component{
+					{Path: "/*", Comment: "handle all urls"},
+				}},
+			},
+		},
+	}, nil
+}

--- a/pkg/controller/mobileapp/create.go
+++ b/pkg/controller/mobileapp/create.go
@@ -1,0 +1,171 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var (
+	ErrNoAppIDSpecified = errors.New("OS selection requires app id")
+	ErrBadSHALength     = errors.New("sha wasn't 95 characters")
+	ErrBadSHAFormat     = errors.New("sha must be of the form AA:...:BB")
+)
+
+type FormData struct {
+	Name  string          `form:"name"`
+	OS    database.OSType `form:"os"`
+	AppID string          `form:"appID"`
+	SHA   string          `form:"sha"`
+}
+
+// cleanSHA cleans an input string.
+func cleanSHA(input string) string {
+	input = strings.ToUpper(input)
+	input = strings.Trim(input, " \n\t\r")
+	input = strings.ReplaceAll(input, ",", "\n")
+	input = strings.ReplaceAll(input, " ", "\n")
+	input = strings.ReplaceAll(input, "\t", "\n")
+	input = strings.ReplaceAll(input, "\r", "\n")
+	res := []string{}
+	for _, str := range strings.Split(input, "\n") {
+		if len(str) == 0 {
+			continue
+		}
+		res = append(res, str)
+	}
+	return strings.Join(res, "\n")
+}
+
+// verifySHA verifies that we have a valid sha.
+func verifySHA(input string) error {
+	for _, sha := range strings.Split(input, "\n") {
+		if len(sha) != 95 {
+			return ErrBadSHALength
+		}
+		if strings.Count(sha, ":") != 31 {
+			return ErrBadSHAFormat
+		}
+		for _, c := range strings.Split(sha, ":") {
+			if len(c) != 2 {
+				return ErrBadSHAFormat
+			}
+		}
+	}
+	return nil
+}
+
+// verify verifies that the form is valid.
+func (f FormData) verify() error {
+	if f.OS == database.OSTypeIOS {
+		if len(f.AppID) == 0 {
+			return ErrNoAppIDSpecified
+		}
+	}
+
+	if f.OS == database.OSTypeAndroid {
+		if len(f.AppID) == 0 {
+			return ErrNoAppIDSpecified
+		}
+		if err := verifySHA(f.SHA); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *Controller) HandleCreate() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		// Requested form, stop processing.
+		if r.Method == http.MethodGet {
+			var app database.MobileApp
+			c.renderNew(ctx, w, &app)
+			return
+		}
+
+		var form FormData
+		if err := controller.BindForm(w, r, &form); err != nil {
+			app := &database.MobileApp{
+				Name:  form.Name,
+				OS:    form.OS,
+				AppID: form.AppID,
+				SHA:   form.SHA,
+			}
+
+			flash.Error("Failed to process form: %v", err)
+			c.renderNew(ctx, w, app)
+			return
+		}
+		form.SHA = cleanSHA(form.SHA)
+
+		// Build the authorized app struct
+		app := &database.MobileApp{
+			Name:  form.Name,
+			OS:    form.OS,
+			AppID: form.AppID,
+			SHA:   form.SHA,
+		}
+
+		// Verify the form.
+		if err := form.verify(); err != nil {
+			flash.Error("Failed to verify: %v", err)
+			c.renderNew(ctx, w, app)
+		}
+
+		err := realm.CreateMobileApp(c.db, app)
+		if err != nil {
+			flash.Error("Failed to create mobile app: %v", err)
+			c.renderNew(ctx, w, app)
+			return
+		}
+
+		// Store the app name in the session so we can properly display it on
+		// the next page.
+		session.Values["appName"] = form.Name
+
+		flash.Alert("Successfully created Mobile App %v", form.Name)
+		http.Redirect(w, r, fmt.Sprintf("/mobileapp/%d", app.ID), http.StatusSeeOther)
+	})
+}
+
+// renderNew renders the new page.
+func (c *Controller) renderNew(ctxt context.Context, w http.ResponseWriter, app *database.MobileApp) {
+	m := templateMap(ctxt)
+	m["app"] = app
+	c.h.RenderHTML(w, "mobileapp/new", m)
+}

--- a/pkg/controller/mobileapp/create_test.go
+++ b/pkg/controller/mobileapp/create_test.go
@@ -1,0 +1,61 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var goodSHA = "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA"
+
+func TestVerifySHA(t *testing.T) {
+	tests := []struct {
+		sha      string
+		expected error
+	}{
+		{"", ErrBadSHALength},
+		{"abc", ErrBadSHALength},
+		{";;;;;;;;;;;;;;;;;;;;;;;;;;;;;;;", ErrBadSHALength},
+		{"A:AAA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA", ErrBadSHAFormat},
+		{goodSHA, nil},
+	}
+
+	for i, test := range tests {
+		if res := verifySHA(test.sha); res != test.expected {
+			t.Errorf("[%d] verifySHA(%q) = %v, expected %v", i, test.sha, res, test.expected)
+		}
+	}
+}
+
+func TestFormVerify(t *testing.T) {
+	tests := []struct {
+		form     FormData
+		expected error
+	}{
+		{FormData{OS: database.OSTypeIOS}, ErrNoAppIDSpecified},
+		{FormData{OS: database.OSTypeAndroid}, ErrNoAppIDSpecified},
+		{FormData{OS: database.OSTypeIOS, AppID: "foo"}, nil},
+		{FormData{OS: database.OSTypeAndroid, AppID: "foo"}, ErrBadSHALength},
+		{FormData{OS: database.OSTypeAndroid, AppID: "foo", SHA: goodSHA}, nil},
+	}
+
+	for i, test := range tests {
+		if res := test.form.verify(); res != test.expected {
+			t.Errorf("[%d] form.vertify() = %v, expected %v", i, res, test.expected)
+		}
+	}
+}

--- a/pkg/controller/mobileapp/disable.go
+++ b/pkg/controller/mobileapp/disable.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/gorilla/mux"
+)
+
+func (c *Controller) HandleDisable() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		app, err := realm.FindMobileApp(c.db, vars["id"])
+		if err != nil {
+			if database.IsNotFound(err) {
+				controller.Unauthorized(w, r, c.h)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		if err := app.Disable(c.db); err != nil {
+			flash.Error("Failed to disable mobile app: %v", err)
+			http.Redirect(w, r, "/mobileapp", http.StatusSeeOther)
+		}
+
+		flash.Alert("Successfully disabled mobile app '%v'", app.Name)
+		http.Redirect(w, r, "/mobileapp", http.StatusSeeOther)
+	})
+}

--- a/pkg/controller/mobileapp/enable.go
+++ b/pkg/controller/mobileapp/enable.go
@@ -1,0 +1,62 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/gorilla/mux"
+)
+
+func (c *Controller) HandleEnable() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		app, err := realm.FindMobileApp(c.db, vars["id"])
+		if err != nil {
+			if database.IsNotFound(err) {
+				controller.Unauthorized(w, r, c.h)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		if err := app.Enable(c.db); err != nil {
+			flash.Error("Failed to enable mobile app: %v", err)
+			http.Redirect(w, r, "/mobileapp", http.StatusSeeOther)
+		}
+
+		flash.Alert("Successfully enabled mobile app '%v'", app.Name)
+		http.Redirect(w, r, "/mobileapp", http.StatusSeeOther)
+	})
+}

--- a/pkg/controller/mobileapp/index.go
+++ b/pkg/controller/mobileapp/index.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func (c *Controller) HandleIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		// Perform the lazy load on authorized apps for the realm.
+		apps, err := realm.ListMobileApps(c.db)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.renderIndex(ctx, w, apps)
+	})
+}
+
+// renderIndex renders the index page.
+func (c *Controller) renderIndex(ctx context.Context, w http.ResponseWriter, apps []*database.MobileApp) {
+	m := templateMap(ctx)
+	m["apps"] = apps
+	c.h.RenderHTML(w, "mobileapp/index", m)
+}

--- a/pkg/controller/mobileapp/mobileapp.go
+++ b/pkg/controller/mobileapp/mobileapp.go
@@ -1,0 +1,56 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package mobileapp contains web controllers for listing and adding mobile
+// apps.
+package mobileapp
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"go.uber.org/zap"
+)
+
+type Controller struct {
+	config *config.ServerConfig
+	cacher cache.Cacher
+	db     *database.Database
+	h      *render.Renderer
+	logger *zap.SugaredLogger
+}
+
+func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, h *render.Renderer) *Controller {
+	logger := logging.FromContext(ctx).Named("mobileapp")
+
+	return &Controller{
+		config: config,
+		cacher: cacher,
+		db:     db,
+		h:      h,
+		logger: logger,
+	}
+}
+
+func templateMap(ctxt context.Context) controller.TemplateMap {
+	m := controller.TemplateMapFromContext(ctxt)
+	m["iOS"] = database.OSTypeIOS
+	m["android"] = database.OSTypeAndroid
+	return m
+}

--- a/pkg/controller/mobileapp/update.go
+++ b/pkg/controller/mobileapp/update.go
@@ -1,0 +1,108 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package mobileapp
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/schema"
+)
+
+// HandleUpdate handles an update.
+func (c *Controller) HandleUpdate() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctxt := r.Context()
+		vars := mux.Vars(r)
+
+		session := controller.SessionFromContext(ctxt)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		realm := controller.RealmFromContext(ctxt)
+		if realm == nil {
+			controller.MissingRealm(w, r, c.h)
+			return
+		}
+
+		app, err := realm.FindMobileApp(c.db, vars["id"])
+		if err != nil {
+			if database.IsNotFound(err) {
+				controller.Unauthorized(w, r, c.h)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		// Requested form, stop processing.
+		if r.Method == http.MethodGet {
+			c.renderEdit(ctxt, w, app)
+			return
+		}
+
+		var form FormData
+		if err := controller.BindForm(w, r, &form); err != nil {
+			app.Name = form.Name
+
+			if terr, ok := err.(schema.MultiError); ok {
+				for k, err := range terr {
+					app.AddError(k, err.Error())
+				}
+			}
+
+			flash.Error("Failed to process form: %v", err)
+			c.renderEdit(ctxt, w, app)
+		}
+		form.SHA = cleanSHA(form.SHA)
+
+		// Build the authorized app struct
+		app.Name = form.Name
+		app.OS = form.OS
+		app.AppID = form.AppID
+		app.SHA = form.SHA
+
+		// Verify the form.
+		if err := form.verify(); err != nil {
+			flash.Error("Failed to verify: %v", err)
+			c.renderEdit(ctxt, w, app)
+			return
+		}
+
+		// Save
+		if err := c.db.SaveMobileApp(app); err != nil {
+			flash.Error("Failed to save mobile app: %v", err)
+			c.renderEdit(ctxt, w, app)
+			return
+		}
+
+		flash.Alert("Successfully updated mobile app!")
+		http.Redirect(w, r, "/mobileapp", http.StatusSeeOther)
+	})
+}
+
+// renderEdit renders the edit page.
+func (c *Controller) renderEdit(ctxt context.Context, w http.ResponseWriter, app *database.MobileApp) {
+	m := templateMap(ctxt)
+	m["app"] = app
+	c.h.RenderHTML(w, "mobileapp/edit", m)
+}

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -61,7 +61,7 @@ type AuthorizedApp struct {
 	// APIKey is the HMACed API key.
 	APIKey string `gorm:"type:varchar(512);unique_index"`
 
-	// APIKeyType s the API key type.
+	// APIKeyType is the API key type.
 	APIKeyType APIUserType `gorm:"default:0"`
 }
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1223,6 +1223,16 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			},
 		},
 		{
+			ID: "00050-CreateMobileApps",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("creating authorized apps table")
+				return tx.AutoMigrate(&MobileApp{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.DropTable("mobile_apps").Error
+			},
+		},
+		{
 			ID: "00051-CreateSystemSMSConfig",
 			Migrate: func(tx *gorm.DB) error {
 				sqls := []string{

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -1,0 +1,93 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"github.com/jinzhu/gorm"
+)
+
+type OSType int
+
+const (
+	OSTypeIOS OSType = iota
+	OSTypeAndroid
+)
+
+type MobileApp struct {
+	gorm.Model
+	Errorable
+
+	// Name is the name of the app.
+	Name string `gorm:"name,varchar(512);unique_index:realm_app_name"`
+
+	// RealmID is the id of the mobile app.
+	RealmID uint `gorm:"unique_index:realm_app_name"`
+
+	// OS is the type of the application we're using (eg, iOS, Android).
+	OS OSType `gorm:"os,type:int"`
+
+	// IOSAppID is a unique string representing the app.
+	AppID string `gorm:"app_id,type:varchar(512)"`
+
+	// SHA is a unique hash of the app.
+	// It is only present for Android devices, and should be of the form:
+	//   AA:BB:CC:DD...
+	SHA string `gorm:"sha,type:text"`
+}
+
+// ListActiveAppsByOS finds all authorized by their OS.
+func (db *Database) ListActiveAppsByOS(os OSType) ([]*MobileApp, error) {
+	// Find the apps.
+	var apps []*MobileApp
+	if err := db.db.
+		Model(&MobileApp{}).
+		Where("os = ?", os).
+		Where("deleted_at IS NULL").
+		Find(&apps).
+		Error; err != nil {
+		return nil, err
+	}
+	return apps, nil
+}
+
+// CreateMobileApp adds a mobile app to the DB.
+func (r *Realm) CreateMobileApp(db *Database, app *MobileApp) error {
+	app.RealmID = r.ID
+	return db.db.Save(&app).Error
+}
+
+// SaveMobileApp saves the authorized app.
+func (db *Database) SaveMobileApp(r *MobileApp) error {
+	if r.Model.ID == 0 {
+		return db.db.Create(r).Error
+	}
+	return db.db.Save(r).Error
+}
+
+// Disable disables the mobile app.
+func (a *MobileApp) Disable(db *Database) error {
+	if err := db.db.Delete(a).Error; err != nil {
+		return err
+	}
+	return nil
+}
+
+// Enable enables the mobile app.
+func (a *MobileApp) Enable(db *Database) error {
+	if err := db.db.Unscoped().Model(a).Update("deleted_at", nil).Error; err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -571,6 +571,37 @@ func (r *Realm) FindAuthorizedApp(db *Database, id interface{}) (*AuthorizedApp,
 	return &app, nil
 }
 
+// ListMobileApps gets all the mobile apps for the realm.
+func (r *Realm) ListMobileApps(db *Database) ([]*MobileApp, error) {
+	var apps []*MobileApp
+	if err := db.db.
+		Unscoped().
+		Model(r).
+		Order("mobile_apps.deleted_at DESC, LOWER(mobile_apps.name)").
+		Related(&apps).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return apps, nil
+		}
+		return nil, err
+	}
+	return apps, nil
+}
+
+// FindMobileApp finds the mobile app by the given id associated with the realm.
+func (r *Realm) FindMobileApp(db *Database, id interface{}) (*MobileApp, error) {
+	var app MobileApp
+	if err := db.db.
+		Unscoped().
+		Model(MobileApp{}).
+		Where("id = ?", id).
+		First(&app).
+		Error; err != nil {
+		return nil, err
+	}
+	return &app, nil
+}
+
 // CountUsers returns the count users on this realm.
 func (r *Realm) CountUsers(db *Database) (int, error) {
 	var count int

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -31,6 +31,74 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-enx-redirect" {
   ]
 }
 
+resource "google_secret_manager_secret_iam_member" "enx-redirect-db" {
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-csrf" {
+  secret_id = google_secret_manager_secret.csrf-token.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-cookie-hmac-key" {
+  provider  = google-beta
+  secret_id = google_secret_manager_secret.cookie-hmac-key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_kms_key_ring_iam_member" "enx-redirect-verification-key-admin" {
+  key_ring_id = google_kms_key_ring.verification.self_link
+  role        = "roles/cloudkms.admin"
+  member      = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_kms_key_ring_iam_member" "enx-redirect-verification-key-signer-verifier" {
+  key_ring_id = google_kms_key_ring.verification.self_link
+  role        = "roles/cloudkms.signerVerifier"
+  member      = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_kms_crypto_key_iam_member" "enx-redirect-database-encrypter" {
+  crypto_key_id = google_kms_crypto_key.database-encrypter.self_link
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-db-apikey-db-hmac" {
+  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-db-apikey-sig-hmac" {
+  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-db-verification-code-hmac" {
+  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "enx-redirect-cache-hmac-key" {
+  secret_id = google_secret_manager_secret.cache-hmac-key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+}
+
 resource "google_project_iam_member" "enx-redirect-observability" {
   for_each = toset([
     "roles/cloudtrace.agent",
@@ -69,6 +137,8 @@ resource "google_cloud_run_service" "enx-redirect" {
           for_each = merge(
             local.gcp_config,
             local.enx_redirect_config,
+            local.cache_config,
+            local.database_config,
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "enx-redirect", {}),

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -167,6 +167,27 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infow("created device api key", "key", deviceAPIKey)
 
+	// Create some Apps
+	apps := []*database.MobileApp{
+		{
+			Name:  "iOS App",
+			OS:    database.OSTypeIOS,
+			AppID: "iOS.app-id",
+		},
+		{
+			Name:  "Android App",
+			OS:    database.OSTypeAndroid,
+			AppID: "Android.app-id",
+			SHA:   "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
+		},
+	}
+	for i := range apps {
+		app := apps[i]
+		if err := realm1.CreateMobileApp(db, app); err != nil {
+			return fmt.Errorf("failed to create app: %w", err)
+		}
+	}
+
 	// Create an admin API key
 	adminAPIKey, err := realm1.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       "Tracing Tracker",


### PR DESCRIPTION
Reviewers:

Please take a close look at caching and the terraform config work here. For caching, I went with purely the DB cache -- not going any deeper. If we need more, please LMK.


Fixes #580

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Creates a pair of endpoints for iOS and Android to get app redirect information
* Adds the a few new fields to `authorized_apps` to hold data needed for the redirection service.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Redirection service now publishes the iOS and Android redirection metadata.
APIKeys now includes support for specifying the needed iOS and Android metadata for redirection.
```
