### PR TITLE
Create a login page for re-authing a user

### DIFF
--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -20,10 +20,12 @@
         },
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/x-www-form-urlencoded',
+        {{if not .currentUser}}
         success: function(returnData) {
           // The user successfully signed in, redirect to realm selection.
           window.location.assign('/login/select-realm');
         },
+        {{end}}
         error: function(xhr, status, e) {
           // There was an error finding the user. Redirect to the
           // sign-out page to clear the firebase cookie and any session

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -22,7 +22,7 @@
               <form id="login-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">
                   <input type="email" id="email" name="email" class="form-control" placeholder="Email address" required
-                    autofocus />
+                    autofocus {{if .currentUser}}disabled value="{{.currentUser.Email}}"{{end}}/>
                   <label for="email">Email address</label>
                 </div>
 
@@ -90,11 +90,15 @@
         // Disable the submit button so we only attempt once.
         $submit.prop('disabled', true);
 
+        {{if .currentUser}}
+        let credentials = firebase.auth.EmailAuthProvider.credential($email.val(),$password.val());
+        firebase.auth().currentUser.reauthenticateWithCredential(credentials)
+        {{else}}
         firebase.auth().signInWithEmailAndPassword($email.val(), $password.val())
+        {{end}}
           .then(function(userCredential) {
-            flash.clear();
-          })
-          .catch(function(error) {
+            loginSuccess();
+          }).catch(function(error) {
             if (error.code == 'auth/multi-factor-auth-required') {
               resolver = error.resolver;
               populatePinText(resolver.hints);
@@ -140,7 +144,9 @@
         let multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
         // Complete sign-in.
         resolver.resolveSignIn(multiFactorAssertion)
-          .catch(function(err) {
+          .then(function(userCredential) {
+              loginSuccess();
+          }).catch(function(err) {
             flash.clear();
             flash.error(err.message);
             $submitPin.prop('disabled', false);
@@ -242,6 +248,16 @@
         });
 
         $factors.append($li);
+      }
+
+      function loginSuccess() {
+        {{if .loginRedirect}}
+        window.location.assign('{{.loginRedirect}}');
+        {{else}}
+        {{if .currentUser}}
+          flash.alert('Successfully refreshed auth credentials.');
+        {{end}}
+        {{end}}
       }
     });
   </script>

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -9,6 +9,9 @@
 </head>
 
 <body class="tab-content">
+  {{if .currentUser}}
+  {{template "navbar" .}}
+  {{end}}
   <main role="main" class="container">
     {{template "flash" .}}
 
@@ -17,7 +20,11 @@
         <div class="col-sm-6">
 
           <div class="card shadow-sm" id="login-div">
+            {{if .currentUser}}
+            <div class="card-header">Refresh authentication</div>
+            {{else}}
             <div class="card-header">COVID-19 test verification</div>
+            {{end}}
             <div class="card-body">
               <form id="login-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -224,6 +224,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(requireAuth)
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
+			sub.Handle("/login", loginController.HandleReauth()).Methods("GET")
 			sub.Handle("/login/select-realm", loginController.HandleSelectRealm()).Methods("GET", "POST")
 			sub.Handle("/login/change-password", loginController.HandleResetPassword()).Methods("GET")
 			sub.Handle("/account", loginController.HandleAccountSettings()).Methods("GET")

--- a/pkg/controller/login/reauth.go
+++ b/pkg/controller/login/reauth.go
@@ -1,0 +1,28 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines the controller for the login page.
+package login
+
+import (
+	"net/http"
+)
+
+func (c *Controller) HandleReauth() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		// No redirect for reauth
+		c.renderLogin(ctx, w)
+	})
+}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/609

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Creates and serves the login page without the /home redirect
* Pre-fill email field if session has a user alreadu
* Calls reauthenticateWithCredential for existing user
* Allows the session to specify a redirect on success. This will be used to get  back  to the phone, email change, or password change page respectively.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Created a login page for re-authorizing an already logged-in user
```
