### PR TITLE
Make sure password change time is something

### DIFF
--- a/pkg/controller/middleware/realm.go
+++ b/pkg/controller/middleware/realm.go
@@ -195,7 +195,7 @@ func checkRealmPasswordAge(user *database.User, realm *database.Realm) error {
 	}
 
 	now := time.Now().UTC()
-	nextPasswordChange := user.LastPasswordChange.Add(
+	nextPasswordChange := user.PasswordChanged().Add(
 		time.Hour * 24 * time.Duration(realm.PasswordRotationPeriodDays))
 
 	if now.After(nextPasswordChange) {

--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -91,7 +91,7 @@ func TestUserLifecycle(t *testing.T) {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
 
-		if got, want := got.LastPasswordChange, now; got != want {
+		if got, want := got.PasswordChanged(), now; got != want {
 			t.Errorf("expected %#v to be %#v", got.String(), want.String())
 		}
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Password change will be the account creation time if the new column is unset
* "unknown" string for the UI just in case, but we don't expect to see that

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Password creation time field falls back to user creation time
```
