### PR TITLE
Update APIKeyType to have a basis of 0

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -140,8 +140,8 @@ func realMain(ctx context.Context) error {
 	r.Use(rateLimit)
 
 	// Other common middlewares
-	requireAPIKey := middleware.RequireAPIKey(ctx, cacher, db, h, []database.APIUserType{
-		database.APIUserTypeAdmin,
+	requireAPIKey := middleware.RequireAPIKey(ctx, cacher, db, h, []database.APIKeyType{
+		database.APIKeyTypeAdmin,
 	})
 	processFirewall := middleware.ProcessFirewall(ctx, h, "adminapi")
 

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -153,8 +153,8 @@ func realMain(ctx context.Context) error {
 	r.Use(rateLimit)
 
 	// Other common middlewares
-	requireAPIKey := middleware.RequireAPIKey(ctx, cacher, db, h, []database.APIUserType{
-		database.APIUserTypeDevice,
+	requireAPIKey := middleware.RequireAPIKey(ctx, cacher, db, h, []database.APIKeyType{
+		database.APIKeyTypeDevice,
 	})
 	processFirewall := middleware.ProcessFirewall(ctx, h, "apiserver")
 

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -124,7 +124,7 @@ func realMain(ctx context.Context) error {
 
 	adminKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       adminKeyName + suffix,
-		APIKeyType: database.APIUserTypeAdmin,
+		APIKeyType: database.APIKeyTypeAdmin,
 	}, database.System)
 	if err != nil {
 		return fmt.Errorf("error trying to create a new Admin API Key: %w", err)
@@ -145,7 +145,7 @@ func realMain(ctx context.Context) error {
 
 	deviceKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       deviceKeyName + suffix,
-		APIKeyType: database.APIUserTypeDevice,
+		APIKeyType: database.APIKeyTypeDevice,
 	}, database.System)
 	if err != nil {
 		return fmt.Errorf("error trying to create a new Device API Key: %w", err)

--- a/cmd/server/assets/apikeys/new.html
+++ b/cmd/server/assets/apikeys/new.html
@@ -38,7 +38,7 @@
 
           <div class="form-group">
             <select class="form-control{{if $authApp.ErrorsFor "type"}} is-invalid{{end}}" name="type" id="type">
-              <option value="-1" {{if (eq $authApp.APIKeyType -1)}}selected{{else}}disabled{{end}}>Select type...</option>
+              <option selected disabled>Select type...</option>
               <option value="{{.typeDevice}}" {{if (eq $authApp.APIKeyType .typeDevice)}}selected{{end}}>Device (can verify codes)</option>
               <option value="{{.typeAdmin}}" {{if (eq $authApp.APIKeyType .typeAdmin)}}selected{{end}}>Admin (can issue codes)</option>
             </select>

--- a/cmd/server/assets/apikeys/show.html
+++ b/cmd/server/assets/apikeys/show.html
@@ -49,12 +49,12 @@
 
         <strong>Type</strong>
         <div>
-          {{if (eq $authApp.APIKeyType 0)}}
-          Device (can verify codes)
-          {{else if (eq $authApp.APIKeyType 1)}}
-          Admin (can issue codes)
+          {{if $authApp.IsDeviceType}}
+            Device (can verify codes)
+          {{else if $authApp.IsAdminType}}
+            Admin (can issue codes)
           {{else}}
-          Unknown
+            Unknown
           {{end}}
         </div>
       </div>

--- a/cmd/server/assets/mobileapps/_app.html
+++ b/cmd/server/assets/mobileapps/_app.html
@@ -11,7 +11,7 @@
 
 <div class="form-group">
   <select name="os" id="os" class="form-control custom-select{{if $app.ErrorsFor "os"}} is-invalid{{end}}">
-    <option disabled selected>Choose platform...</option>
+    <option selected disabled>Choose platform...</option>
     <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS</option>
     <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android</option>
   </select>

--- a/cmd/server/assets/realmadmin/_form_sms.html
+++ b/cmd/server/assets/realmadmin/_form_sms.html
@@ -73,7 +73,7 @@
 
   <div class="form-label-group">
     <select name="sms_country" id="sms_country" class="form-control custom-select">
-      <option disabled selected hidden>SMS country</option>
+      <option selected disabled>SMS country</option>
       {{range $name, $value := $countries}}
         <option value="{{$value}}"{{if eq $realm.SMSCountry $value}} selected{{end}}>{{$name}}</option>
       {{end}}

--- a/pkg/controller/apikey/create.go
+++ b/pkg/controller/apikey/create.go
@@ -25,8 +25,8 @@ import (
 
 func (c *Controller) HandleCreate() http.Handler {
 	type FormData struct {
-		Name string               `form:"name"`
-		Type database.APIUserType `form:"type"`
+		Name string              `form:"name"`
+		Type database.APIKeyType `form:"type"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -54,7 +54,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		// Requested form, stop processing.
 		if r.Method == http.MethodGet {
 			var authApp database.AuthorizedApp
-			authApp.APIKeyType = -1
+			authApp.APIKeyType = database.APIKeyTypeInvalid
 			c.renderNew(ctx, w, &authApp)
 			return
 		}
@@ -97,7 +97,7 @@ func (c *Controller) HandleCreate() http.Handler {
 func (c *Controller) renderNew(ctx context.Context, w http.ResponseWriter, authApp *database.AuthorizedApp) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["authApp"] = authApp
-	m["typeAdmin"] = database.APIUserTypeAdmin
-	m["typeDevice"] = database.APIUserTypeDevice
+	m["typeAdmin"] = database.APIKeyTypeAdmin
+	m["typeDevice"] = database.APIKeyTypeDevice
 	c.h.RenderHTML(w, "apikeys/new", m)
 }

--- a/pkg/controller/middleware/apikey.go
+++ b/pkg/controller/middleware/apikey.go
@@ -39,10 +39,10 @@ const (
 // RequireAPIKey reads the X-API-Key header and validates it is a real
 // authorized app. It also ensures currentAuthorizedApp is set in the template
 // map.
-func RequireAPIKey(ctx context.Context, cacher cache.Cacher, db *database.Database, h *render.Renderer, allowedTypes []database.APIUserType) mux.MiddlewareFunc {
+func RequireAPIKey(ctx context.Context, cacher cache.Cacher, db *database.Database, h *render.Renderer, allowedTypes []database.APIKeyType) mux.MiddlewareFunc {
 	logger := logging.FromContext(ctx).Named("middleware.RequireAPIKey")
 
-	allowedTypesMap := make(map[database.APIUserType]struct{}, len(allowedTypes))
+	allowedTypesMap := make(map[database.APIKeyType]struct{}, len(allowedTypes))
 	for _, t := range allowedTypes {
 		allowedTypesMap[t] = struct{}{}
 	}

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -28,14 +28,28 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-type APIUserType int
-
 const (
 	apiKeyBytes = 64 // 64 bytes is 86 chararacters in non-padded base64.
-
-	APIUserTypeDevice APIUserType = 0
-	APIUserTypeAdmin  APIUserType = 1
 )
+
+type APIKeyType int
+
+const (
+	APIKeyTypeInvalid APIKeyType = iota - 1
+	APIKeyTypeDevice
+	APIKeyTypeAdmin
+)
+
+func (a APIKeyType) Display() string {
+	switch a {
+	case APIKeyTypeDevice:
+		return "device"
+	case APIKeyTypeAdmin:
+		return "admin"
+	default:
+		return "invalid"
+	}
+}
 
 var _ Auditable = (*AuthorizedApp)(nil)
 
@@ -64,7 +78,7 @@ type AuthorizedApp struct {
 	APIKey string `gorm:"type:varchar(512);unique_index"`
 
 	// APIKeyType is the API key type.
-	APIKeyType APIUserType `gorm:"default:0"`
+	APIKeyType APIKeyType `gorm:"column:api_key_type; type:integer; not null;"`
 }
 
 // BeforeSave runs validations. If there are errors, the save fails.
@@ -75,7 +89,7 @@ func (a *AuthorizedApp) BeforeSave(tx *gorm.DB) error {
 		a.AddError("name", "cannot be blank")
 	}
 
-	if !(a.APIKeyType == APIUserTypeDevice || a.APIKeyType == APIUserTypeAdmin) {
+	if !(a.APIKeyType == APIKeyTypeDevice || a.APIKeyType == APIKeyTypeAdmin) {
 		a.AddError("type", "is invalid")
 	}
 
@@ -86,11 +100,11 @@ func (a *AuthorizedApp) BeforeSave(tx *gorm.DB) error {
 }
 
 func (a *AuthorizedApp) IsAdminType() bool {
-	return a.APIKeyType == APIUserTypeAdmin
+	return a.APIKeyType == APIKeyTypeAdmin
 }
 
 func (a *AuthorizedApp) IsDeviceType() bool {
-	return a.APIKeyType == APIUserTypeDevice
+	return a.APIKeyType == APIKeyTypeDevice
 }
 
 // Realm returns the associated realm for this app.

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -33,7 +33,7 @@ func TestDatabase_CreateFindAPIKey(t *testing.T) {
 
 	authApp := &AuthorizedApp{
 		Name:       "University System Health Org",
-		APIKeyType: APIUserTypeAdmin,
+		APIKeyType: APIKeyTypeAdmin,
 	}
 
 	apiKey, err := realm.CreateAuthorizedApp(db, authApp, System)

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -160,7 +160,7 @@ func realMain(ctx context.Context) error {
 	// Create a device API key
 	deviceAPIKey, err := realm1.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       "Corona Capture",
-		APIKeyType: database.APIUserTypeDevice,
+		APIKeyType: database.APIKeyTypeDevice,
 	}, admin)
 	if err != nil {
 		return fmt.Errorf("failed to create device api key: %w", err)
@@ -193,7 +193,7 @@ func realMain(ctx context.Context) error {
 	// Create an admin API key
 	adminAPIKey, err := realm1.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       "Tracing Tracker",
-		APIKeyType: database.APIUserTypeAdmin,
+		APIKeyType: database.APIKeyTypeAdmin,
 	}, admin)
 	if err != nil {
 		return fmt.Errorf("failed to create admin api key: %w", err)


### PR DESCRIPTION
Since Go's default value for ints is 0, there have been a number of edge
cases where we have to manually set or check the APIKeyType as -1 to
indicate a value of "unset".

This PR changes the APIKeyType to be an iota with a default value of 0.
That means existing database records are updated 0->1 and 1->2.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
