### PR TITLE
Ensure provider type is always set

### DIFF
--- a/pkg/controller/admin/sms.go
+++ b/pkg/controller/admin/sms.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 )
 
 // HandleSMSUpdate creates or updates the SMS config.
@@ -64,6 +65,7 @@ func (c *Controller) HandleSMSUpdate() http.Handler {
 		}
 
 		// Update
+		smsConfig.ProviderType = sms.ProviderTypeTwilio
 		smsConfig.TwilioAccountSid = form.TwilioAccountSid
 		smsConfig.TwilioAuthToken = form.TwilioAuthToken
 		smsConfig.TwilioFromNumber = form.TwilioFromNumber

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -193,6 +193,7 @@ func (c *Controller) HandleSettings() http.Handler {
 			if smsConfig != nil && !smsConfig.IsSystem {
 				// We have an existing record and the existing record is NOT the system
 				// record.
+				smsConfig.ProviderType = sms.ProviderTypeTwilio
 				smsConfig.TwilioAccountSid = form.TwilioAccountSid
 				smsConfig.TwilioAuthToken = form.TwilioAuthToken
 				smsConfig.TwilioFromNumber = form.TwilioFromNumber


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure SMS provider type is set on system configs
```