### PR TITLE
Set default to tls 1.2

### DIFF
--- a/terraform/verification-lb.tf
+++ b/terraform/verification-lb.tf
@@ -17,6 +17,12 @@ locals {
   enable_lb = length(local.all_hosts) > 0
 }
 
+resource "google_compute_ssl_policy" "one-two-ssl-policy" {
+  name            = "one-two-ssl-policy"
+  profile         = "MODERN"
+  min_tls_version = "TLS_1_2"
+}
+
 resource "google_compute_global_address" "verification-server" {
   count = local.enable_lb ? 1 : 0
 
@@ -122,6 +128,7 @@ resource "google_compute_target_https_proxy" "https" {
 
   url_map          = google_compute_url_map.urlmap-https[0].id
   ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
+  ssl_policy       = google_compute_ssl_policy.one-two-ssl-policy
 }
 
 resource "google_compute_global_forwarding_rule" "http" {


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Sets the TLS policy to 1.2+ and modern as defined in https://cloud.google.com/load-balancing/docs/ssl-policies-concepts#defining_an_ssl_policy

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Sets the default TLS to 1.2+ for the verification server loadbalancer.
```
