### PR TITLE
Add application-level per-realm firewall configuration

### DIFF
--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -79,7 +79,8 @@
       all traffic is allowed from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
       target="_BLANK">CIDR notation</a>
-      of the format (e.g. <code>192.1.2.0/24</code>).
+      of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
+      post-authentication.
     </small>
   </div>
 
@@ -96,7 +97,8 @@
       from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
       target="_BLANK">CIDR notation</a>
-      of the format (e.g. <code>192.1.2.0/24</code>).
+      of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
+      post-authentication.
     </small>
   </div>
 
@@ -111,7 +113,8 @@
       from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
       target="_BLANK">CIDR notation</a>
-      of the format (e.g. <code>192.1.2.0/24</code>).
+      of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
+      post-authentication.
     </small>
   </div>
 

--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -17,6 +17,7 @@
       <option value="0" {{if eq $realm.EmailVerifiedMode.String "prompt"}}selected{{end}}>Prompt after login</option>
       <option value="2" {{if eq $realm.EmailVerifiedMode.String "optional"}}selected{{end}}>Optional</option>
     </select>
+    {{template "errorable" $realm.ErrorsFor "emailVerifiedMode"}}
     <small class="form-text text-muted">
       Email verification requires users to verify their email address before
       using the system.
@@ -30,6 +31,7 @@
       <option value="0" {{if eq $realm.MFAMode.String "prompt"}}selected{{end}}>Prompt after login</option>
       <option value="2" {{if eq $realm.MFAMode.String "optional"}}selected{{end}}>Optional</option>
     </select>
+    {{template "errorable" $realm.ErrorsFor "mfaMode"}}
     <small class="form-text text-muted">
       Multi-factor authentication requires users to supply a second factor (e.g.
       a code via an SMS text message) when authenticating to the system.
@@ -44,6 +46,7 @@
       <option value="{{$prd}}" {{if (eq $prd $current)}}selected{{end}}>{{if (eq $prd 0)}}Off{{else}}Every {{$prd}} days{{end}}</option>
       {{end}}
     </select>
+    {{template "errorable" $realm.ErrorsFor "passwordRotationPeriodDays"}}
     <small class="form-text text-muted">
       If enabled, users will be required to change their password after this
       number of days elapse since their last password change.
@@ -58,9 +61,57 @@
       <option value="{{$pwd }}" {{if (eq $pwd $current)}}selected{{end}}>{{if (eq $pwd 0)}}Off{{else}}{{$pwd}} days before{{end}}</option>
       {{end}}
     </select>
+    {{template "errorable" $realm.ErrorsFor "passwordRotationWarningDays"}}
     <small class="form-text text-muted">
       If enabled, users will be warned to change their password within this
       number of days before expiration.
