### PR TITLE
Fix realm token related metrics in /api/issue.

### DIFF
--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -39,7 +39,9 @@ var (
 
 	mSMSRequest = stats.Int64(metricPrefix+"/sms_request", "# of sms requests", stats.UnitDimensionless)
 
-	mRealmToken = stats.Int64(metricPrefix+"/realm_token", "# of realm tokens", stats.UnitDimensionless)
+	mRealmToken = stats.Int64(metricPrefix+"/realm_token", "# of realm tokens from limiter", stats.UnitDimensionless)
+
+	mRealmTokenUsed = stats.Int64(metricPrefix+"/realm_token_used", "# of realm token used.", stats.UnitDimensionless)
 )
 
 var (
@@ -124,6 +126,12 @@ func init() {
 			TagKeys:     append(observability.CommonTagKeys(), tokenStateTagKey),
 			Measure:     mRealmToken,
 			Aggregation: view.LastValue(),
+		}, {
+			Name:        metricPrefix + "/realm_token_used_count",
+			Description: "The count of # of realm token used.",
+			TagKeys:     observability.CommonTagKeys(),
+			Measure:     mRealmTokenUsed,
+			Aggregation: view.Count(),
 		},
 	}...)
 }


### PR DESCRIPTION
Prior to this change, the # of used tokens are calculated by:

    issued := uint64(limit) - remaining

This calculation doesn't take burst tokens into consideration. Imaging
the limit is set to 10, and at a time someone added 1000 burst into the
bucket, and the actual used token is 10. We now have limit=10,
remaining=1000, and the calculated issued=-1000, which doesn't make
sense.

The used token should be a CUMULATIVE/view.Count metric, which is
recorded each time we successfully called `limiter.Take()`.