### PR TITLE
add ZERO WIDTH NO-BREAK SPACE to our cut set

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -49,6 +49,8 @@ var (
 	// callbackLock prevents multiple callbacks from being registered
 	// simultaneously because that's a data race in gorm.
 	callbackLock sync.Mutex
+
+	ExtraCutset = fmt.Sprintf("%v", '\uFEFF')
 )
 
 // Database is a handle to the database layer for the Exposure Notifications
@@ -71,6 +73,10 @@ type Database struct {
 	secretManager secrets.SecretManager
 
 	statsCloser func()
+}
+
+func trim(s string) string {
+	return strings.Trim(strings.TrimSpace(s), ExtraCutset)
 }
 
 // Overrides the postgresql driver with

--- a/pkg/database/database_test.go
+++ b/pkg/database/database_test.go
@@ -1,0 +1,30 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestSpecialTrim(t *testing.T) {
+	extraChars := fmt.Sprintf("%s%v", "state", '\uFEFF')
+	want := "state"
+	got := trim(extraChars)
+
+	if want != got {
+		t.Fatalf("wrong trim, want: %q got: %q", want, got)
+	}
+}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -385,6 +385,8 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 		}
 	}
 
+	r.CertificateIssuer = trim(r.CertificateIssuer)
+	r.CertificateAudience = trim(r.CertificateIssuer)
 	if r.UseRealmCertificateKey {
 		if r.CertificateIssuer == "" {
 			r.AddError("certificateIssuer", "cannot be blank")


### PR DESCRIPTION

## Proposed Changes

* add unicode zero width no-break space to our cutset for certififcate issuer and audience

Workaround of https://github.com/golang/go/issues/42274

**Release Note**

```release-note
Fixes an issue where certain non-printable unicode characters would accepted as valid characters for the verification certificate issuer and audience.
```
