### PR TITLE
Create alerts using MQL

### DIFF
--- a/terraform/alerting/verification-server/alerts.tf
+++ b/terraform/alerting/verification-server/alerts.tf
@@ -1,0 +1,35 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  realm_token_remaining_capacity_low = "RealmTokenRemainingCapacityLow.yaml"
+}
+
+resource "null_resource" "RealmTokenRemainingCapacityLowAlert" {
+  triggers = {
+    # trigger a provision if the content changes.
+    file_content = file("${path.module}/alerts/${local.realm_token_remaining_capacity_low}"),
+  }
+  provisioner "local-exec" {
+    command = "${path.module}/scripts/upsert_alert_policy.sh"
+    environment = {
+      CLOUDSDK_CORE_PROJECT = var.monitoring-host-project
+      POLICY                = self.triggers.file_content
+      DISPLAY_NAME          = trimsuffix(local.realm_token_remaining_capacity_low, ".yaml")
+    }
+  }
+  depends_on = [
+    google_monitoring_metric_descriptor.api--issue--realm_token_latest,
+  ]
+}

--- a/terraform/alerting/verification-server/alerts/RealmTokenRemainingCapacityLow.yaml
+++ b/terraform/alerting/verification-server/alerts/RealmTokenRemainingCapacityLow.yaml
@@ -1,0 +1,29 @@
+combiner: OR
+conditions:
+- conditionMonitoringQueryLanguage:
+    duration: 600s
+    query: >
+        fetch
+          generic_task ::
+          custom.googleapis.com/opencensus/en-verification-server/api/issue/realm_token_latest
+        | {
+            AVAILABLE: filter metric.state == 'AVAILABLE' | align
+            ;
+            LIMIT: filter metric.state == 'LIMIT' | align
+        }
+        | group_by [metric.realm], [val: sum(value.realm_token_latest)]
+        | ratio
+        | value [capped_ratio: if(ratio > 1.0, 1.0, ratio)]
+        | window 1m
+        | condition capped_ratio < 0.1
+    trigger:
+      count: 1
+  displayName: Per-realm issue API token remaining capacity
+displayName: RealmTokenRemainingCapacityLow
+enabled: true
+documentation:
+  content: |
+    ## ${policy.display_name}
+
+    Realm ${metric.label.realm} daily verification code issuing remaining capacity below 10%.
+  mimeType: text/markdown

--- a/terraform/alerting/verification-server/alerts/RealmTokenRemainingCapacityLow.yaml
+++ b/terraform/alerting/verification-server/alerts/RealmTokenRemainingCapacityLow.yaml
@@ -13,9 +13,8 @@ conditions:
         }
         | group_by [metric.realm], [val: sum(value.realm_token_latest)]
         | ratio
-        | value [capped_ratio: if(ratio > 1.0, 1.0, ratio)]
         | window 1m
-        | condition capped_ratio < 0.1
+        | condition ratio < 0.1
     trigger:
       count: 1
   displayName: Per-realm issue API token remaining capacity

--- a/terraform/alerting/verification-server/scripts/upsert_alert_policy.sh
+++ b/terraform/alerting/verification-server/scripts/upsert_alert_policy.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+
+set -o errexit
+set -o nounset
+
+function eexit() {
+    echo "ERROR: ${@}" 1>&2
+    exit 1
+}
+
+[[ -x $(command -v gcloud) ]] || "gcloud is not installed"
+
+cat <<EOF
+
+WARNING: this is a temporary workaround to create alert policies using MQL.
+
+See https://github.com/hashicorp/terraform-provider-google/issues/7464 for
+upstream feature request.
+---------------------------------------------------------------------------
+
+EOF
+
+# Sanity check: ensure required environment variables are set.
+[[ ${CLOUDSDK_CORE_PROJECT:?} ]]
+[[ ${POLICY:?} ]]
+[[ ${DISPLAY_NAME:?} ]]
+
+# Sanity check: ensure DISPLAY_NAME matches the POLICY
+DISPLAY_NAME_IN_POLICY=$(echo "${POLICY}"|sed -n 's/^displayName: \(.*\)/\1/p')
+[[ ${DISPLAY_NAME} == ${DISPLAY_NAME_IN_POLICY} ]] || eexit "Policy contains displayName=${DISPLAY_NAME_IN_POLICY}, expect ${DISPLAY_NAME}"
+
+EXISTING_POLICIES=($(gcloud alpha monitoring policies list --filter="display_name='${DISPLAY_NAME}'" --uri| sed -n 's|https://monitoring.googleapis.com/v3/\(.*\)|\1|p'))
+
+case ${#EXISTING_POLICIES[@]} in
+    0)
+        echo "Creating policy..."
+        gcloud alpha monitoring policies create --policy="${POLICY}"
+        ;;
+    1)
+        TO_UPDATE=${EXISTING_POLICIES[0]}
+        echo "Updating policy [${TO_UPDATE}]..."
+        gcloud alpha monitoring policies update ${TO_UPDATE} --policy="${POLICY}"
+        ;;
+    *)
+        cat <<HERE
+ERROR: multiple policies matching display_name='${DISPLAY_NAME}'.
+Please make sure there's only one alert policy with display_name='${DISPLAY_NAME}'
+
+${EXISTING_POLICIES[@]/#/https:\/\/monitoring.googleapis.com\/v3\/}
+HERE
+        exit 1
+        ;;
+esac

--- a/terraform/alerting/verification-server/scripts/upsert_alert_policy.sh
+++ b/terraform/alerting/verification-server/scripts/upsert_alert_policy.sh
@@ -8,7 +8,9 @@ function eexit() {
     exit 1
 }
 
-[[ -x $(command -v gcloud) ]] || "gcloud is not installed"
+[[ -x $(command -v gcloud) ]] || eexit "gcloud is not installed"
+
+[[ $(gcloud components list --filter='id=alpha state.name=Installed' --format=json) != "[]" ]] || eexit "gcloud alpha component not installed. Install using: gcloud components install alpha"
 
 cat <<EOF
 


### PR DESCRIPTION
This alert is currently set up using a local-exec provisioner, due to
the lack of support to define alert policies using MQL in Terraform.

Part of #810

This is a revive of #831.