### PR TITLE
Introduce concept of "system SMS config"

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -497,6 +497,14 @@ aria-expanded="false" aria-label="Toggle navigation">
 </div>
 {{end}}
 
+{{define "errorable"}}
+{{if .}}
+<div class="invalid-feedback">
+  {{joinStrings . ", "}}
+</div>
+{{end}}
+{{end}}
+
 {{define "beta-notice"}}
 <div class="alert alert-warning">
   <span class="oi oi-beaker"></span> This feature is still under active

--- a/cmd/server/assets/realmadmin/_form_abuse_prevention.html
+++ b/cmd/server/assets/realmadmin/_form_abuse_prevention.html
@@ -19,13 +19,14 @@
   </p>
 
   <div class="form-group form-check">
-    <input type="checkbox" name="abuse_prevention_enabled" id="abuse-prevention-enabled" class="form-check-input" value="1" {{if $realm.AbusePreventionEnabled}} checked{{end}}>
+    <input type="checkbox" name="abuse_prevention_enabled" id="abuse-prevention-enabled" class="form-check-input" value="1" {{if $realm.AbusePreventionEnabled}} checked{{end}}
+      data-toggle="collapse" data-target="#abuse-prevention-configuration">
     <label class="form-check-label" for="abuse-prevention-enabled">
       Enable abuse prevention
     </label>
   </div>
 
-  <div id="abuse-prevention-configuration" class="{{if not $realm.AbusePreventionEnabled}}d-none{{end}}">
+  <div id="abuse-prevention-configuration" class="collapse{{if $realm.AbusePreventionEnabled}} show{{end}}">
     <div class="form-label-group">
       <input type="text" name="abuse_prevention_limit" id="abuse-prevention-limit" class="form-control" placeholder="Computed limit" value="{{$realm.AbusePreventionLimit}}" readonly />
       <label for="abuse-prevention-limit">Computed limit</label>
