### PR TITLE
Split admin and regular users in system-admin. Allow delete user

### DIFF
--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -27,7 +27,11 @@
   </li>
 
   <li class="nav-item">
-    <a class="nav-link{{if .currentPath.IsDir "/admin/users"}} active{{end}}" href="/admin/users">System admins</a>
+    <a class="nav-link{{if .currentPath.IsDir "/admin/superusers"}} active{{end}}" href="/admin/superusers">System admins</a>
+  </li>
+
+  <li class="nav-item">
+    <a class="nav-link{{if .currentPath.IsDir "/admin/users"}} active{{end}}" href="/admin/users">Users</a>
   </li>
 
   <li class="nav-item">

--- a/cmd/server/assets/admin/superusers/index.html
+++ b/cmd/server/assets/admin/superusers/index.html
@@ -1,7 +1,7 @@
-{{define "admin/users/index"}}
+{{define "admin/superusers/index"}}
 
 {{$currentUser := .currentUser}}
-{{$users := .users}}
+{{$admins := .admins}}
 
 <!doctype html>
 <html lang="en">
@@ -16,8 +16,14 @@
     {{template "flash" .}}
 
     <div class="card mb-3 shadow-sm">
-      <div class="card-header">Users</div>
+      <div class="card-header">System admins</div>
       <div class="card-body">
+        <div class="clearfix mb-3">
+          <a class="btn btn-outline-secondary btn-sm float-right" href="/admin/superusers/new">
+            <span class="oi oi-plus" aria-hidden="true"></span>
+            New system admin
+          </a>
+        </div>
 
         <div class="table-responsive">
           <table class="table table-bordered table-striped mb-0">
@@ -29,19 +35,19 @@
               </tr>
             </thead>
             <tbody>
-            {{range $users}}
+            {{range $admins}}
               <tr>
                 <td>{{.Name}}</td>
                 <td>{{.Email}}</td>
                 <td class="text-center">
                   {{- /* cannot delete yourself */ -}}
                   {{if not (eq .ID $currentUser.ID)}}
-                  <a href="/admin/users/{{.ID}}"
+                  <a href="/admin/superusers/{{.ID}}"
                     class="d-block text-danger"
                     data-method="DELETE"
-                    data-confirm="Are you sure you want to delete this user? This will prevent access to all realms system-wide."
+                    data-confirm="Are you sure you want to remove this system admin?"
                     data-toggle="tooltip"
-                    title="Delete this user">
+                    title="Remove this system admin">
                     <span class="oi oi-trash" aria-hidden="true"></span>
                   </a>
                   {{end}}

--- a/cmd/server/assets/admin/superusers/new.html
+++ b/cmd/server/assets/admin/superusers/new.html
@@ -1,4 +1,4 @@
-{{define "admin/users/new"}}
+{{define "admin/superusers/new"}}
 
 {{$user := .user}}
 
@@ -23,7 +23,7 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">System admin details</div>
       <div class="card-body">
-        <form method="POST" action="/admin/users">
+        <form method="POST" action="/admin/superusers">
           {{ .csrfField }}
 
           <div class="form-label-group">

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -18,6 +18,19 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Users</div>
       <div class="card-body">
+        <form method="GET" action="/admin/users" id="search-form">
+          <div class="input-group">
+            <span class="input-group-prepend">
+              <div class="input-group-text bg-transparent">
+                <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
+              </div>
+            </span>
+            <input type="search" name="q" id="search" value="{{.query}}" placeholder="Search"
+              autocomplete="off" class="form-control" />
+          </div>
+        </form>
+      </div>
+      <div class="card-body">
 
         <div class="table-responsive">
           <table class="table table-bordered table-striped mb-0">

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -53,6 +53,8 @@
         </div>
       </div>
     </div>
