### PR TITLE
Create a grace period before MFA is required

### DIFF
--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -39,6 +39,23 @@
   </div>
 
   <div class="form-group">
+    <label for="mfa-grace-period">Require MFA after</label>
+    <select name="mfa_grace_period" id="mfa-grace-period" class="form-control custom-select" {{if ne $realm.MFAMode.String "required"}}disabled{{end}}>
+      {{$current := $realm.MFARequiredGracePeriod}}
+      {{range $prd := .mfaGracePeriod}}
+      <option value="{{$prd}}" {{if eq $prd $current.Days}}selected{{end}}>
+        {{if (eq $prd 0)}}Immediate{{else}}After {{$prd}} days{{end}}
+      </option>
+      {{end}}
+    </select>
+    {{template "errorable" $realm.ErrorsFor "mfaMode"}}
+    <small class="form-text text-muted">
+      Allows users to continue without registering multi-factor authentication for a period of time. This can be
+      less burdensome to new users or short-term users.
+    </small>
+  </div>
+
+  <div class="form-group">
     <label for="password-rotation-period-days">Require password rotation</label>
     <select name="password_rotation_period_days" id="password-rotation-period-days" class="form-control custom-select">
       {{$current := $realm.PasswordRotationPeriodDays}}
@@ -122,5 +139,20 @@
     <input type="submit" class="btn btn-primary btn-block" value="Update security settings" />
   </div>
 </form>
+
+<script type="text/javascript">
+  $(function(){
+    let $grace = $('#mfa-grace-period');
+    let $mfaMode = $('#mfa-mode');
+
+    $mfaMode.change(function() {
+      if ($mfaMode.val() == 1) {
+        $grace.prop("disabled", false);
+      } else {
+        $grace.prop("disabled", true);
+      }
+    });
+  });
+  </script>
 
 {{end}}

--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -39,12 +39,12 @@
   </div>
 
   <div class="form-group">
-    <label for="mfa-grace-period">Require MFA after</label>
+    <label for="mfa-grace-period">Require MFA</label>
     <select name="mfa_grace_period" id="mfa-grace-period" class="form-control custom-select" {{if ne $realm.MFAMode.String "required"}}disabled{{end}}>
       {{$current := $realm.MFARequiredGracePeriod}}
       {{range $prd := .mfaGracePeriod}}
       <option value="{{$prd}}" {{if eq $prd $current.Days}}selected{{end}}>
-        {{if (eq $prd 0)}}Immediate{{else}}After {{$prd}} days{{end}}
+        {{if (eq $prd 0)}}Immediately{{else}}After {{$prd}} days{{end}}
       </option>
       {{end}}
     </select>

--- a/cmd/server/assets/realmadmin/_form_security.html
+++ b/cmd/server/assets/realmadmin/_form_security.html
@@ -38,7 +38,7 @@
     </small>
   </div>
 
-  <div class="form-group">
+  <div class="form-group" id="grace-div" {{if ne $realm.MFAMode.String "required"}}style="display:none;"{{end}}>
     <label for="mfa-grace-period">Require MFA</label>
     <select name="mfa_grace_period" id="mfa-grace-period" class="form-control custom-select" {{if ne $realm.MFAMode.String "required"}}disabled{{end}}>
       {{$current := $realm.MFARequiredGracePeriod}}
