### PR TITLE
Pull CSRF token from metadata

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -12,6 +12,7 @@
 <meta name="msapplication-TileColor" content="#ff0554">
 <meta name="msapplication-config" content="/static/browserconfig.xml">
 <meta name="theme-color" content="#ffffff">
+{{.csrfMeta}}
 
 <link rel="stylesheet" href="https://stackpath.bootstrapcdn.com/bootstrap/4.5.2/css/bootstrap.min.css"
   integrity="sha384-JcKb8q3iqJ61gNV9KGb8thSsNjpSL0n8PARn9HuZOnIxN0hoP+VmmDGMN5t9UJ0Z" crossorigin="anonymous">

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -34,7 +34,11 @@ $(function () {
       }
     }
 
-    let $csrfField = $("{{.csrfField}}");
+    let csrfToken = $("meta[name=csrf-token]").attr("content");
+    let $csrfField = $("<input>")
+      .attr("type", "hidden")
+      .attr("name", "gorilla.csrf.Token")
+      .attr("value", csrfToken);
 
     let $inputField = $("<input>")
       .attr("type", "hidden")

--- a/pkg/controller/middleware/csrf.go
+++ b/pkg/controller/middleware/csrf.go
@@ -16,6 +16,7 @@ package middleware
 
 import (
 	"context"
+	"html/template"
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
@@ -44,12 +45,10 @@ func ConfigureCSRF(ctx context.Context, config *config.ServerConfig, h *render.R
 
 			// Save csrf configuration on the template map.
 			m := controller.TemplateMapFromContext(ctx)
-			if _, ok := m["csrfField"]; !ok {
-				m["csrfField"] = csrf.TemplateField(r)
-			}
-			if _, ok := m["csrfToken"]; !ok {
-				m["csrfToken"] = csrf.Token(r)
-			}
+			m["csrfField"] = csrf.TemplateField(r)
+			m["csrfToken"] = csrf.Token(r)
+			m["csrfMeta"] = template.HTML(
+				`<meta name="csrf-token" content="` + csrf.Token(r) + `">`)
 
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)


### PR DESCRIPTION
When I moved the javascript to be external, `{{.csrfToken}}` no longer renders.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pull CSRF token from meta tags
```
