### PR TITLE
Too many attempts message

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -138,6 +138,10 @@
                 flash.clear();
                 flash.error('Unsupported 2nd factor authentication type.');
               }
+            } else if (error.code == 'auth/too-many-requests'){
+              flash.clear();
+              flash.error(err.message);
+              $submit.prop('disabled', false);
             } else {
               flash.clear();
               flash.error("Sign-in failed. Please try again.");

--- a/internal/firebase/error.go
+++ b/internal/firebase/error.go
@@ -25,6 +25,7 @@ var (
 	ErrCredentialTooOld = &ErrorDetails{Err: "CREDENTIAL_TOO_OLD_LOGIN_AGAIN"}
 	ErrTokenExpired     = &ErrorDetails{Err: "TOKEN_EXPIRED"}
 	ErrInvalidToken     = &ErrorDetails{Err: "INVALID_ID_TOKEN"}
+	ErrTooManyAttempts  = &ErrorDetails{Err: "TOO_MANY_ATTEMPTS_TRY_LATER"}
 )
 
 var _ error = (*ErrorDetails)(nil)

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -57,6 +57,12 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		}
 
 		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, strings.TrimSpace(form.Email)); err != nil {
+			if errors.Is(err, firebase.ErrTooManyAttempts) {
+				flash.Error("Too many attempts have been made. Please wait and try again later.")
+				c.renderResetPassword(ctx, w, flash)
+				return
+			}
+
 			// Treat not-found like success so we don't leak details.
 			if !errors.Is(err, firebase.ErrEmailNotFound) {
 				flash.Error("Password reset failed.")


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Show "Too many attempts" error message in flash
     * We currently eat firebase errors and show a generic one. This was done to hide certain responses (user not-found) that could leak information. However too-many-attempts/requests we should let the user know about so they don't keep trying.
* This issue was found by an early tester who was rapidly resetting password.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show error message on too-many-attempts
```
