### PR TITLE
Use Android intent links in place of bouncing.

### DIFF
--- a/pkg/controller/redirect/appstore.go
+++ b/pkg/controller/redirect/appstore.go
@@ -21,20 +21,23 @@ import (
 )
 
 type AppStoreData struct {
-	AndroidURL string `json:"androidURL"`
-	IOSURL     string `json:"iosURL"`
+	AndroidURL   string `json:"androidURL"`
+	AndroidAppID string `json:"androidAppID"`
+	IOSURL       string `json:"iosURL"`
 }
 
 // getAppStoreData finds data tied to app store listings.
 func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 	// Pick first Android app (in the realm) for Play Store redirect.
 	androidURL := ""
+	androidAppID := ""
 	androidApps, err := c.db.ListActiveAppsByOS(realmID, database.OSTypeAndroid)
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Android Apps: %w", err)
 	}
 	if len(androidApps) > 0 {
 		androidURL = androidApps[0].URL
+		androidAppID = androidApps[0].AppID
 	}
 
 	// Pick first iOS app (in the realm) for Store redirect.
@@ -48,7 +51,8 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 	}
 
 	return &AppStoreData{
-		AndroidURL: androidURL,
-		IOSURL:     iosURL,
+		AndroidURL:   androidURL,
+		AndroidAppID: androidAppID,
+		IOSURL:       iosURL,
 	}, nil
 }


### PR DESCRIPTION
This fixes behavior of Facebook Messenger when
the app is installed (currently it always redirects to the store),
and appears to generalize to more SMS clients.

It also more closely matches this approach:
https://firebase.google.com/docs/dynamic-links/operating-system-integrations

NOTE: For iOS ENX, Store URL should be left blank, as no App Link triggers ENX.
Custom Apps using the verification server currently can't do the
"fancier" clipboard trick described in the link above, see:
https://github.com/google/exposure-notifications-verification-server/issues/844

```release-note
NOTE: ENX Apps configured for Android for Android should configure Store URL.
iOS ENX regions should NOT.
```
