### PR TITLE
Add a /request metric with blame/result field.

### DIFF
--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -28,6 +28,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/jwthelper"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"go.opencensus.io/stats"
+	"go.opencensus.io/tag"
 
 	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
@@ -36,11 +37,21 @@ func (c *Controller) HandleCertificate() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := observability.WithBuildInfo(r.Context())
 
+		var blame = controller.BlameNone
+		var result = controller.APIResultOK()
+
+		defer func() {
+			mutators := []tag.Mutator{blame, result}
+			stats.RecordWithTags(ctx, mutators, mRequest.M(1))
+		}()
+
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.logger.Errorf("missing authorized app")
 			controller.MissingAuthorizedApp(w, r, c.h)
+			blame = controller.BlameClient
+			result = controller.APIResultError("MISSING_AUTHORIZED_APP")
 			return
 		}
 
@@ -55,6 +66,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 			if err != nil {
 				c.logger.Errorw("failed to get public key", "error", err)
 				c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
+				blame = controller.BlameServer
+				result = controller.APIResultError("FAILED_TO_GET_PUBLIC_KEY")
 				return
 			}
 			allowedPublicKeys[kid] = publicKey
@@ -65,6 +78,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 			c.logger.Errorw("failed to parse json request", "error", err)
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenInvalid))
+			blame = controller.BlameClient
+			result = controller.APIResultError("FAILED_TO_PARSE_JSON_REQUEST")
 			return
 		}
 
@@ -73,6 +88,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 		if err != nil {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenInvalid))
+			blame = controller.BlameClient
+			result = controller.APIResultError("FAILED_TO_VALIDATE_TOKEN")
 			return
 		}
 
@@ -82,12 +99,16 @@ func (c *Controller) HandleCertificate() http.Handler {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest,
 				api.Errorf("exposure key HMAC is not a valid base64: %v", err).WithCode(api.ErrHMACInvalid))
+			blame = controller.BlameClient
+			result = controller.APIResultError("FAILED_TO_DECODE_HMAC")
 			return
 		}
 		if len(hmacBytes) != 32 {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest,
 				api.Errorf("exposure key HMAC is not the correct length, want: 32 got: %v", len(hmacBytes)).WithCode(api.ErrHMACInvalid))
+			blame = controller.BlameClient
+			result = controller.APIResultError("INVALID_HMAC_LENGTH")
 			return
 		}
 
@@ -97,6 +118,9 @@ func (c *Controller) HandleCertificate() http.Handler {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.logger.Errorw("failed to get signer", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.InternalError())
+			// FIXME: should we blame server here?
+			blame = controller.BlameServer
+			result = controller.APIResultError("FAILED_TO_GET_SIGNER")
 			return
 		}
 
@@ -123,6 +147,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 			stats.Record(ctx, mCertificateErrors.M(1))
 			c.logger.Errorw("failed to sign certificate", "error", err)
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrInternal))
+			blame = controller.BlameServer
+			result = controller.APIResultError("FAILED_TO_SIGN_JWT")
 			return
 		}
 
