### PR TITLE
Clean up deleted API keys after 1 week

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -40,11 +40,12 @@ type CleanupConfig struct {
 	RateLimit uint64 `env:"RATE_LIMIT,default=60"`
 
 	// Cleanup config
+	AuditEntryMaxAge        time.Duration `env:"AUDIT_ENTRY_MAX_AGE,default=720h"`
+	AuthorizedAppMaxAge     time.Duration `env:"AUTHORIZED_APP_MAX_AGE,default=168h"`
 	CleanupPeriod           time.Duration `env:"CLEANUP_PERIOD,default=15m"`
+	MobileAppMaxAge         time.Duration `env:"MOBILE_APP_MAX_AGE,default=168h"`
 	VerificationCodeMaxAge  time.Duration `env:"VERIFICATION_CODE_MAX_AGE,default=24h"`
 	VerificationTokenMaxAge time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE,default=24h"`
-	MobileAppMaxAge         time.Duration `env:"MOBILE_APP_MAX_AGE,default=168h"`
-	AuditEntryMaxAge        time.Duration `env:"AUDIT_ENTRY_MAX_AGE,default=720h"`
 }
 
 // NewCleanupConfig returns the environment config for the cleanup server.

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -41,7 +41,7 @@ type CleanupConfig struct {
 
 	// Cleanup config
 	AuditEntryMaxAge        time.Duration `env:"AUDIT_ENTRY_MAX_AGE,default=720h"`
-	AuthorizedAppMaxAge     time.Duration `env:"AUTHORIZED_APP_MAX_AGE,default=168h"`
+	AuthorizedAppMaxAge     time.Duration `env:"AUTHORIZED_APP_MAX_AGE,default=336h"`
 	CleanupPeriod           time.Duration `env:"CLEANUP_PERIOD,default=15m"`
 	MobileAppMaxAge         time.Duration `env:"MOBILE_APP_MAX_AGE,default=168h"`
 	VerificationCodeMaxAge  time.Duration `env:"VERIFICATION_CODE_MAX_AGE,default=24h"`

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -97,6 +97,17 @@ func (c *Controller) HandleCleanup() http.Handler {
 		// attempt the other purges.
 		var merr *multierror.Error
 
+		// API keys
+		item = tag.Upsert(itemTagKey, "API_KEYS")
+		if count, err := c.db.PurgeAuthorizedApps(c.config.AuthorizedAppMaxAge); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to purge authorized apps: %w", err))
+			result = observability.ResultError("FAILED")
+		} else {
+			c.logger.Infow("purged authorized apps", "count", count)
+			result = observability.ResultOK()
+		}
+		stats.RecordWithTags(ctx, []tag.Mutator{result, item}, mRequests.M(1))
+
 		// Verification codes
 		item = tag.Upsert(itemTagKey, "VERIFICATION_CODE")
 		if count, err := c.db.PurgeVerificationCodes(c.config.VerificationCodeMaxAge); err != nil {

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -418,3 +418,18 @@ func (a *AuthorizedApp) AuditID() string {
 func (a *AuthorizedApp) AuditDisplay() string {
 	return a.Name
 }
+
+// PurgeAuthorizedApps will delete authorized apps that have been deleted for
+// more than the specified time.
+func (db *Database) PurgeAuthorizedApps(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	deleteBefore := time.Now().UTC().Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("deleted_at IS NOT NULL AND deleted_at < ?", deleteBefore).
+		Delete(&AuthorizedApp{})
+	return result.RowsAffected, result.Error
+}


### PR DESCRIPTION
Fixes #905

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Clean up deleted API keys after 1 week
```
