### PR TITLE
Allow system admin users to see/edit all users

### DIFF
--- a/pkg/controller/user/delete.go
+++ b/pkg/controller/user/delete.go
@@ -46,7 +46,7 @@ func (c *Controller) HandleDelete() http.Handler {
 			return
 		}
 
-		user, err := realm.FindUser(c.db, vars["id"])
+		user, err := c.findUser(currentUser, realm, vars["id"])
 		if err != nil {
 			if database.IsNotFound(err) {
 				controller.Unauthorized(w, r, c.h)

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -48,8 +48,14 @@ func (c *Controller) Show(w http.ResponseWriter, r *http.Request, resetPassword 
 		return
 	}
 
+	currentUser := controller.UserFromContext(ctx)
+	if currentUser == nil {
+		controller.MissingUser(w, r, c.h)
+		return
+	}
+
 	// Pull the user from the id.
-	user, err := realm.FindUser(c.db, vars["id"])
+	user, err := c.findUser(currentUser, realm, vars["id"])
 	if err != nil {
 		if database.IsNotFound(err) {
 			controller.Unauthorized(w, r, c.h)
@@ -84,6 +90,13 @@ func (c *Controller) getStats(ctx context.Context, user *database.User, realm *d
 		return nil, err
 	}
 	return stats, nil
+}
+
+func (c *Controller) findUser(currentUser *database.User, realm *database.Realm, id interface{}) (*database.User, error) {
+	if currentUser.Admin {
+		return c.db.FindUser(id)
+	}
+	return realm.FindUser(c.db, id)
 }
 
 func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, user *database.User, stats []*database.UserStats) {

--- a/pkg/controller/user/update.go
+++ b/pkg/controller/user/update.go
@@ -54,7 +54,7 @@ func (c *Controller) HandleUpdate() http.Handler {
 			return
 		}
 
-		user, err := realm.FindUser(c.db, vars["id"])
+		user, err := c.findUser(currentUser, realm, vars["id"])
 		if err != nil {
 			if database.IsNotFound(err) {
 				controller.Unauthorized(w, r, c.h)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We currently look at currentRealm to find a user within the realm
* System admins should be able to find users globally
    * Technically we could go further (someone could be a realm admin of more than one realm so we could instead check that currentuser canAdmin the other user) but this should be good enough to build a system admin view.