### PR TITLE
Show code createdAt in local time

### DIFF
--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -50,12 +50,12 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Recently issued codes</div>
       <div class="card-body">
-        <div class="list-group">
+        <div class="list-group" id="recent-codes">
           {{range $code := .recentCodes}}
           <a href="/code/show/{{$code.UUID}}" class="list-group-item list-group-item-action">
             {{$code.UUID}}
             <small class="form-text text-muted">
-              Created at: {{$code.CreatedAt.Format "Mon Jan 02 15:04:05 MST"}}
+              Created at: {{$code.CreatedAt}}
             </small>
           </a>
           {{end}}
@@ -72,6 +72,12 @@
 
       let allowedChars = new RegExp("[0-9a-fA-F]");
       let dashLocations = [8, 13, 18, 23];
+
+      $('#recent-codes').children('a').each(function () {
+        let $dateText = $(this).find('small');
+        let date = new Date($dateText.text());
+        $dateText.text(date.toString());
+      });
 
       $uuid.on('keyup', function() {
         let s = $uuid.val();

--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -55,7 +55,7 @@
           <a href="/code/show/{{$code.UUID}}" class="list-group-item list-group-item-action">
             {{$code.UUID}}
             <small class="form-text text-muted">
-              Created at: {{$code.CreatedAt}}
+              Created at: {{$code.CreatedAt.Format "Mon Jan 02 15:04:05 MST"}}
             </small>
           </a>
           {{end}}

--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -50,12 +50,14 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Recently issued codes</div>
       <div class="card-body">
-        <div class="list-group" id="recent-codes">
+        <div class="list-group">
           {{range $code := .recentCodes}}
           <a href="/code/show/{{$code.UUID}}" class="list-group-item list-group-item-action">
-            {{$code.UUID}}
-            <small class="form-text text-muted">
-              Created at: {{$code.CreatedAt}}
+            {{$code.UUID}}<br />
+            <small
+              data-timestamp="{{$code.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}"
+              data-toggle="tooltip" title="{{$code.CreatedAt.Format "2006-02-01 15:04 UTC"}}">
+              {{$code.CreatedAt.Format "2006-02-01 15:04"}}
             </small>
           </a>
           {{end}}
@@ -72,12 +74,6 @@
 
       let allowedChars = new RegExp("[0-9a-fA-F]");
       let dashLocations = [8, 13, 18, 23];
-
-      $('#recent-codes').children('a').each(function () {
-        let $dateText = $(this).find('small');
-        let date = new Date($dateText.text());
-        $dateText.text(date.toString());
-      });
 
       $uuid.on('keyup', function() {
         let s = $uuid.val();


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/232

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Server sends createdAt in UTC, now we interpret them on the client in javascript and replace them in local time
    * Should be a little user-friendlier

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show code created time in local timezone
```
