### PR TITLE
Add metrics for cleanup and audits

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -94,7 +94,10 @@ func realMain(ctx context.Context) error {
 	// Create the router
 	r := mux.NewRouter()
 
-	cleanupController := cleanup.New(ctx, cfg, db, h)
+	cleanupController, err := cleanup.New(ctx, cfg, db, h)
+	if err != nil {
+		return fmt.Errorf("failed to create cleanup controller: %w", err)
+	}
 	r.Handle("/", cleanupController.HandleCleanup()).Methods("GET")
 
 	srv, err := server.New(cfg.Port)

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -24,6 +24,8 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/hashicorp/go-multierror"
+	"go.opencensus.io/stats"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -32,24 +34,32 @@ import (
 
 // Controller is a controller for the cleanup service.
 type Controller struct {
-	config *config.CleanupConfig
-	db     *database.Database
-	h      *render.Renderer
-	logger *zap.SugaredLogger
+	config  *config.CleanupConfig
+	db      *database.Database
+	h       *render.Renderer
+	logger  *zap.SugaredLogger
+	metrics *Metrics
 }
 
 // New creates a new cleanup controller.
-func New(ctx context.Context, config *config.CleanupConfig, db *database.Database, h *render.Renderer) *Controller {
-	logger := logging.FromContext(ctx)
-	return &Controller{
-		config: config,
-		db:     db,
-		h:      h,
-		logger: logger,
+func New(ctx context.Context, config *config.CleanupConfig, db *database.Database, h *render.Renderer) (*Controller, error) {
+	metrics, err := registerMetrics()
+	if err != nil {
+		return nil, err
 	}
+
+	logger := logging.FromContext(ctx).Named("cleanup")
+
+	return &Controller{
+		config:  config,
+		db:      db,
+		h:       h,
+		logger:  logger,
+		metrics: metrics,
+	}, nil
 }
 
-func (c *Controller) shouldCleanup() error {
+func (c *Controller) shouldCleanup(ctx context.Context) error {
 	cStat, err := c.db.CreateCleanup(database.CleanupName)
 	if err != nil {
 		return fmt.Errorf("failed to create cleanup: %w", err)
@@ -60,49 +70,88 @@ func (c *Controller) shouldCleanup() error {
 	}
 
 	// Attempt to advance the generation.
+	stats.Record(ctx, c.metrics.ClaimAttempts.M(1))
 	if _, err = c.db.ClaimCleanup(cStat, c.config.CleanupPeriod); err != nil {
-		return fmt.Errorf("unable to lock cleanup: %v", err)
+		stats.Record(ctx, c.metrics.ClaimErrors.M(1))
+		return fmt.Errorf("failed to claim cleanup: %w", err)
 	}
 	return nil
 }
 
 func (c *Controller) HandleCleanup() http.Handler {
 	type CleanupResult struct {
-		Cleanup bool `json:"cleanup"`
+		OK     bool    `json:"ok"`
+		Errors []error `json:"errors,omitempty"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if err := c.shouldCleanup(); err != nil {
-			c.logger.Errorf("shouldCleanUp: %v", err)
-			c.h.RenderJSON(w, http.StatusOK, &CleanupResult{false})
+		ctx := r.Context()
+
+		if err := c.shouldCleanup(ctx); err != nil {
+			c.logger.Errorw("failed to run shouldCleanup", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, &CleanupResult{
+				OK:     false,
+				Errors: []error{err},
+			})
 			return
 		}
 
-		// Cleanup tasks
+		// Construct a multi-error. If one of the purges fails, we still want to
+		// attempt the other purges.
+		var merr *multierror.Error
+
+		// Verification codes
+		stats.Record(ctx, c.metrics.PurgeVerificationCodesAttempts.M(1))
 		if count, err := c.db.PurgeVerificationCodes(c.config.VerificationCodeMaxAge); err != nil {
-			c.logger.Errorf("db.PurgeVerificationCodes: %v", err)
+			stats.Record(ctx, c.metrics.PurgeVerificationCodesErrors.M(1))
+			merr = multierror.Append(merr, fmt.Errorf("failed to purge verification codes: %w", err))
 		} else {
-			c.logger.Infof("purged %v verification codes", count)
+			stats.Record(ctx, c.metrics.PurgeVerificationCodesPurged.M(count))
+			c.logger.Infow("purged verification codes", "count", count)
 		}
 
+		// Verification tokens
+		stats.Record(ctx, c.metrics.PurgeVerificationTokensAttempts.M(1))
 		if count, err := c.db.PurgeTokens(c.config.VerificationTokenMaxAge); err != nil {
-			c.logger.Errorf("db.PurgeTokens: %v", err)
+			stats.Record(ctx, c.metrics.PurgeVerificationTokensErrors.M(1))
+			merr = multierror.Append(merr, fmt.Errorf("failed to purge tokens: %w", err))
 		} else {
-			c.logger.Infof("purged %v verification tokens", count)
+			stats.Record(ctx, c.metrics.PurgeVerificationTokensPurged.M(count))
+			c.logger.Infow("purged verification tokens", "count", count)
 		}
 
+		// Mobile apps
+		stats.Record(ctx, c.metrics.PurgeMobileAppsAttempts.M(1))
 		if count, err := c.db.PurgeMobileApps(c.config.MobileAppMaxAge); err != nil {
-			c.logger.Errorf("db.PurgeMobileApps: %v", err)
+			stats.Record(ctx, c.metrics.PurgeMobileAppsErrors.M(1))
+			merr = multierror.Append(merr, fmt.Errorf("failed to purge mobile apps: %w", err))
 		} else {
-			c.logger.Infof("purged %v mobile apps tokens", count)
+			stats.Record(ctx, c.metrics.PurgeMobileAppsPurged.M(count))
+			c.logger.Infow("purged mobile apps", "count", count)
 		}
 
+		// Audit entries
+		stats.Record(ctx, c.metrics.PurgeAuditEntriesAttempts.M(1))
 		if count, err := c.db.PurgeAuditEntries(c.config.AuditEntryMaxAge); err != nil {
-			c.logger.Errorf("db.PurgeAuditEntries: %v", err)
+			stats.Record(ctx, c.metrics.PurgeAuditEntriesErrors.M(1))
+			merr = multierror.Append(merr, fmt.Errorf("failed to purge audit entries: %w", err))
 		} else {
-			c.logger.Infof("purged %v audit entries", count)
+			stats.Record(ctx, c.metrics.PurgeAuditEntriesPurged.M(count))
+			c.logger.Infow("purged audit entries", "count", count)
 		}
 
-		c.h.RenderJSON(w, http.StatusOK, &CleanupResult{true})
+		// If there are any errors, return them
+		if errs := merr.WrappedErrors(); len(errs) > 0 {
+			c.logger.Errorw("failed to cleanup", "errors", errs)
+			c.h.RenderJSON(w, http.StatusInternalServerError, &CleanupResult{
+				OK:     false,
+				Errors: errs,
+			})
+			return
+		}
+
+		c.h.RenderJSON(w, http.StatusOK, &CleanupResult{
+			OK: true,
+		})
 	})
 }

--- a/pkg/controller/cleanup/metrics.go
+++ b/pkg/controller/cleanup/metrics.go
@@ -1,0 +1,216 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cleanup
+
+import (
+	"fmt"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+var (
+	MetricPrefix = observability.MetricRoot + "/cleanup"
+)
+
+type Metrics struct {
+	ClaimAttempts *stats.Int64Measure
+	ClaimErrors   *stats.Int64Measure
+
+	PurgeVerificationCodesAttempts *stats.Int64Measure
+	PurgeVerificationCodesErrors   *stats.Int64Measure
+	PurgeVerificationCodesPurged   *stats.Int64Measure
+
+	PurgeVerificationTokensAttempts *stats.Int64Measure
+	PurgeVerificationTokensErrors   *stats.Int64Measure
+	PurgeVerificationTokensPurged   *stats.Int64Measure
+
+	PurgeMobileAppsAttempts *stats.Int64Measure
+	PurgeMobileAppsErrors   *stats.Int64Measure
+	PurgeMobileAppsPurged   *stats.Int64Measure
+
+	PurgeAuditEntriesAttempts *stats.Int64Measure
+	PurgeAuditEntriesErrors   *stats.Int64Measure
+	PurgeAuditEntriesPurged   *stats.Int64Measure
+}
+
+func registerMetrics() (*Metrics, error) {
+	mClaimAttempts := stats.Int64(MetricPrefix+"/claim_attempts", "The number of attempts to claim the cleanup", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/claim_attempt_count",
+		Measure:     mClaimAttempts,
+		Description: "The count of the number of attempts to claim the cleanup",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register claim_attempts: %w", err)
+	}
+
+	mClaimErrors := stats.Int64(MetricPrefix+"/claim_errors", "The number of errors to claim the cleanup", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/claim_error_count",
+		Measure:     mClaimErrors,
+		Description: "The count of the number of errors to claim the cleanup",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register claim_errors: %w", err)
+	}
+
+	// Verification codes
+	mPurgeVerificationCodesAttempts := stats.Int64(MetricPrefix+"/purge_verification_codes_attempts", "The number of attempts to purge verification codes", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_codes_attempt_count",
+		Measure:     mPurgeVerificationCodesAttempts,
+		Description: "The count of the number of attempts to purge verification codes",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_codes_attempts: %w", err)
+	}
+
+	mPurgeVerificationCodesErrors := stats.Int64(MetricPrefix+"/purge_verification_codes_errors", "The number of attempts to purge verification codes", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_codes_error_count",
+		Measure:     mPurgeVerificationCodesErrors,
+		Description: "The count of the number of errors to purge verification codes",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_codes_errors: %w", err)
+	}
+
+	mPurgeVerificationCodesPurged := stats.Int64(MetricPrefix+"/purge_verification_codes_purged", "The number of verification codes that were purged", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_codes_purged_count",
+		Measure:     mPurgeVerificationCodesPurged,
+		Description: "The count of the number of verification codes purged",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_codes_purged: %w", err)
+	}
+
+	// Verification tokens
+	mPurgeVerificationTokensAttempts := stats.Int64(MetricPrefix+"/purge_verification_tokens_attempts", "The number of attempts to purge verification tokens", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_tokens_attempt_count",
+		Measure:     mPurgeVerificationTokensAttempts,
+		Description: "The count of the number of attempts to purge verification tokens",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_tokens_attempts: %w", err)
+	}
+
+	mPurgeVerificationTokensErrors := stats.Int64(MetricPrefix+"/purge_verification_tokens_errors", "The number of attempts to purge verification tokens", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_tokens_error_count",
+		Measure:     mPurgeVerificationTokensErrors,
+		Description: "The count of the number of errors to purge verification tokens",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_tokens_errors: %w", err)
+	}
+
+	mPurgeVerificationTokensPurged := stats.Int64(MetricPrefix+"/purge_verification_tokens_purged", "The number of verification tokens that were purged", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_verification_tokens_purged_count",
+		Measure:     mPurgeVerificationTokensPurged,
+		Description: "The count of the number of verification tokens purged",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_verification_tokens_purged: %w", err)
+	}
+
+	// Mobile apps
+	mPurgeMobileAppsAttempts := stats.Int64(MetricPrefix+"/purge_mobile_apps_attempts", "The number of attempts to purge mobile apps", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_mobile_apps_attempt_count",
+		Measure:     mPurgeMobileAppsAttempts,
+		Description: "The count of the number of attempts to purge mobile apps",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_mobile_apps_attempts: %w", err)
+	}
+
+	mPurgeMobileAppsErrors := stats.Int64(MetricPrefix+"/purge_mobile_apps_errors", "The number of attempts to purge mobile apps", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_mobile_apps_error_count",
+		Measure:     mPurgeMobileAppsErrors,
+		Description: "The count of the number of errors to purge mobile apps",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_mobile_apps_errors: %w", err)
+	}
+
+	mPurgeMobileAppsPurged := stats.Int64(MetricPrefix+"/purge_mobile_apps_purged", "The number of mobile apps that were purged", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_mobile_apps_purged_count",
+		Measure:     mPurgeMobileAppsPurged,
+		Description: "The count of the number of mobile apps purged",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_mobile_apps_purged: %w", err)
+	}
+
+	// Audit entries
+	mPurgeAuditEntriesAttempts := stats.Int64(MetricPrefix+"/purge_audit_entries_attempts", "The number of attempts to purge audit entries", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_audit_entries_attempt_count",
+		Measure:     mPurgeAuditEntriesAttempts,
+		Description: "The count of the number of attempts to purge audit entries",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_audit_entries_attempts: %w", err)
+	}
+
+	mPurgeAuditEntriesErrors := stats.Int64(MetricPrefix+"/purge_audit_entries_errors", "The number of attempts to purge audit entries", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_audit_entries_error_count",
+		Measure:     mPurgeAuditEntriesErrors,
+		Description: "The count of the number of errors to purge audit entries",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_audit_entries_errors: %w", err)
+	}
+
+	mPurgeAuditEntriesPurged := stats.Int64(MetricPrefix+"/purge_audit_entries_purged", "The number of audit entries that were purged", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/purge_audit_entries_purged_count",
+		Measure:     mPurgeAuditEntriesPurged,
+		Description: "The count of the number of audit entries purged",
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register purge_audit_entries_purged: %w", err)
+	}
+
+	return &Metrics{
+		ClaimAttempts: mClaimAttempts,
+		ClaimErrors:   mClaimErrors,
+
+		PurgeVerificationCodesAttempts: mPurgeVerificationCodesAttempts,
+		PurgeVerificationCodesErrors:   mPurgeVerificationCodesErrors,
+		PurgeVerificationCodesPurged:   mPurgeVerificationCodesPurged,
+
+		PurgeVerificationTokensAttempts: mPurgeVerificationTokensAttempts,
+		PurgeVerificationTokensErrors:   mPurgeVerificationTokensErrors,
+		PurgeVerificationTokensPurged:   mPurgeVerificationTokensPurged,
+
+		PurgeMobileAppsAttempts: mPurgeMobileAppsAttempts,
+		PurgeMobileAppsErrors:   mPurgeMobileAppsErrors,
+		PurgeMobileAppsPurged:   mPurgeMobileAppsPurged,
+
+		PurgeAuditEntriesAttempts: mPurgeAuditEntriesAttempts,
+		PurgeAuditEntriesErrors:   mPurgeAuditEntriesErrors,
+		PurgeAuditEntriesPurged:   mPurgeAuditEntriesPurged,
+	}, nil
+}

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -31,8 +31,11 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"github.com/jinzhu/gorm"
 	"github.com/sethvargo/go-retry"
+	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 	"go.uber.org/zap"
 
 	// ensure the postgres dialiect is compiled in.
@@ -61,6 +64,9 @@ type Database struct {
 
 	// logger is the internal logger.
 	logger *zap.SugaredLogger
+
+	// metrics is the metrics handler.
+	metrics *Metrics
 
 	// secretManager is used to resolve secrets.
 	secretManager secrets.SecretManager
@@ -95,6 +101,11 @@ func (db *Database) KeyManager() keys.KeyManager {
 func (c *Config) Load(ctx context.Context) (*Database, error) {
 	logger := logging.FromContext(ctx).Named("database")
 
+	metrics, err := registerMetrics()
+	if err != nil {
+		return nil, fmt.Errorf("failed to register metrics: %w", err)
+	}
+
 	// Create the secret manager.
 	secretManager, err := secrets.SecretManagerFor(ctx, c.Secrets.SecretManagerType)
 	if err != nil {
@@ -120,6 +131,7 @@ func (c *Config) Load(ctx context.Context) (*Database, error) {
 		signingKeyManager: signingKeyManager,
 		logger:            logger,
 		secretManager:     secretManager,
+		metrics:           metrics,
 	}, nil
 }
 
@@ -198,6 +210,9 @@ func (db *Database) OpenWithCacher(ctx context.Context, cacher cache.Cacher) err
 	rawDB.Callback().Create().Before("gorm:create").Register("verification_codes:hmac_code", callbackHMAC(ctx, db.GenerateVerificationCodeHMAC, "verification_codes", "code"))
 	rawDB.Callback().Create().Before("gorm:create").Register("verification_codes:hmac_long_code", callbackHMAC(ctx, db.GenerateVerificationCodeHMAC, "verification_codes", "long_code"))
 
+	// Metrics
+	rawDB.Callback().Create().After("gorm:create").Register("audit_entires:metrics", callbackIncrementMetric(ctx, db.metrics.AuditEntryCreated, "audit_entries"))
+
 	// Cache clearing
 	if cacher != nil {
 		// Apps
@@ -240,6 +255,34 @@ func (db *Database) RawDB() *gorm.DB {
 // IsNotFound determines if an error is a record not found.
 func IsNotFound(err error) bool {
 	return errors.Is(err, gorm.ErrRecordNotFound) || gorm.IsRecordNotFoundError(err)
+}
+
+// callbackIncremementMetric incremements the provided metric
+func callbackIncrementMetric(ctx context.Context, m *stats.Int64Measure, table string) func(scope *gorm.Scope) {
+	return func(scope *gorm.Scope) {
+		if scope.TableName() != table {
+			return
+		}
+
+		if scope.HasError() {
+			return
+		}
+
+		// Add realm so that metrics are groupable on a per-realm basis.
+		field, ok := scope.FieldByName("realm_id")
+		if ok && field.Field.CanInterface() && field.Field.Interface() != nil {
+			realmID := field.Field.Interface()
+
+			var err error
+			ctx, err = tag.New(ctx, tag.Upsert(observability.RealmTagKey, fmt.Sprintf("%d", realmID)))
+			if err != nil {
+				_ = scope.Err(fmt.Errorf("failed to add realm tag to metrics: %w", err))
+				return
+			}
+		}
+
+		stats.Record(ctx, m.M(1))
+	}
 }
 
 // callbackPurgeCache purges the cache key for the given record.

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -1,0 +1,50 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
+)
+
+var (
+	MetricPrefix = observability.MetricRoot + "/database"
+)
+
+type Metrics struct {
+	AuditEntryCreated *stats.Int64Measure
+}
+
+func registerMetrics() (*Metrics, error) {
+	mAuditEntryCreated := stats.Int64(MetricPrefix+"/audit_entry_created", "The number of times an audit entry was created", stats.UnitDimensionless)
+	if err := view.Register(&view.View{
+		Name:        MetricPrefix + "/audit_entry_created_count",
+		Measure:     mAuditEntryCreated,
+		Description: "The count of the number of audit entries created",
+		TagKeys:     []tag.Key{observability.RealmTagKey},
+		Aggregation: view.Count(),
+	}); err != nil {
+		return nil, fmt.Errorf("failed to register audit_entry_created: %w", err)
+	}
+
+	return &Metrics{
+		AuditEntryCreated: mAuditEntryCreated,
+	}, nil
+}


### PR DESCRIPTION
Fixes GH-716

Add metrics for cleanup and audits.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add metrics for cleanup and audits
```

/cc @icco 