### PR TITLE
Disable editing user email

### DIFF
--- a/cmd/server/assets/users/_form.html
+++ b/cmd/server/assets/users/_form.html
@@ -25,7 +25,7 @@
 
     <div class="form-label-group">
       <input type="email" id="email" name="email" class="form-control{{if $user.ErrorsFor "email"}} is-invalid{{end}}"
-        value="{{$user.Email}}" placeholder="Email address" required />
+        value="{{$user.Email}}" placeholder="Email address" {{if $user.ID}}disabled{{else}}required{{end}} />
       <label for="name">Email address</label>
       {{if $user.ErrorsFor "email"}}
       <div class="invalid-feedback">

--- a/pkg/controller/user/update.go
+++ b/pkg/controller/user/update.go
@@ -27,7 +27,6 @@ import (
 
 func (c *Controller) HandleUpdate() http.Handler {
 	type FormData struct {
-		Email string `form:"email"`
 		Name  string `form:"name"`
 		Admin bool   `form:"admin"`
 	}
@@ -76,7 +75,6 @@ func (c *Controller) HandleUpdate() http.Handler {
 		err = controller.BindForm(w, r, &form)
 
 		// Build the user struct
-		user.Email = strings.TrimSpace(form.Email)
 		user.Name = strings.TrimSpace(form.Name)
 		if err != nil {
 			if terr, ok := err.(schema.MultiError); ok {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Admins may not change user emails

![disabled](https://user-images.githubusercontent.com/36240966/94949339-9ae0e400-0495-11eb-8722-72db38c6b30a.png)


### Alternatives
1) We could allow changing email, but we would also want to update the firebase login and chang email-verified to false.
2) We could have a separate, editable 'contact email' that isn't the same as login email

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Disable modifying user email
```