### PR TITLE
Ensure password validity updated on retype

### DIFF
--- a/cmd/server/assets/login/_loginscripts.html
+++ b/cmd/server/assets/login/_loginscripts.html
@@ -83,9 +83,9 @@
 {{end}}
 
 {{define "login/pwd-validate"}}
-{{if .requirements.HasRequirements}}
 <p class="card-text ml-4">
   <small class="form-text text-muted">
+    {{if .requirements.HasRequirements}}
     <span class="row">Password should be:</span>
     {{if gt .requirements.Length 0}}
     <span class="row ml-1" id="length-req">
@@ -112,12 +112,12 @@
       <span id="icon" aria-hidden="true"></span>Contain {{.requirements.Special}} special character
     </span>
     {{end}}
+    {{end}}
     <span class="row ml-1" id="retyped">
       <span id="icon" aria-hidden="true"></span>Retyped password must match password
     </span>
   </small>
 </p>
-{{end}}
 {{end}}
 
 {{define "login/pwd-validate-js"}}

--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -74,6 +74,9 @@
       $password.keyup(function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
+      $retype.keyup(function() {
+        $submit.prop('disabled', !checkPasswordValid($password.val()));
+      });
 
       $form.on('submit', function(event) {
         try {

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -69,6 +69,9 @@
       $password.keyup(function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
+      $retype.keyup(function() {
+        $submit.prop('disabled', !checkPasswordValid($password.val()));
+      });
 
       $form.on('submit', function(event) {
         try {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Password validity should get re-checked on retype because we now validate that they match

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Minor fix to password selection validation UI
```
