### PR TITLE
[WIP] Custom email verify page

### DIFF
--- a/cmd/server/assets/login/verify-email-check.html
+++ b/cmd/server/assets/login/verify-email-check.html
@@ -1,0 +1,32 @@
+{{define "login/verify-email-check"}}
+<!doctype html>
+<html lang="en">
+
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <div class="d-flex vh-100">
+      <div class="d-flex w-100 justify-content-center">
+        <div class="col-sm-6">
+
+          <div class="card mb-3 shadow-sm">
+            <div class="card-header">Email verification</div>
+            <div class="card-body">
+              <p>Email address ownership.</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+
+</html>
+{{end}}

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -234,6 +234,8 @@ func realMain(ctx context.Context) error {
 				Queries("oobCode", "", "mode", "{mode:(?:resetPassword|recoverEmail)}").Methods("POST")
 			sub.Handle("/session", loginController.HandleCreateSession()).Methods("POST")
 			sub.Handle("/signout", loginController.HandleSignOut()).Methods("GET")
+			sub.Handle("/login/manage-account", loginController.HandleSubmitVerifyEmail()).
+				Queries("oobCode", "{oobCode:.+}", "mode", "verifyEmail").Methods("GET")
 
 			// Realm selection & account settings
 			sub = r.PathPrefix("").Subrouter()
@@ -254,7 +256,7 @@ func realMain(ctx context.Context) error {
 			sub.Use(loadCurrentRealm)
 			sub.Use(requireRealm)
 			sub.Use(processFirewall)
-			sub.Handle("/login/manage-account", loginController.HandleVerifyEmail()).
+			sub.Handle("/login/manage-account", loginController.HandleShowVerifyEmail()).
 				Queries("mode", "verifyEmail").Methods("GET")
 
 			// SMS auth registration is realm-specific, so it needs to load the current realm.

--- a/pkg/controller/login/verify_email.go
+++ b/pkg/controller/login/verify_email.go
@@ -16,12 +16,15 @@
 package login
 
 import (
+	"errors"
 	"net/http"
 
+	"github.com/google/exposure-notifications-verification-server/internal/firebase"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/flash"
 )
 
-func (c *Controller) HandleVerifyEmail() http.Handler {
+func (c *Controller) HandleShowVerifyEmail() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -37,5 +40,47 @@ func (c *Controller) HandleVerifyEmail() http.Handler {
 		m := controller.TemplateMapFromContext(ctx)
 		m["firebase"] = c.config.Firebase
 		c.h.RenderHTML(w, "login/verify-email", m)
+	})
+}
+
+func (c *Controller) HandleSubmitVerifyEmail() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		session := controller.SessionFromContext(ctx)
+		flash := flash.New(session.Values)
+		m := controller.TemplateMapFromContext(ctx)
+		m["flash"] = flash
+
+		code := r.FormValue("oobCode")
+		if code == "" {
+			flash.Error("No oobCode.")
+			c.h.RenderHTML(w, "login/verify-email-check", m)
+			return
+		}
+
+		key := r.FormValue("apiKey")
+		if code == "" {
+			flash.Error("No apiKey.")
+			c.h.RenderHTML(w, "login/verify-email-check", m)
+			return
+		}
+
+		flash.Alert("code is %v", code)
+		flash.Alert("key is %v", key)
+
+		if err := c.firebaseInternal.VerifyEmailCode(ctx, code, key); err != nil {
+			if errors.Is(err, firebase.ErrInvalidOOBCode) || errors.Is(err, firebase.ErrExpiredOOBCode) {
+				flash.Error("The action code is invalid. This can happen if the code is malformed, expired, or has already been used.")
+				c.h.RenderHTML(w, "login/verify-email-check", m)
+			} else {
+				flash.Error("Error checking code. %v", err)
+				c.h.RenderHTML(w, "login/verify-email-check", m)
+			}
+			return
+		}
+
+		flash.Alert("Success.")
+
+		c.h.RenderHTML(w, "login/verify-email-check", m)
 	})
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Now that we've switched to a custom password-verify page, the firebase one is gone. It's all-or-nothing with the custom email links, so we need a custom email-verify too.

* I'm trying to use an internal API but get 'missing_local_id' from the API response. It doesn't appear to like our credential on the API call from the server (even with an API key attached).
    * We may have to go back to JS on the client for this call. Note: with the oobCode included that may be okay, this API doesn't leak details.
    * I also may have missed something here on my request. It looks like account:update is highly overloaded for many purposes.