### PR TITLE
Allow override of invite template

### DIFF
--- a/cmd/server/assets/email/_plainheader.txt
+++ b/cmd/server/assets/email/_plainheader.txt
@@ -4,4 +4,4 @@ To: {{.ToEmail}}
 From: {{.FromEmail}}
 MIME-Version: 1.0
 Content-Type: text/plain; charset="utf-8"
-{{- end -}}
+{{end}}

--- a/cmd/server/assets/email/default_email_verify.txt
+++ b/cmd/server/assets/email/default_email_verify.txt
@@ -1,6 +1,5 @@
 {{- define "email/verifyemail" -}}
 {{template "email/plainheader" .}}
-
 Hello,
 
 Click the link below to verify your email address for {{.RealmName}} on the COVID-19 exposure notifications verification server:

--- a/cmd/server/assets/email/default_invite.txt
+++ b/cmd/server/assets/email/default_invite.txt
@@ -1,6 +1,5 @@
 {{- define "email/invite" -}}
 {{template "email/plainheader" .}}
-
 Welcome,
 
 You have been invited to join the {{.RealmName}} COVID-19 exposure notifications verification server.

--- a/cmd/server/assets/email/default_reset_password.txt
+++ b/cmd/server/assets/email/default_reset_password.txt
@@ -1,6 +1,5 @@
 {{- define "email/passwordresetemail" -}}
 {{template "email/plainheader" .}}
-
 Hello,
 
 Click the link below to reset your password for the COVID-19 exposure notifications verification server.

--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -175,7 +175,7 @@
     {{end}}
     <small class="form-text text-muted">
       The SMS message will be constructed based on the template you provide. The overall
-      length of of the SMS message should not exceede 160 characters, or your message will need to be split
+      length of of the SMS message should not exceed 160 characters, or your message will need to be split
       in transit and may not be joined correctly. There are some special strings that you can use
       to substitute items.
       {{if $realm.EnableENExpress}}

--- a/cmd/server/assets/realmadmin/_form_email.html
+++ b/cmd/server/assets/realmadmin/_form_email.html
@@ -4,7 +4,7 @@
 {{$emailConfig := .emailConfig}}
 
 <p class="mb-4">
-  These are the settings for configuring an SMTP email provider. The verification server
+  These are the settings for configuring an SMTP email provider and email templates. The verification server
   will use this email account to send invitations, password resets, and account-verifications
   for the realm.
 </p>
@@ -117,7 +117,7 @@
   </div>
 
   <div class="mt-4">
-    <input type="submit" class="btn btn-primary btn-block" value="Update SMTP settings" />
+    <input type="submit" class="btn btn-primary btn-block" value="Update email settings" />
   </div>
 </form>
 

--- a/cmd/server/assets/realmadmin/_form_email.html
+++ b/cmd/server/assets/realmadmin/_form_email.html
@@ -81,8 +81,8 @@
     </div>
 
     <div class="form-label-group">
-      <textarea name="email_invite_template" id="email-invite-template" class="form-control text-monospace{{if $realm.ErrorsFor "SMSTextTemplate"}} is-invalid{{end}}"
-        rows="5" placeholder="SMS text template">{{$realm.EmailInviteTemplate}}</textarea>
+      <textarea name="email_invite_template" id="email-invite-template" class="form-control text-monospace{{if $realm.ErrorsFor "EmailInviteTemplate"}} is-invalid{{end}}"
+        rows="5" placeholder="Email invite template">{{$realm.EmailInviteTemplate}}</textarea>
       <label for="email-invite-template">Email invitation template</label>
       {{if $realm.ErrorsFor "EmailInviteTemplate"}}
       <div class="invalid-feedback">

--- a/cmd/server/assets/realmadmin/_form_email.html
+++ b/cmd/server/assets/realmadmin/_form_email.html
@@ -79,6 +79,41 @@
         587 is the default port for SMTP, and legacy port 25 is blocked.
       </small>
     </div>
+
+    <div class="form-label-group">
+      <textarea name="email_invite_template" id="email-invite-template" class="form-control text-monospace{{if $realm.ErrorsFor "SMSTextTemplate"}} is-invalid{{end}}"
+        rows="5" placeholder="SMS text template">{{$realm.EmailInviteTemplate}}</textarea>
+      <label for="email-invite-template">Email invitation template</label>
+      {{if $realm.ErrorsFor "EmailInviteTemplate"}}
+      <div class="invalid-feedback">
+        {{joinStrings ($realm.ErrorsFor "EmailInviteTemplate") ", "}}
+      </div>
+      {{end}}
+      <small class="form-text text-muted">
+        <p>
+        The invitation email message will be constructed based on the template you provide.
+        This can be helpful for introducing new users to the system or providing additional instructions.
+        There are some special strings that you can use to substitute items.
+
+        Your email invite template <em>MUST</em> contain <code>[invitelink]</code>.
+        </p>
+
+        <ul>
+          <li><code>[invitelink]</code> The link given to the user to accept the invitation.</li>
+          <li><code>[realname]</code> The name of the current realm. Currently <em>{{$realm.Name}}</em>.</li>
+        </ul>
+
+        Here is an example invitation template.
+        <p>
+          <samp class="text-dark">
+            Welcome,<br/>
+            You have been invited to the State of Wonder Dept. of Health COVID-19 exposure notification
+            server. You may use the following link to set your password and sign-in:<br/>
+            [invitelink]
+          </samp>
+        </p>
+      </small>
+    </div>
   </div>
 
   <div class="mt-4">

--- a/pkg/controller/email.go
+++ b/pkg/controller/email.go
@@ -95,7 +95,7 @@ func SendPasswordResetEmailFunc(ctx context.Context, db *database.Database, h *r
 
 	return func(ctx context.Context, resetLink string) error {
 		var message []byte
-		if realm.EmailInviteTemplate != "" {
+		if realm.EmailPasswordResetTemplate != "" {
 			// Render from the realm template with the plain header.
 			header, err := h.RenderEmail("email/plainheader", map[string]interface{}{
 				"ToEmail":   email,
@@ -147,7 +147,7 @@ func SendEmailVerificationEmailFunc(ctx context.Context, db *database.Database, 
 
 	return func(ctx context.Context, verifyLink string) error {
 		var message []byte
-		if realm.EmailInviteTemplate != "" {
+		if realm.EmailVerifyTemplate != "" {
 			// Render from the realm template with the plain header.
 			header, err := h.RenderEmail("email/plainheader", map[string]interface{}{
 				"ToEmail":   email,

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -73,6 +73,7 @@ func (c *Controller) HandleSettings() http.Handler {
 		SMTPPassword         string `form:"smtp_password"`
 		SMTPHost             string `form:"smtp_host"`
 		SMTPPort             string `form:"smtp_port"`
+		EmailInviteTemplate  string `form:"email_invite_template"`
 
 		Security                    bool   `form:"security"`
 		MFAMode                     int16  `form:"mfa_mode"`
@@ -170,6 +171,7 @@ func (c *Controller) HandleSettings() http.Handler {
 		// Email
 		if form.Email {
 			realm.UseSystemEmailConfig = form.UseSystemEmailConfig
+			realm.EmailInviteTemplate = form.EmailInviteTemplate
 		}
 
 		// Security


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add UI for admins to override  the realm invitation template

![invitetemplate](https://user-images.githubusercontent.com/36240966/97473205-f7ee7f00-1907-11eb-8016-596141ada728.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow realm custom template for invitations
```
