### PR TITLE
Recreate firebase user, no metric

### DIFF
--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -43,9 +43,11 @@
           {{$user.CanAdminRealm $currentRealm.ID}}
         </div>
 
-        <button id="password-reset" class="btn btn-primary btn-block disabled">
-          Send password reset
-        </button>
+        <form class="floating-form" action="/users/{{$user.ID}}" method="POST">
+          {{ .csrfField }}
+          <input type="hidden" name="email" value="{{$user.Email}}"/>
+          <button type="password-reset" id="submit" class="btn btn-primary btn-block">Send password reset</button>
+        </form>
       </div>
     </div>
 
@@ -111,33 +113,6 @@
     }
   </script>
   {{end}}
-
-  <script type="text/javascript">
-  $(function() {
-    $resetPassword = $('#password-reset');
-    $resetPassword.removeClass('disabled');
-
-    $resetPassword.on('click', function(event) {
-      event.preventDefault();
-      sendReset(function() {
-        flash.alert(`Password reset email sent.`);
-      });
-    });
-
-    function sendReset(successFn) {
-      $resetPassword.addClass('disabled');
-      let email = {{$user.Email}};
-      return firebase.auth().sendPasswordResetEmail(email)
-      .then(function() {
-          setTimeout($resetPassword.addClass('disabled'), 10000);
-          successFn();
-      }).catch(function(error) {
-        $resetPassword.removeClass('disabled');
-        flash.error(error.message);
-      });
-    }
-  });
-  </script>
 </body>
 </html>
 {{end}}

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -56,6 +56,11 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 			return
 		}
 
+		// Ensure that if we have a user, they have auth
+		if user, err := c.db.FindUserByEmail(form.Email); err == nil {
+			user.CreateFirebaseUser(ctx, c.client)
+		}
+
 		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, strings.TrimSpace(form.Email)); err != nil {
 			if errors.Is(err, firebase.ErrTooManyAttempts) {
 				flash.Error("Too many attempts have been made. Please wait and try again later.")

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -81,16 +81,9 @@ func (c *Controller) HandleCreate() http.Handler {
 		}
 
 		// Create firebase user first, if this fails we don't want a db.User entry
-		if created, err := user.CreateFirebaseUser(ctx, c.client); err != nil {
-			flash.Alert("Failed to create user: %v", err)
+		if _, err := c.createFirebaseUser(ctx, user); err != nil {
 			c.renderNew(ctx, w)
 			return
-		} else if created {
-			if err := c.firebaseInternal.SendPasswordResetEmail(ctx, user.Email); err != nil {
-				flash.Error("Failed sending new user invitation: %v", err)
-				c.renderNew(ctx, w)
-				return
-			}
 		}
 
 		// Build the user struct

--- a/pkg/controller/user/reset_password.go
+++ b/pkg/controller/user/reset_password.go
@@ -50,7 +50,7 @@ func (c *Controller) maybeResetPassword(ctx context.Context, reset bool, user *d
 	// Reset if we just created or a reset was asked for.
 	if created || reset {
 		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, user.Email); err != nil {
-			flash.Error("Failed sending new user invitation: %v", err)
+			flash.Error("Could not send new user invitation: %v", err)
 			return true, err
 		}
 	}

--- a/pkg/controller/user/reset_password.go
+++ b/pkg/controller/user/reset_password.go
@@ -1,0 +1,58 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func (c *Controller) HandleResetPassword() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		c.Show(w, r, true)
+	})
+}
+
+func (c *Controller) resetPassword(ctx context.Context, user *database.User) (bool, error) {
+	return c.maybeResetPassword(ctx, true, user)
+}
+
+func (c *Controller) createFirebaseUser(ctx context.Context, user *database.User) (bool, error) {
+	return c.maybeResetPassword(ctx, false, user)
+}
+
+func (c *Controller) maybeResetPassword(ctx context.Context, reset bool, user *database.User) (bool, error) {
+	session := controller.SessionFromContext(ctx)
+	flash := controller.Flash(session)
+
+	// Ensure the firebase user is created
+	created, err := user.CreateFirebaseUser(ctx, c.client)
+	if err != nil {
+		flash.Alert("Failed to create user auth: %v", err)
+		return created, err
+	}
+
+	// Reset if we just created or a reset was asked for.
+	if created || reset {
+		if err := c.firebaseInternal.SendPasswordResetEmail(ctx, user.Email); err != nil {
+			flash.Error("Failed sending new user invitation: %v", err)
+			return true, err
+		}
+	}
+	return created, nil
+}

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -27,41 +27,52 @@ import (
 
 func (c *Controller) HandleShow() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-		vars := mux.Vars(r)
-
-		session := controller.SessionFromContext(ctx)
-		if session == nil {
-			controller.MissingSession(w, r, c.h)
-			return
-		}
-
-		realm := controller.RealmFromContext(ctx)
-		if realm == nil {
-			controller.MissingRealm(w, r, c.h)
-			return
-		}
-
-		// Pull the user from the id.
-		user, err := realm.FindUser(c.db, vars["id"])
-		if err != nil {
-			if database.IsNotFound(err) {
-				controller.Unauthorized(w, r, c.h)
-				return
-			}
-
-			controller.InternalError(w, r, c.h, err)
-			return
-		}
-
-		stats, err := c.getStats(ctx, user, realm)
-		if err != nil {
-			controller.InternalError(w, r, c.h, err)
-			return
-		}
-
-		c.renderShow(ctx, w, user, stats)
+		c.Show(w, r, false)
 	})
+}
+
+func (c *Controller) Show(w http.ResponseWriter, r *http.Request, resetPassword bool) {
+	ctx := r.Context()
+	vars := mux.Vars(r)
+
+	session := controller.SessionFromContext(ctx)
+	if session == nil {
+		controller.MissingSession(w, r, c.h)
+		return
+	}
+	flash := controller.Flash(session)
+
+	realm := controller.RealmFromContext(ctx)
+	if realm == nil {
+		controller.MissingRealm(w, r, c.h)
+		return
+	}
+
+	// Pull the user from the id.
+	user, err := realm.FindUser(c.db, vars["id"])
+	if err != nil {
+		if database.IsNotFound(err) {
+			controller.Unauthorized(w, r, c.h)
+			return
+		}
+
+		controller.InternalError(w, r, c.h, err)
+		return
+	}
+
+	if resetPassword {
+		if _, err := c.resetPassword(ctx, user); err == nil {
+			flash.Alert("Password reset email sent.")
+		}
+	}
+
+	userStats, err := c.getStats(ctx, user, realm)
+	if err != nil {
+		controller.InternalError(w, r, c.h, err)
+		return
+	}
+
+	c.renderShow(ctx, w, user, userStats)
 }
 
 // Get and cache the stats for this user.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* When resetting password, ensure that if we have a db.User that we also have a firebase user
* Move password-reset to server-side for Users/ page

**Note: ** This does send the user back through the email verification flow (which is currently bundled with our password-reset invitation and therefore not seen by most users)


_This PR fixes the issue without adding a metric. That will be done as a separate PR. See https://github.com/google/exposure-notifications-verification-server/pull/685_

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure that password-reset flows also check that the firebase user auth is created if it's missing and we have an entry for the user.
```
