### PR TITLE
Backup the Cloud SQL database to GCS every 6 hours

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -298,6 +298,10 @@ resource "google_storage_bucket" "backups" {
     enabled = true
   }
 
+  retention_policy {
+    retention_period = "2592000" // 30 days in seconds
+  }
+
   lifecycle_rule {
     action {
       type = "Delete"

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -285,6 +285,95 @@ resource "null_resource" "migrate" {
   ]
 }
 
+# Create a storage bucket where database backups will be housed.
+resource "google_storage_bucket" "backups" {
+  project  = var.project
+  name     = "${var.project}-backups"
+  location = var.storage_location
+
+  force_destroy               = true
+  uniform_bucket_level_access = true
+
+  versioning {
+    enabled = true
+  }
+
+  lifecycle_rule {
+    action {
+      type = "Delete"
+    }
+
+    condition {
+      num_newer_versions = "120" // Default backup is 4x/day * 30 days
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["storage.googleaips.com"],
+  ]
+}
+
+# Give Cloud SQL the ability to create and manage backups.
+resource "google_storage_bucket_iam_member" "instance-objectAdmin" {
+  bucket = google_storage_bucket.backups.name
+  role   = "roles/storage.objectAdmin"
+  member = "serviceAccount:${google_sql_database_instance.db-inst.service_account_email_address}"
+}
+
+# Create a service account that can initiate backups.
+resource "google_service_account" "database-backuper" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-database-backuper"
+  display_name = "Verification database backuper"
+}
+
+# Give the service account the ability to initiate backups - unfortunately this
+# has to be granted at the project level and isn't scoped to a single database
+# instance.
+resource "google_project_iam_member" "database-backuper-cloudsql-viewer" {
+  project = var.project
+  role    = "roles/cloudsql.viewer"
+  member  = "serviceAccount:${google_service_account.database-backuper.email}"
+}
+
+# Create a Cloud Scheduler job that generates a backup every interval.
+resource "google_cloud_scheduler_job" "backup-database-worker" {
+  name             = "backup-database-worker"
+  region           = var.cloudscheduler_location
+  schedule         = var.database_backup_schedule
+  time_zone        = "America/Los_Angeles"
+  attempt_deadline = "1800s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "POST"
+    uri         = "${google_sql_database_instance.db-inst.self_link}/export"
+
+    body = base64encode(jsonencode({
+      exportContext = {
+        fileType  = "SQL"
+        uri       = "gs://${google_storage_bucket.backups.name}/database/${google_sql_database.db.name}",
+        databases = [google_sql_database.db.name]
+        offload   = true,
+      }
+    }))
+
+    oauth_token {
+      service_account_email = google_service_account.database-backuper.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_project_iam_member.database-backuper-cloudsql-viewer,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}
+
+
 output "db_conn" {
   value = google_sql_database_instance.db-inst.connection_name
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -61,6 +61,13 @@ variable "database_backup_location" {
   description = "Location in which to backup the database."
 }
 
+variable "database_backup_schedule" {
+  type    = string
+  default = "0 */6 * * *"
+
+  description = "Cron schedule in which to do a full backup of the database to Cloud Storage."
+}
+
 variable "storage_location" {
   type    = string
   default = "US"


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/864

**Nuances**

- Cloud SQL doesn't seem to support per-instance IAM, so we have to grant at the project level (yuck, but it's only viewer)

- I'm relying on bucket versioning instead of actually naming the exports with a datetime. This is mostly a design decision to avoid needing a middle service. Ideally Cloud Scheduler would support a template syntax, but it does not.

- The backups aren't compressed (for the same reason as above), but our last backup was 2MB. I'm not really worried about large databases for this project.

- Backup time is configurable via the cron notation.

**Release Note**

```release-note
Automatically backup the Cloud SQL database to GCS every 6 hours
```

/assign @jeremyfaller @icco 
