### PR TITLE
Automatic code review: comment wheen there is a new .Errorw added

### DIFF
--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -1,0 +1,40 @@
+name: Code Review
+
+on:
+  pull_request:
+    branches: [ 'main' ]
+
+jobs:
+
+  donotsubmit:
+    name: Reminder
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - name: Reminder
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |
+          set -e
+          cd "${GITHUB_WORKSPACE}" || exit 1
+          TEMP_PATH="$(mktemp -d)"
+          PATH="${TEMP_PATH}:$PATH"
+          echo '::group::🐶 Installing reviewdog ... https://github.com/reviewdog/reviewdog'
+          curl -sfL https://raw.githubusercontent.com/reviewdog/reviewdog/master/install.sh | sh -s -- -b "${TEMP_PATH}" 2>&1
+          echo '::endgroup::'
+          echo '::group:: Running Reminder with reviewdog 🐶 ...'
+          # Don't fail because of grep
+          set +o pipefail
+          find . -type f -not -path './.git/*' -not -path './.github/workflows/*' |
+          xargs grep -n ".Errorw" |
+          reviewdog -efm="%f:%l:%m" \
+                -name="Make sure this is not a user error" \
+                -reporter="github-pr-check" \
+                -filter-mode="added" \
+                -fail-on-error="false" \
+                -level="info"
+          echo '::endgroup::'


### PR DESCRIPTION
Inspired by @mattmoor 's work in knative, adding a code review github action. This action does:

- Comment when upcoming PR contains `.Errorw`

A POC is: https://github.com/chaodaiG/github-action-exp/pull/3/files

![Screen Shot 2020-09-28 at 9 25 49 AM](https://user-images.githubusercontent.com/45011425/94459734-a1f1b480-016c-11eb-8b9f-8bafad1dddda.png)
