### PR TITLE
Direct users back to password reset email if code invalid/expired

### DIFF
--- a/cmd/server/assets/_flash.html
+++ b/cmd/server/assets/_flash.html
@@ -1,5 +1,6 @@
 {{define "flash"}}
 <div id="alerts-container" style="position:absolute; top:0; right:1rem; z-index:2000;">
+  {{- if .flash}}
   {{range $msg := .flash.Errors}}
     <div class="toast bg-white" role="alert" aria-live="assertive" aria-atomic="true" data-autohide="false">
       <div class="toast-header text-danger">
@@ -41,6 +42,7 @@
         {{$msg}}
       </div>
     </div>
+  {{end}}
   {{end}}
 </div>
 {{end}}

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -27,18 +27,26 @@
 
                 <div class="form-label-group mb-2">
                   <input type="password" name="password" id="password" class="form-control" placeholder="Password"
-                    autocomplete="new-password" required />
+                    autocomplete="new-password" required {{if .codeInvalid}}disabled{{end}}/>
                   <label for="password">Password</label>
                 </div>
                 <div class="form-label-group">
                   <input type="password" id="retype" class="form-control" placeholder="Retype password"
-                    autocomplete="new-password" required />
+                    autocomplete="new-password" required {{if .codeInvalid}}disabled{{end}}/>
                   <label for="retype">Retype password</label>
                 </div>
 
                 {{template "login/pwd-validate" .}}
 
-                <button type="submit" id="submit" class="btn btn-primary btn-block">Set password</button>
+                <button type="submit" id="submit" class="btn btn-primary btn-block mb-3"{{if .codeInvalid}}disabled{{end}}>
+                  Set password
+                </button>
+
+                {{if .codeInvalid}}
+                <a class="card-link" href="/login/reset-password">
+                  Resend password reset email
+                </a>
+                {{end}}
               </form>
             </div>
             <div class="card-body">


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This is based on some user feedback / confusing over expired invite links. I'm hoping this makes it clear what to do to make a login.
* Disable fields and link to password reset if there is an invalid code
    * We could just redirect there and skip over this with a flash message, but I find that jarring
* Wrap flash with if in case it's not set. That can be the case pre-login where there is no session/middleware setting flash to empty