### PR TITLE
Attempt to fix realm quota alert

### DIFF
--- a/cmd/server/assets/realmadmin/_form_abuse_prevention.html
+++ b/cmd/server/assets/realmadmin/_form_abuse_prevention.html
@@ -1,6 +1,8 @@
 {{define "realmadmin/_form_abuse_prevention"}}
 
 {{$realm := .realm}}
+{{$quotaRemaining := .quotaRemaining}}
+{{$quotaLimit := .quotaLimit}}
 
 <form method="POST" action="/realm/settings#abuse-prevention" class="floating-form">
   {{ .csrfField }}
@@ -27,6 +29,17 @@
   </div>
 
   <div id="abuse-prevention-configuration" class="collapse{{if $realm.AbusePreventionEnabled}} show{{end}}">
+    <div class="alert alert-primary" role="alert">
+      Your current remaining daily quota is:
+      <small class="text-monospace">{{$quotaRemaining}}/{{$quotaLimit}}</small>. This value resets at
+      midnight UTC.
+
+      {{if gt $quotaRemaining $quotaLimit}}
+        If your remaining quota exceeds the maximum quota, it means a realm
+        administrator added a temporary burst.
+      {{end}}
+    </div>
+
     <div class="form-label-group">
       <input type="text" name="abuse_prevention_limit" id="abuse-prevention-limit" class="form-control" placeholder="Computed limit" value="{{$realm.AbusePreventionLimit}}" readonly />
       <label for="abuse-prevention-limit">Computed limit</label>

--- a/go.mod
+++ b/go.mod
@@ -47,9 +47,9 @@ require (
 	github.com/rakutentech/jwk-go v1.0.1
 	github.com/russross/blackfriday/v2 v2.0.1
 	github.com/sethvargo/go-envconfig v0.3.2
-	github.com/sethvargo/go-limiter v0.5.2
+	github.com/sethvargo/go-limiter v0.6.0
 	github.com/sethvargo/go-password v0.2.0
-	github.com/sethvargo/go-redisstore v0.2.1-opencensus
+	github.com/sethvargo/go-redisstore v0.3.0-opencensus
 	github.com/sethvargo/go-retry v0.1.0
 	github.com/sethvargo/go-signalcontext v0.1.0
 	github.com/sirupsen/logrus v1.7.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1153,12 +1153,12 @@ github.com/sethvargo/go-envconfig v0.3.2 h1:277Lb2iTpUZjUZu1qLoLa/aetwvtZbKh8wNW
 github.com/sethvargo/go-envconfig v0.3.2/go.mod h1:XZ2JRR7vhlBEO5zMmOpLgUhgYltqYqq4d4tKagtPUv0=
 github.com/sethvargo/go-gcpkms v0.1.0 h1:pyjDLqLwpk9pMjDSTilPpaUjgP1AfSjX9WGzitZwGUY=
 github.com/sethvargo/go-gcpkms v0.1.0/go.mod h1:33BuvqUjsYk0bpMgn+WCclCYtMLOyaqtn5j0fCo4vvk=
-github.com/sethvargo/go-limiter v0.5.2 h1:NIFp7xy3NyE2+mEHbengdLQF0C0STOpwF5Qw5JtayIs=
-github.com/sethvargo/go-limiter v0.5.2/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
+github.com/sethvargo/go-limiter v0.6.0 h1:186jmCdl1ItQUXbHFdTBrFSZztN6/bL9855C5jfMlKU=
+github.com/sethvargo/go-limiter v0.6.0/go.mod h1:C0kbSFbiriE5k2FFOe18M1YZbAR2Fiwf72uGu0CXCcU=
 github.com/sethvargo/go-password v0.2.0 h1:BTDl4CC/gjf/axHMaDQtw507ogrXLci6XRiLc7i/UHI=
 github.com/sethvargo/go-password v0.2.0/go.mod h1:Ym4Mr9JXLBycr02MFuVQ/0JHidNetSgbzutTr3zsYXE=
-github.com/sethvargo/go-redisstore v0.2.1-opencensus h1:EAwZAuZr5DJdLmEruJTj2zeBvmZsIXI7wqgMueuaxks=
-github.com/sethvargo/go-redisstore v0.2.1-opencensus/go.mod h1:TMFAy7azG5hDd/Hb5ng2CDsawcxg1+oEuGhuVp7eycI=
+github.com/sethvargo/go-redisstore v0.3.0-opencensus h1:H9W15fuJHwHmttV+G6oY94J/YjxhRz0E/1S5y7elxlg=
+github.com/sethvargo/go-redisstore v0.3.0-opencensus/go.mod h1:byILvIz3sOqWiKLQmL7KUK0CzD3MWHajkksZH7V43yk=
 github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGjQaI=
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=
 github.com/sethvargo/go-signalcontext v0.1.0 h1:3IU7HOlmRXF0PSDf85C4nJ/zjYDjF+DS+LufcKfLvyk=

--- a/pkg/controller/realmadmin/express.go
+++ b/pkg/controller/realmadmin/express.go
@@ -46,7 +46,7 @@ func (c *Controller) HandleDisableExpress() http.Handler {
 
 		if !realm.EnableENExpress {
 			flash.Error("Realm is not currently enrolled in EN Express.")
-			c.renderSettings(ctx, w, r, realm, nil)
+			c.renderSettings(ctx, w, r, realm, nil, 0, 0)
 			return
 		}
 
@@ -56,7 +56,7 @@ func (c *Controller) HandleDisableExpress() http.Handler {
 		if err := c.db.SaveRealm(realm, currentUser); err != nil {
 			flash.Error("Failed to disable EN Express: %v", err)
 
-			c.renderSettings(ctx, w, r, realm, nil)
+			c.renderSettings(ctx, w, r, realm, nil, 0, 0)
 			return
 		}
 
@@ -90,7 +90,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 
 		if realm.EnableENExpress {
 			flash.Error("Realm already has EN Express Enabled.")
-			c.renderSettings(ctx, w, r, realm, nil)
+			c.renderSettings(ctx, w, r, realm, nil, 0, 0)
 			return
 		}
 
@@ -110,7 +110,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 			// This will allow the user to correct other validation errors and then click "uprade" again.
 			realm.EnableENExpress = false
 			realm.SMSTextTemplate = enxSettings.SMSTextTemplate
-			c.renderSettings(ctx, w, r, realm, nil)
+			c.renderSettings(ctx, w, r, realm, nil, 0, 0)
 			return
 		}
 


### PR DESCRIPTION
- Display the currently configured limit and remaining tokens on the realm settings page.
- Only create the metrics for realms that have abuse prevention enabled.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/735

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Display the currently configured limit and remaining tokens on the realm settings page
```
