### PR TITLE
Use ochttp.DefaultLatencyDistribution.

### DIFF
--- a/pkg/clients/e2e.go
+++ b/pkg/clients/e2e.go
@@ -48,7 +48,7 @@ func timeToInterval(t time.Time) int32 {
 func recordLatency(step string) func(context.Context, *tag.Mutator) {
 	start := time.Now()
 	return func(ctx context.Context, result *tag.Mutator) {
-		latency := time.Since(start).Milliseconds()
+		latency := float64(time.Since(start)) / float64(time.Millisecond)
 		step := tag.Upsert(stepTagKey, step)
 		stats.RecordWithTags(ctx, []tag.Mutator{*result, step}, mLatencyMs.M(latency))
 	}

--- a/pkg/clients/metrics.go
+++ b/pkg/clients/metrics.go
@@ -18,6 +18,7 @@ import (
 	enobservability "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 
+	"go.opencensus.io/plugin/ochttp"
 	"go.opencensus.io/stats"
 	"go.opencensus.io/stats/view"
 	"go.opencensus.io/tag"
@@ -26,7 +27,7 @@ import (
 const metricPrefix = observability.MetricRoot + "/e2e"
 
 var (
-	mLatencyMs = stats.Int64(metricPrefix+"/request", "request latency", stats.UnitMilliseconds)
+	mLatencyMs = stats.Float64(metricPrefix+"/request", "request latency", stats.UnitMilliseconds)
 
 	// The name of step in e2e test.
 	stepTagKey = tag.MustNewKey("step")
@@ -49,7 +50,7 @@ func init() {
 			Measure:     mLatencyMs,
 			Description: "Distribution of e2e requests latency in ms",
 			TagKeys:     append(observability.CommonTagKeys(), stepTagKey, testTypeTagKey),
-			Aggregation: view.Distribution(0, 0.1, 1, 10, 100, 1000, 10000, 100000),
+			Aggregation: ochttp.DefaultLatencyDistribution,
 		},
 	}...)
 }


### PR DESCRIPTION
Also switch to calculate latency in millisecond instead of
.Milliseconds(). The latter will return an integer and thus we lose
points in the [0, 1) bucket.