### PR TITLE
List recent codes on code-status page

### DIFF
--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -24,7 +24,7 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Code status</div>
       <div class="card-body">
-        <form method="POST" action="show" class="floating-form">
+        <form method="POST" id="code-form" action="show" class="floating-form">
           {{ .csrfField }}
           <div class="form-group">
             <div class="form-label-group ">
@@ -43,17 +43,36 @@
             </div>
           </div>
 
-          <button id="submit" class="btn btn-primary btn-block">Check status</button>
+          <button class="btn btn-primary btn-block">Check status</button>
         </form>
+      </div>
+    </div>
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Recently issued codes</div>
+      <div class="card-body">
+        <div class="list-group">
+          {{range $code := .recentCodes}}
+          <a class="list-group-item list-group-item-action" onclick="clickCode('{{$code.UUID}}')">
+            {{$code.UUID}}
+            <small class="form-text text-muted">
+              Created at: {{$code.CreatedAt}}
+            </small>
+          </a>
+          {{end}}
+        </div>
       </div>
     </div>
   </main>
 
   {{template "scripts" .}}
   <script type="text/javascript">
+    let $uuid
+    let $form
 
     $(function() {
-      let $uuid = $('#uuid');
+      $uuid = $('#uuid');
+      $form = $('#code-form');
       let allowedChars = new RegExp("[0-9a-fA-F]");
       let dashLocations = [8, 13, 18, 23];
 
@@ -73,6 +92,11 @@
         $uuid.val(r);
       });
     });
+
+    function clickCode(uuid) {
+      $uuid.val(uuid);
+      $form.submit();
+    }
   </script>
 </body>
 

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -145,7 +145,7 @@ func (db *Database) ClaimToken(realmID uint, tokenID string, subject *Subject) e
 	})
 }
 
-// VerifyCodeAndIssueToken takes a previously issed verification code and exchanges
+// VerifyCodeAndIssueToken takes a previously issued verification code and exchanges
 // it for a long term token. The verification code must not have expired and must
 // not have been previously used. Both acctions are done in a single database
 // transaction.


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/232

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

Show a few (5) recently issued codes on the code-status page

* TODO: change code status page to GET, make links real links instead of JS filling the form
* TODO: consider indexing this query
* TODO: clean up the date format

![listcodes](https://user-images.githubusercontent.com/36240966/95368613-335ad800-088b-11eb-9c57-41887bd2844b.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show a list of recent codes on the code-status page
```
