### PR TITLE
Optionally mirror dependent Docker Hub images

### DIFF
--- a/terraform/mirror/docker.tf
+++ b/terraform/mirror/docker.tf
@@ -1,0 +1,39 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_artifact_registry_repository" "mirrors" {
+  provider = google-beta
+
+  project       = var.project
+  format        = "DOCKER"
+  location      = var.artifact_registry_location
+  repository_id = "mirrors"
+  description   = "Internally-mirrored images from the public Docker Hub."
+
+  depends_on = [
+    google_project_service.services["artifactregistry.googleapis.com"],
+  ]
+}
+
+resource "google_artifact_registry_repository_iam_member" "mirrors-readers" {
+  provider = google-beta
+
+  project    = google_artifact_registry_repository.mirrors.project
+  location   = google_artifact_registry_repository.mirrors.location
+  repository = google_artifact_registry_repository.mirrors.name
+
+  for_each = toset(var.repository_readers)
+  member   = each.key
+  role     = "roles/artifactregistry.reader"
+}

--- a/terraform/mirror/main.tf
+++ b/terraform/mirror/main.tf
@@ -1,0 +1,54 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+provider "google" {
+  project = var.project
+  region  = var.region
+
+  user_project_override = true
+}
+
+provider "google-beta" {
+  project = var.project
+  region  = var.region
+
+  user_project_override = true
+}
+
+data "google_project" "project" {
+  project_id = var.project
+}
+
+resource "google_project_service" "resourcemanager" {
+  project = var.project
+  service = "cloudresourcemanager.googleapis.com"
+
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "services" {
+  project = var.project
+
+  for_each = toset([
+    "artifactregistry.googleapis.com",
+    "run.googleapis.com",
+  ])
+  service = each.value
+
+  disable_on_destroy = false
+
+  depends_on = [
+    google_project_service.resourcemanager,
+  ]
+}

--- a/terraform/mirror/service.tf
+++ b/terraform/mirror/service.tf
@@ -1,0 +1,121 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "docker-mirror" {
+  project      = var.project
+  account_id   = "docker-mirror"
+  display_name = "Docker Hub Mirror"
+}
+
+resource "google_artifact_registry_repository_iam_member" "mirror-cloud-run-writer" {
+  provider = google-beta
+
+  project    = google_artifact_registry_repository.mirrors.project
+  location   = google_artifact_registry_repository.mirrors.location
+  repository = google_artifact_registry_repository.mirrors.name
+
+  member = "serviceAccount:${google_service_account.docker-mirror.email}"
+  role   = "roles/artifactregistry.writer"
+}
+
+resource "google_cloud_run_service" "docker-mirror" {
+  name     = "docker-mirror"
+  location = var.region
+
+  autogenerate_revision_name = true
+
+  template {
+    spec {
+      service_account_name = google_service_account.docker-mirror.email
+      timeout_seconds      = 900
+
+      containers {
+        image = "us-docker.pkg.dev/vargolabs/cloud-run-docker-mirror/server:latest"
+
+        resources {
+          limits = {
+            cpu    = "2"
+            memory = "1Gi"
+          }
+        }
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["run.googleapis.com"],
+  ]
+}
+
+resource "google_service_account" "docker-mirror-invoker" {
+  project      = data.google_project.project.project_id
+  account_id   = "docker-mirror-invoker"
+  display_name = "Docker Mirror Invoker"
+}
+
+resource "google_cloud_run_service_iam_member" "docker-mirror-invoker" {
+  project  = google_cloud_run_service.docker-mirror.project
+  location = google_cloud_run_service.docker-mirror.location
+  service  = google_cloud_run_service.docker-mirror.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.docker-mirror-invoker.email}"
+}
+
+resource "google_cloud_scheduler_job" "docker-mirror-worker" {
+  name             = "docker-mirror-worker"
+  region           = var.cloudscheduler_location
+  schedule         = "0 7 * * *"
+  time_zone        = "UTC"
+  attempt_deadline = "900s"
+
+  http_target {
+    http_method = "POST"
+    uri         = "${google_cloud_run_service.docker-mirror.status.0.url}/"
+
+    body = base64encode(jsonencode({
+      mirrors = [
+        {
+          src = "postgres:12"
+          dst = "${google_artifact_registry_repository.mirrors.location}-docker.pkg.dev/${var.project}/mirrors/postgres:12"
+        },
+        {
+          src = "postgres:12-alpine"
+          dst = "${google_artifact_registry_repository.mirrors.location}-docker.pkg.dev/${var.project}/mirrors/postgres:12-alpine"
+        },
+        {
+          src = "redis:6"
+          dst = "${google_artifact_registry_repository.mirrors.location}-docker.pkg.dev/${var.project}/mirrors/redis:6"
+        },
+        {
+          src = "redis:6-alpine"
+          dst = "${google_artifact_registry_repository.mirrors.location}-docker.pkg.dev/${var.project}/mirrors/redis:6-alpine"
+        },
+      ]
+    }))
+
+    oidc_token {
+      audience              = google_cloud_run_service.docker-mirror.status.0.url
+      service_account_email = google_service_account.docker-mirror-invoker.email
+    }
+  }
+
+  depends_on = [
+    # This also depends on AppEngine, but we can't declare that dependency here
+    # because it was actually created upstream.
+
+    google_cloud_run_service_iam_member.docker-mirror-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+    google_artifact_registry_repository_iam_member.mirror-cloud-run-writer,
+  ]
+}

--- a/terraform/mirror/variables.tf
+++ b/terraform/mirror/variables.tf
@@ -1,0 +1,56 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+variable "project" {
+  type = string
+}
+
+variable "region" {
+  type    = string
+  default = "us-central1"
+}
+
+variable "artifact_registry_location" {
+  type    = string
+  default = "us"
+
+  description = "Location for Artifact Registry repositories."
+}
+
+variable "repository_readers" {
+  type    = list(string)
+  default = []
+
+  description = "List of entities that should be able to pull from the mirror."
+}
+
+variable "cloudscheduler_location" {
+  type    = string
+  default = "us-central1"
+}
+
+terraform {
+  required_version = ">= 0.13.1"
+
+  required_providers {
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 3.46"
+    }
+    google-beta = {
+      source  = "hashicorp/google-beta"
+      version = "~> 3.46"
+    }
+  }
+}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -209,11 +209,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.38"
+      version = "~> 3.46"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.38"
+      version = "~> 3.46"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
Also allow customizing the image used in CI via an environment variable.

Fixes #959

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add Terraform module to optionally mirror dependent Docker Hub images for tests
```

/assign @chaodaiG 