### PR TITLE
Give system admins ability to clear caches

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -85,10 +85,7 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey),
-		cache.PrefixKeyFunc("cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -88,10 +88,7 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey),
-		cache.PrefixKeyFunc("cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -80,10 +80,7 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey),
-		cache.PrefixKeyFunc("cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/modeler/main.go
+++ b/cmd/modeler/main.go
@@ -79,10 +79,7 @@ func realMain(ctx context.Context) error {
 	logger.Infow("observability exporter", "config", oeConfig)
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey),
-		cache.PrefixKeyFunc("cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &cfg.Cache, cache.HMACKeyFunc(sha1.New, cfg.Cache.HMACKey))
 	if err != nil {
 		return fmt.Errorf("failed to create cacher: %w", err)
 	}

--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -35,6 +35,10 @@
   </li>
 
   <li class="nav-item">
+    <a class="nav-link{{if .currentPath.IsDir "/admin/caches"}} active{{end}}" href="/admin/caches">Caches</a>
+  </li>
+
+  <li class="nav-item">
     <a class="nav-link{{if .currentPath.IsDir "/admin/info"}} active{{end}}" href="/admin/info">Info</a>
   </li>
 </ul>

--- a/cmd/server/assets/admin/caches/index.html
+++ b/cmd/server/assets/admin/caches/index.html
@@ -1,0 +1,41 @@
+{{define "admin/caches/index"}}
+
+{{$caches := .caches}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  {{template "admin/navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Caches</div>
+      <ul class="list-group list-group-flush">
+        {{range $k, $cache := $caches}}
+          <li class="list-group-item d-flex justify-content-between align-items-center">
+            <div>
+              <h5 class="mb-1">{{$cache.Name}}</h5>
+              <small>{{$cache.Description}}</small>
+            </div>
+            <a href="/admin/caches/clear/{{$k}}"
+              data-method="POST"
+              data-confirm="Are you sure you want to clear the {{$cache.Name}} cache?"
+              class="btn btn-danger">
+              Clear
+            </a>
+          </li>
+        {{end}}
+      </ul>
+    </div>
+  </main>
+
+  {{template "scripts" .}}
+</body>
+</html>
+{{end}}

--- a/pkg/cache/noop.go
+++ b/pkg/cache/noop.go
@@ -35,7 +35,7 @@ func NewNoop() (Cacher, error) {
 }
 
 // Fetch calls FetchFunc and does no caching.
-func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Duration, f FetchFunc) error {
+func (c *noop) Fetch(_ context.Context, _ *Key, out interface{}, ttl time.Duration, f FetchFunc) error {
 	if c.isStopped() {
 		return ErrStopped
 	}
@@ -55,7 +55,7 @@ func (c *noop) Fetch(_ context.Context, key string, out interface{}, ttl time.Du
 }
 
 // Write does nothing.
-func (c *noop) Write(_ context.Context, _ string, _ interface{}, ttl time.Duration) error {
+func (c *noop) Write(_ context.Context, _ *Key, _ interface{}, ttl time.Duration) error {
 	if c.isStopped() {
 		return ErrStopped
 	}
@@ -63,7 +63,7 @@ func (c *noop) Write(_ context.Context, _ string, _ interface{}, ttl time.Durati
 }
 
 // Read always returns ErrNotFound.
-func (c *noop) Read(_ context.Context, _ string, _ interface{}) error {
+func (c *noop) Read(_ context.Context, _ *Key, _ interface{}) error {
 	if c.isStopped() {
 		return ErrStopped
 	}
@@ -71,7 +71,15 @@ func (c *noop) Read(_ context.Context, _ string, _ interface{}) error {
 }
 
 // Delete does nothing.
-func (c *noop) Delete(_ context.Context, _ string) error {
+func (c *noop) Delete(_ context.Context, _ *Key) error {
+	if c.isStopped() {
+		return ErrStopped
+	}
+	return nil
+}
+
+// DeletePrefix does nothing.
+func (c *noop) DeletePrefix(_ context.Context, _ string) error {
 	if c.isStopped() {
 		return ErrStopped
 	}

--- a/pkg/cache/redis_test.go
+++ b/pkg/cache/redis_test.go
@@ -90,7 +90,7 @@ func TestRedis(t *testing.T) {
 	b = retry.WithCappedDuration(2*time.Second, b)
 
 	if err := retry.Do(ctx, b, func(_ context.Context) error {
-		if err := cacher.Delete(ctx, "foo"); err != nil {
+		if err := cacher.Delete(ctx, &Key{}); err != nil {
 			return retry.RetryableError(err)
 		}
 		return nil

--- a/pkg/controller/admin/admin.go
+++ b/pkg/controller/admin/admin.go
@@ -19,6 +19,7 @@ import (
 	"context"
 
 	"firebase.google.com/go/auth"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -29,6 +30,7 @@ import (
 )
 
 type Controller struct {
+	cacher       cache.Cacher
 	config       *config.ServerConfig
 	db           *database.Database
 	firebaseAuth *auth.Client
@@ -36,11 +38,12 @@ type Controller struct {
 	logger       *zap.SugaredLogger
 }
 
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, firebaseAuth *auth.Client, h *render.Renderer) *Controller {
+func New(ctx context.Context, config *config.ServerConfig, cacher cache.Cacher, db *database.Database, firebaseAuth *auth.Client, h *render.Renderer) *Controller {
 	logger := logging.FromContext(ctx).Named("admin")
 
 	return &Controller{
 		config:       config,
+		cacher:       cacher,
 		db:           db,
 		firebaseAuth: firebaseAuth,
 		h:            h,

--- a/pkg/controller/admin/caches.go
+++ b/pkg/controller/admin/caches.go
@@ -1,0 +1,84 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/gorilla/mux"
+)
+
+type cacheItem struct {
+	Name        string
+	Description string
+}
+
+var caches = map[string]*cacheItem{
+	"authorized_apps:": {"API keys", "Authentication caches for mobile devices"},
+	"apps:":            {"Mobile apps", "Registered mobile apps for the redirector service"},
+	"jwks:":            {"JWKs", "JSON web tokens"},
+	"realms:":          {"Realms", "Caches of realm data"},
+	"stats:":           {"Statistics", "API key, user, and realm statistic caches"},
+	"publickeys:":      {"Public keys", "PEM data from upstream key provider"},
+	"users:":           {"Users", "Caches of user data"},
+}
+
+// HandleCachesIndex shows the caches page.
+func (c *Controller) HandleCachesIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		c.renderCachesIndex(ctx, w)
+	})
+}
+
+// HandleCachesClear clears the given caches.
+func (c *Controller) HandleCachesClear() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		id := vars["id"]
+		item, ok := caches[id]
+		if !ok {
+			flash.Error("Unknown cache type: %q", id)
+			c.renderCachesIndex(ctx, w)
+			return
+		}
+
+		if err := c.cacher.DeletePrefix(ctx, id); err != nil {
+			flash.Error("Failed to clear cache for %s: %v", item.Name, err)
+			c.renderCachesIndex(ctx, w)
+			return
+		}
+
+		flash.Alert("Successfully cleared cache for %s!", item.Name)
+		controller.Back(w, r, c.h)
+	})
+}
+
+func (c *Controller) renderCachesIndex(ctx context.Context, w http.ResponseWriter) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["caches"] = caches
+	c.h.RenderHTML(w, "admin/caches/index", m)
+}

--- a/pkg/controller/admin/caches.go
+++ b/pkg/controller/admin/caches.go
@@ -33,7 +33,7 @@ var caches = map[string]*cacheItem{
 	"jwks:":            {"JWKs", "JSON web key sets"},
 	"realms:":          {"Realms", "All realm data"},
 	"stats:":           {"Statistics", "API key, user, and realm statistics"},
-	"publickeys:":      {"Public keys", "PEM data from upstream key provider"},
+	"public_keys:":     {"Public keys", "PEM data from upstream key provider"},
 	"users:":           {"Users", "All user data"},
 }
 

--- a/pkg/controller/admin/caches.go
+++ b/pkg/controller/admin/caches.go
@@ -28,13 +28,13 @@ type cacheItem struct {
 }
 
 var caches = map[string]*cacheItem{
-	"authorized_apps:": {"API keys", "Authentication caches for mobile devices"},
+	"authorized_apps:": {"API keys", "Authentication for API keys"},
 	"apps:":            {"Mobile apps", "Registered mobile apps for the redirector service"},
-	"jwks:":            {"JWKs", "JSON web tokens"},
-	"realms:":          {"Realms", "Caches of realm data"},
-	"stats:":           {"Statistics", "API key, user, and realm statistic caches"},
+	"jwks:":            {"JWKs", "JSON web key sets"},
+	"realms:":          {"Realms", "All realm data"},
+	"stats:":           {"Statistics", "API key, user, and realm statistics"},
 	"publickeys:":      {"Public keys", "PEM data from upstream key provider"},
-	"users:":           {"Users", "Caches of user data"},
+	"users:":           {"Users", "All user data"},
 }
 
 // HandleCachesIndex shows the caches page.

--- a/pkg/controller/apikey/show.go
+++ b/pkg/controller/apikey/show.go
@@ -16,10 +16,11 @@ package apikey
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
@@ -70,7 +71,10 @@ func (c *Controller) HandleShow() http.Handler {
 
 		// Get and cache the stats for this user.
 		var stats []*database.AuthorizedAppStats
-		cacheKey := fmt.Sprintf("stats:app:%d:%d", realm.ID, authApp.ID)
+		cacheKey := &cache.Key{
+			Namespace: "stats:app",
+			Key:       strconv.FormatUint(uint64(authApp.ID), 10),
+		}
 		if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
 			now := time.Now().UTC()
 			past := now.Add(-14 * 24 * time.Hour)

--- a/pkg/controller/associated/index.go
+++ b/pkg/controller/associated/index.go
@@ -67,7 +67,10 @@ func (c *Controller) HandleIos() http.Handler {
 			return
 		}
 
-		cacheKey := fmt.Sprintf("iosapps:by_region:%s", region)
+		cacheKey := &cache.Key{
+			Namespace: "apps:ios:by_region",
+			Key:       region,
+		}
 		var iosData *IOSData
 		if err := c.cacher.Fetch(ctx, cacheKey, &iosData, c.config.AppCacheTTL, func() (interface{}, error) {
 			c.logger.Debug("fetching new ios data")
@@ -96,7 +99,10 @@ func (c *Controller) HandleAndroid() http.Handler {
 			return
 		}
 
-		cacheKey := fmt.Sprintf("androidapps:by_region:%s", region)
+		cacheKey := &cache.Key{
+			Namespace: "apps:android:by_region",
+			Key:       region,
+		}
 		var androidData []AndroidData
 		if err := c.cacher.Fetch(ctx, cacheKey, &androidData, c.config.AppCacheTTL, func() (interface{}, error) {
 			c.logger.Debug("fetching new android data")

--- a/pkg/controller/jwks/jwks.go
+++ b/pkg/controller/jwks/jwks.go
@@ -54,7 +54,10 @@ func (c *Controller) HandleIndex() http.Handler {
 		ctx := r.Context()
 
 		// key is the key in the cacher where the values for this JWK are cached.
-		key := r.URL.String()
+		key := &cache.Key{
+			Namespace: "jwks",
+			Key:       r.URL.String(),
+		}
 
 		// See if there's a cached value. Note we cannot use Fetch here because our
 		// fetch function also depends on the cacher to lookup pubic keys and

--- a/pkg/controller/middleware/auth.go
+++ b/pkg/controller/middleware/auth.go
@@ -95,7 +95,10 @@ func RequireAuth(ctx context.Context, cacher cache.Cacher, fbClient *auth.Client
 			// Load the user by using the cache to alleviate pressure on the database
 			// layer.
 			var user database.User
-			cacheKey := fmt.Sprintf("users:by_email:%s", email)
+			cacheKey := &cache.Key{
+				Namespace: "users:by_email",
+				Key:       email,
+			}
 			if err := cacher.Fetch(ctx, cacheKey, &user, cacheTTL, func() (interface{}, error) {
 				return db.FindUserByEmail(email)
 			}); err != nil {

--- a/pkg/controller/middleware/realm.go
+++ b/pkg/controller/middleware/realm.go
@@ -19,6 +19,7 @@ import (
 	"errors"
 	"fmt"
 	"net/http"
+	"strconv"
 	"strings"
 	"time"
 
@@ -60,7 +61,10 @@ func LoadCurrentRealm(ctx context.Context, cacher cache.Cacher, db *database.Dat
 			// Load the realm by using the cache to alleviate pressure on the database
 			// layer.
 			var realm database.Realm
-			cacheKey := fmt.Sprintf("realms:by_id:%d", realmID)
+			cacheKey := &cache.Key{
+				Namespace: "realms:by_id",
+				Key:       strconv.FormatUint(uint64(realmID), 10),
+			}
 			if err := cacher.Fetch(ctx, cacheKey, &realm, cacheTTL, func() (interface{}, error) {
 				return db.FindRealm(realmID)
 			}); err != nil {

--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -25,7 +25,6 @@ import (
 	"github.com/gonum/matrix/mat64"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
-	"github.com/google/exposure-notifications-verification-server/pkg/digest"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/hashicorp/go-multierror"
 
@@ -206,11 +205,10 @@ func (c *Controller) rebuildModel(ctx context.Context, id uint64) error {
 	logger.Debugw("next effective limit", "value", effective)
 
 	// Update the limiter to use the new value.
-	dig, err := digest.HMACUint64(id, c.config.RateLimit.HMACKey)
+	key, err := realm.QuotaKey(c.config.RateLimit.HMACKey)
 	if err != nil {
 		return fmt.Errorf("failed to digest realm id: %w", err)
 	}
-	key := fmt.Sprintf("realm:quota:%s", dig)
 	if err := c.limiter.Set(ctx, key, uint64(effective), 24*time.Hour); err != nil {
 		return fmt.Errorf("failed to update limit: %w", err)
 	}

--- a/pkg/controller/realmadmin/show.go
+++ b/pkg/controller/realmadmin/show.go
@@ -16,10 +16,11 @@ package realmadmin
 
 import (
 	"context"
-	"fmt"
 	"net/http"
+	"strconv"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
@@ -40,7 +41,10 @@ func (c *Controller) HandleShow() http.Handler {
 
 		// Get and cache the stats for this realm.
 		var stats []*database.RealmStats
-		cacheKey := fmt.Sprintf("stats:realm:%d", realm.ID)
+		cacheKey := &cache.Key{
+			Namespace: "stats:realm",
+			Key:       strconv.FormatUint(uint64(realm.ID), 10),
+		}
 		if err := c.cacher.Fetch(ctx, cacheKey, &stats, timeout, func() (interface{}, error) {
 			return realm.Stats(c.db, past, now)
 		}); err != nil {
@@ -50,7 +54,10 @@ func (c *Controller) HandleShow() http.Handler {
 
 		// Also get the per-user stats.
 		var userStats []*database.RealmUserStats
-		cacheKey = fmt.Sprintf("userstats:realm:%d", realm.ID)
+		cacheKey = &cache.Key{
+			Namespace: "stats:realm:per_user",
+			Key:       strconv.FormatUint(uint64(realm.ID), 10),
+		}
 		if err := c.cacher.Fetch(ctx, cacheKey, &userStats, timeout, func() (interface{}, error) {
 			return realm.CodesPerUser(c.db, past, now)
 		}); err != nil {

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -15,11 +15,11 @@
 package redirect
 
 import (
-	"fmt"
 	"net/http"
 	"net/url"
 	"strings"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
@@ -53,8 +53,11 @@ func (c *Controller) HandleIndex() http.Handler {
 		}
 
 		// Get App Store Data.
-		cacheKey := fmt.Sprintf("appstoredata:by_region:%s", hostRegion)
 		var appStoreData AppStoreData
+		cacheKey := &cache.Key{
+			Namespace: "apps:appstoredata:by_region",
+			Key:       hostRegion,
+		}
 		if err := c.cacher.Fetch(ctx, cacheKey, &appStoreData, c.config.AppCacheTTL, func() (interface{}, error) {
 			c.logger.Debug("fetching new app store data")
 			return c.getAppStoreData(realm.ID)

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -20,6 +20,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
@@ -75,7 +76,10 @@ func (c *Controller) Show(w http.ResponseWriter, r *http.Request, resetPassword 
 // Get and cache the stats for this user.
 func (c *Controller) getStats(ctx context.Context, user *database.User, realm *database.Realm) ([]*database.UserStats, error) {
 	var stats []*database.UserStats
-	cacheKey := fmt.Sprintf("stats:user:%d:%d", realm.ID, user.ID)
+	cacheKey := &cache.Key{
+		Namespace: "stats:user",
+		Key:       fmt.Sprintf("%d:%d", realm.ID, user.ID),
+	}
 	if err := c.cacher.Fetch(ctx, cacheKey, &stats, 5*time.Minute, func() (interface{}, error) {
 		now := time.Now().UTC()
 		past := now.Add(-14 * 24 * time.Hour)

--- a/pkg/database/authorized_app_stats.go
+++ b/pkg/database/authorized_app_stats.go
@@ -18,7 +18,8 @@ import (
 	"time"
 )
 
-// AuthorizedAppStats represents statistics related to a user in the database.
+// AuthorizedAppStats represents statistics related to an API key in the
+// database.
 type AuthorizedAppStats struct {
 	Date            time.Time `gorm:"date"`
 	AuthorizedAppID uint      `gorm:"authorized_app_id"`

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -206,20 +206,20 @@ func (db *Database) OpenWithCacher(ctx context.Context, cacher cache.Cacher) err
 	// Cache clearing
 	if cacher != nil {
 		// Apps
-		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:authorized_apps:by_id", callbackPurgeCache(ctx, cacher, "authorized_apps:by_id:%d", "authorized_apps", "id"))
-		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:authorized_apps:by_id", callbackPurgeCache(ctx, cacher, "authorized_apps:by_id:%d", "authorized_apps", "id"))
+		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:authorized_apps:by_id", callbackPurgeCache(ctx, cacher, "authorized_apps:by_id", "authorized_apps", "id"))
+		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:authorized_apps:by_id", callbackPurgeCache(ctx, cacher, "authorized_apps:by_id", "authorized_apps", "id"))
 
 		// Realms
-		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id:%d", "realms", "id"))
-		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id:%d", "realms", "id"))
+		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
+		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
 
 		// Users
-		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id:%d", "users", "id"))
-		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id:%d", "users", "id"))
+		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id", "users", "id"))
+		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id", "users", "id"))
 
 		// Users (by email)
-		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:users:by_email", callbackPurgeCache(ctx, cacher, "users:by_email:%s", "users", "email"))
-		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:users:by_email", callbackPurgeCache(ctx, cacher, "users:by_email:%s", "users", "email"))
+		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:users:by_email", callbackPurgeCache(ctx, cacher, "users:by_email", "users", "email"))
+		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:users:by_email", callbackPurgeCache(ctx, cacher, "users:by_email", "users", "email"))
 	}
 
 	db.db = rawDB
@@ -306,7 +306,7 @@ func callbackIncrementMetric(ctx context.Context, m *stats.Int64Measure, table s
 }
 
 // callbackPurgeCache purges the cache key for the given record.
-func callbackPurgeCache(ctx context.Context, cacher cache.Cacher, keyFormat, table, column string) func(scope *gorm.Scope) {
+func callbackPurgeCache(ctx context.Context, cacher cache.Cacher, namespace, table, column string) func(scope *gorm.Scope) {
 	return func(scope *gorm.Scope) {
 		if scope.TableName() != table {
 			return
@@ -332,7 +332,10 @@ func callbackPurgeCache(ctx context.Context, cacher cache.Cacher, keyFormat, tab
 			return
 		}
 
-		key := fmt.Sprintf(keyFormat, val)
+		key := &cache.Key{
+			Namespace: namespace,
+			Key:       fmt.Sprintf("%v", val),
+		}
 		if err := cacher.Delete(ctx, key); err != nil {
 			scope.Log(fmt.Sprintf("failed to delete cache key: %v", err))
 			return

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/digest"
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 	"github.com/microcosm-cc/bluemonday"
 
@@ -1123,6 +1124,16 @@ func (r *Realm) RenderWelcomeMessage() string {
 
 	raw := blackfriday.Run([]byte(msg))
 	return string(bluemonday.UGCPolicy().SanitizeBytes(raw))
+}
+
+// QuotaKey returns the unique and consistent key to use for storing quota data
+// for this realm, given the provided HMAC key.
+func (r *Realm) QuotaKey(hmacKey []byte) (string, error) {
+	dig, err := digest.HMACUint(r.ID, hmacKey)
+	if err != nil {
+		return "", fmt.Errorf("failed to create realm quota key: %w", err)
+	}
+	return fmt.Sprintf("realm:quota:%s", dig), nil
 }
 
 // ToCIDRList converts the newline-separated and/or comma-separated CIDR list

--- a/pkg/integration/helpers.go
+++ b/pkg/integration/helpers.go
@@ -144,10 +144,7 @@ func (s *Suite) newAdminAPIServer(ctx context.Context, tb testing.TB) *server.Se
 	}
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &s.cfg.APISrvConfig.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, s.cfg.APISrvConfig.Cache.HMACKey),
-		cache.PrefixKeyFunc("apiserver:cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &s.cfg.APISrvConfig.Cache, cache.HMACKeyFunc(sha1.New, s.cfg.APISrvConfig.Cache.HMACKey))
 	if err != nil {
 		tb.Fatalf("failed to create cacher: %v", err)
 	}
@@ -211,10 +208,7 @@ func (s *Suite) newAPIServer(ctx context.Context, tb testing.TB) *server.Server 
 	}
 
 	// Setup cacher
-	cacher, err := cache.CacherFor(ctx, &s.cfg.APISrvConfig.Cache, cache.MultiKeyFunc(
-		cache.HMACKeyFunc(sha1.New, s.cfg.APISrvConfig.Cache.HMACKey),
-		cache.PrefixKeyFunc("apiserver:cache:"),
-	))
+	cacher, err := cache.CacherFor(ctx, &s.cfg.APISrvConfig.Cache, cache.HMACKeyFunc(sha1.New, s.cfg.APISrvConfig.Cache.HMACKey))
 	if err != nil {
 		tb.Fatalf("failed to create cacher: %v", err)
 	}

--- a/pkg/keyutils/public_keys.go
+++ b/pkg/keyutils/public_keys.go
@@ -45,10 +45,13 @@ func NewPublicKeyCache(ctx context.Context, cacher cache.Cacher, ttl time.Durati
 
 // GetPublicKey returns the public key for the provided ID.
 func (c *PublicKeyCache) GetPublicKey(ctx context.Context, id string, kms keys.KeyManager) (crypto.PublicKey, error) {
-	key := fmt.Sprintf("publickey:%s", id)
+	cacheKey := &cache.Key{
+		Namespace: "publickeys",
+		Key:       id,
+	}
 
 	var b []byte
-	if err := c.cacher.Fetch(ctx, key, &b, c.ttl, func() (interface{}, error) {
+	if err := c.cacher.Fetch(ctx, cacheKey, &b, c.ttl, func() (interface{}, error) {
 		signer, err := kms.NewSigner(ctx, id)
 		if err != nil {
 			return nil, err

--- a/pkg/keyutils/public_keys.go
+++ b/pkg/keyutils/public_keys.go
@@ -46,7 +46,7 @@ func NewPublicKeyCache(ctx context.Context, cacher cache.Cacher, ttl time.Durati
 // GetPublicKey returns the public key for the provided ID.
 func (c *PublicKeyCache) GetPublicKey(ctx context.Context, id string, kms keys.KeyManager) (crypto.PublicKey, error) {
 	cacheKey := &cache.Key{
-		Namespace: "publickeys",
+		Namespace: "public_keys",
 		Key:       id,
 	}
 


### PR DESCRIPTION
In some situations, a system admin may want to clear the caches, either
for development/testing or because a misconfiguration has made it into
the system. This introduces a way for system admins to perform cache
resets.

This required a bit of a refactor of the cacher, separating the
namespace property from the actual key value.

Fixes #821 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Give system admins the ability to clear (Redis) caches.
```
