### PR TITLE
Make certificate swapping easier for enx-redirect

### DIFF
--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -1,0 +1,99 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  enable_enx_redirect = length(var.enx_redirect_domain_map) > 0
+}
+
+resource "google_compute_global_address" "verification-enx-redirect" {
+  count   = local.enable_enx_redirect ? 1 : 0
+  name    = "verification-enx-redirect-address"
+  project = var.project
+}
+
+# Redirects all requests to https
+resource "google_compute_url_map" "urlmap-http" {
+  name     = "https-redirect"
+  provider = google-beta
+  project  = var.project
+
+  default_url_redirect {
+    strip_query    = false
+    https_redirect = true
+  }
+}
+
+resource "google_compute_url_map" "enx-redirect-urlmap-https" {
+  count           = local.enable_enx_redirect ? 1 : 0
+  name            = "verification-enx-redirect"
+  provider        = google-beta
+  project         = var.project
+  default_service = google_compute_backend_service.enx-redirect[0].id
+}
+
+resource "google_compute_target_http_proxy" "enx-redirect-http" {
+  count    = local.enable_enx_redirect ? 1 : 0
+  provider = google-beta
+  name     = "verification-enx-redirect"
+  project  = var.project
+
+  url_map = google_compute_url_map.urlmap-http.id
+}
+
+resource "google_compute_target_https_proxy" "enx-redirect-https" {
+  count   = local.enable_enx_redirect ? 1 : 0
+  name    = "verification-enx-redirect"
+  project = var.project
+
+  url_map          = google_compute_url_map.enx-redirect-urlmap-https[0].id
+  ssl_certificates = [google_compute_managed_ssl_certificate.enx-redirect[0].id]
+}
+
+resource "google_compute_global_forwarding_rule" "enx-redirect-http" {
+  count    = local.enable_enx_redirect ? 1 : 0
+  provider = google-beta
+  name     = "verification-enx-redirect-http"
+  project  = var.project
+
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_global_address.verification-enx-redirect[0].address
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = "80"
+  target                = google_compute_target_http_proxy.enx-redirect-http[0].id
+}
+
+resource "google_compute_global_forwarding_rule" "enx-redirect-https" {
+  count    = local.enable_enx_redirect ? 1 : 0
+  provider = google-beta
+  name     = "verification-enx-redirect-https"
+  project  = var.project
+
+  ip_protocol           = "TCP"
+  ip_address            = google_compute_global_address.verification-enx-redirect[0].address
+  load_balancing_scheme = "EXTERNAL"
+  port_range            = "443"
+  target                = google_compute_target_https_proxy.enx-redirect-https[0].id
+}
+
+resource "google_compute_managed_ssl_certificate" "enx-redirect" {
+  count    = local.enable_enx_redirect ? 1 : 0
+  provider = google-beta
+
+  name = "verification-enx-redirect-cert"
+
+  managed {
+    // we can only have 100 domains in this list.
+    domains = [for o in var.enx_redirect_domain_map : o.host]
+  }
+}

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -58,7 +58,7 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
 
   url_map = google_compute_url_map.enx-redirect-urlmap-https[0].id
   ssl_certificates = [
-    // First certificate is harder to change in UI, so let's keep a seperate
+    // First certificate is harder to change in UI, so let's keep a separate
     // unused cert in the first slot.
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id

--- a/terraform/verification-lb.tf
+++ b/terraform/verification-lb.tf
@@ -13,19 +13,12 @@
 # limitations under the License.
 
 locals {
-  enable_lb           = var.server-host != "" && var.apiserver-host != "" && var.adminapi-host != ""
-  enable_enx_redirect = length(var.enx_redirect_domain_map) > 0
+  enable_lb = var.server-host != "" && var.apiserver-host != "" && var.adminapi-host != ""
 }
 
 resource "google_compute_global_address" "verification-server" {
   count   = local.enable_lb ? 1 : 0
   name    = "verification-server-address"
-  project = var.project
-}
-
-resource "google_compute_global_address" "verification-enx-redirect" {
-  count   = local.enable_enx_redirect ? 1 : 0
-  name    = "verification-enx-redirect-address"
   project = var.project
 }
 
@@ -79,14 +72,6 @@ resource "google_compute_url_map" "urlmap-https" {
   }
 }
 
