### PR TITLE
Always include build_id and build_tag in metrics

### DIFF
--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -28,14 +28,13 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/jwthelper"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
 
 func (c *Controller) HandleCertificate() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+		ctx := observability.WithBuildInfo(r.Context())
 
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {
@@ -45,17 +44,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 			return
 		}
 
-		// This is a non terminal error, as we're only using the realm for stats.
-		realm, err := authApp.Realm(c.db)
-		if err != nil {
-			c.logger.Errorf("unable to load realm", "error", err)
-		} else {
-			ctx, err = tag.New(ctx,
-				tag.Upsert(observability.RealmTagKey, realm.Name))
-			if err != nil {
-				c.logger.Errorw("unable to record metrics for realm", "realmID", realm.ID, "error", err)
-			}
-		}
+		ctx = observability.WithRealmID(ctx, authApp.RealmID)
+
 		stats.Record(ctx, c.metrics.Attempts.M(1))
 
 		// Get the public key for the token.

--- a/pkg/controller/certapi/metrics.go
+++ b/pkg/controller/certapi/metrics.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 var (
@@ -43,7 +42,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/attempt_count",
 		Measure:     mAttempts,
 		Description: "The count of certificate issue attempts",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -53,7 +52,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/token_expired_count",
 		Measure:     mTokenExpired,
 		Description: "The count of expired tokens on certificate issue",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -63,7 +62,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/token_used_count",
 		Measure:     mTokenUsed,
 		Description: "The count of already used tokens on certificate issue",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -73,7 +72,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/invalid_token_count",
 		Measure:     mTokenInvalid,
 		Description: "The count of invalid tokens on certificate issue",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -83,7 +82,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/issue_count",
 		Measure:     mCertificateIssued,
 		Description: "The count of certificates issued",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -93,7 +92,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/error_count",
 		Measure:     mCertificateErrors,
 		Description: "The count of certificate issue errors",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
@@ -85,7 +86,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+		ctx := observability.WithBuildInfo(r.Context())
 
 		if err := c.shouldCleanup(ctx); err != nil {
 			c.logger.Errorw("failed to run shouldCleanup", "error", err)

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 var (
@@ -47,7 +46,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/attempt_count",
 		Measure:     mIssueAttempts,
 		Description: "The count of the number of attempts to issue codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -58,7 +57,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/quota_errors_count",
 		Measure:     mQuotaErrors,
 		Description: "The count of the number of errors to the limiter",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -69,7 +68,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/quota_exceeded_count",
 		Measure:     mQuotaExceeded,
 		Description: "The count of the number of times quota has been exceeded",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -80,7 +79,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/codes_issued_count",
 		Measure:     mCodesIssued,
 		Description: "The count of verification codes issued",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -91,7 +90,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/code_issue_error_count",
 		Measure:     mCodeIssueErrors,
 		Description: "The count of the number of times a code fails to issue",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -102,7 +101,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/sms_sent_count",
 		Measure:     mSMSSent,
 		Description: "The count of verification codes sent over SMS",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -113,7 +112,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/sms_send_error_count",
 		Measure:     mSMSSendErrors,
 		Description: "The count of the number of a code issue failed due to SMS send failure",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -123,7 +122,7 @@ func registerMetrics() (*Metrics, error) {
 	if err := view.Register(&view.View{
 		Name:        MetricPrefix + "/realm_token_remaining_latest",
 		Description: "Latest realm remaining tokens",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Measure:     mRealmTokenRemaining,
 		Aggregation: view.LastValue(),
 	}); err != nil {
@@ -134,7 +133,7 @@ func registerMetrics() (*Metrics, error) {
 	if err := view.Register(&view.View{
 		Name:        MetricPrefix + "/realm_token_issued_latest",
 		Description: "Latest realm issued tokens",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Measure:     mRealmTokenIssued,
 		Aggregation: view.LastValue(),
 	}); err != nil {
@@ -145,7 +144,7 @@ func registerMetrics() (*Metrics, error) {
 	if err := view.Register(&view.View{
 		Name:        MetricPrefix + "/realm_token_capacity_latest",
 		Description: "Latest realm token capacity utilization",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Measure:     mRealmTokenCapacity,
 		Aggregation: view.LastValue(),
 	}); err != nil {

--- a/pkg/controller/verifyapi/metrics.go
+++ b/pkg/controller/verifyapi/metrics.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 var (
@@ -43,7 +42,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/attempt_count",
 		Measure:     mCodeVerifyAttempts,
 		Description: "The count of attempted code verifications",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -53,7 +52,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/code_expired_count",
 		Measure:     mCodeVerifyExpired,
 		Description: "The count of attempted claims on expired verification codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -63,7 +62,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/code_used_count",
 		Measure:     mCodeVerifyCodeUsed,
 		Description: "The count of attempted claims on an already used verification codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -73,7 +72,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/code_invalid_count",
 		Measure:     mCodeVerifyInvalid,
 		Description: "The count of attempted claims on invalid verification codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -83,7 +82,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/code_verified_count",
 		Measure:     mCodeVerified,
 		Description: "The count of successfully verified codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)
@@ -93,7 +92,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/error_count",
 		Measure:     mCodeVerificationError,
 		Description: "The count of errors issuing verification codes",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("stat view registration failure: %w", err)

--- a/pkg/database/metrics.go
+++ b/pkg/database/metrics.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 var (
@@ -38,7 +37,7 @@ func registerMetrics() (*Metrics, error) {
 		Name:        MetricPrefix + "/audit_entry_created_count",
 		Measure:     mAuditEntryCreated,
 		Description: "The count of the number of audit entries created",
-		TagKeys:     []tag.Key{observability.RealmTagKey},
+		TagKeys:     observability.CommonTagKeys(),
 		Aggregation: view.Count(),
 	}); err != nil {
 		return nil, fmt.Errorf("failed to register audit_entry_created: %w", err)

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -2,8 +2,11 @@
 package observability
 
 import (
-	"log"
+	"context"
+	"strconv"
 
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
 	"go.opencensus.io/tag"
 )
 
@@ -12,13 +15,46 @@ const (
 )
 
 var (
-	RealmTagKey tag.Key
+	BuildIDTagKey  = tag.MustNewKey("build_id")
+	BuildTagTagKey = tag.MustNewKey("build_tag")
+	RealmTagKey    = tag.MustNewKey("realm")
 )
 
-func init() {
-	var err error
-	RealmTagKey, err = tag.NewKey("realm")
-	if err != nil {
-		log.Fatalf("invalid observability tag: %v", err)
+// CommonTagKeys returns the slice of common tag keys that should used in all
+// views.
+func CommonTagKeys() []tag.Key {
+	return []tag.Key{
+		BuildIDTagKey,
+		BuildTagTagKey,
+		RealmTagKey,
 	}
+}
+
+// WithRealmID creates a new context with the realm id attached to the
+// observability context.
+func WithRealmID(octx context.Context, realmID uint) context.Context {
+	realmIDStr := strconv.FormatUint(uint64(realmID), 10)
+	ctx, err := tag.New(octx, tag.Upsert(RealmTagKey, realmIDStr))
+	if err != nil {
+		logger := logging.FromContext(octx).Named("observability.WithRealmID")
+		logger.Errorw("failed to upsert realm on observability context",
+			"error", err,
+			"realm_id", realmIDStr)
+		return octx
+	}
+	return ctx
+}
+
+// WithBuildInfo creates a new context with the build info attached to the
+// observability context.
+func WithBuildInfo(octx context.Context) context.Context {
+	ctx, err := tag.New(octx,
+		tag.Upsert(BuildIDTagKey, buildinfo.BuildID),
+		tag.Upsert(BuildTagTagKey, buildinfo.BuildTag))
+	if err != nil {
+		logger := logging.FromContext(octx).Named("observability.WithBuildInfo")
+		logger.Errorw("failed to upsert buildinfo on observability context", "error", err)
+		return octx
+	}
+	return ctx
 }

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -142,7 +142,7 @@ func NewMiddleware(ctx context.Context, s limiter.Store, f httplimit.KeyFunc, op
 // metadata about when it's safe to retry.
 func (m *Middleware) Handle(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
+		ctx := observability.WithBuildInfo(r.Context())
 
 		// Call the key function - if this fails, it's an internal server error.
 		key, err := m.keyFunc(r)


### PR DESCRIPTION
Also refactor realm_id injection to be simpler, save a database lookup.

Refs https://github.com/google/exposure-notifications-server/issues/1023

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Always include build_id and build_tag in metrics
```
