### PR TITLE
remove attempts at country code validation and just require one is set

### DIFF
--- a/cmd/server/assets/realmadmin/_form_general.html
+++ b/cmd/server/assets/realmadmin/_form_general.html
@@ -44,6 +44,9 @@
       3166-1 country codes and ISO 3166-2 subdivision codes</a> where
       applicable. For example, Washington state would be <code>US-WA</code>.
       This value must globally unique in the system.
+      {{if $realm.EnableENExpress}}<strong>This value is required for EN Express and
+        must match the region code as configured with Apple and Google.</strong>
+      {{end}}
     </small>
   </div>
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -252,20 +252,6 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 	if r.EnableENExpress {
 		if r.RegionCode == "" {
 			r.AddError("regionCode", "cannot be blank when using EN Express")
-		} else {
-			parts := strings.Split(r.RegionCode, "-")
-			if lp := len(parts); lp != 2 {
-				if lp == 1 && len(parts[0]) != 2 {
-					r.AddError("regionCode", "must be formated like 'region' (2 characters) or 'region-subregion' (2 characters dash 2 or 3 characters)")
-				}
-			} else {
-				if len(parts[0]) != 2 {
-					r.AddError("regionCode", "first part must be exactly 2 characters in length")
-				}
-				if l := len(parts[1]); !(l == 2 || l == 3) {
-					r.AddError("regionCode", "second part must be exactly 2 or 3 characters in length")
-				}
-			}
 		}
 	}
 


### PR DESCRIPTION
## Proposed Changes

* Go back to allowing any non-empty region code - the validation was breaking test environments.

**Release Note**


```release-note
NONE
```
