### PR TITLE
Refresh session on MFA enrollment

### DIFF
--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -229,9 +229,7 @@
         // Complete enrollment.
         let user = firebase.auth().currentUser
         user.multiFactor.enroll(multiFactorAssertion, $displayName.val()).then(function() {
-          flash.clear();
-          flash.alert('SMS authentication enrolled successfully.');
-          $skip.text('Continue');
+          setSession(user);
 
           let l = user.multiFactor.enrolledFactors.length
           appendAuthFactor(user.multiFactor.enrolledFactors[l - 1], l - 1);
@@ -279,6 +277,30 @@
             $submit.prop('disabled', false);
           });
       });
+
+      function setSession(user) {
+        let factorCount = user.multiFactor.enrolledFactors.length;
+        user.getIdToken().then(idToken => {
+          $.ajax({
+            type: 'POST',
+            url: '/session',
+            data: {
+              idToken: idToken,
+              factorCount: factorCount,
+            },
+            headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
+            contentType: 'application/x-www-form-urlencoded',
+            success: function(returnData) {
+              flash.clear();
+              flash.alert('SMS authentication enrolled successfully.');
+              $skip.text('Continue');
+            },
+            error: function(xhr, status, e) {
+              window.location.assign("/signout");
+            }
+          })
+        });
+      }
     });
   </script>
 </body>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We can't check MFA factors from the server (not in the go library yet) so we push the MFA factor count to session. However we need to refresh the count as new factors are enrolled, or a user can get stuck without logout/sign-in for a realm with MFA marked 'required'

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Refresh session with enrolled MFA on registration
```
