### PR TITLE
e2e test script is guarded against prod resources

### DIFF
--- a/scripts/terraform.sh
+++ b/scripts/terraform.sh
@@ -42,7 +42,7 @@ readonly PROTECTED_DB_INSTANCE_NAMES="en-verification en-server"
 LIST_PROJECTED_DB="$(gcloud sql instances list --project=${PROJECT_ID} --filter="name=( ${PROTECTED_DB_INSTANCE_NAMES} )")"
 if [[ -n "${LIST_PROJECTED_DB}" ]]; then
   # The output will only exist when the database exist
-  echo "✋ Running this script if prohibited when database below exist:"
+  echo "✋ Running this script is prohibited when database below exist:"
   echo "${LIST_PROJECTED_DB}"
   exit 100
 fi


### PR DESCRIPTION
There are 2 scripts used for running e2e tests: `scripts/e2e-tests.sh` and `scripts/terraform.sh`, the former is a thin wrapper of the latter. Adding guard to the latter in this PR to avoid it from being used on prod resource