@@ -130,19 +156,24 @@ func (c *Controller) HandleCertificate() http.Handler {
 		// client can retry.
 		if err := c.db.ClaimToken(authApp.RealmID, tokenID, subject); err != nil {
 			c.logger.Errorw("failed to claim token", "tokenID", tokenID, "error", err)
+			blame = controller.BlameClient
 			switch {
 			case errors.Is(err, database.ErrTokenExpired):
 				stats.Record(ctx, mTokenExpired.M(1), mCertificateErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrTokenExpired))
+				result = controller.APIResultError("TOKEN_EXPIRED")
 			case errors.Is(err, database.ErrTokenUsed):
 				stats.Record(ctx, mTokenUsed.M(1), mCertificateErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
+				result = controller.APIResultError("TOKEN_USED")
 			case errors.Is(err, database.ErrTokenMetadataMismatch):
 				stats.Record(ctx, mTokenInvalid.M(1), mCertificateErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("verification token invalid").WithCode(api.ErrTokenExpired))
+				result = controller.APIResultError("TOKEN_METADATA_MISMATCH")
 			default:
 				stats.Record(ctx, mTokenInvalid.M(1), mCertificateErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+				result = controller.APIResultError("UNKNOWN_TOKEN_CLAIM_ERROR")
 			}
 			return
 		}

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -43,7 +43,8 @@ func (c *Controller) HandleCertificate() http.Handler {
 		defer func(blame, result *tag.Mutator) {
 			ctx, err := tag.New(ctx, *blame, *result)
 			if err != nil {
-				c.logger.Errorw("failed to create context with additional tags", "error", err)
+				c.logger.Warnw("failed to create context with additional tags", "error", err)
+				// NOTE: do not return here. We should log it as success.
 			}
 			stats.Record(ctx, mRequest.M(1))
 		}(&blame, &result)

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -40,10 +40,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		var blame = controller.BlameNone
 		var result = controller.APIResultOK()
 
-		defer func() {
-			mutators := []tag.Mutator{blame, result}
-			stats.RecordWithTags(ctx, mutators, mRequest.M(1))
-		}()
+		defer stats.RecordWithTags(ctx, []tag.Mutator{blame, result}, mRequest.M(1))
 
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {

--- a/pkg/controller/certapi/metrics.go
+++ b/pkg/controller/certapi/metrics.go
@@ -15,7 +15,6 @@
 package certapi
 
 import (
-	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 
 	enobservability "github.com/google/exposure-notifications-server/pkg/observability"
@@ -85,7 +84,7 @@ func init() {
 			Name:        metricPrefix + "/request_count",
 			Measure:     mAttempts,
 			Description: "The count of certificate issue requests",
-			TagKeys:     controller.APITagKeys(),
+			TagKeys:     observability.APITagKeys(),
 			Aggregation: view.Count(),
 		},
 	}...)

--- a/pkg/controller/certapi/metrics.go
+++ b/pkg/controller/certapi/metrics.go
@@ -15,6 +15,7 @@
 package certapi
 
 import (
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 
 	enobservability "github.com/google/exposure-notifications-server/pkg/observability"
@@ -32,6 +33,8 @@ var (
 	mTokenInvalid      = stats.Int64(metricPrefix+"/invalid_token", "invalid tokens on certificate issue", stats.UnitDimensionless)
 	mCertificateIssued = stats.Int64(metricPrefix+"/issue", "certificates issued", stats.UnitDimensionless)
 	mCertificateErrors = stats.Int64(metricPrefix+"/errors", "certificate issue errors", stats.UnitDimensionless)
+
+	mRequest = stats.Int64(metricPrefix+"/request", "# of certificate issue requests", stats.UnitDimensionless)
 )
 
 func init() {
@@ -76,6 +79,13 @@ func init() {
 			Measure:     mCertificateErrors,
 			Description: "The count of certificate issue errors",
 			TagKeys:     observability.CommonTagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/request_count",
+			Measure:     mAttempts,
+			Description: "The count of certificate issue requests",
+			TagKeys:     controller.APITagKeys(),
 			Aggregation: view.Count(),
 		},
 	}...)

--- a/pkg/controller/certapi/metrics.go
+++ b/pkg/controller/certapi/metrics.go
@@ -82,7 +82,7 @@ func init() {
 		},
 		{
 			Name:        metricPrefix + "/request_count",
-			Measure:     mAttempts,
+			Measure:     mRequest,
 			Description: "The count of certificate issue requests",
 			TagKeys:     observability.APITagKeys(),
 			Aggregation: view.Count(),

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -59,7 +59,7 @@ var (
 	BlameServer = tag.Upsert(tagBlame, "SERVER")
 
 	// BlameExternal indicate some third party is at fault
-	BlameExternal = tag.Upsert(tagBlame, "SERVER")
+	BlameExternal = tag.Upsert(tagBlame, "EXTERNAL")
 
 	// BlameUnknown can be used for everything else
 	BlameUnknown = tag.Upsert(tagBlame, "UNKOWN")

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -21,7 +21,6 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
-	"go.opencensus.io/tag"
 )
 
 const metricPrefix = observability.MetricRoot + "/server/login"
@@ -29,57 +28,6 @@ const metricPrefix = observability.MetricRoot + "/server/login"
 var (
 	MFirebaseRecreates = stats.Int64(metricPrefix+"/fb_recreates", "firebase user recreates", stats.UnitDimensionless)
 )
-
-var (
-	// tagBlame indicating Who to blame for the API request failure.
-	// NONE: no failure
-	// CLIENT: the client is at fault (e.g. invalid request)
-	// SERVER: the server is at fault
-	// EXTERNAL: some third party is at fault
-	// UNKNOWN: for everything else
-	tagBlame = tag.MustNewKey("blame")
-
-	// tagResult contains a free format text describing the result of the
-	// request. Preferrably ALL CAPS WITH UNDERSCORE.
-	// OK indicating a successful request.
-	// You can losely base this string on
-	// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
-	// but feel free to use any text as long as it's easy to filter.
-	tagResult = tag.MustNewKey("result")
-)
-
-var (
-	// BlameNone indicate no API failure
-	BlameNone = tag.Upsert(tagBlame, "NONE")
-
-	// BlameClient indicate the client is at fault (e.g. invalid request)
-	BlameClient = tag.Upsert(tagBlame, "CLIENT")
-
-	// BlameServer indicate the server is at fault
-	BlameServer = tag.Upsert(tagBlame, "SERVER")
-
-	// BlameExternal indicate some third party is at fault
-	BlameExternal = tag.Upsert(tagBlame, "EXTERNAL")
-
-	// BlameUnknown can be used for everything else
-	BlameUnknown = tag.Upsert(tagBlame, "UNKOWN")
-)
-
-// APIResultOK add a tag indicating the API call is a success.
-func APIResultOK() tag.Mutator {
-	return tag.Upsert(tagResult, "OK")
-}
-
-// APIResultError add a tag with the given string as the result.
-func APIResultError(result string) tag.Mutator {
-	return tag.Upsert(tagResult, result)
-}
-
-// APITagKeys return a slice of tag.Key with common tag keys + additional API
-// specific tag keys.
-func APITagKeys() []tag.Key {
-	return append(observability.CommonTagKeys(), tagBlame, tagResult)
-}
 
 func init() {
 	enobservability.CollectViews([]*view.View{

--- a/pkg/controller/metrics.go
+++ b/pkg/controller/metrics.go
@@ -21,6 +21,7 @@ import (
 
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
+	"go.opencensus.io/tag"
 )
 
 const metricPrefix = observability.MetricRoot + "/server/login"
@@ -28,6 +29,57 @@ const metricPrefix = observability.MetricRoot + "/server/login"
 var (
 	MFirebaseRecreates = stats.Int64(metricPrefix+"/fb_recreates", "firebase user recreates", stats.UnitDimensionless)
 )
+
+var (
+	// tagBlame indicating Who to blame for the API request failure.
+	// NONE: no failure
+	// CLIENT: the client is at fault (e.g. invalid request)
+	// SERVER: the server is at fault
+	// EXTERNAL: some third party is at fault
+	// UNKNOWN: for everything else
+	tagBlame = tag.MustNewKey("blame")
+
+	// tagResult contains a free format text describing the result of the
+	// request. Preferrably ALL CAPS WITH UNDERSCORE.
+	// OK indicating a successful request.
+	// You can losely base this string on
+	// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
+	// but feel free to use any text as long as it's easy to filter.
+	tagResult = tag.MustNewKey("result")
+)
+
+var (
+	// BlameNone indicate no API failure
+	BlameNone = tag.Upsert(tagBlame, "NONE")
+
+	// BlameClient indicate the client is at fault (e.g. invalid request)
+	BlameClient = tag.Upsert(tagBlame, "CLIENT")
+
+	// BlameServer indicate the server is at fault
+	BlameServer = tag.Upsert(tagBlame, "SERVER")
+
+	// BlameExternal indicate some third party is at fault
+	BlameExternal = tag.Upsert(tagBlame, "SERVER")
+
+	// BlameUnknown can be used for everything else
+	BlameUnknown = tag.Upsert(tagBlame, "UNKOWN")
+)
+
+// APIResultOK add a tag indicating the API call is a success.
+func APIResultOK() tag.Mutator {
+	return tag.Upsert(tagResult, "OK")
+}
+
+// APIResultError add a tag with the given string as the result.
+func APIResultError(result string) tag.Mutator {
+	return tag.Upsert(tagResult, result)
+}
+
+// APITagKeys return a slice of tag.Key with common tag keys + additional API
+// specific tag keys.
+func APITagKeys() []tag.Key {
+	return append(observability.CommonTagKeys(), tagBlame, tagResult)
+}
 
 func init() {
 	enobservability.CollectViews([]*view.View{

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -38,7 +38,7 @@ var (
 	blameTagKey = tag.MustNewKey("blame")
 
 	// resultTagKey contains a free format text describing the result of the
-	// request. Preferrably ALL CAPS WITH UNDERSCORE.
+	// request. Preferably ALL CAPS WITH UNDERSCORE.
 	// OK indicating a successful request.
 	// You can losely base this string on
 	// https://github.com/googleapis/googleapis/blob/master/google/rpc/code.proto
@@ -60,7 +60,7 @@ var (
 	BlameExternal = tag.Upsert(blameTagKey, "EXTERNAL")
 
 	// BlameUnknown can be used for everything else
-	BlameUnknown = tag.Upsert(blameTagKey, "UNKOWN")
+	BlameUnknown = tag.Upsert(blameTagKey, "UNKNOWN")
 )
 
 // APIResultOK add a tag indicating the API call is a success.


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/773

The new metric will eventually replace all other metrics under /api/certificate.