### PR TITLE
Add log errors for e2e fail

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -184,10 +184,12 @@ func defaultHandler(ctx context.Context, c *config.E2ETestConfig) func(http.Resp
 	return func(w http.ResponseWriter, r *http.Request) {
 		c.DoRevise = false
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
+			log.Errorw("could not run default end to end", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
-		} else {
-			fmt.Fprint(w, "ok")
+			return
 		}
+
+		fmt.Fprint(w, "ok")
 	}
 }
 
@@ -195,9 +197,11 @@ func reviseHandler(ctx context.Context, c *config.E2ETestConfig) func(http.Respo
 	return func(w http.ResponseWriter, r *http.Request) {
 		c.DoRevise = true
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
+			log.Errorw("could not run revise end to end", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
-		} else {
-			fmt.Fprint(w, "ok")
+			return
 		}
+
+		fmt.Fprint(w, "ok")
 	}
 }

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -181,10 +181,11 @@ func realMain(ctx context.Context) error {
 }
 
 func defaultHandler(ctx context.Context, c *config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {
+	logger := logging.FromContext(ctx)
 	return func(w http.ResponseWriter, r *http.Request) {
 		c.DoRevise = false
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			log.Errorw("could not run default end to end", "error", err)
+			logger.Errorw("could not run default end to end", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -194,10 +195,11 @@ func defaultHandler(ctx context.Context, c *config.E2ETestConfig) func(http.Resp
 }
 
 func reviseHandler(ctx context.Context, c *config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {
+	logger := logging.FromContext(ctx)
 	return func(w http.ResponseWriter, r *http.Request) {
 		c.DoRevise = true
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			log.Errorw("could not run revise end to end", "error", err)
+			logger.Errorw("could not run revise end to end", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Currently are our logs are incomplete for e2e failures.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
