### PR TITLE
Return CSV if requested from realm stats.

### DIFF
--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -302,7 +302,9 @@ func Server(
 		realmSub.Handle("/settings", realmadminController.HandleSettings()).Methods("GET", "POST")
 		realmSub.Handle("/settings/enable-express", realmadminController.HandleEnableExpress()).Methods("POST")
 		realmSub.Handle("/settings/disable-express", realmadminController.HandleDisableExpress()).Methods("POST")
-		realmSub.Handle("/stats", realmadminController.HandleShow()).Methods("GET")
+		realmSub.Handle("/stats", realmadminController.HandleShow(realmadmin.HTML)).Methods("GET")
+		realmSub.Handle("/stats.json", realmadminController.HandleShow(realmadmin.JSON)).Methods("GET")
+		realmSub.Handle("/stats.csv", realmadminController.HandleShow(realmadmin.CSV)).Methods("GET")
 		realmSub.Handle("/stats/{date}", realmadminController.HandleStats()).Methods("GET")
 		realmSub.Handle("/events", realmadminController.HandleEvents()).Methods("GET")
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1316,6 +1316,19 @@ type RealmUserStats struct {
 	Date        time.Time `json:"date"`
 }
 
+// RealmUserStatsCSVHeader is a header for CSV stats
+var RealmUserStatsCSVHeader = []string{"User ID", "Name", "Codes Issued", "Date"}
+
+// CSV returns a slice of the data from a RealmUserStats for CSV writing.
+func (s *RealmUserStats) CSV() []string {
+	return []string{
+		fmt.Sprintf("%d", s.UserID),
+		s.Name,
+		fmt.Sprintf("%d", s.CodesIssued),
+		s.Date.Format("2006-01-02"),
+	}
+}
+
 // CodesPerUser returns a set of UserStats for a given date range.
 func (r *Realm) CodesPerUser(db *Database, start, stop time.Time) ([]*RealmUserStats, error) {
 	start = timeutils.UTCMidnight(start)

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -15,6 +15,7 @@
 package database
 
 import (
+	"fmt"
 	"time"
 )
 
@@ -24,6 +25,19 @@ type RealmStats struct {
 	RealmID      uint      `gorm:"realm_id; not null"`
 	CodesIssued  uint      `gorm:"codes_issued; default: 0"`
 	CodesClaimed uint      `gorm:"codes_claimed; default: 0"`
+}
+
+// RealmStatsCSVHeader is a header for CSV files for RealmStats.
+var RealmStatsCSVHeader = []string{"Date", "Realm ID", "Codes Issued", "Codes Claimed"}
+
+// CSV returns the CSV encoded values for a RealmStats.
+func (r *RealmStats) CSV() []string {
+	return []string{
+		r.Date.Format("2006-01-02"),
+		fmt.Sprintf("%d", r.RealmID),
+		fmt.Sprintf("%d", r.CodesIssued),
+		fmt.Sprintf("%d", r.CodesClaimed),
+	}
 }
 
 // TableName sets the RealmStats table name


### PR DESCRIPTION
Supports 2 modes:

${SERVER}/realm/stats?csv
  Returns overall realm stats.
${SERVER}/realm/stats?csv&user
  Returns the per-user realm stats.

Fixes #916

![image](https://user-images.githubusercontent.com/3063869/97494778-2b97cc00-193d-11eb-9708-fb6c17d709f0.png)

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Realm stats now supports CSV export:
${SERVER}/realm/stats?csv
  Returns overall realm stats.
${SERVER}/realm/stats?csv&user
  Returns the per-user realm stats.
```
