### PR TITLE
thread test date all the way through

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -290,6 +290,7 @@ type VerifyCodeResponse struct {
 
 	TestType          string `json:"testtype,omitempty"`
 	SymptomDate       string `json:"symptomDate,omitempty"` // ISO 8601 formatted date, YYYY-MM-DD
+	TestDate          string `json:"testDate,omitempty"`    // ISO 8601 formatted date, YYYY-MM-DD
 	VerificationToken string `json:"token,omitempty"`       // JWT - signed, not encrypted.
 	Error             string `json:"error,omitempty"`
 	ErrorCode         string `json:"errorCode,omitempty"`

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -143,6 +143,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		c.h.RenderJSON(w, http.StatusOK, api.VerifyCodeResponse{
 			TestType:          verificationToken.TestType,
 			SymptomDate:       verificationToken.FormatSymptomDate(),
+			TestDate:          verificationToken.FormatTestDate(),
 			VerificationToken: signedJWT,
 		})
 	})

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1544,6 +1544,26 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return nil
 			},
 		},
+		{
+			ID: "00062-AddTestDate",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("adding verification code test date")
+				return tx.AutoMigrate(&VerificationCode{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE verification_codes DROP COLUMN IF EXISTS test_date").Error
+			},
+		},
+		{
+			ID: "00063-AddTokenTestDate",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("adding token test date")
+				return tx.AutoMigrate(&Token{}).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec("ALTER TABLE tokens DROP COLUMN IF EXISTS test_date").Error
+			},
+		},
 	})
 }
 

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -98,7 +98,7 @@ func ParseSubject(sub string) (*Subject, error) {
 	}
 
 	var testDate *time.Time
