### PR TITLE
Add output for backup command

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -429,3 +429,7 @@ output "db_apikey_signature_key_secret" {
 output "db_verification_code_key_secret" {
   value = "secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
 }
+
+output "db_backup_command" {
+  value = "gcloud scheduler jobs run backup-database-worker --project ${var.project}"
+}


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/885

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add Terraform output for backup command
```
