### PR TITLE
Respond to paste, keyup, and change

### DIFF
--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -69,10 +69,10 @@
           $submit.prop('disabled', false);
         });
 
-      $password.keyup(function() {
+      $password.on("change keyup paste", function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
-      $retype.keyup(function() {
+      $retype.on("change keyup paste", function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
 

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -66,10 +66,10 @@
       let $password = $('#password');
       let $retype = $('#retype');
 
-      $password.keyup(function() {
+      $password.on("change keyup paste", function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
-      $retype.keyup(function() {
+      $retype.on("change keyup paste", function() {
         $submit.prop('disabled', !checkPasswordValid($password.val()));
       });
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Password select/change should respond to both keyup, paste, and change to handle all methods of input
    * It currently assumes the user is typing

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Password validation responds to copy/paste
```
