### PR TITLE
Show mobile apps in system admin  - Part 1

### DIFF
--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -31,6 +31,10 @@
   </li>
 
   <li class="nav-item">
+    <a class="nav-link{{if .currentPath.IsDir "/admin/mobileapps"}} active{{end}}" href="/admin/mobileapps">Mobile apps</a>
+  </li>
+
+  <li class="nav-item">
     <a class="nav-link{{if .currentPath.IsDir "/admin/sms"}} active{{end}}" href="/admin/sms">SMS</a>
   </li>
 

--- a/cmd/server/assets/admin/mobileapps/show.html
+++ b/cmd/server/assets/admin/mobileapps/show.html
@@ -1,0 +1,82 @@
+{{define "admin/mobileapps/show"}}
+
+{{$apps := .apps}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  {{template "admin/navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Mobile apps</div>
+      <div class="card-body">
+
+        {{if .apps}}
+        <div class="table-responsive">
+          <table class="table table-bordered table-striped bg-white">
+            <thead>
+              <tr>
+                <th scope="col">App</th>
+                <th scope="col" width="95">Enabled</th>
+                <th scope="col" width="40"></th>
+              </tr>
+            </thead>
+            <tbody>
+            {{range .apps}}
+              <tr>
+
+                <td>
+                  <a href="/mobile-apps/{{.ID}}" class="text-truncate">{{.Name}}</a>
+                </td>
+
+                <td>
+                  {{if .DeletedAt}}
+                    <span class="badge badge-pill badge-danger">Deleted</span>
+                  {{else}}
+                    <span class="badge badge-pill badge-success">Enabled</span>
+                  {{end}}
+                </td>
+
+                <td class="text-center">
+                  {{if .DeletedAt}}
+                  <a href="/mobile-apps/{{.ID}}/enable" class="d-block text-danger"
+                    data-method="patch"
+                    data-confirm="Are you sure you want to restore '{{.Name}}'?"
+                    data-toggle="tooltip"
+                    title="Restore this mobile app">
+                    <span class="oi oi-loop-circular" aria-hidden="true"></span>
+                  </a>
+                  {{else}}
+                  <a href="/mobile-apps/{{.ID}}/disable" class="d-block text-danger"
+                    data-method="patch"
+                    data-confirm="Are you sure you want to disable '{{.Name}}'?"
+                    data-toggle="tooltip"
+                    title="Disable this mobile app">
+                    <span class="oi oi-trash" aria-hidden="true"></span>
+                  </a>
+                  {{end}}
+                </td>
+
+              </tr>
+            {{end}}
+            </tbody>
+          </table>
+        </div>
+        {{else}}
+        <p class="text-center">
+          <em>There are no mobile apps.</em>
+        </p>
+        {{end}}
+      </div>
+    </div>
+  </main>
+</body>
+</html>
+{{end}}

--- a/cmd/server/assets/admin/mobileapps/show.html
+++ b/cmd/server/assets/admin/mobileapps/show.html
@@ -25,7 +25,6 @@
               <tr>
                 <th scope="col">App</th>
                 <th scope="col" width="95">Enabled</th>
-                <th scope="col" width="40"></th>
               </tr>
             </thead>
             <tbody>
@@ -43,27 +42,6 @@
                     <span class="badge badge-pill badge-success">Enabled</span>
                   {{end}}
                 </td>
-
-                <td class="text-center">
-                  {{if .DeletedAt}}
-                  <a href="/mobile-apps/{{.ID}}/enable" class="d-block text-danger"
-                    data-method="patch"
-                    data-confirm="Are you sure you want to restore '{{.Name}}'?"
-                    data-toggle="tooltip"
-                    title="Restore this mobile app">
-                    <span class="oi oi-loop-circular" aria-hidden="true"></span>
-                  </a>
-                  {{else}}
-                  <a href="/mobile-apps/{{.ID}}/disable" class="d-block text-danger"
-                    data-method="patch"
-                    data-confirm="Are you sure you want to disable '{{.Name}}'?"
-                    data-toggle="tooltip"
-                    title="Disable this mobile app">
-                    <span class="oi oi-trash" aria-hidden="true"></span>
-                  </a>
-                  {{end}}
-                </td>
-
               </tr>
             {{end}}
             </tbody>

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -350,13 +350,14 @@ func Server(
 		adminSub.Handle("/realms/{id:[0-9]+}/leave", adminController.HandleRealmsLeave()).Methods("PATCH")
 		adminSub.Handle("/realms/{id:[0-9]+}", adminController.HandleRealmsUpdate()).Methods("PATCH")
 
-		adminSub.Handle("/sms", adminController.HandleSMSUpdate()).Methods("GET", "POST")
-		adminSub.Handle("/email", adminController.HandleEmailUpdate()).Methods("GET", "POST")
-
 		adminSub.Handle("/users", adminController.HandleUsersIndex()).Methods("GET")
 		adminSub.Handle("/users", adminController.HandleUsersCreate()).Methods("POST")
 		adminSub.Handle("/users/new", adminController.HandleUsersCreate()).Methods("GET")
 		adminSub.Handle("/users/{id:[0-9]+}", adminController.HandleUsersDelete()).Methods("DELETE")
+
+		adminSub.Handle("/mobileapps", adminController.HandleMobileAppsShow()).Methods("GET")
+		adminSub.Handle("/sms", adminController.HandleSMSUpdate()).Methods("GET", "POST")
+		adminSub.Handle("/email", adminController.HandleEmailUpdate()).Methods("GET", "POST")
 
 		adminSub.Handle("/caches", adminController.HandleCachesIndex()).Methods("GET")
 		adminSub.Handle("/caches/clear/{id}", adminController.HandleCachesClear()).Methods("POST")

--- a/pkg/controller/admin/mobile_apps.go
+++ b/pkg/controller/admin/mobile_apps.go
@@ -1,0 +1,44 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+// HandleMobileAppsShow shows the configured mobile apps.
+func (c *Controller) HandleMobileAppsShow() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		apps, err := c.db.ListActiveApps()
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		c.renderShowMobileApps(ctx, w, apps)
+	})
+}
+
+func (c *Controller) renderShowMobileApps(ctx context.Context, w http.ResponseWriter, apps []*database.MobileApp) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["apps"] = apps
+	c.h.RenderHTML(w, "admin/mobileapps/show", m)
+}

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -133,6 +133,23 @@ func (a *MobileApp) BeforeSave(tx *gorm.DB) error {
 	return nil
 }
 
+// ListActiveApps finds all active mobile apps.
+func (db *Database) ListActiveApps() ([]*MobileApp, error) {
+	// Find the apps.
+	var apps []*MobileApp
+	if err := db.db.
+		Model(&MobileApp{}).
+		Find(&apps).
+		Order("mobile_apps.deleted_at DESC, LOWER(mobile_apps.name)").
+		Error; err != nil {
+		if IsNotFound(err) {
+			return apps, nil
+		}
+		return nil, err
+	}
+	return apps, nil
+}
+
 // ListActiveAppsByOS finds mobile apps by their realm and OS.
 func (db *Database) ListActiveAppsByOS(realmID uint, os OSType) ([]*MobileApp, error) {
 	// Find the apps.


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/910

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Gets the basic pages of mobile-apps into system admin
* Lists all mobile  apps

TODO
* currently action links / hrefs go back to realm admin
* Show realm name per app
* Might want pagination/filtering?

![sysadminmobileapp](https://user-images.githubusercontent.com/36240966/97935667-1dc3bb80-1d2e-11eb-8887-24c580b13a15.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show all mobile apps in system  admin
```
