### PR TITLE
Adding support for App Links, fallback to Play Store.

### DIFF
--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -141,7 +141,7 @@ func realMain(ctx context.Context) error {
 
 	r.Handle("/health", controller.HandleHealthz(ctx, nil, h)).Methods("GET")
 
-	redirectController, err := redirect.New(ctx, cfg, h)
+	redirectController, err := redirect.New(ctx, db, cfg, cacher, h)
 	if err != nil {
 		return err
 	}

--- a/pkg/controller/redirect/appstore.go
+++ b/pkg/controller/redirect/appstore.go
@@ -1,0 +1,54 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package redirect
+
+import (
+	"fmt"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+type AppStoreData struct {
+	AndroidURL string `json:"androidURL"`
+	IOSURL     string `json:"iosURL"`
+}
+
+// getAppStoreData finds data tied to app store listings.
+func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
+	// Pick first Android app (in the realm) for Play Store redirect.
+	androidURL := ""
+	androidApps, err := c.db.ListActiveAppsByOS(realmID, database.OSTypeAndroid)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get Android Apps: %w", err)
+	}
+	if len(androidApps) > 0 {
+		androidURL = androidApps[0].URL
+	}
+
+	// Pick first iOS app (in the realm) for Store redirect.
+	iosURL := ""
+	iosApps, err := c.db.ListActiveAppsByOS(realmID, database.OSTypeIOS)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get iOS Apps: %w", err)
+	}
+	if len(iosApps) > 0 {
+		iosURL = iosApps[0].URL
+	}
+
+	return &AppStoreData{
+		AndroidURL: androidURL,
+		IOSURL:     iosURL,
+	}, nil
+}

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -15,6 +15,7 @@
 package redirect
 
 import (
+	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
@@ -24,42 +25,115 @@ import (
 
 func (c *Controller) HandleIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
 
-		path := strings.ToLower(r.URL.RequestURI())
-		host := strings.ToLower(r.Host)
 		// Strip of the port if that was passed along in the host header.
-		if i := strings.Index(host, ":"); i > 0 {
-			host = host[0:i]
+		baseHost := strings.ToLower(r.Host)
+		if i := strings.Index(baseHost, ":"); i > 0 {
+			baseHost = baseHost[0:i]
 		}
 
+		var hostRegion string = ""
 		for hostname, region := range c.hostnameToRegion {
-			if host == hostname {
-				sendTo := buildURL(path, region)
-				http.Redirect(w, r, sendTo, http.StatusSeeOther)
-				return
+			if hostname == baseHost {
+				hostRegion = region
+				break
 			}
 		}
+		realm, err := c.db.FindRealmByRegion(hostRegion)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+		}
 
-		c.logger.Warnw("unknown host", "host", host)
-		ctx := r.Context()
+		// Get App Store Data.
+		cacheKey := fmt.Sprintf("appstoredata:by_region:%s", hostRegion)
+		var appStoreData AppStoreData
+		if err := c.cacher.Fetch(ctx, cacheKey, &appStoreData, c.config.AppCacheTTL, func() (interface{}, error) {
+			c.logger.Debug("fetching new app store data")
+			return c.getAppStoreData(realm.ID)
+		}); err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		if sendto, success := decideRedirect(hostRegion, r.UserAgent(), *r.URL, appStoreData); success {
+			http.Redirect(w, r, sendto, http.StatusSeeOther)
+			return
+		}
+
+		c.logger.Warnw("unknown host", "host", r.Host)
 		m := controller.TemplateMapFromContext(ctx)
 		m["requestURI"] = (&url.URL{
 			Scheme: "https",
-			Host:   host,
-			Path:   strings.TrimPrefix(path, "/"),
+			Host:   r.Host,
+			Path:   strings.TrimPrefix(r.URL.RequestURI(), "/"),
 		}).String()
 		c.h.RenderHTMLStatus(w, http.StatusNotFound, "404", m)
 	})
 }
 
