### PR TITLE
Make mobile app names unique by realm_id and platform

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -62,16 +62,6 @@
     margin: auto;
   }
 
-  .form-info {
-	padding-top: 10px;
-	padding-right: 30px;
-	padding-left: 30px;
-  }
-
-  .form-info p {
-	background-color: rgba(0,0,0,.03);
-  }
-
   .form-label-group {
     position: relative;
     margin-bottom: 1rem;

--- a/cmd/server/assets/mobileapps/_app.html
+++ b/cmd/server/assets/mobileapps/_app.html
@@ -28,17 +28,15 @@
   <textarea name="sha" id="sha" class="form-control text-monospace{{if $app.ErrorsFor "sha"}} is-invalid{{end}}"
     placeholder="SHAs (one per line)" rows="5">{{$app.SHA}}</textarea>
   <label for="sha">SHA256 from the app signing certificate (one per line) </label>
-  <div id="sha-explanation" class="form-info">
-  <p>
-	SHAs are unique fingerprints of android applications from their signing
-	certificate. We support multiple SHAs for different versions of the app
-	(eg, development and production). SHAs should be 95 characters long and of
-	the form: <tt>AA:BB:CC:..</tt> A developer can generate a SHA with the
-	following command: <br>
-    <tt style="padding-left:10px;">keytool -list -v -keystore my-release-key.keystore</tt>
-  </p>
-  </div>
   {{template "errorable" $app.ErrorsFor "sha"}}
+  <small class="form-text text-muted">
+    SHAs are unique fingerprints of Android applications from their signing
+    certificate. We support multiple SHAs for different versions of the app
+    (e.g. development and production). SHAs should be 95 characters and of the
+    form: <code>AA:BB:CC:..</code>. You can generate a SHA with the following
+    command:
+    <pre class="mt-3 mb-4 ml-3"><code>keytool -list -v -keystore my-release-key.keystore</code></pre>
+  </small>
 </div>
 
 <script type="text/javascript">

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1336,6 +1336,37 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00054-ChangeMobileAppNameUniqueness",
+			Migrate: func(tx *gorm.DB) error {
+				sqls := []string{
+					`DROP INDEX IF EXISTS realm_app_name`,
+					`ALTER TABLE mobile_apps ADD CONSTRAINT uix_name_realm_id_os UNIQUE (name, realm_id, os)`,
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+			Rollback: func(tx *gorm.DB) error {
+				sqls := []string{
+					`CREATE UNIQUE INDEX realm_app_name ON mobile_apps (name, realm_id)`,
+					`ALTER TABLE mobile_apps DROP CONSTRAINT uix_name_realm_id_os UNIQUE (name, realm_id, os)`,
+				}
+
+				for _, sql := range sqls {
+					if err := tx.Exec(sql).Error; err != nil {
+						return err
+					}
+				}
+
+				return nil
+			},
+		},
 	})
 }
 

--- a/pkg/database/mobile_app_test.go
+++ b/pkg/database/mobile_app_test.go
@@ -19,12 +19,14 @@ import "testing"
 func TestMobileApp_Validation(t *testing.T) {
 	t.Parallel()
 
+	db := NewTestDatabase(t)
+
 	t.Run("name", func(t *testing.T) {
 		t.Parallel()
 
 		var m MobileApp
 		m.Name = ""
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		nameErrs := m.ErrorsFor("name")
 		if len(nameErrs) < 1 {
@@ -37,7 +39,7 @@ func TestMobileApp_Validation(t *testing.T) {
 
 		var m MobileApp
 		m.AppID = ""
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		appIDErrs := m.ErrorsFor("app_id")
 		if len(appIDErrs) < 1 {
@@ -50,7 +52,7 @@ func TestMobileApp_Validation(t *testing.T) {
 
 		var m MobileApp
 		m.OS = 0
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		osErrs := m.ErrorsFor("os")
 		if len(osErrs) < 1 {
@@ -58,7 +60,7 @@ func TestMobileApp_Validation(t *testing.T) {
 		}
 
 		m.OS = 4
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		osErrs = m.ErrorsFor("os")
 		if len(osErrs) < 1 {
@@ -71,7 +73,7 @@ func TestMobileApp_Validation(t *testing.T) {
 
 		var m MobileApp
 		m.OS = OSTypeIOS
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		shaErrs := m.ErrorsFor("sha")
 		if len(shaErrs) > 0 {
@@ -79,7 +81,7 @@ func TestMobileApp_Validation(t *testing.T) {
 		}
 
 		m.OS = OSTypeAndroid
-		_ = m.BeforeSave(nil)
+		_ = m.BeforeSave(db.RawDB())
 
 		shaErrs = m.ErrorsFor("sha")
 		if len(shaErrs) < 1 {
@@ -117,7 +119,7 @@ func TestMobileApp_Validation(t *testing.T) {
 
 				var m MobileApp
 				m.SHA = tc.sha
-				_ = m.BeforeSave(nil)
+				_ = m.BeforeSave(db.RawDB())
 
 				shaErrs := m.ErrorsFor("sha")
 				if !tc.err && len(shaErrs) > 0 {


### PR DESCRIPTION
Fixes GH-697

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make mobile app names unique by realm_id _and_ platform
```
