### PR TITLE
Record metric for recreated firebase user

### DIFF
--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -1,0 +1,42 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import (
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+
+	enobservability "github.com/google/exposure-notifications-server/pkg/observability"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+const metricPrefix = observability.MetricRoot + "/server/login"
+
+var (
+	MFirebaseRecreates = stats.Int64(metricPrefix+"/fb_recreates", "firebase user recreates", stats.UnitDimensionless)
+)
+
+func init() {
+	enobservability.CollectViews([]*view.View{
+		{
+			Name:        metricPrefix + "/fb_recreate_count",
+			Measure:     MFirebaseRecreates,
+			Description: "The count of firebase user recreations",
+			TagKeys:     observability.CommonTagKeys(),
+			Aggregation: view.Count(),
+		},
+	}...)
+}

--- a/pkg/controller/user/reset_password.go
+++ b/pkg/controller/user/reset_password.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"go.opencensus.io/stats"
 )
 
 func (c *Controller) HandleResetPassword() http.Handler {
@@ -28,8 +29,12 @@ func (c *Controller) HandleResetPassword() http.Handler {
 	})
 }
 
-func (c *Controller) resetPassword(ctx context.Context, user *database.User) (bool, error) {
-	return c.maybeResetPassword(ctx, true, user)
+func (c *Controller) resetPassword(ctx context.Context, user *database.User) error {
+	created, err := c.maybeResetPassword(ctx, true, user)
+	if created {
+		stats.Record(ctx, controller.MFirebaseRecreates.M(1))
+	}
+	return err
 }
 
 func (c *Controller) createFirebaseUser(ctx context.Context, user *database.User) (bool, error) {

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -61,7 +61,7 @@ func (c *Controller) Show(w http.ResponseWriter, r *http.Request, resetPassword 
 	}
 
 	if resetPassword {
-		if _, err := c.resetPassword(ctx, user); err == nil {
+		if err := c.resetPassword(ctx, user); err == nil {
 			flash.Alert("Password reset email sent.")
 		}
 	}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Record a metric for recreating firebase users

There was some discussion on initializing metrics on:  https://github.com/google/exposure-notifications-verification-server/pull/685 with  the switch to openCensus sharing should be a non-issue as everything is handled in init()