-// buildURL returns the ens:// URL for the given path and region.
-func buildURL(path, region string) string {
+// isAndroid determines if a User-Agent is a Android device.
+func isAndroid(userAgent string) bool {
+	return strings.Contains(strings.ToLower(userAgent), "android")
+}
+
+// isIOS determines if a User-Agent is an iOS EN device.
+func isIOS(userAgent string) bool {
+	return strings.Contains(strings.ToLower(userAgent), "iphone")
+}
+
+// decideRedirect selects where to redirect based on several signals.
+func decideRedirect(region, userAgent string, url url.URL,
+	appStoreData AppStoreData) (string, bool) {
+	// Canonicalize path as lowercase.
+	path := strings.ToLower(url.Path)
+
+	// Check for browser type.
+	onAndroid := isAndroid(userAgent)
+	onIOS := isIOS(userAgent)
+
+	// A subset of SMS clients (e.g. Facebook Messenger) open links
+	// in inline WebViews without giving https Intents a opportunity
+	// to trigger App Links.
+	// Redirect to ourselves once to attempt to trigger the link.
+	// Bounce to self if we haven't already (on Android only).
+	// Keep track of state by including an extra bounce=1 url param.
+	if onAndroid && url.Query().Get("bounce") == "" {
+		q := url.Query()
+		q.Set("bounce", "1")
+		url.RawQuery = q.Encode()
+		return url.String(), true
+	}
+
+	// On Android redirect to Play Store if App Link doesn't trigger
+	// and an a link is set up.
+	if onAndroid && appStoreData.AndroidURL != "" {
+		return appStoreData.AndroidURL, true
+	}
+
+	// On iOS redirect to App Store if App Link doesn't trigger
+	// and an a link is set up.
+	if onIOS && appStoreData.IOSURL != "" {
+		return appStoreData.IOSURL, true
+	}
+
+	if onIOS || onAndroid {
+		return buildEnsURL(path, url.Query(), region), true
+	}
+
+	return "", false
+}
+
+// buildEnsURL returns the ens:// URL for the given path, query, and region.
+func buildEnsURL(path string, query url.Values, region string) string {
 	u := &url.URL{
 		Scheme: "ens",
 		Path:   strings.TrimPrefix(path, "/"),
 	}
+	u.RawQuery = query.Encode()
 	q := u.Query()
 	q.Set("r", region)
+	q.Del("bounce")
 	u.RawQuery = q.Encode()
 
 	return u.String()

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -14,14 +14,18 @@
 
 package redirect
 
-import "testing"
+import (
+	"net/url"
+	"testing"
+)
 
-func TestBuildURL(t *testing.T) {
+func TestBuildEnsURL(t *testing.T) {
 	t.Parallel()
 
 	cases := []struct {
 		name   string
 		path   string
+		query  url.Values
 		region string
 		exp    string
 	}{
@@ -49,6 +53,34 @@ func TestBuildURL(t *testing.T) {
 			region: "US-AA",
 			exp:    "ens://v/?r=US-AA",
 		},
+		{
+			name:   "includes_code",
+			path:   "v",
+			query:  url.Values{"c": []string{"1234567890abcdef"}},
+			region: "US-AA",
+			exp:    "ens://v?c=1234567890abcdef&r=US-AA",
+		},
+		{
+			name:   "includes_other",
+			path:   "v",
+			query:  url.Values{"foo": []string{"bar"}},
+			region: "US-AA",
+			exp:    "ens://v?foo=bar&r=US-AA",
+		},
+		{
+			name:   "replace_region",
+			path:   "v",
+			query:  url.Values{"r": []string{"US-XX"}},
+			region: "US-AA",
+			exp:    "ens://v?r=US-AA",
+		},
+		{
+			name:   "drop_bounce",
+			path:   "v",
+			query:  url.Values{"c": []string{"12345678"}, "bounce": []string{"123"}},
+			region: "US-AA",
+			exp:    "ens://v?c=12345678&r=US-AA",
+		},
 	}
 
 	for _, tc := range cases {
@@ -57,9 +89,195 @@ func TestBuildURL(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			got, want := buildURL(tc.path, tc.region), tc.exp
+			got, want := buildEnsURL(tc.path, tc.query, tc.region), tc.exp
 			if got != want {
 				t.Errorf("expected %q to be %q", got, want)
+			}
+		})
+	}
+}
+
+func TestAgentDetection(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name      string
+		userAgent string
+		android   bool
+		ios       bool
+	}{
+		{
+			name:      "android_chrome",
+			userAgent: "Mozilla/5.0 (Linux; Android 6.0.1; Nexus 6P Build/MMB29P) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/47.0.2526.83 Mobile Safari/537.36",
+			android:   true,
+			ios:       false,
+		},
+		{
+			name:      "android_webview",
+			userAgent: "Mozilla/5.0 (Linux; U; Android 2.2.1; en-us; Nexus One Build/FRG83) AppleWebKit/533.1 (KHTML, like Gecko) Version/4.0 Mobile Safari/533.1",
+			android:   true,
+			ios:       false,
+		},
+		{
+			name:      "iphone_safari",
+			userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Mobile/15E148 Safari/604.1",
+			android:   false,
+			ios:       true,
+		},
+		{
+			name:      "iphone_safari",
+			userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 13_3_1 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/13.0.5 Mobile/15E148 Safari/604.1",
+			android:   false,
+			ios:       true,
+		},
+		{
+			name:      "iphone_chrome",
+			userAgent: "Mozilla/5.0 (iPhone; CPU iPhone OS 10_3 like Mac OS X) AppleWebKit/602.1.50 (KHTML, like Gecko) CriOS/56.0.2924.75 Mobile/14E5239e Safari/602.1",
+			android:   false,
+			ios:       true,
+		},
+		{
+			name:      "windows_chrome",
+			userAgent: "Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/69.0.3497.100 Safari/537.36",
+			android:   false,
+			ios:       false,
+		},
+		{
+			name:      "ipad_safari",
+			userAgent: "Mozilla/5.0 (iPad; CPU OS 11_3 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/11.0 Mobile/15E148 Safari/604.1",
+			android:   false,
+			// For ENX purposes exclude iPad as it's unsupported.
+			ios: false,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			onAndroid := isAndroid(tc.userAgent)
+			onIOS := isIOS(tc.userAgent)
+			if onAndroid != tc.android || onIOS != tc.ios {
+				t.Errorf("expected android=%t ios=%t, got android=%t ios=%t", tc.android, tc.ios, onAndroid, onIOS)
+			}
+		})
+	}
+}
+
+func TestDecideRedirect(t *testing.T) {
+	t.Parallel()
+
+	appLinkBoth := AppStoreData{
+		AndroidURL: "https://android.example.com/store/moosylvania",
+		IOSURL:     "https://ios.example.com/store/moosylvania",
+	}
+	appLinkOnlyAndroid := AppStoreData{
+		AndroidURL: "https://android.example.com/store/moosylvania",
+		IOSURL:     "",
+	}
+	appLinkNeither := AppStoreData{
+		AndroidURL: "",
+		IOSURL:     "",
+	}
+
+	userAgentAndroid := "Android"
+	userAgentIOS := "iPhone"
+	userAgentNeither := "Neither"
+
+	relativePinURL := url.URL{
+		Path: "/v",
+	}
+	q := relativePinURL.Query()
+	q.Set("c", "1234567890abcdef")
+	relativePinURL.RawQuery = q.Encode()
+
+	cases := []struct {
+		name         string
+		host         string
+		url          string
+		altURL       *url.URL
+		userAgent    string
+		appStoreData *AppStoreData
+		expected     string
+	}{
+		{
+			name:         "moosylvania_android_pre_bounce",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkBoth,
+			expected:     "https://moosylvania.gov/v?bounce=1&c=1234567890abcdef",
+		},
+		{
+			name:         "moosylvania_android_post_bounce",
+			url:          "https://moosylvania.gov/v?bounce=1&c=1234567890abcdef",
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkBoth,
+			expected:     "https://android.example.com/store/moosylvania",
+		},
+		{
+			name:         "moosylvania_android_pre_bounce_relative",
+			altURL:       &relativePinURL,
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkBoth,
+			expected:     "/v?bounce=1&c=1234567890abcdef",
+		},
+		{
+			name:         "moosylvania_android_no_applink_pre_bounce",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkNeither,
+			expected:     "https://moosylvania.gov/v?bounce=1&c=1234567890abcdef",
+		},
+		{
+			name:         "moosylvania_android_no_applink_post_bounce",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef&bounce=1",
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkNeither,
+			expected:     "ens://v?c=1234567890abcdef&r=US-MOO",
+		},
+		{
+			name:         "moosylvania_ios_no_applink",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			userAgent:    userAgentIOS,
+			appStoreData: &appLinkOnlyAndroid,
+			expected:     "ens://v?c=1234567890abcdef&r=US-MOO",
+		},
+		{
+			name:         "moosylvania_ios_no_applink",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			userAgent:    userAgentIOS,
+			appStoreData: &appLinkBoth,
+			expected:     "https://ios.example.com/store/moosylvania",
+		},
+		{
+			name:         "moosylvania_windows",
+			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			userAgent:    userAgentNeither,
+			appStoreData: &appLinkOnlyAndroid,
+			expected:     "",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			url := tc.altURL
+			if url == nil {
+				otherURL, err := url.Parse(tc.url)
+				if err != nil {
+					t.Errorf("invalid url %s", tc.url)
+				}
+				url = otherURL
+			}
+			result, success := decideRedirect("US-MOO", tc.userAgent, *url, *tc.appStoreData)
+			if tc.expected != result {
+				t.Errorf("expected %s, got %s", tc.expected, result)
+			}
+			if (tc.expected != "") != success {
+				t.Errorf("expected doesn't match success")
 			}
 		})
 	}

