### PR TITLE
Trim whitespace from user-input

### DIFF
--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -88,7 +88,7 @@
       });
 
       function changePassword() {
-        let email = $email.val();
+        let email = $email.val().trim();
         let pwd = $password.val();
         if (pwd != $retype.val()) {
           flash.error("Password and retyped passwords must match.");

--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -104,7 +104,7 @@
         $submit.prop('disabled', true);
 
         {{if .currentUser}}
-        let credentials = firebase.auth.EmailAuthProvider.credential($email.val(),$password.val());
+        let credentials = firebase.auth.EmailAuthProvider.credential($email.val().trim(),$password.val());
         firebase.auth().currentUser.reauthenticateWithCredential(credentials)
         {{else}}
         firebase.auth().signInWithEmailAndPassword($email.val(), $password.val())
@@ -153,7 +153,7 @@
         $submitPin.prop('disabled', true);
 
         // Ask user for the SMS verification code.
-        let cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
+        let cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val().trim());
         let multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
         // Complete sign-in.
         resolver.resolveSignIn(multiFactorAssertion)

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -236,7 +236,7 @@
         // Disable the submit button so we only attempt once.
         $submitPin.prop('disabled', true);
 
-        var cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val());
+        var cred = firebase.auth.PhoneAuthProvider.credential(verId, $pin.val().trim());
         var multiFactorAssertion = firebase.auth.PhoneMultiFactorGenerator.assertion(cred);
 
         // Complete enrollment.

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/internal/firebase"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
@@ -55,7 +56,7 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 			return
 		}
 
-		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, form.Email); err != nil {
+		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, strings.TrimSpace(form.Email)); err != nil {
 			// Treat not-found like success so we don't leak details.
 			if !errors.Is(err, firebase.ErrEmailNotFound) {
 				flash.Error("Password reset failed.")

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -17,6 +17,7 @@ package user
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -63,10 +64,11 @@ func (c *Controller) HandleCreate() http.Handler {
 			c.renderNew(ctx, w)
 			return
 		}
+		email := strings.TrimSpace(form.Email)
 
 		// See if the user already exists by email - they may be a member of another
 		// realm.
-		user, err := c.db.FindUserByEmail(form.Email)
+		user, err := c.db.FindUserByEmail(email)
 		if err != nil {
 			if !database.IsNotFound(err) {
 				controller.InternalError(w, r, c.h, err)
@@ -74,7 +76,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			}
 
 			user = new(database.User)
-			user.Email = form.Email
+			user.Email = email
 			user.Name = form.Name
 		}
 

--- a/pkg/controller/user/update.go
+++ b/pkg/controller/user/update.go
@@ -17,6 +17,7 @@ package user
 import (
 	"context"
 	"net/http"
+	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -72,10 +73,12 @@ func (c *Controller) HandleUpdate() http.Handler {
 		}
 
 		var form FormData
-		if err := controller.BindForm(w, r, &form); err != nil {
-			user.Email = form.Email
-			user.Name = form.Name
+		err = controller.BindForm(w, r, &form)
 
+		// Build the user struct
+		user.Email = strings.TrimSpace(form.Email)
+		user.Name = strings.TrimSpace(form.Name)
+		if err != nil {
 			if terr, ok := err.(schema.MultiError); ok {
 				for k, err := range terr {
 					user.AddError(k, err.Error())
@@ -86,10 +89,6 @@ func (c *Controller) HandleUpdate() http.Handler {
 			c.renderEdit(ctx, w, user)
 			return
 		}
-
-		// Build the user struct
-		user.Email = form.Email
-		user.Name = form.Name
 
 		// Manage realm admin permissions.
 		if form.Admin {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/726

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Trim whitespace from a few user-input spots
    * User name/email input
    * Login email input
    * Login MFA code input

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Trim whitespace from login and create-user inputs
```
