### PR TITLE
Fix uses of time.Truncate

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -194,8 +195,8 @@ func (c *Controller) HandleIssue() http.Handler {
 				return
 			} else {
 				// Max date is today (UTC time) and min date is AllowedTestAge ago, truncated.
-				maxDate := time.Now().UTC().Truncate(24 * time.Hour)
-				minDate := maxDate.Add(-1 * c.config.GetAllowedSymptomAge()).Truncate(24 * time.Hour)
+				maxDate := timeutils.UTCMidnight(time.Now())
+				minDate := timeutils.Midnight(maxDate.Add(-1 * c.config.GetAllowedSymptomAge()))
 
 				symptomDate, err = validateDate(parsed, minDate, maxDate, int(request.TZOffset))
 				if err != nil {

--- a/pkg/controller/realmadmin/show_test.go
+++ b/pkg/controller/realmadmin/show_test.go
@@ -20,12 +20,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 func TestFormatStats(t *testing.T) {
-	now := time.Now().Truncate(24 * time.Hour)
-	yesterday := now.Add(-24 * time.Hour).Truncate(24 * time.Hour)
+	now := timeutils.Midnight(time.Now())
+	yesterday := timeutils.Midnight(now.Add(-24 * time.Hour))
 	tests := []struct {
 		data    []*database.RealmUserStats
 		names   []string

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -25,6 +25,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/base64util"
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/jinzhu/gorm"
 )
 
@@ -205,8 +206,8 @@ func (db *Database) FindAuthorizedAppByAPIKey(apiKey string) (*AuthorizedApp, er
 func (a *AuthorizedApp) Stats(db *Database, start, stop time.Time) ([]*AuthorizedAppStats, error) {
 	var stats []*AuthorizedAppStats
 
-	start = start.Truncate(24 * time.Hour)
-	stop = stop.Truncate(24 * time.Hour)
+	start = timeutils.UTCMidnight(start)
+	stop = timeutils.UTCMidnight(stop)
 
 	if err := db.db.
 		Model(&AuthorizedAppStats{}).

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -24,6 +24,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/digest"
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 	"github.com/microcosm-cc/bluemonday"
@@ -1096,8 +1097,8 @@ func (r *Realm) DestroySigningKeyVersion(ctx context.Context, db *Database, id i
 func (r *Realm) Stats(db *Database, start, stop time.Time) ([]*RealmStats, error) {
 	var stats []*RealmStats
 
-	start = start.Truncate(24 * time.Hour)
-	stop = stop.Truncate(24 * time.Hour)
+	start = timeutils.Midnight(start)
+	stop = timeutils.Midnight(stop)
 
 	if err := db.db.
 		Model(&RealmStats{}).
@@ -1183,8 +1184,8 @@ type RealmUserStats struct {
 
 // CodesPerUser returns a set of UserStats for a given date range.
 func (r *Realm) CodesPerUser(db *Database, start, stop time.Time) ([]*RealmUserStats, error) {
-	start = start.Truncate(time.Hour * 24)
-	stop = stop.Truncate(time.Hour * 24)
+	start = timeutils.UTCMidnight(start)
+	stop = timeutils.UTCMidnight(stop)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -17,6 +17,8 @@ package database
 import (
 	"testing"
 	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 )
 
 func TestSMS(t *testing.T) {
@@ -44,8 +46,8 @@ func TestPerUserRealmStats(t *testing.T) {
 	db := NewTestDatabase(t)
 
 	numDays := 7
-	endDate := time.Now().Truncate(24 * time.Hour)
-	startDate := endDate.Add(time.Duration(numDays) * -24 * time.Hour).Truncate(24 * time.Hour)
+	endDate := timeutils.Midnight(time.Now())
+	startDate := timeutils.Midnight(endDate.Add(time.Duration(numDays) * -24 * time.Hour))
 
 	// Create a new realm
 	realm := NewRealmWithDefaults("test")

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/jinzhu/gorm"
 )
@@ -199,7 +200,7 @@ func (db *Database) VerifyCodeAndIssueToken(realmID uint, verCode string, accept
 		}
 
 		// Update statistics
-		now := time.Now().Truncate(24 * time.Hour)
+		now := timeutils.Midnight(vc.CreatedAt)
 		sql := `
 			INSERT INTO realm_stats(date, realm_id, codes_claimed)
 				VALUES ($1, $2, 1)

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -79,7 +80,7 @@ func TestIssueToken(t *testing.T) {
 	t.Parallel()
 
 	codeAge := time.Hour
-	symptomDate := time.Now().UTC().Truncate(24 * time.Hour)
+	symptomDate := timeutils.UTCMidnight(time.Now())
 	wrongSymptomDate := symptomDate.Add(-48 * time.Hour)
 
 	acceptConfirmed := api.AcceptTypes{

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"firebase.google.com/go/auth"
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/jinzhu/gorm"
 	"github.com/sethvargo/go-password/password"
 )
@@ -204,8 +205,8 @@ func (db *Database) FindUserByEmail(email string) (*User, error) {
 func (u *User) Stats(db *Database, realmID uint, start, stop time.Time) ([]*UserStats, error) {
 	var stats []*UserStats
 
-	start = start.Truncate(24 * time.Hour)
-	stop = stop.Truncate(24 * time.Hour)
+	start = timeutils.Midnight(start)
+	stop = timeutils.Midnight(stop)
 
 	if err := db.db.
 		Model(&UserStats{}).

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -364,7 +364,7 @@ func TestStatDatesOnCreate(t *testing.T) {
 		{
 			var stats []*AuthorizedAppStats
 			if err := db.db.
-				Model(&UserStats{}).
+				Model(&AuthorizedAppStats{}).
 				Select("*").
 				Scan(&stats).
 				Error; err != nil {
@@ -386,7 +386,7 @@ func TestStatDatesOnCreate(t *testing.T) {
 		{
 			var stats []*RealmStats
 			if err := db.db.
-				Model(&UserStats{}).
+				Model(&RealmStats{}).
 				Select("*").
 				Scan(&stats).
 				Error; err != nil {


### PR DESCRIPTION
**** NB *****
This PR will be marked HOLD until all reviews requested on this PR give
it an LGTM. If you want to HOLD this CL, please add yourself as
reviewer, and mark yourself as NON-LGTM.
**** /NB *****

PTAL. These are all references to Truncate that:

`grep -R Truncate * | grep 24`

returned, and I think all changes are correct. Please verify.

Fixes #848
<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixed statistics reporting dates.
Previously, it was possible for many statistics to report themselves on the wrong day. This has been fixed.
```
