### PR TITLE
Use .id on google_compute_ssl_policy

### DIFF
--- a/terraform/verification-lb.tf
+++ b/terraform/verification-lb.tf
@@ -128,7 +128,7 @@ resource "google_compute_target_https_proxy" "https" {
 
   url_map          = google_compute_url_map.urlmap-https[0].id
   ssl_certificates = [google_compute_managed_ssl_certificate.default[0].id]
-  ssl_policy       = google_compute_ssl_policy.one-two-ssl-policy
+  ssl_policy       = google_compute_ssl_policy.one-two-ssl-policy.id
 }
 
 resource "google_compute_global_forwarding_rule" "http" {


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
