### PR TITLE
Redirect firebase emails on 'mode' query param

### DIFF
--- a/cmd/server/assets/login/account.html
+++ b/cmd/server/assets/login/account.html
@@ -115,7 +115,7 @@
 
           let $link = $('<a/>');
           $link.addClass('card-link');
-          $link.attr('href','/login/verify-email');
+          $link.attr('href','/login/manage-account?mode=verifyEmail');
           $link.text('Verify email');
           $emailVer.after($link);
         }

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -17,7 +17,7 @@
           <div class="card shadow-sm">
             <div class="card-header">Select new password</div>
             <div class="card-body">
-              <form id="loginForm" class="floating-form" action="/login/select-password?oobCode={{.code}}" method="POST">
+              <form id="loginForm" class="floating-form" action="/login/select-password?mode=resetPassword&oobCode={{.code}}" method="POST">
                 {{.csrfField}}
                 <div class="form-label-group">
                   <input type="email" name="email" class="form-control" placeholder="Email address" value="{{.email}}"

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -17,7 +17,7 @@
           <div class="card shadow-sm">
             <div class="card-header">Select new password</div>
             <div class="card-body">
-              <form id="loginForm" class="floating-form" action="/login/select-password?mode=resetPassword&oobCode={{.code}}" method="POST">
+              <form id="loginForm" class="floating-form" action="/login/manage-account?mode=resetPassword&oobCode={{.code}}" method="POST">
                 {{.csrfField}}
                 <div class="form-label-group">
                   <input type="email" name="email" class="form-control" placeholder="Email address" value="{{.email}}"

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -36,7 +36,7 @@
                 link.</small>
 
               {{if ne .currentRealm.EmailVerifiedMode.String "required"}}
-              <a id="skip" class="float-right mt-3 text-muted" href="/home">Skip for now</a>
+              <a id="skip" class="card-link float-right mt-3" href="/home">Skip for now</a>
               {{end}}
             </div>
           </div>

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -229,9 +229,13 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/login/reset-password", loginController.HandleSubmitResetPassword()).Methods("POST")
 			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
 			sub.Handle("/login/manage-account", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
+				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("GET")
+			sub.Handle("/login/manage-account", loginController.HandleSubmitNewPassword()).
+				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("POST")
 			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
+				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("GET")
+			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
+				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -227,8 +227,10 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/", loginController.HandleLogin()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleShowResetPassword()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleSubmitResetPassword()).Methods("POST")
-			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).Queries("oobCode", "").Methods("GET")
-			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).Queries("oobCode", "").Methods("POST")
+			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
+				Queries("oobCode", "", "mode", "").Methods("GET")
+			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
+				Queries("oobCode", "").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
 
