### PR TITLE
Allow authed user to change password

### DIFF
--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -81,3 +81,94 @@
   </div>
 </div>
 {{end}}
+
+{{define "login/pwd-validate-js"}}
+  {{if .requirements.HasRequirements}}
+  let $lenReq = $('#length-req');
+  let $upperReq = $('#upper-req');
+  let $lowerReq = $('#lower-req');
+  let $numReq = $('#num-req');
+  let $specialReq = $('#special-req');
+  {{end}}
+
+  function checkPasswordValid(pwd) {
+    {{if .requirements.HasRequirements}}
+    let upper = 0;
+    let lower = 0;
+    let digit = 0;
+    let special = 0;
+    let specialPattern = new RegExp(/[~`!#$%\^&*+=\-\[\]\\';,/{}|\\":<>\?]/);
+    for (let i = 0; i < pwd.length; i++) {
+      let c = pwd.charAt(i);
+      if (!isNaN(parseInt(c, 10))) {
+        digit++;
+      } else if (specialPattern.test(c)) {
+        special++;
+      } else if (c == c.toUpperCase()) {
+        upper++;
+      } else if (c == c.toLowerCase()) {
+        lower++;
+      }
+    }
+
+    let errClass = "oi oi-circle-x pr-1";
+    let checkClass = "oi oi-circle-check pr-1";
+
+    {{if gt .requirements.Length 0}}
+    if (pwd.length < {{.requirements.Length}}) {
+      $lenReq.find("#icon").attr("class", errClass)
+      $lenReq.addClass("text-danger");
+      return false;
+    } else {
+      $lenReq.find("#icon").attr("class", checkClass)
+      $lenReq.addClass("text-muted");
+    }
+    {{end}}
+
+    {{if gt .requirements.Uppercase 0}}
+    if (upper < {{.requirements.Uppercase}}) {
+      $upperReq.find("#icon").attr("class", errClass);
+      $upperReq.addClass("text-danger");
+      return false;
+    } else {
+      $upperReq.find("#icon").attr("class", checkClass);
+      $upperReq.addClass("text-muted");
+    }
+    {{end}}
+
+    {{if gt .requirements.Lowercase 0}}
+    if (lower < {{.requirements.Lowercase}}) {
+      $lowerReq.find("#icon").attr("class", errClass);
+      $lowerReq.addClass("text-danger");
+      return false;
+    } else {
+      $lowerReq.find("#icon").attr("class", checkClass);
+      $lowerReq.addClass("text-muted");
+    }
+    {{end}}
+
+    {{if gt .requirements.Number 0}}
+    if (digit < {{.requirements.Number}}) {
+      $numReq.find("#icon").attr("class", errClass);
+      $numReq.addClass("text-danger");
+      return false;
+    } else {
+      $numReq.find("#icon").attr("class", checkClass);
+      $numReq.addClass("text-muted");
+    }
+    {{end}}
+
+    {{if gt .requirements.Special 0}}
+    if (special < {{.requirements.Special}}) {
+      $specialReq.find("#icon").attr("class", errClass);
+      $specialReq.addClass("text-danger");
+      return false;
+    } else {
+      $specialReq.find("#icon").attr("class", checkClass);
+      $specialReq.addClass("text-muted");
+    }
+    {{end}}
+    {{end}}
+    return true;
+  }
+{{end}}

--- a/cmd/server/assets/login/account.html
+++ b/cmd/server/assets/login/account.html
@@ -52,7 +52,7 @@
         <li class="list-group-item">
           <div class="card-text">Password was last changed <span class="text-info">{{$user.PasswordAgeString}}</span>
             ago</div>
-          <a href="/login/change-password" class="card-link">Reset password</a>
+          <a href="/login/change-password" class="card-link">Change password</a>
         </li>
       </ul>
     </div>

--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -110,7 +110,8 @@
         try {
           return changePassword();
         } catch(e) {
-          return false;
+          flash.clear();
+          flash.error(error);
         }
       });
 

--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -1,4 +1,4 @@
-{{define "login/select-password"}}
+{{define "login/change-password"}}
 <!doctype html>
 <html lang="en">
 
@@ -9,6 +9,8 @@
 </head>
 
 <body class="tab-content">
+  {{template "navbar" .}}
+
   <main role="main" class="container">
     {{template "flash" .}}
 
@@ -16,13 +18,13 @@
       <div class="d-flex w-100 justify-content-center align-self-center">
         <div class="col-sm-6">
           <div class="card shadow-sm">
-            <div class="card-header">Select new password</div>
+            <div class="card-header">Change password</div>
             <div class="card-body">
-              <form id="loginForm" class="floating-form" action="/login/select-password" method="POST">
+              <form id="passwordForm" class="floating-form" action="/login/change-password" method="POST">
                 {{.csrfField}}
                 <div class="form-label-group">
-                  <input type="email" id="email" name="email" class="form-control" placeholder="Email address" required
-                    autofocus />
+                  <input type="email" id="email" name="email" class="form-control" placeholder="Email address"
+                  value="{{.currentUser.Email}}" required autofocus disabled/>
                   <label for="email">Email address</label>
                 </div>
 
@@ -70,7 +72,7 @@
                 </p>
                 {{end}}
 
-                <button type="submit" id="submit" class="btn btn-primary btn-block">Set password</button>
+                <button type="submit" id="submit" class="btn btn-primary btn-block" disabled>Set password</button>
               </form>
             </div>
             <div class="card-body">
@@ -85,25 +87,19 @@
   {{template "scripts" .}}
   <script type="text/javascript">
     $(function() {
-      let $form = $('#loginForm');
+      let $form = $('#passwordForm');
       let $submit = $('#submit');
       let $email = $('#email');
       let $password = $('#password');
       let $retype = $('#retype');
 
-      let urlVars = getUrlVars();
-      let code = urlVars["oobCode"];
-      if (!code) {
-        code = "";
-      }
+      firebase.auth().onAuthStateChanged(function(user) {
+          if (!user) {
+            window.location.assign("/signout");
+            return;
+          }
 
-      firebase.auth().verifyPasswordResetCode(code)
-        .then(function(email) {
-          $email.val(email);
-        }).catch(function(error) {
-          flash.error("Invalid password reset code. "
-            + "The code may be malformed, expired, or has already been used.");
-           $submit.prop('disabled', true);
+          $submit.prop('disabled', false);
         });
 
       $password.keyup(function() {
@@ -111,10 +107,17 @@
       });
 
       $form.on('submit', function(event) {
+        try {
+          return changePassword();
+        } catch(e) {
+          return false;
+        }
+      });
+
+      function changePassword() {
         let email = $email.val();
         let pwd = $password.val();
         if (pwd != $retype.val()) {
-          flash.clear();
           flash.error("Password and retyped passwords must match.");
           return false;
         }
@@ -126,30 +129,23 @@
         // Disable the submit button so we only attempt once.
         $submit.prop('disabled', true);
 
-        return firebase.auth().confirmPasswordReset(code, pwd)
+        return firebase.auth().currentUser.updatePassword(pwd)
           .then(function() {
             return true;
           }).catch(function(error) {
+            if (err.code == 'auth/requires-recent-login') {
+              window.location.assign('/login?redir=login/change-password');
+            }
+
             flash.clear();
             flash.error(error);
             $submit.prop('disabled', false);
             return false;
           });
-      });
+      }
 
       {{template "login/pwd-validate-js" .}}
     });
-
-    function getUrlVars() {
-      let vars = [], hash;
-      let queryParams = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-      for (var i = 0; i < queryParams.length; i++) {
-        v = queryParams[i].split('=');
-        vars.push(v[0]);
-        vars[v[0]] = v[1];
-      }
-      return vars;
-    }
   </script>
 </body>
 

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -111,6 +111,16 @@
       });
 
       $form.on('submit', function(event) {
+        try {
+          return selectPassword();
+        } catch(error) {
+          flash.clear();
+          flash.error(error);
+          return false;
+        }
+      });
+
+      function selectPassword() {
         let email = $email.val();
         let pwd = $password.val();
         if (pwd != $retype.val()) {
@@ -135,7 +145,7 @@
             $submit.prop('disabled', false);
             return false;
           });
-      });
+      }
 
       {{template "login/pwd-validate-js" .}}
     });

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -220,7 +220,7 @@ func realMain(ctx context.Context) error {
 
 			sub.Handle("/", loginController.HandleLogin()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleResetPassword()).Methods("GET")
-			sub.Handle("/login/select-password", loginController.HandleSelectNewPassword()).Methods("GET")
+			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
@@ -233,7 +233,8 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/login", loginController.HandleReauth()).Methods("GET")
 			sub.Handle("/login", loginController.HandleReauth()).Queries("redir", "").Methods("GET")
 			sub.Handle("/login/select-realm", loginController.HandleSelectRealm()).Methods("GET", "POST")
-			sub.Handle("/login/change-password", loginController.HandleResetPassword()).Methods("GET")
+			sub.Handle("/login/change-password", loginController.HandleShowChangePassword()).Methods("GET")
+			sub.Handle("/login/change-password", loginController.HandleSubmitChangePassword()).Methods("POST")
 			sub.Handle("/account", loginController.HandleAccountSettings()).Methods("GET")
 
 			// Verifying email requires the user is logged in

--- a/pkg/controller/middleware/emailverified.go
+++ b/pkg/controller/middleware/emailverified.go
@@ -54,7 +54,7 @@ func RequireVerified(ctx context.Context, client *auth.Client, db *database.Data
 				logger.Debugw("no user found when checking email verification")
 				flash.Error("Log in first to verify email.")
 				controller.ClearSessionFirebaseCookie(session)
-				controller.Unauthorized(w, r, h)
+				controller.MissingUser(w, r, h)
 				return
 			}
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/609

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allow an authenticated user to change their password
    * No longer need to send a reset password email
    * Handles recent-auth redirect

TODO: Switch this to Seth's server-side client library

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow users to change their password
```