--- a/pkg/controller/redirect/redirect.go
+++ b/pkg/controller/redirect/redirect.go
@@ -19,23 +19,28 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"go.uber.org/zap"
 )
 
 type Controller struct {
 	config           *config.RedirectConfig
+	cacher           cache.Cacher
+	db               *database.Database
 	h                *render.Renderer
 	logger           *zap.SugaredLogger
 	hostnameToRegion map[string]string
 }
 
-// New creates a new login controller.
-func New(ctx context.Context, config *config.RedirectConfig, h *render.Renderer) (*Controller, error) {
+// New creates a new redirect controller.
+func New(ctx context.Context, db *database.Database, config *config.RedirectConfig, cacher cache.Cacher, h *render.Renderer) (*Controller, error) {
 	logger := logging.FromContext(ctx).Named("login")
 
 	cfgMap, err := config.HostnameToRegion()
@@ -46,6 +51,8 @@ func New(ctx context.Context, config *config.RedirectConfig, h *render.Renderer)
 
 	return &Controller{
 		config:           config,
+		db:               db,
+		cacher:           cacher,
 		h:                h,
 		logger:           logger,
 		hostnameToRegion: cfgMap,

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -172,7 +172,7 @@ func realMain(ctx context.Context) error {
 		{
 			Name:    "Example iOS app",
 			RealmID: realm1.ID,
-			URL:     "http://apple.com",
+			URL:     "",
 			OS:      database.OSTypeIOS,
 			AppID:   "ios.example.app",
 		},


### PR DESCRIPTION
Redirector will first redirect to itself,
on Android adding bounce=1 to ensure app link has a chance
to trigger.

iOS is also supported, but for now assuming it doesn't need
the extra bounce.

When an App Link is not configured for a platform,
continue to fall back to ens://

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Apps that can support app links should now configure a store URL.
```
