### PR TITLE
Return on realm lookup error

### DIFF
--- a/cmd/server/assets/400.html
+++ b/cmd/server/assets/400.html
@@ -1,0 +1,17 @@
+{{define "400"}}
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body>
+  <main role="main" class="container mt-5">
+    <h1>Not found</h1>
+    <p>
+      The page you requested does not exist.
+    </p>
+  </main>
+</body>
+</html>
+{{end}}

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -64,6 +64,21 @@ func InternalError(w http.ResponseWriter, r *http.Request, h *render.Renderer, e
 	}
 }
 
+// NotFound returns an error indicating the URL was not found.
+func NotFound(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
+	accept := strings.Split(r.Header.Get("Accept"), ",")
+	accept = append(accept, strings.Split(r.Header.Get("Content-Type"), ",")...)
+
+	switch {
+	case prefixInList(accept, ContentTypeHTML):
+		h.RenderHTMLStatus(w, http.StatusNotFound, "400", nil)
+	case prefixInList(accept, ContentTypeJSON):
+		h.RenderJSON(w, http.StatusNotFound, http.StatusText(http.StatusNotFound))
+	default:
+		http.Error(w, http.StatusText(http.StatusUnauthorized), http.StatusUnauthorized)
+	}
+}
+
 // Unauthorized returns an error indicating the request was unauthorized.
 func Unauthorized(w http.ResponseWriter, r *http.Request, h *render.Renderer) {
 	accept := strings.Split(r.Header.Get("Accept"), ",")

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -43,6 +43,7 @@ func (c *Controller) HandleIndex() http.Handler {
 		realm, err := c.db.FindRealmByRegion(hostRegion)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 
 		// Get App Store Data.

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -21,6 +21,7 @@ import (
 	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 func (c *Controller) HandleIndex() http.Handler {
@@ -42,6 +43,11 @@ func (c *Controller) HandleIndex() http.Handler {
 		}
 		realm, err := c.db.FindRealmByRegion(hostRegion)
 		if err != nil {
+			if database.IsNotFound(err) {
+				controller.NotFound(w, r, c.h)
+				return
+			}
+
 			controller.InternalError(w, r, c.h, err)
 			return
 		}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return 404 on enx-redirect lookup when realm is not found.
```