+
+  {{template "shared/pagination" .}}
   </main>
 </body>
 </html>

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -349,10 +349,13 @@ func Server(
 		adminSub.Handle("/realms/{id:[0-9]+}/leave", adminController.HandleRealmsLeave()).Methods("PATCH")
 		adminSub.Handle("/realms/{id:[0-9]+}", adminController.HandleRealmsUpdate()).Methods("PATCH")
 
+		adminSub.Handle("/superusers", adminController.HandleSuperUsersIndex()).Methods("GET")
+		adminSub.Handle("/superusers", adminController.HandleSuperUsersCreate()).Methods("POST")
+		adminSub.Handle("/superusers/new", adminController.HandleSuperUsersCreate()).Methods("GET")
+		adminSub.Handle("/superusers/{id:[0-9]+}", adminController.HandleSuperUsersDelete()).Methods("DELETE")
+
 		adminSub.Handle("/users", adminController.HandleUsersIndex()).Methods("GET")
-		adminSub.Handle("/users", adminController.HandleUsersCreate()).Methods("POST")
-		adminSub.Handle("/users/new", adminController.HandleUsersCreate()).Methods("GET")
-		adminSub.Handle("/users/{id:[0-9]+}", adminController.HandleUsersDelete()).Methods("DELETE")
+		adminSub.Handle("/users/{id:[0-9]+}", adminController.HandleUserDelete()).Methods("DELETE")
 
 		adminSub.Handle("/mobileapps", adminController.HandleMobileAppsShow()).Methods("GET")
 		adminSub.Handle("/sms", adminController.HandleSMSUpdate()).Methods("GET", "POST")

--- a/pkg/controller/admin/superusers.go
+++ b/pkg/controller/admin/superusers.go
@@ -1,0 +1,221 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package admin
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/internal/auth"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/gorilla/mux"
+)
+
+// HandleSuperUsersIndex renders the list of system admins.
+func (c *Controller) HandleSuperUsersIndex() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		admins, err := c.db.ListSystemAdmins()
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		m := controller.TemplateMapFromContext(ctx)
+		m["admins"] = admins
+		c.h.RenderHTML(w, "admin/superusers/index", m)
+	})
+}
+
+// HandleSuperUsersCreate creates a new system admin.
+func (c *Controller) HandleSuperUsersCreate() http.Handler {
+	type FormData struct {
+		Email string `form:"email"`
+		Name  string `form:"name"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		currentUser := controller.UserFromContext(ctx)
+		if currentUser == nil {
+			controller.MissingUser(w, r, c.h)
+			return
+		}
+
+		// Requested form, stop processing.
+		if r.Method == http.MethodGet {
+			var user database.User
+			c.renderNewUser(ctx, w, &user)
+			return
+		}
+
+		var form FormData
+		err := controller.BindForm(w, r, &form)
+		email := project.TrimSpace(form.Email)
+		name := project.TrimSpace(form.Name)
+		if err != nil {
+			user := &database.User{
+				Email: email,
+				Name:  name,
+			}
+
+			flash.Error("Failed to process form: %v", err)
+			c.renderNewUser(ctx, w, user)
+			return
+		}
+
+		// See if the user already exists and use that record.
+		user, err := c.db.FindUserByEmail(email)
+		if err != nil {
+			if !database.IsNotFound(err) {
+				controller.InternalError(w, r, c.h, err)
+				return
+			}
+
+			// User does not exist, create a new one.
+			user = &database.User{
+				Name:  name,
+				Email: email,
+			}
+		}
+
+		user.Admin = true
+		if err := c.db.SaveUser(user, currentUser); err != nil {
+			flash.Error("Failed to create user: %v", err)
+			c.renderNewUser(ctx, w, user)
+			return
+		}
+
+		inviteComposer, err := c.inviteComposer(ctx, email)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		if _, err := c.authProvider.CreateUser(ctx, name, email, "", inviteComposer); err != nil {
+			flash.Alert("Failed to create user: %v", err)
+			c.renderNewUser(ctx, w, user)
+		}
+
+		flash.Alert("Successfully created system admin '%v'", user.Name)
+		http.Redirect(w, r, "/admin/superusers", http.StatusSeeOther)
+	})
+}
+
+func (c *Controller) renderNewUser(ctx context.Context, w http.ResponseWriter, user *database.User) {
+	m := controller.TemplateMapFromContext(ctx)
+	m["user"] = user
+	c.h.RenderHTML(w, "admin/superusers/new", m)
+}
+
+// HandleSuperUsersDelete deletes a system admin.
+func (c *Controller) HandleSuperUsersDelete() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+		vars := mux.Vars(r)
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		currentUser := controller.UserFromContext(ctx)
+		if currentUser == nil {
+			controller.MissingUser(w, r, c.h)
+			return
+		}
+
+		user, err := c.db.FindUser(vars["id"])
+		if err != nil {
+			if database.IsNotFound(err) {
+				controller.Unauthorized(w, r, c.h)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		if user.ID == currentUser.ID {
+			flash.Error("Cannot remove yourself!")
+			controller.Back(w, r, c.h)
+			return
+		}
+
+		user.Admin = false
+		if err := c.db.SaveUser(user, currentUser); err != nil {
+			flash.Error("Failed to remove system admin: %v", err)
+			controller.Back(w, r, c.h)
+			return
+		}
+
+		flash.Alert("Successfully removed %v as a system admin", user.Email)
+		controller.Back(w, r, c.h)
+	})
+}
+
+// inviteComposer returns an email composer function that invites a user using
+// the system email config.
+func (c *Controller) inviteComposer(ctx context.Context, email string) (auth.InviteUserEmailFunc, error) {
+	// Figure out email sending - since this is a system admin, only the system
+	// credentials can be used.
+	emailConfig, err := c.db.SystemEmailConfig()
+	if err != nil {
+		if database.IsNotFound(err) {
+			return nil, nil
+		}
+
+		return nil, err
+	}
+
+	emailer, err := emailConfig.Provider()
+	if err != nil {
+		return nil, err
+	}
+
+	// Return a function that does the actual sending.
+	return func(ctx context.Context, inviteLink string) error {
+		// Render the message invitation.
+		message, err := c.h.RenderEmail("email/invite", map[string]interface{}{
+			"ToEmail":    email,
+			"FromEmail":  emailer.From(),
+			"InviteLink": inviteLink,
+			"RealmName":  "System Admin",
+		})
+		if err != nil {
+			return fmt.Errorf("failed to render invite template: %w", err)
+		}
+
+		// Send the message.
+		if err := emailer.SendEmail(ctx, email, message); err != nil {
+			return fmt.Errorf("failed to send email: %w", err)
+		}
+		return nil
+	}, nil
+}

--- a/pkg/controller/admin/users.go
+++ b/pkg/controller/admin/users.go
@@ -34,7 +34,8 @@ func (c *Controller) HandleUsersIndex() http.Handler {
 			return
 		}
 
-		users, paginator, err := c.db.ListUsers(pageParams)
+		q := r.FormValue(QueryKeySearch)
+		users, paginator, err := c.db.ListUsers(pageParams, q)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
@@ -42,6 +43,7 @@ func (c *Controller) HandleUsersIndex() http.Handler {
 
 		m := controller.TemplateMapFromContext(ctx)
 		m["users"] = users
+		m["query"] = q
 		m["paginator"] = paginator
 		c.h.RenderHTML(w, "admin/users/index", m)
 	})

--- a/pkg/controller/admin/users.go
+++ b/pkg/controller/admin/users.go
@@ -22,7 +22,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
-// HandleUsersIndex renders the list of all non-system-admin usders.
+// HandleUsersIndex renders the list of all non-system-admin users.
 func (c *Controller) HandleUsersIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/controller/admin/users.go
+++ b/pkg/controller/admin/users.go
@@ -15,125 +15,32 @@
 package admin
 
 import (
-	"context"
-	"fmt"
 	"net/http"
 
-	"github.com/google/exposure-notifications-verification-server/internal/auth"
-	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 )
 
-// HandleUsersIndex renders the list of system admins.
+// HandleUsersIndex renders the list of all non-system-admin usders.
 func (c *Controller) HandleUsersIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		admins, err := c.db.ListSystemAdmins()
+		users, err := c.db.ListUsers()
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
 		}
 
 		m := controller.TemplateMapFromContext(ctx)
-		m["admins"] = admins
+		m["users"] = users
 		c.h.RenderHTML(w, "admin/users/index", m)
 	})
 }
 
-// HandleUsersCreate creates a new system admin.
-func (c *Controller) HandleUsersCreate() http.Handler {
-	type FormData struct {
-		Email string `form:"email"`
-		Name  string `form:"name"`
-	}
-
-	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		ctx := r.Context()
-
-		session := controller.SessionFromContext(ctx)
-		if session == nil {
-			controller.MissingSession(w, r, c.h)
-			return
-		}
-		flash := controller.Flash(session)
-
-		currentUser := controller.UserFromContext(ctx)
-		if currentUser == nil {
-			controller.MissingUser(w, r, c.h)
-			return
-		}
-
-		// Requested form, stop processing.
-		if r.Method == http.MethodGet {
-			var user database.User
-			c.renderNewUser(ctx, w, &user)
-			return
-		}
-
-		var form FormData
-		err := controller.BindForm(w, r, &form)
-		email := project.TrimSpace(form.Email)
-		name := project.TrimSpace(form.Name)
-		if err != nil {
-			user := &database.User{
-				Email: email,
-				Name:  name,
-			}
-
-			flash.Error("Failed to process form: %v", err)
-			c.renderNewUser(ctx, w, user)
-			return
-		}
-
-		// See if the user already exists and use that record.
-		user, err := c.db.FindUserByEmail(email)
-		if err != nil {
-			if !database.IsNotFound(err) {
-				controller.InternalError(w, r, c.h, err)
-				return
-			}
-
-			// User does not exist, create a new one.
-			user = &database.User{
-				Name:  name,
-				Email: email,
-			}
-		}
-
-		user.Admin = true
-		if err := c.db.SaveUser(user, currentUser); err != nil {
-			flash.Error("Failed to create user: %v", err)
-			c.renderNewUser(ctx, w, user)
-			return
-		}
-
-		inviteComposer, err := c.inviteComposer(ctx, email)
-		if err != nil {
-			controller.InternalError(w, r, c.h, err)
-			return
-		}
-
-		if _, err := c.authProvider.CreateUser(ctx, name, email, "", inviteComposer); err != nil {
-			flash.Alert("Failed to create user: %v", err)
-			c.renderNewUser(ctx, w, user)
-		}
-
-		flash.Alert("Successfully created system admin '%v'", user.Name)
-		http.Redirect(w, r, "/admin/users", http.StatusSeeOther)
-	})
-}
-
-func (c *Controller) renderNewUser(ctx context.Context, w http.ResponseWriter, user *database.User) {
-	m := controller.TemplateMapFromContext(ctx)
-	m["user"] = user
-	c.h.RenderHTML(w, "admin/users/new", m)
-}
-
-// HandleUsersDelete deletes a system admin.
-func (c *Controller) HandleUsersDelete() http.Handler {
+// HandleUserDelete deletes a user from the system.
+func (c *Controller) HandleUserDelete() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 		vars := mux.Vars(r)
@@ -168,54 +75,14 @@ func (c *Controller) HandleUsersDelete() http.Handler {
 			return
 		}
 
-		user.Admin = false
-		if err := c.db.SaveUser(user, currentUser); err != nil {
-			flash.Error("Failed to remove system admin: %v", err)
+		if err := c.db.DeleteUser(user); err != nil {
+			flash.Error("Failed to delete user: %v", err)
 			controller.Back(w, r, c.h)
 			return
 		}
 
-		flash.Alert("Successfully removed %v as a system admin", user.Email)
-		controller.Back(w, r, c.h)
+		flash.Alert("Successfully deleted %v.", user.Email)
+
+		http.Redirect(w, r, "/admin/users", http.StatusSeeOther)
 	})
-}
-
-// inviteComposer returns an email composer function that invites a user using
-// the system email config.
-func (c *Controller) inviteComposer(ctx context.Context, email string) (auth.InviteUserEmailFunc, error) {
-	// Figure out email sending - since this is a system admin, only the system
-	// credentials can be used.
-	emailConfig, err := c.db.SystemEmailConfig()
-	if err != nil {
-		if database.IsNotFound(err) {
-			return nil, nil
-		}
-
-		return nil, err
-	}
-
-	emailer, err := emailConfig.Provider()
-	if err != nil {
-		return nil, err
-	}
-
-	// Return a function that does the actual sending.
-	return func(ctx context.Context, inviteLink string) error {
-		// Render the message invitation.
-		message, err := c.h.RenderEmail("email/invite", map[string]interface{}{
-			"ToEmail":    email,
-			"FromEmail":  emailer.From(),
-			"InviteLink": inviteLink,
-			"RealmName":  "System Admin",
-		})
-		if err != nil {
-			return fmt.Errorf("failed to render invite template: %w", err)
-		}
-
-		// Send the message.
-		if err := emailer.SendEmail(ctx, email, message); err != nil {
-			return fmt.Errorf("failed to send email: %w", err)
-		}
-		return nil
-	}, nil
 }

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -231,11 +231,16 @@ func (db *Database) DeleteUser(u *User) error {
 
 // ListUsers returns a list of all users sorted by name.
 // Warning: This list may be large. Use Realm.ListUsers() to get users scoped to a realm.
-func (db *Database) ListUsers(p *pagination.PageParams) ([]*User, *pagination.Paginator, error) {
+func (db *Database) ListUsers(p *pagination.PageParams, q string) ([]*User, *pagination.Paginator, error) {
 	var users []*User
 	query := db.db.Model(&User{}).
 		Where("admin IS FALSE").
 		Order("LOWER(name) ASC")
+
+	if q != "" {
+		q = `%` + q + `%`
+		query = query.Where("(users.email ILIKE ? OR users.name ILIKE ?)", q, q)
+	}
 
 	if p == nil {
 		p = new(pagination.PageParams)

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
 	"github.com/jinzhu/gorm"
 )
 
@@ -230,21 +231,25 @@ func (db *Database) DeleteUser(u *User) error {
 
 // ListUsers returns a list of all users sorted by name.
 // Warning: This list may be large. Use Realm.ListUsers() to get users scoped to a realm.
-func (db *Database) ListUsers() ([]*User, error) {
+func (db *Database) ListUsers(p *pagination.PageParams) ([]*User, *pagination.Paginator, error) {
 	var users []*User
-	if err := db.db.
-		Model(&User{}).
+	query := db.db.Model(&User{}).
 		Where("admin IS FALSE").
-		Order("LOWER(name) ASC").
-		Find(&users).
-		Error; err != nil {
-		if IsNotFound(err) {
-			return users, nil
-		}
-		return nil, err
+		Order("LOWER(name) ASC")
+
+	if p == nil {
+		p = new(pagination.PageParams)
 	}
 
-	return users, nil
+	paginator, err := Paginate(query, &users, p.Page, p.Limit)
+	if err != nil {
+		if IsNotFound(err) {
+			return users, nil, nil
+		}
+		return nil, nil, err
+	}
+
+	return users, paginator, nil
 }
 
 // ListSystemAdmins returns a list of users who are system admins sorted by

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -223,6 +223,29 @@ func (u *User) Stats(db *Database, realmID uint, start, stop time.Time) ([]*User
 	return stats, nil
 }
 
+// DeleteUser deletes the user entry.
+func (db *Database) DeleteUser(u *User) error {
+	return db.db.Delete(u).Error
+}
+
+// ListUsers returns a list of all users sorted by name.
+func (db *Database) ListUsers() ([]*User, error) {
+	var users []*User
+	if err := db.db.
+		Model(&User{}).
+		Where("admin IS FALSE").
+		Order("LOWER(name) ASC").
+		Find(&users).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return users, nil
+		}
+		return nil, err
+	}
+
+	return users, nil
+}
+
 // ListSystemAdmins returns a list of users who are system admins sorted by
 // name.
 func (db *Database) ListSystemAdmins() ([]*User, error) {

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -229,6 +229,7 @@ func (db *Database) DeleteUser(u *User) error {
 }
 
 // ListUsers returns a list of all users sorted by name.
+// Warning: This list may be large. Use Realm.ListUsers() to get users scoped to a realm.
 func (db *Database) ListUsers() ([]*User, error) {
 	var users []*User
 	if err := db.db.


### PR DESCRIPTION
Issue #https://github.com/google/exposure-notifications-verification-server/issues/975

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Creates a new users tab in system-admin
    * Keeps system-admin list and regular users separate
* Allow system admin to delete a user
* Searching and pagination

![withsearch](https://user-images.githubusercontent.com/36240966/98279840-57274180-1f4f-11eb-9497-3b5bfce1bdca.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show regular users across realms in system-admin. Allow deletion.
```
