### PR TITLE
Add /api/issue/realm_token metric.

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -351,4 +351,7 @@ func (c *Controller) recordCapacity(ctx context.Context, limit, remaining uint64
 
 	capacity := float64(issued) / float64(limit)
 	stats.Record(ctx, mRealmTokenCapacity.M(capacity))
+
+	stats.RecordWithTags(ctx, []tag.Mutator{tokenAvailableTag()}, mRealmToken.M(int64(remaining)))
+	stats.RecordWithTags(ctx, []tag.Mutator{tokenUsedTag()}, mRealmToken.M(int64(issued)))
 }


### PR DESCRIPTION
Intend to replace

- /api/issue/realm_token_issued
- /api/issue/realm_token_remaining
- /api/issue/realm_token_capacity

The capacity can be calculated like this:

```
generic_task ::
    'custom.googleapis.com/opencensus/en-verification-server/api/issue/realm_token_latest'
| {
  filter metric.state == "USED";
  ident
}
| [metric.realm]
| ratio
```