### PR TITLE
Allow app to disallow particular hostnames

### DIFF
--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -96,6 +96,9 @@ func Server(ctx context.Context, cfg *config.ServerConfig, db *database.Database
 	// Install common security headers
 	r.Use(middleware.SecureHeaders(ctx, cfg.DevMode, "html"))
 
+	// Check disallowed host names
+	r.Use(middleware.CheckBlockedHosts(ctx, cfg.BlockedHosts, h))
+
 	// Enable debug headers
 	processDebug := middleware.ProcessDebug(ctx)
 	r.Use(processDebug)

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -78,6 +78,7 @@ type ServerConfig struct {
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
 	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
+	BlockedHosts        []string      `env:"BLOCKED_HOSTS"` // Disallowed host names
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`
 

--- a/pkg/controller/middleware/blockedhosts.go
+++ b/pkg/controller/middleware/blockedhosts.go
@@ -17,7 +17,6 @@ package middleware
 
 import (
 	"context"
-	"net"
 	"net/http"
 	"strings"
 
@@ -39,13 +38,8 @@ func CheckBlockedHosts(ctx context.Context, blockedHosts []string, h *render.Ren
 				next.ServeHTTP(w, r)
 			}
 
-			rHost, _, err := net.SplitHostPort(r.Host)
-			if err != nil { // No port or invalid address
-				rHost = r.Host
-			}
-
 			for _, host := range blockedHosts {
-				if strings.HasSuffix(rHost, host) {
+				if strings.HasSuffix(r.URL.Hostname(), host) {
 					logger.Warnf("received request from blocked domain %s", r.Host)
 					controller.Unauthorized(w, r, h)
 					return

--- a/pkg/controller/middleware/blockedhosts.go
+++ b/pkg/controller/middleware/blockedhosts.go
@@ -1,0 +1,51 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package middleware defines shared middleware for handlers.
+package middleware
+
+import (
+	"context"
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/gorilla/mux"
+)
+
+// CheckBlockedHosts can disable requests to particular hostnames.
+// It is primarily used to disable the default serving URL in favor of a custom doamin.
+func CheckBlockedHosts(ctx context.Context, blockedHosts []string, h *render.Renderer) mux.MiddlewareFunc {
+	logger := logging.FromContext(ctx).Named("middleware.CheckBlockedHosts")
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if blockedHosts == nil {
+				next.ServeHTTP(w, r)
+			}
+
+			for _, host := range blockedHosts {
+				if strings.HasSuffix(r.Host, host) {
+					logger.Warnf("received request from blocked domain %s", r.Host)
+					controller.Unauthorized(w, r, h)
+					return
+				}
+			}
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/blockedhosts.go
+++ b/pkg/controller/middleware/blockedhosts.go
@@ -38,11 +38,15 @@ func CheckBlockedHosts(ctx context.Context, blockedHosts []string, h *render.Ren
 				next.ServeHTTP(w, r)
 			}
 
+			hName := r.URL.Hostname()
 			for _, host := range blockedHosts {
-				if strings.HasSuffix(r.URL.Hostname(), host) {
-					logger.Warnf("received request from blocked domain %s", r.Host)
-					controller.Unauthorized(w, r, h)
-					return
+				if strings.HasSuffix(hName, host) {
+					lDiff := len(hName) - len(host)
+					if lDiff <= 0 || string(hName[lDiff-1]) == "." { // exact match or subdomain prefix
+						logger.Warnf("received request from blocked domain %s", r.Host)
+						controller.Unauthorized(w, r, h)
+						return
+					}
 				}
 			}
 			next.ServeHTTP(w, r)

--- a/pkg/controller/middleware/blockedhosts.go
+++ b/pkg/controller/middleware/blockedhosts.go
@@ -17,6 +17,7 @@ package middleware
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"strings"
 
@@ -38,8 +39,13 @@ func CheckBlockedHosts(ctx context.Context, blockedHosts []string, h *render.Ren
 				next.ServeHTTP(w, r)
 			}
 
+			rHost, _, err := net.SplitHostPort(r.Host)
+			if err != nil { // No port or invalid address
+				rHost = r.Host
+			}
+
 			for _, host := range blockedHosts {
-				if strings.HasSuffix(r.Host, host) {
+				if strings.HasSuffix(rHost, host) {
 					logger.Warnf("received request from blocked domain %s", r.Host)
 					controller.Unauthorized(w, r, h)
 					return


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allow server to block particular hostnames
    * Can be used to stop run.app from serving in favor of a custom domain

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow blocking configured hostnames from serving eg. 'run.app'
```
