### PR TITLE
Move password-reset to the client for users/show in admin

### DIFF
--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -53,8 +53,8 @@
       $('#submit').on('submit', function(event) {
         return window.confirm("Are you sure you want to reset your password?");
       });
-    {{if .firebase}}
-      firebase.auth().sendPasswordResetEmail({{.email}})
+      {{if .firebase}}
+      firebase.auth().sendPasswordResetEmail('{{.email}}')
       .then(function() {
         flash.clear();
         flash.alert('Password reset email sent.');
@@ -66,8 +66,8 @@
         flash.clear();
         flash.error(error.message);
       });
+      {{end}}
     });
-    {{end}}
   </script>
 </body>
 

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -89,8 +89,8 @@
   {{template "scripts" .}}
 
   {{if $stats}}
-  <script src="https://www.gstatic.com/charts/loader.js"></script>
-  <script>
+  <script src="https://www.gstatic.com/charts/loader.js" type="text/javascript"></script>
+  <script type="text/javascript">
     google.charts.load('current', {packages: ['line']});
     google.charts.setOnLoadCallback(drawChart)
 
@@ -111,6 +111,25 @@
       var chart = new google.charts.Line(document.getElementById('chart'));
       chart.draw(data, google.charts.Line.convertOptions(options));
     }
+  </script>
+  {{end}}
+
+  {{if .firebase}}
+  <script type="text/javascript">
+  $(function() {
+    firebase.auth().sendPasswordResetEmail('{{$user.Email}}')
+    .then(function() {
+      flash.clear();
+      flash.alert('Password reset email sent.');
+      $('#submit').prop('disabled', true);
+    }).catch(function(error) {
+      if (error.code == "auth/too-many-requests") {
+        $('#submit').prop('disabled', true);
+      }
+      flash.clear();
+      flash.error(error.message);
+    });
+  });
   </script>
   {{end}}
 </body>

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -378,6 +378,7 @@ func realMain(ctx context.Context) error {
 		userSub.Handle("/{id}", userController.HandleShow()).Methods("GET")
 		userSub.Handle("/{id}", userController.HandleUpdate()).Methods("PATCH")
 		userSub.Handle("/{id}", userController.HandleDelete()).Methods("DELETE")
+		userSub.Handle("/{id}", userController.HandleResetPassword()).Methods("POST")
 	}
 
 	// realms

--- a/internal/firebase/password_reset_email.go
+++ b/internal/firebase/password_reset_email.go
@@ -29,10 +29,14 @@ type sendPasswordResetEmailRequest struct {
 	Email       string `json:"email"`
 }
 
-// SendPasswordResetEmail sends a password reset email to the user.
+// SendNewUserInvitation sends a password reset email to the user.
+//
+// TODO(whaught): we're heading towards deprecating this in favor of directly sending our own email
+// this currently sends password-reset and needs to be sending an invitation, but also may
+// face rate-limiting on the firebase side if called too quickly.
 //
 // See: https://firebase.google.com/docs/reference/rest/auth#section-send-password-reset-email
-func (c *Client) SendPasswordResetEmail(ctx context.Context, email string) error {
+func (c *Client) SendNewUserInvitation(ctx context.Context, email string) error {
 	r := &sendPasswordResetEmailRequest{
 		RequestType: "PASSWORD_RESET",
 		Email:       email,

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -81,7 +81,7 @@ func (c *Controller) HandleCreate() http.Handler {
 		}
 
 		// Create firebase user first, if this fails we don't want a db.User entry
-		if _, err := c.createFirebaseUser(ctx, user); err != nil {
+		if _, err := c.ensureFirebaseUserExists(ctx, user); err != nil {
 			c.renderNew(ctx, w)
 			return
 		}
@@ -106,7 +106,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			return
 		}
 
-		c.renderShow(ctx, w, user, stats)
+		c.renderShow(ctx, w, user, stats, false /*resetPassword*/)
 	})
 }
 

--- a/pkg/controller/user/importbatch.go
+++ b/pkg/controller/user/importbatch.go
@@ -73,7 +73,7 @@ func (c *Controller) HandleImportBatch() http.Handler {
 				continue
 			} else if created {
 				newUsers = append(newUsers, &batchUser)
-				if err := c.firebaseInternal.SendPasswordResetEmail(ctx, user.Email); err != nil {
+				if err := c.firebaseInternal.SendNewUserInvitation(ctx, user.Email); err != nil {
 					batchErr = multierror.Append(batchErr, err)
 					continue
 				}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Move the password-reset send to the client from the users page
* Change the name of firebase/internal  SendPasswordResetEmail to SendNewUserInvite with a note about its current and future usage
* Fix a few javascript nits

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Move the send-password-reset email to the client for admin users
```