+    </small>
+  </div>
+
+  <div class="form-label-group">
+    <textarea name="allowed_cidrs_adminapi" id="allowed-cidrs-adminapi" class="form-control text-monospace{{if $realm.ErrorsFor "allowedCIDRsAdminAPI"}} is-invalid{{end}}"
+      rows="5" placeholder="Allowed CIDRs (Admin API)">{{joinStrings $realm.AllowedCIDRsAdminAPI "\n"}}</textarea>
+    <label for="allowed-cidrs-adminapi">Allowed CIDRs (Admin API)</label>
+    {{template "errorable" $realm.ErrorsFor "allowedCIDRsAdminAPI"}}
+    <small class="form-text text-muted">
+      An optional list of CIDR blocks from which to allow traffic to the
+      <strong>Admin API</strong> which can be used to generate codes. If blank,
+      all traffic is allowed from all IPs. These should be of <a
+      href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
+      target="_BLANK">CIDR notation</a>
+      of the format (e.g. <code>192.1.2.0/24</code>).
+    </small>
+  </div>
+
+  <div class="form-label-group">
+    <textarea name="allowed_cidrs_apiserver" id="allowed-cidrs-apiserver" class="form-control text-monospace{{if $realm.ErrorsFor "allowedCIDRsAPIServer"}} is-invalid{{end}}"
+      rows="5" placeholder="Allowed CIDRs (Device API)">{{joinStrings $realm.AllowedCIDRsAPIServer "\n"}}</textarea>
+    <label for="allowed-cidrs-apiserver">Allowed CIDRs (Device API)</label>
+    {{template "errorable" $realm.ErrorsFor "allowedCIDRsAPIServer"}}
+    <small class="form-text text-muted">
+      An optional list of CIDR blocks from which to allow traffic to the
+      <strong>Device API</strong> which is where devices exchange their code for
+      a certificate. It is highly recommended that you <strong>leave this
+      service publicly accessible</strong>. If blank, all traffic is allowed
+      from all IPs. These should be of <a
+      href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
+      target="_BLANK">CIDR notation</a>
+      of the format (e.g. <code>192.1.2.0/24</code>).
+    </small>
+  </div>
+
+  <div class="form-label-group">
+    <textarea name="allowed_cidrs_server" id="allowed-cidrs-server" class="form-control text-monospace{{if $realm.ErrorsFor "allowedCIDRsServer"}} is-invalid{{end}}"
+      rows="5" placeholder="Allowed CIDRs (UI server)">{{joinStrings $realm.AllowedCIDRsServer "\n"}}</textarea>
+    <label for="allowed-cidrs-server">Allowed CIDRs (UI server)</label>
+    {{template "errorable" $realm.ErrorsFor "allowedCIDRsServer"}}
+    <small class="form-text text-muted">
+      An optional list of CIDR blocks from which to allow traffic to the
+      <strong>UI server</strong> (this server). If blank, all traffic is allowed
+      from all IPs. These should be of <a
+      href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
+      target="_BLANK">CIDR notation</a>
+      of the format (e.g. <code>192.1.2.0/24</code>).
     </small>
   </div>
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -193,6 +193,7 @@ func realMain(ctx context.Context) error {
 	requireRealm := middleware.RequireRealm(ctx, h)
 	requireSystemAdmin := middleware.RequireAdmin(ctx, h)
 	requireMFA := middleware.RequireMFA(ctx, h)
+	processFirewall := middleware.ProcessFirewall(ctx, h, "server")
 	rateLimit := httplimiter.Handle
 
 	{
@@ -242,6 +243,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
 			sub.Use(requireRealm)
+			sub.Use(processFirewall)
 			sub.Handle("/login/verify-email", loginController.HandleVerifyEmail()).Methods("GET")
 
 			// SMS auth registration is realm-specific, so it needs to load the current realm.
@@ -250,6 +252,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
 			sub.Use(requireRealm)
+			sub.Use(processFirewall)
 			sub.Use(requireVerified)
 			sub.Handle("/login/register-phone", loginController.HandleRegisterPhone()).Methods("GET")
 		}
@@ -260,6 +263,7 @@ func realMain(ctx context.Context) error {
 		sub.Use(requireAuth)
 		sub.Use(loadCurrentRealm)
 		sub.Use(requireRealm)
+		sub.Use(processFirewall)
 		sub.Use(requireVerified)
 		sub.Use(requireMFA)
 		sub.Use(rateLimit)
@@ -280,6 +284,7 @@ func realMain(ctx context.Context) error {
 		sub.Use(requireAuth)
 		sub.Use(loadCurrentRealm)
 		sub.Use(requireRealm)
+		sub.Use(processFirewall)
 		sub.Use(requireVerified)
 		sub.Use(requireMFA)
 		sub.Use(rateLimit)
@@ -295,6 +300,8 @@ func realMain(ctx context.Context) error {
 		sub := r.PathPrefix("/apikeys").Subrouter()
 		sub.Use(requireAuth)
 		sub.Use(loadCurrentRealm)
+		sub.Use(requireRealm)
+		sub.Use(processFirewall)
 		sub.Use(requireAdmin)
 		sub.Use(requireVerified)
 		sub.Use(requireMFA)
@@ -316,6 +323,8 @@ func realMain(ctx context.Context) error {
 		userSub := r.PathPrefix("/users").Subrouter()
 		userSub.Use(requireAuth)
 		userSub.Use(loadCurrentRealm)
+		userSub.Use(requireRealm)
+		userSub.Use(processFirewall)
 		userSub.Use(requireAdmin)
 		userSub.Use(requireVerified)
 		userSub.Use(requireMFA)
@@ -339,6 +348,8 @@ func realMain(ctx context.Context) error {
 		realmSub := r.PathPrefix("/realm").Subrouter()
 		realmSub.Use(requireAuth)
 		realmSub.Use(loadCurrentRealm)
+		realmSub.Use(requireRealm)
+		realmSub.Use(processFirewall)
 		realmSub.Use(requireAdmin)
 		realmSub.Use(requireVerified)
 		realmSub.Use(requireMFA)

--- a/pkg/controller/middleware/firewall.go
+++ b/pkg/controller/middleware/firewall.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"context"
+	"net"
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"github.com/gorilla/mux"
+)
+
+// ProcessFirewall verifies the application-level firewall configuration.
+//
+// This must come after the realm has been loaded in the context, probably via a
+// different middleware.
+func ProcessFirewall(ctx context.Context, h *render.Renderer, typ string) mux.MiddlewareFunc {
+	logger := logging.FromContext(ctx).Named("middleware.ProcessFirewall")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			realm := controller.RealmFromContext(ctx)
+			if realm == nil {
+				controller.MissingRealm(w, r, h)
+				return
+			}
+
+			var allowedCIDRs []string
+			switch typ {
+			case "adminapi":
+				allowedCIDRs = realm.AllowedCIDRsAdminAPI
+			case "apiserver":
+				allowedCIDRs = realm.AllowedCIDRsAPIServer
+			case "server":
+				allowedCIDRs = realm.AllowedCIDRsServer
+			}
+
+			// If there's no CIDRs, all traffic is allowed.
+			if len(allowedCIDRs) == 0 {
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			logger.Debugw("validating ip in cidr block", "type", typ)
+
+			// Get the remote address.
+			ipStr := r.RemoteAddr
+
+			// Check if x-forwarded-for exists, the load balancer sets this, and the
+			// first entry is the real client IP.
+			xff := r.Header.Get("x-forwarded-for")
+			if xff != "" {
+				ipStr = strings.Split(xff, ",")[0]
+			}
+
+			ip := net.ParseIP(ipStr)
+			for _, c := range allowedCIDRs {
+				_, cidr, err := net.ParseCIDR(c)
+				if err != nil {
+					logger.Warnw("failed to parse cidr", "cidr", c, "error", err)
+					continue
+				}
+
+				if cidr.Contains(ip) {
+					next.ServeHTTP(w, r)
+					return
+				}
+			}
+
+			logger.Errorw("ip is not in an allowed cidr block")
+			controller.Unauthorized(w, r, h)
+		})
+	}
+}

--- a/pkg/controller/middleware/firewall.go
+++ b/pkg/controller/middleware/firewall.go
@@ -53,6 +53,8 @@ func ProcessFirewall(ctx context.Context, h *render.Renderer, typ string) mux.Mi
 				allowedCIDRs = realm.AllowedCIDRsAPIServer
 			case "server":
 				allowedCIDRs = realm.AllowedCIDRsServer
+			default:
+				logger.Errorw("unknown firewall type", "type", typ)
 			}
 
 			// If there's no CIDRs, all traffic is allowed.
@@ -73,7 +75,12 @@ func ProcessFirewall(ctx context.Context, h *render.Renderer, typ string) mux.Mi
 				ipStr = strings.Split(xff, ",")[0]
 			}
 
+			// Parse as an IP.
 			ip := net.ParseIP(ipStr)
+			if ip == nil {
+				logger.Errorw("provided ip could not be parsed")
+			}
+
 			for _, c := range allowedCIDRs {
 				_, cidr, err := net.ParseCIDR(c)
 				if err != nil {

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -139,9 +139,32 @@ func (c *Controller) HandleSettings() http.Handler {
 			realm.PasswordRotationPeriodDays = form.PasswordRotationPeriodDays
 			realm.PasswordRotationWarningDays = form.PasswordRotationWarningDays
 
-			realm.AllowedCIDRsAdminAPI = database.ToCIDRList(form.AllowedCIDRsAdminAPI)
-			realm.AllowedCIDRsAPIServer = database.ToCIDRList(form.AllowedCIDRsAPIServer)
-			realm.AllowedCIDRsServer = database.ToCIDRList(form.AllowedCIDRsServer)
+			allowedCIDRsAdminADPI, err := database.ToCIDRList(form.AllowedCIDRsAdminAPI)
+			if err != nil {
+				realm.AddError("allowedCIDRsAdminAPI", err.Error())
+				flash.Error("Failed to update realm")
+				c.renderSettings(ctx, w, r, realm, nil)
+				return
+			}
+			realm.AllowedCIDRsAdminAPI = allowedCIDRsAdminADPI
+
+			allowedCIDRsAPIServer, err := database.ToCIDRList(form.AllowedCIDRsAPIServer)
+			if err != nil {
+				realm.AddError("allowedCIDRsAPIServer", err.Error())
+				flash.Error("Failed to update realm")
+				c.renderSettings(ctx, w, r, realm, nil)
+				return
+			}
+			realm.AllowedCIDRsAPIServer = allowedCIDRsAPIServer
+
+			allowedCIDRsServer, err := database.ToCIDRList(form.AllowedCIDRsServer)
+			if err != nil {
+				realm.AddError("allowedCIDRsServer", err.Error())
+				flash.Error("Failed to update realm")
+				c.renderSettings(ctx, w, r, realm, nil)
+				return
+			}
+			realm.AllowedCIDRsServer = allowedCIDRsServer
 		}
 
 		// Abuse prevention

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -66,11 +66,14 @@ func (c *Controller) HandleSettings() http.Handler {
 		TwilioAuthToken    string `form:"twilio_auth_token"`
 		TwilioFromNumber   string `form:"twilio_from_number"`
 
-		Security                    bool  `form:"security"`
-		MFAMode                     int16 `form:"mfa_mode"`
-		EmailVerifiedMode           int16 `form:"email_verified_mode"`
-		PasswordRotationPeriodDays  uint  `form:"password_rotation_period_days"`
-		PasswordRotationWarningDays uint  `form:"password_rotation_warning_days"`
+		Security                    bool   `form:"security"`
+		MFAMode                     int16  `form:"mfa_mode"`
+		EmailVerifiedMode           int16  `form:"email_verified_mode"`
+		PasswordRotationPeriodDays  uint   `form:"password_rotation_period_days"`
+		PasswordRotationWarningDays uint   `form:"password_rotation_warning_days"`
+		AllowedCIDRsAdminAPI        string `form:"allowed_cidrs_adminapi"`
+		AllowedCIDRsAPIServer       string `form:"allowed_cidrs_apiserver"`
+		AllowedCIDRsServer          string `form:"allowed_cidrs_server"`
 
 		AbusePrevention            bool    `form:"abuse_prevention"`
 		AbusePreventionEnabled     bool    `form:"abuse_prevention_enabled"`
@@ -135,6 +138,10 @@ func (c *Controller) HandleSettings() http.Handler {
 			realm.MFAMode = database.AuthRequirement(form.MFAMode)
 			realm.PasswordRotationPeriodDays = form.PasswordRotationPeriodDays
 			realm.PasswordRotationWarningDays = form.PasswordRotationWarningDays
+
+			realm.AllowedCIDRsAdminAPI = database.ToCIDRList(form.AllowedCIDRsAdminAPI)
+			realm.AllowedCIDRsAPIServer = database.ToCIDRList(form.AllowedCIDRsAPIServer)
+			realm.AllowedCIDRsServer = database.ToCIDRList(form.AllowedCIDRsServer)
 		}
 
 		// Abuse prevention

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1278,6 +1278,27 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00052-CreateRealmAllowedCIDRs",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.AutoMigrate(&Realm{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				sqls := []string{
+					`ALTER TABLE realms DROP COLUMN IF EXISTS allowed_cidrs_adminapi`,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS allowed_cidrs_apiserver`,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS allowed_cidrs_server`,
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
 	})
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"net"
 	"sort"
 	"strings"
 	"time"
@@ -826,7 +827,7 @@ func (r *Realm) RenderWelcomeMessage() string {
 
 // ToCIDRList converts the newline-separated and/or comma-separated CIDR list
 // into an array of strings.
-func ToCIDRList(s string) []string {
+func ToCIDRList(s string) ([]string, error) {
 	var cidrs []string
 	for _, line := range strings.Split(s, "\n") {
 		for _, v := range strings.Split(line, ",") {
@@ -847,10 +848,15 @@ func ToCIDRList(s string) []string {
 				}
 			}
 
+			// Basic sanity checking.
+			if _, _, err := net.ParseCIDR(v); err != nil {
+				return nil, err
+			}
+
 			cidrs = append(cidrs, v)
 		}
 	}
 
 	sort.Strings(cidrs)
-	return cidrs
+	return cidrs, nil
 }

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"math"
+	"sort"
 	"strings"
 	"time"
 
@@ -26,6 +27,7 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 
 	"github.com/jinzhu/gorm"
+	"github.com/lib/pq"
 	"github.com/russross/blackfriday/v2"
 )
 
@@ -125,6 +127,11 @@ type Realm struct {
 	// PasswordRotationWarningDays is the number of days before Password expiry
 	// that the user should receive a warning.
 	PasswordRotationWarningDays uint `gorm:"type:smallint; not null; default: 0"`
+
+	// AllowedCIDRs is the list of allowed IPs to the various services.
+	AllowedCIDRsAdminAPI  pq.StringArray `gorm:"column:allowed_cidrs_adminapi; type:varchar(50)[];"`
+	AllowedCIDRsAPIServer pq.StringArray `gorm:"column:allowed_cidrs_apiserver; type:varchar(50)[];"`
+	AllowedCIDRsServer    pq.StringArray `gorm:"column:allowed_cidrs_server; type:varchar(50)[];"`
 
 	// AllowedTestTypes is the type of tests that this realm permits. The default
 	// value is to allow all test types.
@@ -815,4 +822,35 @@ func (r *Realm) RenderWelcomeMessage() string {
 
 	raw := blackfriday.Run([]byte(msg))
 	return string(bluemonday.UGCPolicy().SanitizeBytes(raw))
+}
+
+// ToCIDRList converts the newline-separated and/or comma-separated CIDR list
+// into an array of strings.
+func ToCIDRList(s string) []string {
+	var cidrs []string
+	for _, line := range strings.Split(s, "\n") {
+		for _, v := range strings.Split(line, ",") {
+			v = strings.TrimSpace(v)
+
+			// Ignore blanks
+			if v == "" {
+				continue
+			}
+
+			// If there's no /, assume the most specific. This is intentionally
+			// rudimentary.
+			if !strings.Contains(v, "/") {
+				if strings.Contains(v, ":") {
+					v = fmt.Sprintf("%s/128", v)
+				} else {
+					v = fmt.Sprintf("%s/32", v)
+				}
+			}
+
+			cidrs = append(cidrs, v)
+		}
+	}
+
+	sort.Strings(cidrs)
+	return cidrs
 }

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -199,7 +199,7 @@ func (m *Middleware) Handle(next http.Handler) http.Handler {
 // header. Since APIKeys are assumed to be "public" at some point, they are rate
 // limited by [realm,ip], and API keys have a 1-1 mapping to a realm.
 func APIKeyFunc(ctx context.Context, db *database.Database, scope string, hmacKey []byte) httplimit.KeyFunc {
-	logger := logging.FromContext(ctx).Named(scope + ".ratelimit")
+	logger := logging.FromContext(ctx).Named("ratelimit.APIKeyFunc")
 	ipAddrLimit := IPAddressKeyFunc(ctx, scope, hmacKey)
 
 	return func(r *http.Request) (string, error) {
@@ -224,7 +224,7 @@ func APIKeyFunc(ctx context.Context, db *database.Database, scope string, hmacKe
 // UserIDKeyFunc pulls the user out of the request context and uses that to
 // ratelimit. It falls back to rate limiting by the client ip.
 func UserIDKeyFunc(ctx context.Context, scope string, hmacKey []byte) httplimit.KeyFunc {
-	logger := logging.FromContext(ctx).Named(scope + ".ratelimit")
+	logger := logging.FromContext(ctx).Named("ratelimit.UserIDKeyFunc")
 	ipAddrLimit := IPAddressKeyFunc(ctx, scope, hmacKey)
 
 	return func(r *http.Request) (string, error) {
@@ -247,7 +247,7 @@ func UserIDKeyFunc(ctx context.Context, scope string, hmacKey []byte) httplimit.
 
 // IPAddressKeyFunc uses the client IP to rate limit.
 func IPAddressKeyFunc(ctx context.Context, scope string, hmacKey []byte) httplimit.KeyFunc {
-	logger := logging.FromContext(ctx).Named(scope + ".ratelimit")
+	logger := logging.FromContext(ctx).Named("ratelimit.IPAddressKeyFunc")
 
 	return func(r *http.Request) (string, error) {
 		// Get the remote addr


### PR DESCRIPTION
This adds per-realm firewall settings (by allowed CIDR blocks) for the adminapi, apiserver, and main server. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add per-realm firewall security settings
```

/assign @mikehelmick 