@@ -78,19 +79,9 @@
 
 <script type="text/javascript">
   $(function() {
-    let $abusePreventionEnabled = $('#abuse-prevention-enabled');
-    let $abusePreventionConfiguration = $('#abuse-prevention-configuration');
     let $abusePreventionLimit = $('#abuse-prevention-limit');
     let $abusePreventionLimitFactor = $('#abuse-prevention-limit-factor');
     let $abusePreventionEffectiveLimit = $('#abuse-prevention-effective-limit');
-
-    $abusePreventionEnabled.change(function(e) {
-      if (this.checked) {
-        $abusePreventionConfiguration.removeClass('d-none');
-      } else {
-        $abusePreventionConfiguration.addClass('d-none');
-      }
-    });
 
     $abusePreventionLimitFactor.keyup(function(e){
       let $this = $(e.currentTarget);

--- a/cmd/server/assets/realmadmin/_form_sms.html
+++ b/cmd/server/assets/realmadmin/_form_sms.html
@@ -13,38 +13,61 @@
   {{ .csrfField }}
   <input type="hidden" name="sms" value="1" />
 
-  <div class="form-label-group">
-    <input type="text" name="twilio_account_sid" id="twilio-account-sid" class="form-control text-monospace"
-      placeholder="Twilio account" value="{{if $smsConfig}}{{$smsConfig.TwilioAccountSid}}{{end}}" />
-    <label for="twilio-account-sid">Twilio account</label>
-    <small class="form-text text-muted">
-      This is the Twilio Account SID. Get this value from the Twilio console.
-    </small>
-  </div>
-
-  <div class="form-label-group">
-    <div class="input-group">
-      <input type="password" name="twilio_auth_token" id="twilio-auth-token" class="form-control text-monospace" autocomplete="new-password"
-        placeholder="Twilio auth token" value="{{if $smsConfig}}{{$smsConfig.TwilioAuthToken}}{{end}}">
-      <label for="twilio-auth-token">Twilio auth token</label>
-      <div class="input-group-append">
-        <a class="input-group-text" data-toggle-password="twilio-auth-token">
-          <span class="oi oi-lock-locked" aria-hidden="true"></span>
-        </a>
+  {{if $realm.CanUseSystemSMSConfig}}
+    {{if $realm.UseSystemSMSConfig}}
+      <div class="alert alert-danger">
+        <strong>Warning!</strong> You are currently use the system-provided SMS
+        configuration. Specifying values below will override the system
+        configuration to use your supplied credentials.
       </div>
-    </div>
-    <small class="form-text text-muted">
-      This is the Twilio Auth Token. Get this value from the Twilio console.
-    </small>
-  </div>
+    {{end}}
 
-  <div class="form-label-group">
-    <input type="tel" name="twilio_from_number" id="twilio-from-number" class="form-control text-monospace" autocomplete="new-password"
-      placeholder="Twilio numberx" value="{{if $smsConfig}}{{$smsConfig.TwilioFromNumber}}{{end}}" />
-    <label for="twilio-from-number">Twilio number</label>
-    <small class="form-text text-muted">
-      This is the Twilio From Number. Get this value from the Twilio console.
-    </small>
+    <div class="form-group form-check">
+      <input type="checkbox" name="use_system_sms_config" id="use-system-sms-config" class="form-check-input" value="1" {{if $realm.UseSystemSMSConfig}} checked{{end}}
+        data-toggle="collapse" data-target="#sms-form">
+      <label class="form-check-label" for="use-system-sms-config">
+        Use system SMS configuration
+      </label>
+    </div>
+  {{end}}
+
+  <div id="sms-form" class="collapse{{if not $realm.UseSystemSMSConfig}} show{{end}}">
+    <div class="form-label-group">
+      <input type="text" name="twilio_account_sid" id="twilio-account-sid" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioAccountSid"}} is-invalid{{end}}"
+        placeholder="Twilio account" value="{{if $smsConfig}}{{$smsConfig.TwilioAccountSid}}{{end}}" />
+      <label for="twilio-account-sid">Twilio account</label>
+      {{template "errorable" $smsConfig.ErrorsFor "twilioAccountSid"}}
+      <small class="form-text text-muted">
+        This is the Twilio Account SID. Get this value from the Twilio console.
+      </small>
+    </div>
+
+    <div class="form-label-group">
+      <div class="input-group">
+        <input type="password" name="twilio_auth_token" id="twilio-auth-token" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioAuthToken"}} is-invalid{{end}}" autocomplete="new-password"
+          placeholder="Twilio auth token" value="{{if $smsConfig}}{{$smsConfig.TwilioAuthToken}}{{end}}">
+        <label for="twilio-auth-token">Twilio auth token</label>
+        <div class="input-group-append">
+          <a class="input-group-text" data-toggle-password="twilio-auth-token">
+            <span class="oi oi-lock-locked" aria-hidden="true"></span>
+          </a>
+        </div>
+      </div>
+      {{template "errorable" $smsConfig.ErrorsFor "twilioAuthToken"}}
+      <small class="form-text text-muted">
+        This is the Twilio Auth Token. Get this value from the Twilio console.
+      </small>
+    </div>
+
+    <div class="form-label-group">
+      <input type="tel" name="twilio_from_number" id="twilio-from-number" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioFromNumber"}} is-invalid{{end}}" autocomplete="new-password"
+        placeholder="Twilio numberx" value="{{if $smsConfig}}{{$smsConfig.TwilioFromNumber}}{{end}}" />
+      <label for="twilio-from-number">Twilio number</label>
+      {{template "errorable" $smsConfig.ErrorsFor "twilioFromNumber"}}
+      <small class="form-text text-muted">
+        This is the Twilio From Number. Get this value from the Twilio console.
+      </small>
+    </div>
   </div>
 
   <div class="mt-4">


### PR DESCRIPTION
First part of GH-432.

There's currently no way to create or delegate SMS configs - that will be a follow-up PR. All of the UI is guarded by the SMS config being delegated though.

**Release Note**

```release-note
Introduce scaffolding for system SMS configs
```
