### PR TITLE
Return json if requested from realm-stats page.

### DIFF
--- a/pkg/controller/controller_test.go
+++ b/pkg/controller/controller_test.go
@@ -1,0 +1,36 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package controller
+
+import "testing"
+
+func TestPrefixInList(t *testing.T) {
+	tests := []struct {
+		target   string
+		strs     []string
+		expected bool
+	}{
+		{"foo", []string{}, false},
+		{"foo", []string{"foo", "bar"}, true},
+		{"foo", []string{"bar", "foofoofoo"}, true},
+		{"foo", []string{"Foo", "bar"}, false},
+		{"foo", []string{" foo", "bar"}, false},
+	}
+	for i, test := range tests {
+		if res := prefixInList(test.strs, test.target); res != test.expected {
+			t.Errorf("[%d] prefixInList(%v, %v) = %v, expected %v", i, test.strs, test.target, res, test.expected)
+		}
+	}
+}

--- a/pkg/controller/realmadmin/show.go
+++ b/pkg/controller/realmadmin/show.go
@@ -66,7 +66,15 @@ func (c *Controller) HandleShow() http.Handler {
 			return
 		}
 
-		c.renderShow(ctx, w, realm, stats, userStats)
+		if controller.AcceptsType(r, controller.ContentTypeJSON) {
+			resp := struct {
+				RealmStats []*database.RealmStats     `json:"realm_stats"`
+				UserStats  []*database.RealmUserStats `json:"per_user_stats"`
+			}{stats, userStats}
+			c.h.RenderJSON(w, http.StatusOK, resp)
+		} else {
+			c.renderShow(ctx, w, realm, stats, userStats)
+		}
 	})
 }
 


### PR DESCRIPTION
Fixes #916


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
realm/stats now has support for returning json results if requested through the HTTP headers.
```
