### PR TITLE
Deprecate old routing for resetPassword / verifyemail

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -230,13 +230,13 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/login/reset-password", loginController.HandleSubmitResetPassword()).Methods("POST")
 			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
 			sub.Handle("/login/manage-account", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("GET")
+				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("GET")
 			sub.Handle("/login/manage-account", loginController.HandleSubmitNewPassword()).
-				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("POST")
+				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("POST")
 			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("GET")
+				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("GET")
 			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
-				Queries("oobCode", "", "mode", "{resetPassword|recoverEmail}").Methods("POST")
+				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -228,14 +228,9 @@ func realMain(ctx context.Context) error {
 			sub.Handle("/", loginController.HandleLogin()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleShowResetPassword()).Methods("GET")
 			sub.Handle("/login/reset-password", loginController.HandleSubmitResetPassword()).Methods("POST")
-			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
 			sub.Handle("/login/manage-account", loginController.HandleShowSelectNewPassword()).
 				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("GET")
 			sub.Handle("/login/manage-account", loginController.HandleSubmitNewPassword()).
-				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("POST")
-			sub.Handle("/login/select-password", loginController.HandleShowSelectNewPassword()).
-				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("GET")
-			sub.Handle("/login/select-password", loginController.HandleSubmitNewPassword()).
 				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
@@ -259,10 +254,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(loadCurrentRealm)
 			sub.Use(requireRealm)
 			sub.Use(processFirewall)
-			// TODO(whaught): we can't customize separate links. Migrate to manage-account.
 			sub.Handle("/login/manage-account", loginController.HandleVerifyEmail()).
-				Queries("mode", "verifyEmail").Methods("GET")
-			sub.Handle("/login/select-password", loginController.HandleVerifyEmail()).
 				Queries("mode", "verifyEmail").Methods("GET")
 
 			// SMS auth registration is realm-specific, so it needs to load the current realm.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Minor change to the regex
    * Ensures the verifyEmail link goes to the right place
* Remove deprecated URLs