-	if len(parts) == 3 {
+	if len(parts) == 3 && parts[2] != "" {
 		parsedDate, err := time.Parse("2006-01-02", parts[2])
 		if err != nil {
 			return nil, fmt.Errorf("subject contains invalid test date: %w", err)

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -50,6 +50,7 @@ type Token struct {
 	TokenID     string `gorm:"type:varchar(200); unique_index"`
 	TestType    string `gorm:"type:varchar(20)"`
 	SymptomDate *time.Time
+	TestDate    *time.Time
 	Used        bool `gorm:"default:false"`
 	ExpiresAt   time.Time
 }
@@ -58,14 +59,21 @@ type Token struct {
 type Subject struct {
 	TestType    string
 	SymptomDate *time.Time
+	TestDate    *time.Time
 }
 
 func (s *Subject) String() string {
-	datePortion := ""
+	parts := make([]string, 3)
+
+	parts[0] = s.TestType
 	if s.SymptomDate != nil {
-		datePortion = s.SymptomDate.Format("2006-01-02")
+		parts[1] = s.SymptomDate.Format("2006-01-02")
 	}
-	return s.TestType + "." + datePortion
+	if s.TestDate != nil {
+		parts[2] = s.TestDate.Format("2006-01-02")
+	}
+
+	return strings.Join(parts, ".")
 }
 
 func (s *Subject) SymptomInterval() uint32 {
@@ -77,8 +85,8 @@ func (s *Subject) SymptomInterval() uint32 {
 
 func ParseSubject(sub string) (*Subject, error) {
 	parts := strings.Split(sub, ".")
-	if length := len(parts); length < 1 || length > 2 {
-		return nil, fmt.Errorf("subject must contain 2 parts, got: %v", length)
+	if length := len(parts); length < 2 || length > 3 {
+		return nil, fmt.Errorf("subject must contain 2 or 3 parts, got: %v", length)
 	}
 	var symptomDate *time.Time
 	if parts[1] != "" {
@@ -88,13 +96,24 @@ func ParseSubject(sub string) (*Subject, error) {
 		}
 		symptomDate = &parsedDate
 	}
+
+	var testDate *time.Time
+	if len(parts) == 3 {
+		parsedDate, err := time.Parse("2006-01-02", parts[2])
+		if err != nil {
+			return nil, fmt.Errorf("subject contains invalid test date: %w", err)
+		}
+		testDate = &parsedDate
+	}
+
 	return &Subject{
 		TestType:    parts[0],
 		SymptomDate: symptomDate,
+		TestDate:    testDate,
 	}, nil
 }
 
-// FormatSymptomDate returns YYYY-MM-DD formatted test date, or "" if nil.
+// FormatSymptomDate returns YYYY-MM-DD formatted symptom date, or "" if nil.
 func (t *Token) FormatSymptomDate() string {
 	if t.SymptomDate == nil {
 		return ""
@@ -102,10 +121,19 @@ func (t *Token) FormatSymptomDate() string {
 	return t.SymptomDate.Format("2006-01-02")
 }
 
+// FormatTestDate returns YYYY-MM-DD formatted test date, or "" if nil.
+func (t *Token) FormatTestDate() string {
+	if t.TestDate == nil {
+		return ""
+	}
+	return t.TestDate.Format("2006-01-02")
+}
+
 func (t *Token) Subject() *Subject {
 	return &Subject{
 		TestType:    t.TestType,
 		SymptomDate: t.SymptomDate,
+		TestDate:    t.TestDate,
 	}
 }
 
@@ -138,6 +166,11 @@ func (db *Database) ClaimToken(realmID uint, tokenID string, subject *Subject) e
 		if (tok.SymptomDate == nil && subject.SymptomDate != nil) ||
 			(tok.SymptomDate != nil && subject.SymptomDate == nil) ||
 			(tok.SymptomDate != nil && !tok.SymptomDate.Equal(*subject.SymptomDate)) {
+			return ErrTokenMetadataMismatch
+		}
+		if (tok.TestDate == nil && subject.TestDate != nil) ||
+			(tok.TestDate != nil && subject.TestDate == nil) ||
+			(tok.TestDate != nil && !tok.TestDate.Equal(*subject.TestDate)) {
 			return ErrTokenMetadataMismatch
 		}
 
@@ -222,6 +255,7 @@ func (db *Database) VerifyCodeAndIssueToken(realmID uint, verCode string, accept
 			TokenID:     tokenID,
 			TestType:    vc.TestType,
 			SymptomDate: vc.SymptomDate,
+			TestDate:    vc.TestDate,
 			Used:        false,
 			ExpiresAt:   time.Now().UTC().Add(expireAfter),
 			RealmID:     realmID,

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -39,7 +39,7 @@ func TestSubject(t *testing.T) {
 		Error string
 	}{
 		{
-			Name: "normal parse",
+			Name: "legacy_version",
 			Sub:  "confirmed.2020-07-07",
 			Want: &Subject{
 				TestType:    "confirmed",
@@ -47,12 +47,49 @@ func TestSubject(t *testing.T) {
 			},
 		},
 		{
-			Name: "no date",
+			Name: "legacy_version_no_date",
 			Sub:  "confirmed.",
 			Want: &Subject{
 				TestType:    "confirmed",
 				SymptomDate: nil,
 			},
+		},
+		{
+			Name: "current_version_no_test_date",
+			Sub:  "confirmed.2020-07-07.",
+			Want: &Subject{
+				TestType:    "confirmed",
+				SymptomDate: &testDay,
+			},
+		},
+		{
+			Name: "current_version_no_symptom_date",
+			Sub:  "confirmed..2020-07-07",
+			Want: &Subject{
+				TestType: "confirmed",
+				TestDate: &testDay,
+			},
+		},
+		{
+			Name: "all_fields",
+			Sub:  "confirmed.2020-07-07.2020-07-07",
+			Want: &Subject{
+				TestType:    "confirmed",
+				SymptomDate: &testDay,
+				TestDate:    &testDay,
+			},
+		},
+		{
+			Name:  "invalid_segments",
+			Sub:   "confirmed",
+			Want:  nil,
+			Error: "subject must contain 2 or 3 parts, got: 1",
+		},
+		{
+			Name:  "too_many_segments",
+			Sub:   "confirmed.date.date.whomp",
+			Want:  nil,
+			Error: "subject must contain 2 or 3 parts, got: 4",
 		},
 	}
 

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -196,7 +196,7 @@ func TestIssueToken(t *testing.T) {
 			Accept:     acceptConfirmed,
 			ClaimError: ErrTokenMetadataMismatch.Error(),
 			TokenAge:   time.Hour,
-			Subject:    &Subject{"negative", nil},
+			Subject:    &Subject{"negative", nil, nil},
 		},
 		{
 			Name: "wrong_test_date",
@@ -214,7 +214,7 @@ func TestIssueToken(t *testing.T) {
 			Accept:     acceptConfirmed,
 			ClaimError: ErrTokenMetadataMismatch.Error(),
 			TokenAge:   time.Hour,
-			Subject:    &Subject{"confirmed", &wrongSymptomDate},
+			Subject:    &Subject{"confirmed", &wrongSymptomDate, nil},
 		},
 		{
 			Name: "unsupported_test_type",

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -59,6 +59,7 @@ type VerificationCode struct {
 	Claimed       bool   `gorm:"default:false"`
 	TestType      string `gorm:"type:varchar(20)"`
 	SymptomDate   *time.Time
+	TestDate      *time.Time
 	ExpiresAt     time.Time
 	LongExpiresAt time.Time
 	IssuingUserID uint
@@ -189,9 +190,14 @@ func (v *VerificationCode) Validate(maxAge time.Duration) error {
 	if _, ok := ValidTestTypes[v.TestType]; !ok {
 		return ErrInvalidTestType
 	}
+	minSymptomDate := timeutils.UTCMidnight(now.Add(-1 * maxAge))
 	if v.SymptomDate != nil {
-		minSymptomDate := now.Add(-1 * maxAge).Truncate(oneDay)
 		if minSymptomDate.After(*v.SymptomDate) {
+			return ErrTestTooOld
+		}
+	}
+	if v.TestDate != nil {
+		if minSymptomDate.After(*v.TestDate) {
 			return ErrTestTooOld
 		}
 	}

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -207,12 +207,22 @@ func TestVerCodeValidate(t *testing.T) {
 			Err: ErrInvalidTestType,
 		},
 		{
-			Name: "invalid_test_date",
+			Name: "invalid_symptom_date",
 			Code: VerificationCode{
 				Code:        "123456",
 				LongCode:    "123456",
 				TestType:    "negative",
 				SymptomDate: &oldTest,
+			},
+			Err: ErrTestTooOld,
+		},
+		{
+			Name: "invalid_test_date",
+			Code: VerificationCode{
+				Code:     "123456",
+				LongCode: "123456",
+				TestType: "negative",
+				TestDate: &oldTest,
 			},
 			Err: ErrTestTooOld,
 		},

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -84,6 +84,7 @@ type Request struct {
 	LongExpiresAt  time.Time
 	TestType       string
 	SymptomDate    *time.Time
+	TestDate       *time.Time
 	MaxSymptomAge  time.Duration
 	IssuingUser    *database.User
 	IssuingApp     *database.AuthorizedApp
@@ -127,6 +128,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 			LongCode:      longCode,
 			TestType:      strings.ToLower(o.TestType),
 			SymptomDate:   o.SymptomDate,
+			TestDate:      o.TestDate,
 			ExpiresAt:     o.ShortExpiresAt,
 			LongExpiresAt: o.LongExpiresAt,
 			IssuingUserID: issuingUserID,


### PR DESCRIPTION
Fixes #882

## Proposed Changes

* Add test date into verify API return
* Thread this all the way through the verification token

**Release Note**

```release-note
API CHANGE : /api/verify now returns the testDate in addition to symptom date if present. When the verification certificate is issue only one interval is inserted: symptomDate if present, testDate if not.
```
