### PR TITLE
Add a per-realm-per-user chart on the stats page.

### DIFF
--- a/cmd/server/assets/realmadmin/show.html
+++ b/cmd/server/assets/realmadmin/show.html
@@ -2,6 +2,8 @@
 
 {{$realm := .realm}}
 {{$stats := .stats}}
+{{$names := .names}}
+{{$userStats := .userStats}}
 
 <!doctype html>
 <html lang="en">
@@ -24,7 +26,7 @@
       <div class="card-header">Statistics</div>
       <div class="card-body table-responsive">
         {{if $stats}}
-        <div id="chart" class="mb-3" style="height: 300px;">
+        <div id="realm_chart" class="mb-3" style="height: 300px;">
           <span>Loading chart...</span>
         </div>
         <table class="table table-bordered table-striped">
@@ -45,6 +47,15 @@
             {{end}}
           </tbody>
         </table>
+        {{end}}
+
+    {{if $userStats}}
+        <div id="per_user_chart" class="mb-3" style="height: 300px;">
+          <span>Loading chart...</span>
+        </div>
+    {{end}}
+
+        {{if or $stats $userStats}}
         <div class="font-italic">
           This data is refreshed every 5 minutes.
         </div>
@@ -58,13 +69,18 @@
 
   {{template "scripts" .}}
 
-  {{if $stats}}
   <script src="https://www.gstatic.com/charts/loader.js"></script>
   <script>
     google.charts.load('current', {packages: ['line']});
     google.charts.setOnLoadCallback(drawChart)
 
     function drawChart() {
+      drawRealmChart();
+      drawUsersChart();
+    }
+
+    function drawRealmChart() {
+  {{if $stats}}
       var data = google.visualization.arrayToDataTable([
         ['Date', 'Issued', "Claimed"],
         {{range $stat := $stats}}
@@ -78,11 +94,40 @@
         tooltip: {trigger: 'focus'},
       };
 
-      var chart = new google.charts.Line(document.getElementById('chart'));
+      var chart = new google.charts.Line(document.getElementById('realm_chart'));
       chart.draw(data, google.charts.Line.convertOptions(options));
+  {{end}}
+    }
+
+    function fixDate(arr) {
+      arr[0] = new Date(arr[0])
+      return arr
+    }
+
+  function drawUsersChart() {
+  {{if $userStats}}
+    var data = new google.visualization.DataTable();
+
+      data.addColumn('date', 'Day');
+    {{range $name := $names}}
+      data.addColumn('number', '{{$name}}');
+    {{end}}  
+       data.addRows([
+    {{range $stat := $userStats}}
+       fixDate({{$stat}}),
+    {{end}}
+      ]);
+
+    var options = {
+    legend: {position: 'bottom'},
+    tooltip: {trigger: 'focus'},
+    };
+
+    var chart = new google.charts.Line(document.getElementById('per_user_chart'));
+    chart.draw(data, google.charts.Line.convertOptions(options));
+  {{end}}
     }
   </script>
-  {{end}}
 </body>
 </html>
 {{end}}

--- a/pkg/controller/realmadmin/show.go
+++ b/pkg/controller/realmadmin/show.go
@@ -34,25 +34,77 @@ func (c *Controller) HandleShow() http.Handler {
 			return
 		}
 
-		// Get and cache the stats for this user.
+		now := time.Now().UTC()
+		past := now.Add(-30 * 24 * time.Hour)
+		timeout := 5 * time.Minute
+
+		// Get and cache the stats for this realm.
 		var stats []*database.RealmStats
 		cacheKey := fmt.Sprintf("stats:realm:%d", realm.ID)
-		if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
-			now := time.Now().UTC()
-			past := now.Add(-30 * 24 * time.Hour)
+		if err := c.cacher.Fetch(ctx, cacheKey, &stats, timeout, func() (interface{}, error) {
 			return realm.Stats(c.db, past, now)
 		}); err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
 		}
 
-		c.renderShow(ctx, w, realm, stats)
+		// Also get the per-user stats.
+		var userStats []*database.RealmUserStats
+		cacheKey = fmt.Sprintf("userstats:realm:%d", realm.ID)
+		if err := c.cacher.Fetch(ctx, cacheKey, &userStats, timeout, func() (interface{}, error) {
+			return realm.CodesPerUser(c.db, past, now)
+		}); err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.renderShow(ctx, w, realm, stats, userStats)
 	})
 }
 
