### PR TITLE
Handle re-auth redirect

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -48,6 +48,12 @@
           {{template "login/pindiv" .}}
           {{template "login/factorsdiv" .}}
 
+          {{if .loginRedirect}}
+          <div class="card-body">
+            <a class="card-link" href="/{{.loginRedirect}}">&larr; Back</a>
+          </div>
+          {{end}}
+
         </div>
       </div>
     </div>

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -176,9 +176,12 @@
             if (last) {
               $registeredDiv.addClass('d-none');
             }
-          }).catch(function(error) {
+          }).catch(function(err) {
+            if (err.code == 'auth/requires-recent-login') {
+              window.location.assign('/login?redir=login/register-phone');
+            }
             flash.clear();
-            flash.error(error.message);
+            flash.error(err.message);
           });
       }
 
@@ -205,6 +208,9 @@
           $registerDiv.hide();
           $pinDiv.removeClass('d-none');
         }).catch(function(err) {
+          if (err.code == 'auth/requires-recent-login') {
+              window.location.assign('/login?redir=login/register-phone');
+            }
           flash.clear();
           flash.error(err.message);
           $submit.prop('disabled', false);
@@ -238,6 +244,9 @@
           $registerDiv.show();
           $pinDiv.addClass('d-none');
         }).catch(function(err) {
+          if (err.code == 'auth/requires-recent-login') {
+              window.location.assign('/login?redir=login/register-phone');
+            }
           flash.clear();
           flash.error(err.message);
           $submitPin.prop('disabled', false);

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -231,6 +231,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
 			sub.Handle("/login", loginController.HandleReauth()).Methods("GET")
+			sub.Handle("/login", loginController.HandleReauth()).Queries("redir", "").Methods("GET")
 			sub.Handle("/login/select-realm", loginController.HandleSelectRealm()).Methods("GET", "POST")
 			sub.Handle("/login/change-password", loginController.HandleResetPassword()).Methods("GET")
 			sub.Handle("/account", loginController.HandleAccountSettings()).Methods("GET")

--- a/pkg/controller/login/reauth.go
+++ b/pkg/controller/login/reauth.go
@@ -17,12 +17,21 @@ package login
 
 import (
 	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 )
 
 func (c *Controller) HandleReauth() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
-		// No redirect for reauth
+
+		// No session redirect for reauth
+
+		if r := r.FormValue("redir"); r != "" {
+			m := controller.TemplateMapFromContext(ctx)
+			m["loginRedirect"] = r
+		}
+
 		c.renderLogin(ctx, w)
 	})
 }

--- a/pkg/controller/login/reauth.go
+++ b/pkg/controller/login/reauth.go
@@ -30,6 +30,10 @@ func (c *Controller) HandleReauth() http.Handler {
 		if r := r.FormValue("redir"); r != "" {
 			m := controller.TemplateMapFromContext(ctx)
 			m["loginRedirect"] = r
+
+			session := controller.SessionFromContext(ctx)
+			flash := controller.Flash(session)
+			flash.Alert("This operation is sensitive and requires recent authentication. Please sign-in again.")
 		}
 
 		c.renderLogin(ctx, w)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Phone enrollment can fail if the session is old. Firebase needs re-authentication for sessions that aren't "recent" (which is vaguely unspecified)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Redirect to login if re-authorization is required
```
