### PR TITLE
Realm not required for email verify

### DIFF
--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -251,7 +251,6 @@ func realMain(ctx context.Context) error {
 			sub.Use(requireAuth)
 			sub.Use(rateLimit)
 			sub.Use(loadCurrentRealm)
-			sub.Use(requireRealm)
 			sub.Use(processFirewall)
 			sub.Handle("/login/manage-account", loginController.HandleShowVerifyEmail()).
 				Queries("mode", "verifyEmail").Methods("GET")


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/873

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Verify email does not strictly require a loaded realm. This pops up for a system admin which is not a member of any realm.

This assumes we are requiring system admin to verify their email address. The alternative would be to not require email verification for system admin in the case where no realm is selected, but this feels like the more secure thing to do.