### PR TITLE
Fix verify email flow with no realm

### DIFF
--- a/cmd/server/assets/email/default_email_verify.html
+++ b/cmd/server/assets/email/default_email_verify.html
@@ -5,7 +5,7 @@ Hello,
 
 Click the link below to verify your email address for {{.RealmName}} on the COVID-19 exposure notifications verification server:
 
-{{.VerifyLink | unescape}}
+{{unescape .VerifyLink}}
 
 If you did not request verification of this email, please disregard this message.
 {{end}}

--- a/cmd/server/assets/email/default_email_verify.html
+++ b/cmd/server/assets/email/default_email_verify.html
@@ -5,7 +5,7 @@ Hello,
 
 Click the link below to verify your email address for {{.RealmName}} on the COVID-19 exposure notifications verification server:
 
-{{.VerifyLink}}
+{{.VerifyLink | unescape}}
 
 If you did not request verification of this email, please disregard this message.
 {{end}}

--- a/cmd/server/assets/email/default_email_verify.html
+++ b/cmd/server/assets/email/default_email_verify.html
@@ -5,7 +5,7 @@ Hello,
 
 Click the link below to verify your email address for {{.RealmName}} on the COVID-19 exposure notifications verification server:
 
-{{unescape .VerifyLink}}
+{{safeHTML .VerifyLink}}
 
 If you did not request verification of this email, please disregard this message.
 {{end}}

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -20,7 +20,12 @@
           <div class="card mb-3 shadow-sm">
             <div class="card-header">Email verification</div>
             <div class="card-body">
-              {{if eq .currentRealm.EmailVerifiedMode.String "required"}}
+              {{if not .currentRealm}}
+              <div class="alert alert-warning">
+                <span class="oi oi-warning"></span>
+                Email address verification is required to administer with no realm selected.
+              </div>
+              {{else if eq .currentRealm.EmailVerifiedMode.String "required"}}
               <div class="alert alert-warning">
                 <span class="oi oi-warning"></span>
                 This realm <strong>requires</strong> email address verification.
@@ -38,8 +43,10 @@
                 </small>
               </form>
 
+              {{if .currentRealm}}
               {{if ne .currentRealm.EmailVerifiedMode.String "required"}}
               <a id="skip" class="card-link float-right mt-3" href="/home">Skip for now</a>
+              {{end}}
               {{end}}
             </div>
           </div>

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -60,7 +60,7 @@
     let $skip = $('#skip');
     let $not = $('#not');
 
-    {{if eq .emailVerify "send"}}
+    {{if eq .sendInvite "send"}}
     $(function() {
       let user = firebase.auth().currentUser
       if (!user.emailVerified) {
@@ -79,7 +79,7 @@
         return;
       }
 
-      if ({{if eq .emailVerify "sent"}}true{{else}}user.emailVerified{{end}}) {
+      if ({{if eq .sendInvite "sent"}}true{{else}}user.emailVerified{{end}}) {
         $not.hide();
         $skip.text("Go home");
       } else {

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -36,6 +36,7 @@
               </p>
 
               <form method="POST">
+                {{ .csrfField }}
                 <button id="verify" class="btn btn-primary btn-block" disabled>Send verification email</button>
 
                 <small class="form-text text-muted">
@@ -60,19 +61,6 @@
     let $skip = $('#skip');
     let $not = $('#not');
 
-    {{if eq .sendInvite "send"}}
-    $(function() {
-      let user = firebase.auth().currentUser
-      if (!user.emailVerified) {
-        user.sendEmailVerification().then(function() {
-          flash.clear();
-          flash.alert('Verification email sent.');
-          $verify.prop('disabled', true);
-        });
-      }
-    });
-    {{end}}
-
     firebase.auth().onAuthStateChanged(function(user) {
       if (!user) {
         window.location.assign("/signout");
@@ -85,6 +73,16 @@
       } else {
         $verify.prop('disabled', false);
       }
+
+      {{if eq .sendInvite "send"}}
+      if (!user.emailVerified) {
+        user.sendEmailVerification().then(function() {
+          flash.clear();
+          flash.alert('Verification email sent.');
+          $verify.prop('disabled', true);
+        });
+      }
+      {{end}}
     });
   </script>
 </body>

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -169,13 +169,6 @@ func Server(ctx context.Context, cfg *config.ServerConfig, db *database.Database
 			sub.Handle("/login/change-password", loginController.HandleShowChangePassword()).Methods("GET")
 			sub.Handle("/login/change-password", loginController.HandleSubmitChangePassword()).Methods("POST")
 			sub.Handle("/account", loginController.HandleAccountSettings()).Methods("GET")
-
-			// Verifying email requires the user is logged in
-			sub = r.PathPrefix("").Subrouter()
-			sub.Use(requireAuth)
-			sub.Use(rateLimit)
-			sub.Use(loadCurrentRealm)
-			sub.Use(processFirewall)
 			sub.Handle("/login/manage-account", loginController.HandleShowVerifyEmail()).
 				Queries("mode", "verifyEmail").Methods("GET")
 			sub.Handle("/login/manage-account", loginController.HandleSubmitVerifyEmail()).

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -128,7 +128,8 @@ func loadTemplates(tmpl *template.Template, root string) error {
 	})
 }
 
-func unescape(s string) template.HTML {
+// safeHTML un-escapes known safe html.
+func safeHTML(s string) template.HTML {
 	return template.HTML(s)
 }
 
@@ -139,7 +140,7 @@ func templateFuncs() template.FuncMap {
 		"stringContains": strings.Contains,
 		"toLower":        strings.ToLower,
 		"toUpper":        strings.ToUpper,
-		"unescape":       unescape,
+		"safeHTML":       safeHTML,
 	}
 }
 

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -128,6 +128,10 @@ func loadTemplates(tmpl *template.Template, root string) error {
 	})
 }
 
+func unescape(s string) template.HTML {
+	return template.HTML(s)
+}
+
 func templateFuncs() template.FuncMap {
 	return map[string]interface{}{
 		"joinStrings":    strings.Join,
@@ -135,6 +139,7 @@ func templateFuncs() template.FuncMap {
 		"stringContains": strings.Contains,
 		"toLower":        strings.ToLower,
 		"toUpper":        strings.ToUpper,
+		"unescape":       unescape,
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/873

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Drops the realm required for verifying email
* Protect the template in the case realm is nil
* Make sure the email link works properly (html unescape)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix redirect loop when verifying email for an admin with no realm selected
```