-resource "google_compute_url_map" "enx-redirect-urlmap-https" {
-  count           = local.enable_enx_redirect ? 1 : 0
-  name            = "verification-enx-redirect"
-  provider        = google-beta
-  project         = var.project
-  default_service = google_compute_backend_service.enx-redirect[0].id
-}
-
 resource "google_compute_target_http_proxy" "http" {
   count    = local.enable_lb ? 1 : 0
   provider = google-beta
@@ -103,24 +88,6 @@ resource "google_compute_target_https_proxy" "https" {
 
   url_map          = google_compute_url_map.urlmap-https[0].id
   ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
-}
-
-resource "google_compute_target_http_proxy" "enx-redirect-http" {
-  count    = local.enable_enx_redirect ? 1 : 0
-  provider = google-beta
-  name     = "verification-enx-redirect"
-  project  = var.project
-
-  url_map = google_compute_url_map.urlmap-http.id
-}
-
-resource "google_compute_target_https_proxy" "enx-redirect-https" {
-  count   = local.enable_enx_redirect ? 1 : 0
-  name    = "verification-enx-redirect"
-  project = var.project
-
-  url_map          = google_compute_url_map.enx-redirect-urlmap-https[0].id
-  ssl_certificates = [google_compute_managed_ssl_certificate.enx-redirect[0].id]
 }
 
 resource "google_compute_global_forwarding_rule" "http" {
@@ -149,32 +116,6 @@ resource "google_compute_global_forwarding_rule" "https" {
   target                = google_compute_target_https_proxy.https[0].id
 }
 
-resource "google_compute_global_forwarding_rule" "enx-redirect-http" {
-  count    = local.enable_enx_redirect ? 1 : 0
-  provider = google-beta
-  name     = "verification-enx-redirect-http"
-  project  = var.project
-
-  ip_protocol           = "TCP"
-  ip_address            = google_compute_global_address.verification-enx-redirect[0].address
-  load_balancing_scheme = "EXTERNAL"
-  port_range            = "80"
-  target                = google_compute_target_http_proxy.enx-redirect-http[0].id
-}
-
-resource "google_compute_global_forwarding_rule" "enx-redirect-https" {
-  count    = local.enable_enx_redirect ? 1 : 0
-  provider = google-beta
-  name     = "verification-enx-redirect-https"
-  project  = var.project
-
-  ip_protocol           = "TCP"
-  ip_address            = google_compute_global_address.verification-enx-redirect[0].address
-  load_balancing_scheme = "EXTERNAL"
-  port_range            = "443"
-  target                = google_compute_target_https_proxy.enx-redirect-https[0].id
-}
-
 resource "google_compute_managed_ssl_certificate" "default" {
   count    = local.enable_lb ? 1 : 0
   provider = google-beta
@@ -183,17 +124,5 @@ resource "google_compute_managed_ssl_certificate" "default" {
 
   managed {
     domains = [var.server-host, var.apiserver-host, var.adminapi-host]
-  }
-}
-
-resource "google_compute_managed_ssl_certificate" "enx-redirect" {
-  count    = local.enable_enx_redirect ? 1 : 0
-  provider = google-beta
-
-  name = "verification-enx-redirect-cert"
-
-  managed {
-    // we can only have 100 domains in this list.
-    domains = [for o in var.enx_redirect_domain_map : o.host]
   }
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If you are using enx-redirect, and you modify the map variable, this will recreate the cert, which will create unknown amounts of downtime. So instead, you need to manually create a new cert with the new domains, append it to the FE, and then wait for it to become healthy, and then change the FE again by removing the old cert.
* This changes the FE to use two certs, so that the "main" cert is just `www.` and then the region domains are on a separate cert, this makes the above process easier. 
* Also split the two LBs into separate files.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Changes the certificates on the redirect server.
```