-func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, realm *database.Realm, stats []*database.RealmStats) {
+// formatData formats a slice of RealmUserStats into a format more conducive
+// to charting in Javascript.
+func formatData(userStats []*database.RealmUserStats) ([]string, [][]interface{}) {
+	// We need to format the per-user-per-day data properly for the charts.
+	// Create some LUTs to make this easier.
+	nameLUT := make(map[string]int)
+	datesLUT := make(map[time.Time]int)
+	for _, stat := range userStats {
+		if _, ok := nameLUT[stat.Name]; !ok {
+			nameLUT[stat.Name] = len(nameLUT)
+		}
+		if _, ok := datesLUT[stat.Date]; !ok {
+			datesLUT[stat.Date] = len(datesLUT)
+		}
+	}
+
+	// Figure out the names.
+	names := make([]string, len(nameLUT))
+	for name, i := range nameLUT {
+		names[i] = name
+	}
+
+	// And combine up the data we want to send as well.
+	data := make([][]interface{}, len(datesLUT))
+	for date, i := range datesLUT {
+		data[i] = make([]interface{}, len(names)+1)
+		data[i][0] = date.Format("Jan 2")
+	}
+	for _, stat := range userStats {
+		i := datesLUT[stat.Date]
+		data[i][nameLUT[stat.Name]+1] = stat.CodesIssued
+	}
+
+	// Now, we need to format the data properly.
+	return names, data
+}
+
+func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, realm *database.Realm, stats []*database.RealmStats, userStats []*database.RealmUserStats) {
+	names, format := formatData(userStats)
 	m := controller.TemplateMapFromContext(ctx)
 	m["user"] = realm
 	m["stats"] = stats
+	m["names"] = names
+	m["userStats"] = format
 	c.h.RenderHTML(w, "realmadmin/show", m)
 }

--- a/pkg/controller/realmadmin/show_test.go
+++ b/pkg/controller/realmadmin/show_test.go
@@ -1,0 +1,55 @@
+package realmadmin
+
+import (
+	"reflect"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func TestFormatStats(t *testing.T) {
+	now := time.Now().Truncate(24 * time.Hour)
+	yesterday := now.Add(-24 * time.Hour).Truncate(24 * time.Hour)
+	tests := []struct {
+		data    []*database.RealmUserStats
+		names   []string
+		numDays int
+	}{
+		{[]*database.RealmUserStats{}, []string{}, 0},
+		{
+			[]*database.RealmUserStats{
+				{UserID: 1, Name: "Rocky", CodesIssued: 10, Date: now},
+				{UserID: 1, Name: "Bullwinkle", CodesIssued: 1, Date: now},
+			},
+			[]string{"Rocky", "Bullwinkle"},
+			1,
+		},
+		{
+			[]*database.RealmUserStats{
+				{UserID: 1, Name: "Rocky", CodesIssued: 10, Date: yesterday},
+				{UserID: 1, Name: "Rocky", CodesIssued: 10, Date: now},
+			},
+			[]string{"Rocky"},
+			2,
+		},
+	}
+
+	for i, test := range tests {
+		names, format := formatData(test.data)
+		sort.Strings(test.names)
+		sort.Strings(names)
+		if !reflect.DeepEqual(test.names, names) {
+			t.Errorf("[%d] %v != %v", i, names, test.names)
+		}
+		if len(format) != test.numDays {
+			t.Errorf("[%d] len(format) = %d, expected %d", i, len(format), test.numDays)
+		}
+		for _, f := range format {
+			if len(f) != len(test.names)+1 {
+				t.Errorf("[%d] len(codesIssued) = %d, expected %d", i, len(f), len(test.names)+1)
+			}
+		}
+	}
+}

--- a/pkg/database/user_stats.go
+++ b/pkg/database/user_stats.go
@@ -16,6 +16,8 @@ package database
 
 import (
 	"time"
+
+	"github.com/jinzhu/gorm"
 )
 
 // UserStats represents statistics related to a user in the database.
@@ -29,4 +31,15 @@ type UserStats struct {
 // TableName sets the UserStats table name
 func (UserStats) TableName() string {
 	return "user_stats"
+}
+
+// SaveUserStats saves some UserStats to the database.
+// This function is provided for testing only.
+func (db *Database) SaveUserStats(u *UserStats) error {
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Save(u).Error; err != nil {
+			return err
+		}
+		return nil
+	})
 }


### PR DESCRIPTION
Fixes #799

NB: We display the user's name, **NOT** their ID. The bug was ill-specified. If this is wrogn, please comment.

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add a per-user-per-realm stats chart
![image](https://user-images.githubusercontent.com/3063869/96036291-41cc6500-0e32-11eb-8f99-f0ed4d3f9a0a.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Stats page now contains a per-user-per-realm chart.
```
