### PR TITLE
Fix cache type envvar as CACHE_TYPE

### DIFF
--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -33,7 +33,7 @@ const (
 
 // Config represents configuration for a cacher.
 type Config struct {
-	Type CacherType `env:"TYPE, default=IN_MEMORY"`
+	Type CacherType `env:"CACHE_TYPE, default=IN_MEMORY"`
 
 	// HMACKey is the hash key to use when for keys in the cacher.
 	HMACKey envconfig.Base64Bytes `env:"CACHE_HMAC_KEY, required"`


### PR DESCRIPTION
It was always documented this way, but it's never been honored since it was coded as "TYPE".

This is technically breaking, but I don't think we should accept a config value from an envvar of "TYPE", and I don't think anyone is actually configuring this.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix cache type envvar as `CACHE_TYPE`
```
