### PR TITLE
Limit redirector LB to TLS 1.2+

### DIFF
--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -63,6 +63,9 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id
   ]
+
+  # Defined in verification-lb.tf
+  ssl_policy = google_compute_ssl_policy.one-two-ssl-policy.id
 }
 
 resource "google_compute_global_forwarding_rule" "enx-redirect-http" {


### PR DESCRIPTION
Similar to #852 and https://github.com/google/exposure-notifications-server/pull/1093

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Updates redirector LB to use 1.2+ TLS

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Limits redirector load balancer to only use TLS 1.2+
```
