### PR TITLE
improve verification code retention and UUID checking

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -26,6 +26,7 @@ require (
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
 	github.com/google/exposure-notifications-server v0.15.1-0.20201029203442-ccf3479357e2
 	github.com/google/go-cmp v0.5.2
+	github.com/google/uuid v1.1.2
 	github.com/gorilla/csrf v1.7.0
 	github.com/gorilla/handlers v1.5.1
 	github.com/gorilla/mux v1.8.0

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -40,12 +40,13 @@ type CleanupConfig struct {
 	RateLimit uint64 `env:"RATE_LIMIT,default=60"`
 
 	// Cleanup config
-	AuditEntryMaxAge        time.Duration `env:"AUDIT_ENTRY_MAX_AGE,default=720h"`
-	AuthorizedAppMaxAge     time.Duration `env:"AUTHORIZED_APP_MAX_AGE,default=336h"`
-	CleanupPeriod           time.Duration `env:"CLEANUP_PERIOD,default=15m"`
-	MobileAppMaxAge         time.Duration `env:"MOBILE_APP_MAX_AGE,default=168h"`
-	VerificationCodeMaxAge  time.Duration `env:"VERIFICATION_CODE_MAX_AGE,default=24h"`
-	VerificationTokenMaxAge time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE,default=24h"`
+	AuditEntryMaxAge             time.Duration `env:"AUDIT_ENTRY_MAX_AGE, default=720h"`
+	AuthorizedAppMaxAge          time.Duration `env:"AUTHORIZED_APP_MAX_AGE, default=336h"`
+	CleanupPeriod                time.Duration `env:"CLEANUP_PERIOD, default=15m"`
+	MobileAppMaxAge              time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
+	VerificationCodeMaxAge       time.Duration `env:"VERIFICATION_CODE_MAX_AGE, default=48h"`
+	VerificationCodeStatusMaxAge time.Duration `env:"VERIFICATION_CODE_STATUS_MAX_AGE, default=336h"`
+	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
 }
 
 // NewCleanupConfig returns the environment config for the cleanup server.
@@ -66,6 +67,7 @@ func (c *CleanupConfig) Validate() error {
 		{c.VerificationCodeMaxAge, "VERIFICATION_TOKEN_DURATION"},
 		{c.CleanupPeriod, "CLEANUP_PERIOD"},
 		{c.VerificationCodeMaxAge, "VERIFICATION_CODE_MAX_AGE"},
+		{c.VerificationCodeStatusMaxAge, "VERIFICATION_CODE_STATUS_MAX_AGE"},
 		{c.VerificationTokenMaxAge, "VERIFICATION_TOKEN_MAX_AGE"},
 		{c.AuditEntryMaxAge, "AUDIT_ENTRY_MAX_AGE"},
 	}

--- a/pkg/controller/codestatus/logic.go
+++ b/pkg/controller/codestatus/logic.go
@@ -48,7 +48,7 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 		return nil, http.StatusBadRequest, api.Errorf("missing realm")
 	}
 
