### PR TITLE
Client-side password-reset

### DIFF
--- a/cmd/server/assets/firebase.html
+++ b/cmd/server/assets/firebase.html
@@ -1,4 +1,5 @@
 {{define "firebase"}}
+{{- if .firebase}}
 <script src="https://www.gstatic.com/firebasejs/7.18.0/firebase-app.js"></script>
 <script src="https://www.gstatic.com/firebasejs/7.18.0/firebase-auth.js"></script>
 <script src="https://cdn.firebase.com/libs/firebaseui/3.5.2/firebaseui.js"></script>
@@ -17,4 +18,5 @@
   };
   firebase.initializeApp(firebaseConfig);
 </script>
+{{end}}
 {{end}}

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -58,10 +58,10 @@
       .then(function() {
         flash.clear();
         flash.alert('Password reset email sent.');
+        $('#submit').prop('disabled', true);
       }).catch(function(error) {
         flash.clear();
         flash.error(error.message);
-        $('#submit').prop('disabled', true);
       });
     });
     {{end}}

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -60,12 +60,8 @@
         flash.alert('Password reset email sent.');
       }).catch(function(error) {
         flash.clear();
-        if (error.code == "auth/user-not-found") {
-          flash.alert('Password reset email sent.');
-        } else {
-          flash.error(error.message);
-          $submit.prop('disabled', true);
-        }
+        flash.error(error.message);
+        $('#submit').prop('disabled', true);
       });
     });
     {{end}}

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -60,6 +60,9 @@
         flash.alert('Password reset email sent.');
         $('#submit').prop('disabled', true);
       }).catch(function(error) {
+        if (error.code == "auth/too-many-requests") {
+          $('#submit').prop('disabled', true);
+        }
         flash.clear();
         flash.error(error.message);
       });

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -5,6 +5,7 @@
 <head>
   {{template "floatingform" .}}
   {{template "head" .}}
+  {{template "firebase" .}}
 </head>
 
 <body class="tab-content">
@@ -28,8 +29,8 @@
               <form class="floating-form" action="/login/reset-password" method="POST">
                 {{ .csrfField }}
                 <div class="form-label-group mb-2">
-                  <input type="email" name="email" class="form-control" placeholder="Email address" required
-                    autofocus />
+                  <input type="email" name="email" class="form-control" placeholder="Email address"
+                  {{if .email}}value="{{.email}}"{{end}} required autofocus />
                   <label for="email">Email address</label>
                   <small class="form-text text-muted">
                     A reset link will be sent to this address.
@@ -52,7 +53,22 @@
       $('#submit').on('submit', function(event) {
         return window.confirm("Are you sure you want to reset your password?");
       });
+    {{if .firebase}}
+      firebase.auth().sendPasswordResetEmail({{.email}})
+      .then(function() {
+        flash.clear();
+        flash.alert('Password reset email sent.');
+      }).catch(function(error) {
+        flash.clear();
+        if (error.code == "auth/user-not-found") {
+          flash.alert('Password reset email sent.');
+        } else {
+          flash.error(error.message);
+          $submit.prop('disabled', true);
+        }
+      });
     });
+    {{end}}
   </script>
 </body>
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Sends the password-reset email from the client
    * Should allow for better attribution for IP-based rate-limiting
    * Difference from pre- https://github.com/google/exposure-notifications-verification-server/pull/668 is that we go to the server first to confirm that the user exists and has a firebase account created before responding with firebase details.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Move firebase password reset to the client
```