@@ -143,12 +143,15 @@
 <script type="text/javascript">
   $(function(){
     let $grace = $('#mfa-grace-period');
+    let $graceDiv = $('#grace-div');
     let $mfaMode = $('#mfa-mode');
 
     $mfaMode.change(function() {
       if ($mfaMode.val() == 1) {
         $grace.prop("disabled", false);
+        $graceDiv.show(200);
       } else {
+        $graceDiv.hide(200);
         $grace.prop("disabled", true);
       }
     });

--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -48,7 +48,7 @@
       </div>
 
       <div class="card-body">
-        <div class="progress d-none" id="progress-div" style="display:none;>
+        <div class="progress d-none" id="progress-div" style="display:none;">
           <div id="progress" class="progress-bar" role="progressbar" aria-valuenow="0" aria-valuemin="0"
             aria-valuemax="100"></div>
         </div>

--- a/pkg/controller/middleware/mfa.go
+++ b/pkg/controller/middleware/mfa.go
@@ -59,9 +59,11 @@ func RequireMFA(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 }
 
 func NeedsMFARedirect(session *sessions.Session, user *database.User, realm *database.Realm) bool {
-	if (realm == nil || realm.MFAMode == database.MFARequired) &&
-		time.Since(user.CreatedAt) >= realm.MFARequiredGracePeriod.Duration &&
-		controller.FactorCountFromSession(session) == 0 {
+	if (realm == nil || realm.MFAMode == database.MFARequired) && controller.FactorCountFromSession(session) == 0 {
+		if time.Since(user.CreatedAt) < realm.MFARequiredGracePeriod.Duration && controller.MFAPromptedFromSession(session) {
+			return false
+		}
+
 		return true
 	}
 

--- a/pkg/controller/middleware/mfa.go
+++ b/pkg/controller/middleware/mfa.go
@@ -41,14 +41,14 @@ func RequireMFA(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 				return
 			}
 
-			user := controller.UserFromContext(ctx)
-			if user == nil {
+			currentUser := controller.UserFromContext(ctx)
+			if currentUser == nil {
 				controller.MissingUser(w, r, h)
 				return
 			}
 
 			realm := controller.RealmFromContext(ctx)
-			if NeedsMFARedirect(session, user, realm) {
+			if NeedsMFARedirect(session, currentUser, realm) {
 				controller.RedirectToMFA(w, r, h)
 				return
 			}
@@ -60,7 +60,7 @@ func RequireMFA(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 
 func NeedsMFARedirect(session *sessions.Session, user *database.User, realm *database.Realm) bool {
 	if (realm == nil || realm.MFAMode == database.MFARequired) && controller.FactorCountFromSession(session) == 0 {
-		if time.Since(user.CreatedAt) < realm.MFARequiredGracePeriod.Duration && controller.MFAPromptedFromSession(session) {
+		if time.Since(user.CreatedAt) <= realm.MFARequiredGracePeriod.Duration && controller.MFAPromptedFromSession(session) {
 			return false
 		}
 

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -31,6 +31,7 @@ var (
 	shortCodeMinutes            = []int{}
 	longCodeLengths             = []int{12, 13, 14, 15, 16}
 	longCodeHours               = []int{}
+	mfaGracePeriod              = []int64{0, 1, 7, 30}
 	passwordRotationPeriodDays  = []int{0, 30, 60, 90, 365}
 	passwordRotationWarningDays = []int{0, 1, 3, 5, 7, 30}
 )
@@ -69,6 +70,7 @@ func (c *Controller) HandleSettings() http.Handler {
 
 		Security                    bool   `form:"security"`
 		MFAMode                     int16  `form:"mfa_mode"`
+		MFARequiredGracePeriod      int64  `form:"mfa_grace_period"`
 		EmailVerifiedMode           int16  `form:"email_verified_mode"`
 		PasswordRotationPeriodDays  uint   `form:"password_rotation_period_days"`
 		PasswordRotationWarningDays uint   `form:"password_rotation_warning_days"`
@@ -148,6 +150,7 @@ func (c *Controller) HandleSettings() http.Handler {
 		if form.Security {
 			realm.EmailVerifiedMode = database.AuthRequirement(form.EmailVerifiedMode)
 			realm.MFAMode = database.AuthRequirement(form.MFAMode)
+			realm.MFARequiredGracePeriod = database.FromDuration(time.Duration(form.MFARequiredGracePeriod) * 24 * time.Hour)
 			realm.PasswordRotationPeriodDays = form.PasswordRotationPeriodDays
 			realm.PasswordRotationWarningDays = form.PasswordRotationWarningDays
 
@@ -297,6 +300,7 @@ func (c *Controller) renderSettings(ctx context.Context, w http.ResponseWriter, 
 		"negative":  database.TestTypeConfirmed | database.TestTypeLikely | database.TestTypeNegative,
 	}
 	// Valid settings for pwd rotation.
+	m["mfaGracePeriod"] = mfaGracePeriod
 	m["passwordRotateDays"] = passwordRotationPeriodDays
 	m["passwordWarnDays"] = passwordRotationWarningDays
 	// Valid settings for code parameters.

--- a/pkg/database/duration.go
+++ b/pkg/database/duration.go
@@ -41,7 +41,7 @@ func FromDuration(d time.Duration) DurationSeconds {
 }
 
 func (d *DurationSeconds) Days() int64 {
-	return int64(d.Duration.Hours() / 24)
+	return int64(d.Duration.Hours() / 24.0)
 }
 
 // Update attempts to parse the AsString value and set is as the duration

--- a/pkg/database/duration.go
+++ b/pkg/database/duration.go
@@ -29,7 +29,7 @@ var _ driver.Valuer = (*DurationSeconds)(nil)
 type DurationSeconds struct {
 	Duration time.Duration
 
-	// AsString allows this value to be updatd and parsed using the Update() method.
+	// AsString allows this value to be updated and parsed using the Update() method.
 	AsString string
 }
 
@@ -38,6 +38,10 @@ func FromDuration(d time.Duration) DurationSeconds {
 		Duration: d,
 		AsString: d.String(),
 	}
+}
+
+func (d *DurationSeconds) Days() int64 {
+	return int64(d.Duration.Hours() / 24)
 }
 
 // Update attempts to parse the AsString value and set is as the duration

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1393,6 +1393,16 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return tx.Exec(`DROP TABLE audit_entries`).Error
 			},
 		},
+		{
+			ID: "00056-AddMFARequiredGracePeriod",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("adding email verification required to realm")
+				return tx.Exec("ALTER TABLE realms ADD COLUMN IF NOT EXISTS mfa_required_grace_period BIGINT DEFAULT 0").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE realms DROP COLUMN IF EXISTS mfa_required_grace_period").Error
+			},
+		},
 	})
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -143,6 +143,10 @@ type Realm struct {
 	// MFAMode represents the mode for Multi-Factor-Authorization requirements for the realm.
 	MFAMode AuthRequirement `gorm:"type:smallint; not null; default: 0"`
 
+	// MFARequiredGracePeriod defines how long after creation a user may skip adding
+	// a second auth factor before the server requires it.
+	MFARequiredGracePeriod DurationSeconds `gorm:"type:bigint; not null; default: 0"`
+
 	// EmailVerifiedMode represents the mode for email verification requirements for the realm.
 	EmailVerifiedMode AuthRequirement `gorm:"type:smallint; not null; default: 0"`
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -845,6 +845,12 @@ func (db *Database) SaveRealm(r *Realm, actor Auditable) error {
 				audits = append(audits, audit)
 			}
 
+			if existing.MFARequiredGracePeriod != r.MFARequiredGracePeriod {
+				audit := BuildAuditEntry(actor, "updated MFA required grace period", r, r.ID)
+				audit.Diff = stringDiff(existing.MFARequiredGracePeriod.AsString, r.MFARequiredGracePeriod.AsString)
+				audits = append(audits, audit)
+			}
+
 			if existing.EmailVerifiedMode != r.EmailVerifiedMode {
 				audit := BuildAuditEntry(actor, "updated email verification mode", r, r.ID)
 				audit.Diff = stringDiff(existing.EmailVerifiedMode.String(), r.EmailVerifiedMode.String())


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/607

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a new realm setting for MFA required mode that allows users to skip MFA registration for a number of days.

TODO: Update the registration page to show days remaining

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
MFA registration grace period
```
