### PR TITLE
Increase e2e test timeout.

### DIFF
--- a/pkg/clients/e2e.go
+++ b/pkg/clients/e2e.go
@@ -35,7 +35,7 @@ import (
 )
 
 const (
-	timeout        = 2 * time.Second
+	timeout        = 60 * time.Second
 	oneDay         = 24 * time.Hour
 	intervalLength = 10 * time.Minute
 	maxInterval    = 144


### PR DESCRIPTION
Looks like 2s is too aggressive, and we can see these log lines:

```
error issuing verification code: sending request: Post
"https://adminapi-lilkbg3hpq-uc.a.run.app/api/issue": net/http: request
canceled (Client.Timeout exceeded while awaiting headers)
```