### PR TITLE
add help text around iOS ENX

### DIFF
--- a/cmd/server/assets/mobileapps/_app.html
+++ b/cmd/server/assets/mobileapps/_app.html
@@ -19,8 +19,8 @@
 <div class="form-group">
   <select name="os" id="os" class="form-control custom-select{{if $app.ErrorsFor "os"}} is-invalid{{end}}">
     <option selected disabled>Choose platform...</option>
-    <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS</option>
-    <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android</option>
+    <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS Custom App</option>
+    <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android EN Express or Custom App</option>
   </select>
   {{template "errorable" $app.ErrorsFor "os"}}
 </div>
@@ -29,6 +29,10 @@
   <input type="text" name="app_id" id="app-id" class="form-control text-monospace{{if $app.ErrorsFor "app_id"}} is-invalid{{end}}" value="{{$app.AppID}}">
   <label for="app-id" id="app-id-label"></label>
   {{template "errorable" $app.ErrorsFor "app_id"}}
+  <small class="form-text text-muted d-none" id="ioshelp">
+    The iOS Mobile App configuration must be blank if you are an iOS Exposure Notifications Express (ENX) customer. This should only
+    be filled in for custom applications.
+  </small>
 </div>
 
 <div id="sha-group" class="form-label-group d-none">
@@ -54,6 +58,7 @@
     let $appIDLabel = $('#app-id-label');
     let $sha = $('#sha');
     let $shaGroup = $('#sha-group');
+    let $iosHelp = $('#ioshelp');
 
     function processChange() {
       $appIDGroup.addClass('d-none');
@@ -64,11 +69,13 @@
         $appIDLabel.html('Application ID');
         $shaGroup.addClass('d-none');
         $appIDGroup.removeClass('d-none');
+        $iosHelp.removeClass('d-none');
       } else if (val === '{{.android}}') {
         $appID.attr('placeholder', 'Package name');
         $appIDLabel.html('Package name');
         $shaGroup.removeClass('d-none');
         $appIDGroup.removeClass('d-none');
+        $iosHelp.addClass('d-none');
       }
     }
 


### PR DESCRIPTION
## Proposed Changes

* Add help text around mobile app for iOS. Adding one when using ENX can break things.

**Release Note**


```release-note
NONE
```
