### PR TITLE
change default allowed back dating to 27 days (from 14)

### DIFF
--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -47,7 +47,7 @@ type AdminAPIServerConfig struct {
 	APIKeyCacheDuration time.Duration `env:"API_KEY_CACHE_DURATION,default=5m"`
 
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
-	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
+	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=648h"` // 648h is 27 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	// For EN Express, the link will be

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -76,7 +76,7 @@ type ServerConfig struct {
 	// Application Config
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
-	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=336h"` // 336h is 14 days.
+	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=648h"` // 648h is 27 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	AssetsPath string `env:"ASSETS_PATH,default=./cmd/server/assets"`


### PR DESCRIPTION
## Proposed Changes

* Default symptom age changed to 27 days from 14

This is to cover this use case

Someone has symptom onset 27 days ago, and didn't get their verification code until "today." In that case the oldest TEK on that person's phone would be +14 days from symptom onset and could still cause exposure notifications on someone else's phone.

**Release Note**

```release-note
Change default symptom age from 14 to 27 days.
```