@@ -340,7 +342,7 @@ func realMain(ctx context.Context) error {
 		userController := user.New(ctx, firebaseInternal, auth, cacher, cfg, db, h)
 		userSub.Handle("", userController.HandleIndex()).Methods("GET")
 		userSub.Handle("", userController.HandleIndex()).
-			Queries("offset", "{[0-9]*}").Queries("email", "").Methods("GET")
+			Queries("offset", "{[0-9]*}", "email", "").Methods("GET")
 		userSub.Handle("", userController.HandleCreate()).Methods("POST")
 		userSub.Handle("/new", userController.HandleCreate()).Methods("GET")
 		userSub.Handle("/import", userController.HandleImport()).Methods("GET")

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -232,8 +232,6 @@ func realMain(ctx context.Context) error {
 				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
 				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
-			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
-				Queries("oobCode", "").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -227,8 +227,11 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/", loginController.HandleLogin()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleShowResetPassword()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleSubmitResetPassword()).Methods("POST")
+			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
+			sub.Handle("/login/manage-account", loginController.HandleShowSelectNewPassword()).
+				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "").Methods("GET")
+				Queries("oobCode", "", "mode", "resetPassword|recoverEmail").Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
 				Queries("oobCode", "").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
@@ -253,6 +256,11 @@ func realMain(ctx context.Context) error {
 			sub.Use(loadCurrentRealm)
 			sub.Use(requireRealm)
 			sub.Use(processFirewall)
+			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
+			sub.Handle("/login/manage-account", loginController.HandleVerifyEmail()).
+				Queries("mode", "verifyEmail").Methods("GET")
+			sub.Handle("/login/select-password", loginController.HandleVerifyEmail()).
+				Queries("mode", "verifyEmail").Methods("GET")
 			sub.Handle("/login/verify-email", loginController.HandleVerifyEmail()).Methods("GET")
 
 			// SMS auth registration is realm-specific, so it needs to load the current realm.

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -259,7 +259,6 @@ func realMain(ctx context.Context) error {
 				Queries("mode", "verifyEmail").Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleVerifyEmail()).
 				Queries("mode", "verifyEmail").Methods("GET")
-			sub.Handle("/login/verify-email", loginController.HandleVerifyEmail()).Methods("GET")
 
 			// SMS auth registration is realm-specific, so it needs to load the current realm.
 			sub = r.PathPrefix("").Subrouter()

--- a/pkg/controller/login/select_password.go
+++ b/pkg/controller/login/select_password.go
@@ -30,10 +30,6 @@ import (
 
 func (c *Controller) HandleShowSelectNewPassword() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.FormValue("mode") == "verifyEmail" {
-			http.Redirect(w, r, "/login/verify-email", http.StatusSeeOther)
-		}
-
 		ctx := r.Context()
 		session := controller.SessionFromContext(ctx)
 		flash := flash.New(session.Values)

--- a/pkg/controller/login/select_password.go
+++ b/pkg/controller/login/select_password.go
@@ -30,6 +30,10 @@ import (
 
 func (c *Controller) HandleShowSelectNewPassword() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.FormValue("mode") == "verifyEmail" {
+			http.Redirect(w, r, "/login/verify-email", http.StatusSeeOther)
+		}
+
 		ctx := r.Context()
 		session := controller.SessionFromContext(ctx)
 		flash := flash.New(session.Values)

--- a/pkg/controller/login/select_password.go
+++ b/pkg/controller/login/select_password.go
@@ -110,8 +110,6 @@ func (c *Controller) HandleSubmitNewPassword() http.Handler {
 
 		if err := c.db.PasswordChanged(form.Email, time.Now()); err != nil {
 			logger.Errorw("failed to mark password change time", "error", err)
-			c.renderShowSelectPassword(ctx, w, form.Email, code, false, flash)
-			return
 		}
 
 		flash.Alert("Successfully selected new password.")

--- a/pkg/controller/middleware/emailverified.go
+++ b/pkg/controller/middleware/emailverified.go
@@ -62,7 +62,7 @@ func RequireVerified(ctx context.Context, client *auth.Client, db *database.Data
 			realm := controller.RealmFromContext(ctx)
 			if needsEmailVerification(session, realm, firebaseUser) {
 				logger.Debugw("user email not verified")
-				http.Redirect(w, r, "/login/verify-email", http.StatusSeeOther)
+				http.Redirect(w, r, "/login/manage-account?mode=verifyEmail", http.StatusSeeOther)
 				return
 			}
 

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -85,7 +85,7 @@ func (u *User) PasswordAgeString() string {
 	if ago.Minutes() > 2 {
 		return fmt.Sprintf("%d minutes", int(ago.Minutes()))
 	}
-	return fmt.Sprintf("%d minutes", int(ago.Seconds()))
+	return fmt.Sprintf("%d seconds", int(ago.Seconds()))
 }
 
 // BeforeSave runs validations. If there are errors, the save fails.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Redirect to verify email / select password based on the firebase mode

I like this less, but firebase doesn't allow for custom URL per email template. I think it's pretty geared for their UI component.

Note: We'll switch the template to manage-account and remove the old routing after deployment