### PR TITLE
Also modify how /api/issue/realm_token_latest is recorded.

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -355,5 +355,5 @@ func (c *Controller) recordCapacity(ctx context.Context, limit, remaining uint64
 	stats.Record(ctx, mRealmTokenCapacity.M(capacity))
 
 	stats.RecordWithTags(ctx, []tag.Mutator{tokenAvailableTag()}, mRealmToken.M(int64(remaining)))
-	stats.RecordWithTags(ctx, []tag.Mutator{tokenUsedTag()}, mRealmToken.M(int64(issued)))
+	stats.RecordWithTags(ctx, []tag.Mutator{tokenLimitTag()}, mRealmToken.M(int64(limit)))
 }

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -54,8 +54,8 @@ func tokenAvailableTag() tag.Mutator {
 	return tag.Upsert(tokenStateTagKey, "AVAILABLE")
 }
 
-func tokenUsedTag() tag.Mutator {
-	return tag.Upsert(tokenStateTagKey, "USED")
+func tokenLimitTag() tag.Mutator {
+	return tag.Upsert(tokenStateTagKey, "LIMIT")
 }
 
 func init() {


### PR DESCRIPTION
Since we record the used tokens in a separate metric, we can now keep
using /api/issue/realm_token_latest for the purpose of getting metrics
from the limiter.

We can now calculate the capacity of the limiter by:

    generic_task ::
        'custom.googleapis.com/opencensus/en-verification-server/api/issue/realm_token_latest'
    | {
      filter metric.state == "AVAILABLE";
      filter metric.state == "LIMIT"
    }
    | [metric.realm]
    | ratio
    | value if(val() > 1.0, 1.0, val())