### PR TITLE
Paginate mobile apps in system admin

### DIFF
--- a/cmd/server/assets/admin/mobileapps/show.html
+++ b/cmd/server/assets/admin/mobileapps/show.html
@@ -59,6 +59,8 @@
         {{end}}
       </div>
     </div>
+
+    {{template "shared/pagination" .}}
   </main>
 </body>
 </html>

--- a/pkg/database/mobile_app_test.go
+++ b/pkg/database/mobile_app_test.go
@@ -14,7 +14,11 @@
 
 package database
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
+)
 
 func TestMobileApp_Validation(t *testing.T) {
 	t.Parallel()
@@ -182,7 +186,11 @@ func TestMobileApp_List(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		extapp, err := db.ListActiveAppsWithRealm()
+		page := &pagination.PageParams{
+			Page:  0,
+			Limit: pagination.DefaultLimit,
+		}
+		extapp, _, err := db.ListActiveAppsWithRealm(page)
 		if err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/910

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Paginates the mobile apps in system admin using @sethvargo's common paginator
* Creates another override in paginator for queries that aren't just a gorm .Find() - in this case a join and scan rows.