### PR TITLE
Handle edge case when realm quota is first enabled

### DIFF
--- a/cmd/server/assets/realmadmin/_form_abuse_prevention.html
+++ b/cmd/server/assets/realmadmin/_form_abuse_prevention.html
@@ -31,14 +31,16 @@
   <div id="abuse-prevention-configuration" class="collapse{{if $realm.AbusePreventionEnabled}} show{{end}}">
     <div class="alert alert-primary" role="alert">
       Your current remaining daily quota is:
-      <small class="text-monospace">{{$quotaRemaining}}/{{$quotaLimit}}</small>. This value resets at
-      midnight UTC.
-
-      {{if gt $quotaRemaining $quotaLimit}}
-        If your remaining quota exceeds the maximum quota, it means a realm
-        administrator added a temporary burst.
-      {{end}}
+      <small class="text-monospace">{{$quotaRemaining}}/{{$quotaLimit}}</small>.
+      This value is calculated and reset each day at <strong>11:59:59 UTC</strong>.
     </div>
+
+    {{if gt $quotaRemaining $quotaLimit}}
+      <div class="alert alert-warning" role="alert">
+        Your remaining quota exceeds the maximum quota, meaning a realm
+        administrator added a temporary burst.
+      </div>
+    {{end}}
 
     <div class="form-label-group">
       <input type="text" name="abuse_prevention_limit" id="abuse-prevention-limit" class="form-control" placeholder="Computed limit" value="{{$realm.AbusePreventionLimit}}" readonly />

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -48,7 +48,7 @@ type AdminAPIServerConfig struct {
 
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
-	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=false"`
+	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	// For EN Express, the link will be
 	// https://[realm-region].[ENX_REDIRECT_DOMAIN]/v?c=[longcode]

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -77,7 +77,7 @@ type ServerConfig struct {
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
-	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=false"`
+	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
 

--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -35,6 +35,10 @@ import (
 	"go.uber.org/zap"
 )
 
+const (
+	oneWeek = 7 * 24 * time.Hour
+)
+
 // Controller is a controller for the modeler service.
 type Controller struct {
 	config  *config.Modeler
@@ -211,7 +215,7 @@ func (c *Controller) rebuildModel(ctx context.Context, id uint64) error {
 		return fmt.Errorf("failed to digest realm id: %w", err)
 	}
 	key := fmt.Sprintf("realm:quota:%s", dig)
-	if err := c.limiter.Set(ctx, key, uint64(effective), 24*time.Hour); err != nil {
+	if err := c.limiter.Set(ctx, key, uint64(effective), oneWeek); err != nil {
 		return fmt.Errorf("failed to update limit: %w", err)
 	}
 

--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -35,10 +35,6 @@ import (
 	"go.uber.org/zap"
 )
 
-const (
-	oneWeek = 7 * 24 * time.Hour
-)
-
 // Controller is a controller for the modeler service.
 type Controller struct {
 	config  *config.Modeler
@@ -215,7 +211,7 @@ func (c *Controller) rebuildModel(ctx context.Context, id uint64) error {
 		return fmt.Errorf("failed to digest realm id: %w", err)
 	}
 	key := fmt.Sprintf("realm:quota:%s", dig)
-	if err := c.limiter.Set(ctx, key, uint64(effective), oneWeek); err != nil {
+	if err := c.limiter.Set(ctx, key, uint64(effective), 24*time.Hour); err != nil {
 		return fmt.Errorf("failed to update limit: %w", err)
 	}
 


### PR DESCRIPTION
If realm quota is enabled and then someone "takes" from the bucket before the modeler runs, then the realm gets the default quota (which is low). Worse, it gets the default TTL (60s), which also isn't correct.

More comments inline in the code

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Handle edge case when realm quota is first enabled, enforce realm quota by default.
```