-	code, err := c.db.FindVerificationCodeByUUID(realm.ID, uuid)
+	code, err := realm.FindVerificationCodeByUUID(c.db, uuid)
 	if err != nil {
 		if database.IsNotFound(err) {
 			logger.Debugw("code not found by UUID", "error", err)

--- a/pkg/controller/codestatus/logic.go
+++ b/pkg/controller/codestatus/logic.go
@@ -17,14 +17,12 @@
 package codestatus
 
 import (
-	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
-	"github.com/jinzhu/gorm"
 )
 
 func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.VerificationCode, int, *api.ErrorReturn) {
@@ -52,7 +50,7 @@ func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.Ve
 
 	code, err := c.db.FindVerificationCodeByUUID(realm.ID, uuid)
 	if err != nil {
-		if errors.Is(err, gorm.ErrRecordNotFound) {
+		if database.IsNotFound(err) {
 			logger.Debugw("code not found by UUID", "error", err)
 			return nil, http.StatusNotFound,
 				api.Errorf("code not found, it may have expired and been removed").WithCode(api.ErrVerifyCodeNotFound)

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -138,7 +138,6 @@ func NewTestDatabaseWithCacher(tb testing.TB, cacher cache.Cacher) (*Database, *
 	}
 
 	// Re-enable logging.
-	db.db = db.db.LogMode(true)
 	db.db.SetLogger(gorm.Logger{LogWriter: log.New(os.Stdout, "", 0)})
 
 	// Close db when done.

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -138,6 +138,7 @@ func NewTestDatabaseWithCacher(tb testing.TB, cacher cache.Cacher) (*Database, *
 	}
 
 	// Re-enable logging.
+	db.db = db.db.LogMode(true)
 	db.db.SetLogger(gorm.Logger{LogWriter: log.New(os.Stdout, "", 0)})
 
 	// Close db when done.

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1587,7 +1587,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 			Rollback: func(tx *gorm.DB) error {
 				logger.Debugw("partial verification code cleanup")
 				sqls := []string{
-					"DELETE FROM verification_codes WHERE code IS NULL or long_code IS NULL",
+					"DELETE FROM verification_codes WHERE code = '' or long_code = ''",
 				}
 
 				for _, sql := range sqls {

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -422,6 +422,17 @@ func (r *Realm) GetLongCodeDurationHours() int {
 	return int(r.LongCodeDuration.Duration.Hours())
 }
 
+// FindVerificationCodeByUUID find a verification codes by UUID.
+func (r *Realm) FindVerificationCodeByUUID(db *Database, uuid string) (*VerificationCode, error) {
+	var vc VerificationCode
+	if err := db.db.
+		Where("uuid = ? AND realm_id = ?", uuid, r.ID).
+		First(&vc).Error; err != nil {
+		return nil, err
+	}
+	return &vc, nil
+}
+
 // BuildSMSText replaces certain strings with the right values.
 func (r *Realm) BuildSMSText(code, longCode string, enxDomain string) string {
 	text := r.SMSTextTemplate

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -19,6 +19,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 )
 
@@ -76,11 +79,13 @@ func TestVerificationCode_FindVerificationCodeByUUID(t *testing.T) {
 	t.Parallel()
 
 	db := NewTestDatabase(t)
+	var realmID uint = 123
 
 	vc := &VerificationCode{
 		Code:          "123456",
 		LongCode:      "defghijk329024",
 		TestType:      "confirmed",
+		RealmID:       realmID,
 		ExpiresAt:     time.Now().Add(time.Hour),
 		LongExpiresAt: time.Now().Add(2 * time.Hour),
 	}
@@ -89,20 +94,34 @@ func TestVerificationCode_FindVerificationCodeByUUID(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	uuid := vc.UUID
-	if uuid == "" {
+	codeUUID := vc.UUID
+	if codeUUID == "" {
 		t.Fatal("expected uuid")
 	}
 
-	{
-		got, err := db.FindVerificationCodeByUUID(uuid)
+	t.Run("normal_find", func(t *testing.T) {
+		got, err := db.FindVerificationCodeByUUID(realmID, codeUUID)
 		if err != nil {
 			t.Fatal(err)
 		}
 		if got, want := got.ID, vc.ID; got != want {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
-	}
+	})
+
+	t.Run("wrong_realm", func(t *testing.T) {
+		_, err := db.FindVerificationCodeByUUID(realmID+1, codeUUID)
+		if err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("expected error: not found, got: %v", err)
+		}
+	})
+
+	t.Run("wrong_uuid", func(t *testing.T) {
+		_, err := db.FindVerificationCodeByUUID(realmID, uuid.Must(uuid.NewRandom()).String())
+		if err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
+			t.Fatalf("expected error: not found, got: %v", err)
+		}
+	})
 }
 
 func TestVerificationCode_ListRecentCodes(t *testing.T) {
@@ -286,17 +305,21 @@ func TestDeleteVerificationCode(t *testing.T) {
 	}
 }
 
-func TestPurgeVerificationCodes(t *testing.T) {
+func TestVerificationCodesCleanup(t *testing.T) {
 	t.Parallel()
 	db := NewTestDatabase(t)
 
 	now := time.Now()
 	maxAge := time.Hour // not important to this test case
 
+	realmID := uint(42)
+	cleanUpTo := 1
+
 	testData := []*VerificationCode{
-		{Code: "111111", LongCode: "111111", TestType: "negative", ExpiresAt: now.Add(time.Second), LongExpiresAt: now.Add(time.Second)},
-		{Code: "222222", LongCode: "222222", TestType: "negative", ExpiresAt: now.Add(time.Second), LongExpiresAt: now.Add(time.Second)},
-		{Code: "333333", LongCode: "333333ABCDEF", TestType: "negative", ExpiresAt: now.Add(time.Minute), LongExpiresAt: now.Add(time.Hour)},
+		{Code: "111111", LongCode: "111111", RealmID: realmID, TestType: "negative", ExpiresAt: now.Add(time.Second), LongExpiresAt: now.Add(time.Second)},
+		{Code: "222222", LongCode: "222222", RealmID: realmID, TestType: "negative", ExpiresAt: now.Add(time.Second), LongExpiresAt: now.Add(time.Second)},
+		// Cleanup line - will be cleaned above here.
+		{Code: "333333", LongCode: "333333ABCDEF", RealmID: realmID, TestType: "negative", ExpiresAt: now.Add(time.Minute), LongExpiresAt: now.Add(time.Hour)},
 	}
 	for _, rec := range testData {
 		if err := db.SaveVerificationCode(rec, maxAge); err != nil {
@@ -307,10 +330,59 @@ func TestPurgeVerificationCodes(t *testing.T) {
 	// Need to let some time lapse since we can't back date records through normal channels.
 	time.Sleep(2 * time.Second)
 
+	if count, err := db.RecycleVerificationCodes(time.Millisecond * 500); err != nil {
+		t.Fatalf("error doing purge: %v", err)
+	} else if count != 2 {
+		t.Fatalf("purge record count mismatch, want: 2, got: %v", count)
+	}
+
+	// Find first two by UUID.
+	for i, vc := range testData {
+		got, err := db.FindVerificationCodeByUUID(realmID, vc.UUID)
+		if err != nil {
+			t.Fatalf("can't read back code by UUID")
+		}
+
+		if i <= cleanUpTo {
+			if got.Code != "" {
+				t.Errorf("expected code to be empty, got: %v", got.Code)
+			}
+			if got.LongCode != "" {
+				t.Errorf("expected code to be empty, got: %v", got.LongCode)
+			}
+		} else {
+			if got.Code == "" {
+				t.Errorf("expected code to not be empty, but was")
+			}
+			if got.LongCode == "" {
+				t.Errorf("expected long code to not be empty, but was")
+			}
+		}
+	}
+
+	// Run the purge.
 	if count, err := db.PurgeVerificationCodes(time.Millisecond * 500); err != nil {
 		t.Fatalf("error doing purge: %v", err)
 	} else if count != 2 {
 		t.Fatalf("purge record count mismatch, want: 2, got: %v", count)
+	}
+
+	// Find first two by UUID, expect a not found error
+	for i, vc := range testData {
+
+		got, err := db.FindVerificationCodeByUUID(realmID, vc.UUID)
+		if i <= cleanUpTo {
+			if err == nil {
+				t.Fatalf("expected error, got: %v", got)
+			} else if !errors.Is(err, gorm.ErrRecordNotFound) {
+				t.Fatalf("wrong error, want: %v got: %v", gorm.ErrRecordNotFound, err)
+			}
+		} else {
+			if diff := cmp.Diff(testData[i], got, cmpopts.IgnoreUnexported(VerificationCode{}), cmpopts.IgnoreUnexported(Errorable{})); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+		}
+
 	}
 }
 

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -83,6 +83,10 @@ func TestVerificationCode_FindVerificationCodeByUUID(t *testing.T) {
 	if err != nil {
 		t.Fatalf("failed to create realm: %v", err)
 	}
+	otherRealm, err := db.CreateRealm("notThetestRealm")
+	if err != nil {
+		t.Fatalf("failed to create realm: %v", err)
+	}
 
 	vc := &VerificationCode{
 		Code:          "123456",
@@ -113,7 +117,7 @@ func TestVerificationCode_FindVerificationCodeByUUID(t *testing.T) {
 	})
 
 	t.Run("wrong_realm", func(t *testing.T) {
-		_, err := realm.FindVerificationCodeByUUID(db, codeUUID)
+		_, err := otherRealm.FindVerificationCodeByUUID(db, codeUUID)
 		if err == nil || !errors.Is(err, gorm.ErrRecordNotFound) {
 			t.Fatalf("expected error: not found, got: %v", err)
 		}

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -378,7 +378,7 @@ func TestVerificationCodesCleanup(t *testing.T) {
 				t.Fatalf("wrong error, want: %v got: %v", gorm.ErrRecordNotFound, err)
 			}
 		} else {
-			if diff := cmp.Diff(testData[i], got, cmpopts.IgnoreUnexported(VerificationCode{}), cmpopts.IgnoreUnexported(Errorable{})); diff != "" {
+			if diff := cmp.Diff(testData[i], got, approxTime, cmpopts.IgnoreUnexported(VerificationCode{}), cmpopts.IgnoreUnexported(Errorable{})); diff != "" {
 				t.Fatalf("mismatch (-want, +got):\n%s", diff)
 			}
 		}


### PR DESCRIPTION
Fixes #961 

## Proposed Changes

* Check RealmID at DB when looking up a verification code by UUID
* Re-index verification codes to be scoped by realm (code space currently shared across all realms)
* Split code cleanup into 2 phases (1) recycle codes by returning them to the pool (2) purge status records
* Change code recycle from 24h to 48h
* Retain code status for 14d (configurable)

**Release Note**

```release-note
Verification code changes: available pool is now scoped by realm. codes are retained 48 hours after expiration by default (instead of 24). Status of a code (by UUID) is retained for 14d instead of 24h.
```
