### PR TITLE
Try and fix use case of burst capacity

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -252,6 +252,12 @@ func (c *Controller) HandleIssue() http.Handler {
 				result = observability.ResultError("FAILED_TO_TAKE_FROM_LIMITER")
 				return
 			}
+
+			// Override limit if there has been a burst for this realm.
+			if remaining > limit {
+				remaining = limit
+			}
+
 			c.recordCapacity(ctx, limit, remaining)
 			if !ok {
 				logger.Warnw("realm has exceeded daily quota",


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fixes metric based on conversation with @sethvargo 
* Found while writing docs with @mariliamelo 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fixes overflow error in capacity metrics when burst quota is given.
```
