### PR TITLE
Cleanup issue API metrics

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -329,12 +329,11 @@ func (c *Controller) recordCapacity(ctx context.Context, limit, remaining uint64
 	stats.Record(ctx, mRealmTokenRemaining.M(int64(remaining)))
 
 	issued := uint64(limit) - remaining
-	stats.Record(ctx, mRealmTokenIssued.M(int64(issued)))
-	stats.Record(ctx, mRealmTokenUsed.M(1))
 
 	capacity := float64(issued) / float64(limit)
 	stats.Record(ctx, mRealmTokenCapacity.M(capacity))
 
+	stats.Record(ctx, mRealmTokenUsed.M(1))
 	stats.RecordWithTags(ctx, []tag.Mutator{tokenAvailableTag()}, mRealmToken.M(int64(remaining)))
 	stats.RecordWithTags(ctx, []tag.Mutator{tokenLimitTag()}, mRealmToken.M(int64(limit)))
 }

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -95,12 +95,8 @@ func (c *Controller) HandleIssue() http.Handler {
 			stats.Record(ctx, mRequest.M(1))
 		}(&blame, &result)
 
-		// Record the issue attempt.
-		stats.Record(ctx, mIssueAttempts.M(1))
-
 		var request api.IssueCodeRequest
 		if err := controller.BindJSON(w, r, &request); err != nil {
-			stats.Record(ctx, mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 			blame = observability.BlameClient
 			result = observability.APIResultError("FAILED_TO_PARSE_JSON_REQUEST")
@@ -114,7 +110,6 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		authApp, user, err := c.getAuthorizationFromContext(r)
 		if err != nil {
-			stats.Record(ctx, mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusUnauthorized, api.Error(err))
 			blame = observability.BlameClient
 			result = observability.APIResultError("MISSING_AUTHORIZED_APP")
@@ -125,7 +120,6 @@ func (c *Controller) HandleIssue() http.Handler {
 		if authApp != nil {
 			realm, err = authApp.Realm(c.db)
 			if err != nil {
-				stats.Record(ctx, mCodeIssueErrors.M(1))
 				c.h.RenderJSON(w, http.StatusUnauthorized, nil)
 				blame = observability.BlameClient
 				result = observability.APIResultError("UNAUTHORIZED")
@@ -136,7 +130,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			realm = controller.RealmFromContext(ctx)
 		}
 		if realm == nil {
-			stats.Record(ctx, mIssueAttempts.M(1), mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("missing realm"))
 			blame = observability.BlameServer
 			result = observability.APIResultError("MISSING_REALM")
@@ -148,7 +141,6 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		// If this realm requires a date but no date was specified, return an error.
 		if request.SymptomDate == "" && realm.RequireDate {
-			stats.Record(ctx, mIssueAttempts.M(1), mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("missing either test or symptom date").WithCode(api.ErrMissingDate))
 			blame = observability.BlameClient
 			result = observability.APIResultError("MISSING_REQUIRED_FIELDS")
@@ -158,7 +150,6 @@ func (c *Controller) HandleIssue() http.Handler {
 		// Validate that the request with the provided test type is valid for this
 		// realm.
 		if !realm.ValidTestType(request.TestType) {
-			stats.Record(ctx, mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest,
 				api.Errorf("unsupported test type: %v", request.TestType))
 			blame = observability.BlameClient
@@ -172,7 +163,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			smsProvider, err = realm.SMSProvider(c.db)
 			if err != nil {
 				logger.Errorw("failed to get sms provider", "error", err)
-				stats.Record(ctx, mCodeIssueErrors.M(1))
 				c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to get sms provider"))
 				blame = observability.BlameServer
 				result = observability.APIResultError("FAILED_TO_GET_SMS_PROVIDER")
@@ -180,7 +170,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 			if smsProvider == nil {
 				err := fmt.Errorf("phone provided, but no sms provider is configured")
-				stats.Record(ctx, mCodeIssueErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 				blame = observability.BlameServer
 				result = observability.APIResultError("FAILED_TO_GET_SMS_PROVIDER")
@@ -191,7 +180,6 @@ func (c *Controller) HandleIssue() http.Handler {
 		// Verify the test type
 		request.TestType = strings.ToLower(request.TestType)
 		if _, ok := c.validTestType[request.TestType]; !ok {
-			stats.Record(ctx, mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("invalid test type"))
 			blame = observability.BlameClient
 			result = observability.APIResultError("INVALID_TEST_TYPE")
@@ -201,7 +189,6 @@ func (c *Controller) HandleIssue() http.Handler {
 		var symptomDate *time.Time
 		if request.SymptomDate != "" {
 			if parsed, err := time.Parse("2006-01-02", request.SymptomDate); err != nil {
-				stats.Record(ctx, mCodeIssueErrors.M(1))
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("failed to process symptom onset date: %v", err))
 				blame = observability.BlameClient
 				result = observability.APIResultError("FAILED_TO_PROCESS_SYMPTOM_ONSET_DATE")
@@ -218,7 +205,6 @@ func (c *Controller) HandleIssue() http.Handler {
 						maxDate.Format("2006-01-02"),
 						parsed.Format("2006-01-02"),
 					)
-					stats.Record(ctx, mCodeIssueErrors.M(1))
 					c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
 					blame = observability.BlameClient
 					result = observability.APIResultError("SYMPTOM_ONSET_DATE_NOT_IN_VALID_RANGE")
@@ -241,7 +227,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			limit, remaining, reset, ok, err := c.limiter.Take(ctx, key)
 			if err != nil {
 				logger.Errorw("failed to take from limiter", "error", err)
-				stats.Record(ctx, mQuotaErrors.M(1))
 				c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to verify realm stats, please try again"))
 				blame = observability.BlameServer
 				result = observability.APIResultError("FAILED_TO_TAKE_FROM_LIMITER")
@@ -253,7 +238,6 @@ func (c *Controller) HandleIssue() http.Handler {
 					"realm", realm.ID,
 					"limit", limit,
 					"reset", reset)
-				stats.Record(ctx, mQuotaExceeded.M(1))
 
 				if c.config.GetEnforceRealmQuotas() {
 					c.h.RenderJSON(w, http.StatusTooManyRequests, api.Errorf("exceeded realm quota"))
@@ -291,7 +275,6 @@ func (c *Controller) HandleIssue() http.Handler {
 		code, longCode, uuid, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
 		if err != nil {
 			logger.Errorw("failed to issue code", "error", err)
-			stats.Record(ctx, mCodeIssueErrors.M(1))
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))
 			blame = observability.BlameServer
 			result = observability.APIResultError("FAILED_TO_ISSUE_CODE")
@@ -308,7 +291,6 @@ func (c *Controller) HandleIssue() http.Handler {
 				}
 
 				logger.Errorw("failed to send sms", "error", err)
-				stats.Record(ctx, mCodeIssueErrors.M(1))
 				stats.RecordWithTags(ctx, []tag.Mutator{observability.APIResultError("NOT_OK")}, mSMSRequest.M(1))
 				c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to send sms"))
 				blame = observability.BlameServer
@@ -318,7 +300,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			stats.RecordWithTags(ctx, []tag.Mutator{observability.APIResultOK()}, mSMSRequest.M(1))
 		}
 
-		stats.Record(ctx, mCodesIssued.M(1))
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.IssueCodeResponse{
 				UUID:                   uuid,

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -26,11 +26,6 @@ import (
 const metricPrefix = observability.MetricRoot + "/api/issue"
 
 var (
-	mIssueAttempts       = stats.Int64(metricPrefix+"/attempts", "The number of attempts to issue codes", stats.UnitDimensionless)
-	mQuotaErrors         = stats.Int64(metricPrefix+"/quota_errors", "The number of errors when taking from the limiter", stats.UnitDimensionless)
-	mQuotaExceeded       = stats.Int64(metricPrefix+"/quota_exceeded", "The number of times quota has been exceeded", stats.UnitDimensionless)
-	mCodesIssued         = stats.Int64(metricPrefix+"/codes_issued", "The number of verification codes issued", stats.UnitDimensionless)
-	mCodeIssueErrors     = stats.Int64(metricPrefix+"/code_issue_error", "The number of failed code issues", stats.UnitDimensionless)
 	mRealmTokenRemaining = stats.Int64(metricPrefix+"/realm_token_remaining", "Remaining number of verification codes", stats.UnitDimensionless)
 	mRealmTokenIssued    = stats.Int64(metricPrefix+"/realm_token_issued", "Total issued verification codes", stats.UnitDimensionless)
 	mRealmTokenCapacity  = stats.Float64(metricPrefix+"/realm_token_capacity", "Capacity utilization for issuing verification codes", stats.UnitDimensionless)
@@ -61,36 +56,6 @@ func tokenLimitTag() tag.Mutator {
 func init() {
 	enobservability.CollectViews([]*view.View{
 		{
-			Name:        metricPrefix + "/attempt_count",
-			Measure:     mIssueAttempts,
-			Description: "The count of the number of attempts to issue codes",
-			TagKeys:     observability.CommonTagKeys(),
-			Aggregation: view.Count(),
-		}, {
-			Name:        metricPrefix + "/quota_errors_count",
-			Measure:     mQuotaErrors,
-			Description: "The count of the number of errors to the limiter",
-			TagKeys:     observability.CommonTagKeys(),
-			Aggregation: view.Count(),
-		}, {
-			Name:        metricPrefix + "/quota_exceeded_count",
-			Measure:     mQuotaExceeded,
-			Description: "The count of the number of times quota has been exceeded",
-			TagKeys:     observability.CommonTagKeys(),
-			Aggregation: view.Count(),
-		}, {
-			Name:        metricPrefix + "/codes_issued_count",
-			Measure:     mCodesIssued,
-			Description: "The count of verification codes issued",
-			TagKeys:     observability.CommonTagKeys(),
-			Aggregation: view.Count(),
-		}, {
-			Name:        metricPrefix + "/code_issue_error_count",
-			Measure:     mCodeIssueErrors,
-			Description: "The count of the number of times a code fails to issue",
-			TagKeys:     observability.CommonTagKeys(),
-			Aggregation: view.Count(),
-		}, {
 			Name:        metricPrefix + "/realm_token_remaining_latest",
 			Description: "Latest realm remaining tokens",
 			TagKeys:     observability.CommonTagKeys(),

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -26,6 +26,8 @@ import (
 const metricPrefix = observability.MetricRoot + "/api/issue"
 
 var (
+	mQuotaErrors         = stats.Int64(metricPrefix+"/quota_errors", "The number of errors when taking from the limiter", stats.UnitDimensionless)
+	mQuotaExceeded       = stats.Int64(metricPrefix+"/quota_exceeded", "The number of times quota has been exceeded", stats.UnitDimensionless)
 	mRealmTokenRemaining = stats.Int64(metricPrefix+"/realm_token_remaining", "Remaining number of verification codes", stats.UnitDimensionless)
 	mRealmTokenCapacity  = stats.Float64(metricPrefix+"/realm_token_capacity", "Capacity utilization for issuing verification codes", stats.UnitDimensionless)
 
@@ -55,6 +57,18 @@ func tokenLimitTag() tag.Mutator {
 func init() {
 	enobservability.CollectViews([]*view.View{
 		{
+			Name:        metricPrefix + "/quota_errors_count",
+			Measure:     mQuotaErrors,
+			Description: "The count of the number of errors to the limiter",
+			TagKeys:     observability.CommonTagKeys(),
+			Aggregation: view.Count(),
+		}, {
+			Name:        metricPrefix + "/quota_exceeded_count",
+			Measure:     mQuotaExceeded,
+			Description: "The count of the number of times quota has been exceeded",
+			TagKeys:     observability.CommonTagKeys(),
+			Aggregation: view.Count(),
+		}, {
 			Name:        metricPrefix + "/realm_token_remaining_latest",
 			Description: "Latest realm remaining tokens",
 			TagKeys:     observability.CommonTagKeys(),

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -27,7 +27,6 @@ const metricPrefix = observability.MetricRoot + "/api/issue"
 
 var (
 	mRealmTokenRemaining = stats.Int64(metricPrefix+"/realm_token_remaining", "Remaining number of verification codes", stats.UnitDimensionless)
-	mRealmTokenIssued    = stats.Int64(metricPrefix+"/realm_token_issued", "Total issued verification codes", stats.UnitDimensionless)
 	mRealmTokenCapacity  = stats.Float64(metricPrefix+"/realm_token_capacity", "Capacity utilization for issuing verification codes", stats.UnitDimensionless)
 
 	mRequest = stats.Int64(metricPrefix+"/request", "# of code issue requests", stats.UnitDimensionless)
@@ -60,12 +59,6 @@ func init() {
 			Description: "Latest realm remaining tokens",
 			TagKeys:     observability.CommonTagKeys(),
 			Measure:     mRealmTokenRemaining,
-			Aggregation: view.LastValue(),
-		}, {
-			Name:        metricPrefix + "/realm_token_issued_latest",
-			Description: "Latest realm issued tokens",
-			TagKeys:     observability.CommonTagKeys(),
-			Measure:     mRealmTokenIssued,
 			Aggregation: view.LastValue(),
 		}, {
 			Name:        metricPrefix + "/realm_token_capacity_latest",


### PR DESCRIPTION
Those are not referenced by dashboards or alerts.

Also remove /realm_token_issued. As demonstrated in
https://github.com/google/exposure-notifications-verification-server/pull/801,                            
this metric contains an incorrect number. We already have a                                               
/realm_token_used_count metric which is accurate.

Part of https://github.com/google/exposure-notifications-verification-server/issues/773