### PR TITLE
Allow custom email server for invitations

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -147,7 +147,7 @@ func realMain(ctx context.Context) error {
 
 	// Setup server emailer
 	cfg.Email.ProviderType = email.ProviderTypeFirebase
-	if cfg.Email.SMTPHost != "" {
+	if cfg.Email.HasSMTPCreds() {
 		cfg.Email.ProviderType = email.ProviderTypeSMTP
 	}
 	emailer, err := email.ProviderFor(ctx, &cfg.Email, auth)

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -147,8 +147,8 @@ func realMain(ctx context.Context) error {
 
 	// Setup server emailer
 	cfg.Email.ProviderType = email.ProviderTypeFirebase
-	if cfg.Email.SmtpHost != "" {
-		cfg.Email.ProviderType = email.ProviderTypeSmtp
+	if cfg.Email.SMTPHost != "" {
+		cfg.Email.ProviderType = email.ProviderTypeSMTP
 	}
 	emailer, err := email.ProviderFor(ctx, &cfg.Email, auth)
 	if err != nil {

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/email"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
 
 	"github.com/google/exposure-notifications-server/pkg/observability"
@@ -40,7 +41,7 @@ type PasswordRequirementsConfig struct {
 	Special   int `env:"MIN_PWD_SPECIAL,default=1"`
 }
 
-// HasRequirements is true if any requirments are set.
+// HasRequirements is true if any requirements are set.
 func (c *PasswordRequirementsConfig) HasRequirements() bool {
 	return c.Length > 0 || c.Uppercase > 0 || c.Lowercase > 0 || c.Number > 0 || c.Special > 0
 }
@@ -51,6 +52,7 @@ type ServerConfig struct {
 	Database      database.Config
 	Observability observability.Config
 	Cache         cache.Config
+	Email         email.Config
 
 	Port string `env:"PORT,default=8080"`
 

--- a/pkg/controller/user/importbatch.go
+++ b/pkg/controller/user/importbatch.go
@@ -73,7 +73,7 @@ func (c *Controller) HandleImportBatch() http.Handler {
 				continue
 			} else if created {
 				newUsers = append(newUsers, &batchUser)
-				if err := c.firebaseInternal.SendNewUserInvitation(ctx, user.Email); err != nil {
+				if err := c.emailer.SendNewUserInvitation(ctx, user.Email); err != nil {
 					batchErr = multierror.Append(batchErr, err)
 					continue
 				}

--- a/pkg/controller/user/reset_password.go
+++ b/pkg/controller/user/reset_password.go
@@ -49,7 +49,8 @@ func (c *Controller) ensureFirebaseUserExists(ctx context.Context, user *databas
 	}
 
 	if created {
-		if err := c.firebaseInternal.SendNewUserInvitation(ctx, user.Email); err != nil {
+		err := c.emailer.SendNewUserInvitation(ctx, user.Email)
+		if err != nil {
 			flash.Error("Could not send new user invitation: %v", err)
 			return true, err
 		}

--- a/pkg/controller/user/user.go
+++ b/pkg/controller/user/user.go
@@ -19,10 +19,10 @@ import (
 	"context"
 
 	"firebase.google.com/go/auth"
-	"github.com/google/exposure-notifications-verification-server/internal/firebase"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/email"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
@@ -32,20 +32,20 @@ import (
 
 // Controller manages users
 type Controller struct {
-	cacher           cache.Cacher
-	firebaseInternal *firebase.Client
-	client           *auth.Client
-	config           *config.ServerConfig
-	db               *database.Database
-	h                *render.Renderer
-	logger           *zap.SugaredLogger
+	cacher  cache.Cacher
+	client  *auth.Client
+	emailer email.Provider
+	config  *config.ServerConfig
+	db      *database.Database
+	h       *render.Renderer
+	logger  *zap.SugaredLogger
 }
 
 // New creates a new controller for managing users.
 func New(
 	ctx context.Context,
-	firebaseInternal *firebase.Client,
 	client *auth.Client,
+	emailer email.Provider,
 	cacher cache.Cacher,
 	config *config.ServerConfig,
 	db *database.Database,
@@ -53,12 +53,12 @@ func New(
 	logger := logging.FromContext(ctx)
 
 	return &Controller{
-		cacher:           cacher,
-		firebaseInternal: firebaseInternal,
-		client:           client,
-		config:           config,
-		db:               db,
-		h:                h,
-		logger:           logger,
+		cacher:  cacher,
+		client:  client,
+		emailer: emailer,
+		config:  config,
+		db:      db,
+		h:       h,
+		logger:  logger,
 	}
 }

--- a/pkg/email/config.go
+++ b/pkg/email/config.go
@@ -28,7 +28,7 @@ type ProviderType string
 const (
 	ProviderTypeNoop     ProviderType = "NOOP"
 	ProviderTypeFirebase ProviderType = "FIREBASE"
-	ProviderTypeSmtp     ProviderType = "SIMPLE_SMTP"
+	ProviderTypeSMTP     ProviderType = "SIMPLE_SMTP"
 )
 
 // Config represents the env var based configuration for email SMTP server connection.
@@ -37,8 +37,8 @@ type Config struct {
 
 	User     string `env:"EMAIL_USER" json:",omitempty"`
 	Password string `env:"EMAIL_PASSWORD" json:",omitempty"`
-	SmtpHost string `env:"EMAIL_SMTP_HOST" json:",omitempty"`
-	SmtpPort string `env:"EMAIL_SMTP_PORT" json:",omitempty"`
+	SMTPHost string `env:"EMAIL_SMTP_HOST" json:",omitempty"`
+	SMTPPort string `env:"EMAIL_SMTP_PORT" json:",omitempty"`
 
 	// Secrets is the secret configuration. This is used to resolve values that
 	// are actually pointers to secrets before returning them to the caller. The
@@ -56,8 +56,8 @@ func ProviderFor(ctx context.Context, c *Config, auth *auth.Client) (Provider, e
 	switch typ := c.ProviderType; typ {
 	case ProviderTypeFirebase:
 		return NewFirebase(ctx)
-	case ProviderTypeSmtp:
-		return NewSmtp(ctx, c.User, c.Password, c.SmtpHost, c.SmtpPort, auth)
+	case ProviderTypeSMTP:
+		return NewSMTP(ctx, c.User, c.Password, c.SMTPHost, c.SMTPPort, auth)
 	default:
 		return nil, fmt.Errorf("unknown email provider type: %v", typ)
 	}

--- a/pkg/email/config.go
+++ b/pkg/email/config.go
@@ -52,6 +52,10 @@ type Provider interface {
 	SendNewUserInvitation(ctx context.Context, email string) error
 }
 
+func (c *Config) HasSMTPCreds() bool {
+	return c.User != "" && c.Password != "" && c.SMTPHost != "" && c.SMTPPort != ""
+}
+
 func ProviderFor(ctx context.Context, c *Config, auth *auth.Client) (Provider, error) {
 	switch typ := c.ProviderType; typ {
 	case ProviderTypeFirebase:

--- a/pkg/email/config.go
+++ b/pkg/email/config.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package email
+
+import (
+	"context"
+	"fmt"
+
+	"firebase.google.com/go/auth"
+	"github.com/google/exposure-notifications-server/pkg/secrets"
+)
+
+// ProviderType represents a type of email provider.
+type ProviderType string
+
+const (
+	ProviderTypeNoop     ProviderType = "NOOP"
+	ProviderTypeFirebase ProviderType = "FIREBASE"
+	ProviderTypeSmtp     ProviderType = "SIMPLE_SMTP"
+)
+
+// Config represents the env var based configuration for email SMTP server connection.
+type Config struct {
+	ProviderType ProviderType
+
+	User     string `env:"EMAIL_USER" json:",omitempty"`
+	Password string `env:"EMAIL_PASSWORD" json:",omitempty"`
+	SmtpHost string `env:"EMAIL_SMTP_HOST" json:",omitempty"`
+	SmtpPort string `env:"EMAIL_SMTP_PORT" json:",omitempty"`
+
+	// Secrets is the secret configuration. This is used to resolve values that
+	// are actually pointers to secrets before returning them to the caller. The
+	// table implementation is the source of truth for which values are secrets
+	// and which are plaintext.
+	Secrets secrets.Config
+}
+
+type Provider interface {
+	// SendNewUserInvitation sends an invite to join the server.
+	SendNewUserInvitation(ctx context.Context, email string) error
+}
+
+func ProviderFor(ctx context.Context, c *Config, auth *auth.Client) (Provider, error) {
+	switch typ := c.ProviderType; typ {
+	case ProviderTypeFirebase:
+		return NewFirebase(ctx)
+	case ProviderTypeSmtp:
+		return NewSmtp(ctx, c.User, c.Password, c.SmtpHost, c.SmtpPort, auth)
+	default:
+		return nil, fmt.Errorf("unknown email provider type: %v", typ)
+	}
+}

--- a/pkg/email/firebase.go
+++ b/pkg/email/firebase.go
@@ -1,0 +1,34 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package email is logic for sending email invitations
+package email
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/google/exposure-notifications-verification-server/internal/firebase"
+)
+
+var _ Provider = (*firebase.Client)(nil)
+
+// NewFirebase creates a new Smtp email sender with the given auth.
+func NewFirebase(ctx context.Context) (Provider, error) {
+	firebaseInternal, err := firebase.New(ctx)
+	if err != nil {
+		return nil, fmt.Errorf("failed to configure internal firebase client: %w", err)
+	}
+	return firebaseInternal, nil
+}

--- a/pkg/email/firebase.go
+++ b/pkg/email/firebase.go
@@ -24,7 +24,7 @@ import (
 
 var _ Provider = (*firebase.Client)(nil)
 
-// NewFirebase creates a new Smtp email sender with the given auth.
+// NewFirebase creates a new SMTP email sender with the given auth.
 func NewFirebase(ctx context.Context) (Provider, error) {
 	firebaseInternal, err := firebase.New(ctx)
 	if err != nil {

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -27,7 +27,7 @@ import (
 
 var _ Provider = (*SMTPProvider)(nil)
 
-// SMTP sends messages via an external SMTP server.
+// SMTPProvider sends messages via an external SMTP server.
 type SMTPProvider struct {
 	FirebaseAuth *auth.Client
 
@@ -37,7 +37,7 @@ type SMTPProvider struct {
 	SMTPPort string
 }
 
-// NewSmtp creates a new Smtp email sender with the given auth.
+// NewSMTP creates a new Smtp email sender with the given auth.
 func NewSMTP(ctx context.Context, user, password, host, port string, auth *auth.Client) (Provider, error) {
 	return &SMTPProvider{
 		FirebaseAuth: auth,

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -74,9 +74,7 @@ func (s *SMTPProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 	// Message.
 	body := fmt.Sprintf(
 		`You've been invited to the COVID-19 Verification Server.
-		Use the link below to set up your account.
-
-		%s`, inviteLink)
+		Use the link below to set up your account.<br>%s`, inviteLink)
 	var bodyMessage bytes.Buffer
 	temp := quotedprintable.NewWriter(&bodyMessage)
 	temp.Write([]byte(body))

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -73,8 +73,9 @@ func (s *SMTPProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 
 	// Message.
 	body := fmt.Sprintf(
-		`You've been invited to the COVID-19 Verification Server.
-		Use the link below to set up your account. \n\n %s`, inviteLink)
+		`You've been invited to the COVID-19 Verification Server. Use the link below to set up your account.
+
+		%s`, inviteLink)
 	var bodyMessage bytes.Buffer
 	temp := quotedprintable.NewWriter(&bodyMessage)
 	temp.Write([]byte(body))

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -25,31 +25,31 @@ import (
 	"firebase.google.com/go/auth"
 )
 
-var _ Provider = (*SmtpProvider)(nil)
+var _ Provider = (*SMTPProvider)(nil)
 
-// Smtp sends messages via an external SMTP server.
-type SmtpProvider struct {
+// SMTP sends messages via an external SMTP server.
+type SMTPProvider struct {
 	FirebaseAuth *auth.Client
 
 	User     string
 	Password string
-	SmtpHost string
-	SmtpPort string
+	SMTPHost string
+	SMTPPort string
 }
 
 // NewSmtp creates a new Smtp email sender with the given auth.
-func NewSmtp(ctx context.Context, user, password, host, port string, auth *auth.Client) (Provider, error) {
-	return &SmtpProvider{
+func NewSMTP(ctx context.Context, user, password, host, port string, auth *auth.Client) (Provider, error) {
+	return &SMTPProvider{
 		FirebaseAuth: auth,
 		User:         user,
 		Password:     password,
-		SmtpHost:     host,
-		SmtpPort:     port,
+		SMTPHost:     host,
+		SMTPPort:     port,
 	}, nil
 }
 
 // SendNewUserInvitation sends a password reset email to the user.
-func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string) error {
+func (s *SMTPProvider) SendNewUserInvitation(ctx context.Context, toEmail string) error {
 	// Header
 	header := make(map[string]string)
 	header["From"] = s.User
@@ -57,7 +57,7 @@ func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 	header["Subject"] = "COVID-19 Verification Server Invitation"
 
 	header["MIME-Version"] = "1.0"
-	header["Content-Type"] = fmt.Sprintf(`%s; charset="utf-8"`, "text/html")
+	header["Content-Type"] = `text/html; charset="utf-8"`
 	header["Content-Disposition"] = "inline"
 	header["Content-Transfer-Encoding"] = "quoted-printable"
 
@@ -83,10 +83,10 @@ func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 	finalMessage := headerMessage + "\r\n" + bodyMessage.String()
 
 	// Authentication.
-	auth := smtp.PlainAuth("", s.User, s.Password, s.SmtpHost)
+	auth := smtp.PlainAuth("", s.User, s.Password, s.SMTPHost)
 
 	// Sending email.
-	err = smtp.SendMail(s.SmtpHost+":"+s.SmtpPort, auth, s.User, []string{toEmail}, []byte(finalMessage))
+	err = smtp.SendMail(s.SMTPHost+":"+s.SMTPPort, auth, s.User, []string{toEmail}, []byte(finalMessage))
 	if err != nil {
 		return err
 	}

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -1,0 +1,94 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package email is logic for sending email invitations
+package email
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"mime/quotedprintable"
+	"net/smtp"
+
+	"firebase.google.com/go/auth"
+)
+
+var _ Provider = (*SmtpProvider)(nil)
+
+// Smtp sends messages via an external SMTP server.
+type SmtpProvider struct {
+	FirebaseAuth *auth.Client
+
+	User     string
+	Password string
+	SmtpHost string
+	SmtpPort string
+}
+
+// NewSmtp creates a new Smtp email sender with the given auth.
+func NewSmtp(ctx context.Context, user, password, host, port string, auth *auth.Client) (Provider, error) {
+	return &SmtpProvider{
+		FirebaseAuth: auth,
+		User:         user,
+		Password:     password,
+		SmtpHost:     host,
+		SmtpPort:     port,
+	}, nil
+}
+
+// SendNewUserInvitation sends a password reset email to the user.
+func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string) error {
+	// Header
+	header := make(map[string]string)
+	header["From"] = s.User
+	header["To"] = toEmail
+	header["Subject"] = "COVID-19 Verification Server Invitation"
+
+	header["MIME-Version"] = "1.0"
+	header["Content-Type"] = fmt.Sprintf("%s; charset=\"utf-8\"", "text/html")
+	header["Content-Disposition"] = "inline"
+	header["Content-Transfer-Encoding"] = "quoted-printable"
+
+	headerMessage := ""
+	for key, value := range header {
+		headerMessage += fmt.Sprintf("%s: %s\r\n", key, value)
+	}
+
+	inviteLink, err := s.FirebaseAuth.PasswordResetLink(ctx, toEmail)
+	if err != nil {
+		return err
+	}
+
+	// Message.
+	body := fmt.Sprintf(
+		"You've been invited to the COVID-19 Verification Server. Use the link below to set up your account."+
+			" \n\n %s", inviteLink)
+	var bodyMessage bytes.Buffer
+	temp := quotedprintable.NewWriter(&bodyMessage)
+	temp.Write([]byte(body))
+	temp.Close()
+
+	finalMessage := headerMessage + "\r\n" + bodyMessage.String()
+
+	// Authentication.
+	auth := smtp.PlainAuth("", s.User, s.Password, s.SmtpHost)
+
+	// Sending email.
+	err = smtp.SendMail(s.SmtpHost+":"+s.SmtpPort, auth, s.User, []string{toEmail}, []byte(finalMessage))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -73,7 +73,8 @@ func (s *SMTPProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 
 	// Message.
 	body := fmt.Sprintf(
-		`You've been invited to the COVID-19 Verification Server. Use the link below to set up your account.
+		`You've been invited to the COVID-19 Verification Server.
+		Use the link below to set up your account.
 
 		%s`, inviteLink)
 	var bodyMessage bytes.Buffer

--- a/pkg/email/smtp.go
+++ b/pkg/email/smtp.go
@@ -57,7 +57,7 @@ func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 	header["Subject"] = "COVID-19 Verification Server Invitation"
 
 	header["MIME-Version"] = "1.0"
-	header["Content-Type"] = fmt.Sprintf("%s; charset=\"utf-8\"", "text/html")
+	header["Content-Type"] = fmt.Sprintf(`%s; charset="utf-8"`, "text/html")
 	header["Content-Disposition"] = "inline"
 	header["Content-Transfer-Encoding"] = "quoted-printable"
 
@@ -73,8 +73,8 @@ func (s *SmtpProvider) SendNewUserInvitation(ctx context.Context, toEmail string
 
 	// Message.
 	body := fmt.Sprintf(
-		"You've been invited to the COVID-19 Verification Server. Use the link below to set up your account."+
-			" \n\n %s", inviteLink)
+		`You've been invited to the COVID-19 Verification Server.
+		Use the link below to set up your account. \n\n %s`, inviteLink)
 	var bodyMessage bytes.Buffer
 	temp := quotedprintable.NewWriter(&bodyMessage)
 	temp.Write([]byte(body))


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/787

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This PR allows for a server-level override to sending new user invitations via a custom SMTP server
* If no secret is present, it falls back to our firebase hack with the password-reset template

In the future we can use this to
* Allow per-realm overrides of the email server
* Allow per-realm templates for the invitation email itself

This gets around our server-side call to the firebase client API which may face IP rate limiting.
https://cloud.google.com/identity-platform/quotas#email_link_generation_limits_2
Note that generating the link has 10x quota and is intended to be called from the server.

We could someday send other kinds of emails (eg. TOTP for 2nd factor auth if we want to roll our own 2nd factor via this and Twilio), but that sort of thing is not currently planned.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow for invitations from a custom SMTP server
```
