### PR TITLE
Rename Admin to SystemAdmin in users table

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -102,7 +102,7 @@ aria-expanded="false" aria-label="Toggle navigation">
       {{end}}
       {{end}}
 
-      {{if .currentUser.Admin}}
+      {{if .currentUser.SystemAdmin}}
       <h6 class="dropdown-header">System admin</h6>
       <a class="dropdown-item" href="/admin/realms">Launch</a>
       <div class="dropdown-divider"></div>

--- a/cmd/server/assets/login/account.html
+++ b/cmd/server/assets/login/account.html
@@ -32,7 +32,7 @@
           {{$user.Email}}
         </div>
 
-        {{if $user.Admin}}
+        {{if $user.SystemAdmin}}
         <h6 class="card-title  mt-3">System admin</h6>
         <div class="card-text text-success">Enabled</div>
         {{end}}
@@ -72,7 +72,7 @@
             {{end}}
 
             {{- /* system admins can remove themselves from realms */ -}}
-            {{if $user.Admin}}
+            {{if $user.SystemAdmin}}
             <a href="/users/{{.ID}}" class="d-block text-danger float-right" data-method="DELETE"
               data-confirm="Are you sure you want to leave {{.Name}}?">
               <span class="oi oi-account-logout" aria-hidden="true"></span>

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -111,7 +111,7 @@ func Server(
 	requireAdmin := middleware.RequireRealmAdmin(ctx, h)
 	loadCurrentRealm := middleware.LoadCurrentRealm(ctx, cacher, db, h)
 	requireRealm := middleware.RequireRealm(ctx, h)
-	requireSystemAdmin := middleware.RequireAdmin(ctx, h)
+	requireSystemAdmin := middleware.RequireSystemAdmin(ctx, h)
 	requireMFA := middleware.RequireMFA(ctx, authProvider, h)
 	processFirewall := middleware.ProcessFirewall(ctx, h, "server")
 	rateLimit := httplimiter.Handle

--- a/pkg/controller/admin/superusers.go
+++ b/pkg/controller/admin/superusers.go
@@ -100,7 +100,7 @@ func (c *Controller) HandleSuperUsersCreate() http.Handler {
 			}
 		}
 
-		user.Admin = true
+		user.SystemAdmin = true
 		if err := c.db.SaveUser(user, currentUser); err != nil {
 			flash.Error("Failed to create user: %v", err)
 			c.renderNewUser(ctx, w, user)
@@ -165,7 +165,7 @@ func (c *Controller) HandleSuperUsersDelete() http.Handler {
 			return
 		}
 
-		user.Admin = false
+		user.SystemAdmin = false
 		if err := c.db.SaveUser(user, currentUser); err != nil {
 			flash.Error("Failed to remove system admin: %v", err)
 			controller.Back(w, r, c.h)

--- a/pkg/controller/login/select.go
+++ b/pkg/controller/login/select.go
@@ -47,7 +47,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 		case 0:
 			// If the user is a member of zero realms, it's possible they are an
 			// admin. If so, redirect them to the admin page.
-			if currentUser.Admin {
+			if currentUser.SystemAdmin {
 				http.Redirect(w, r, "/admin", http.StatusSeeOther)
 				return
 			}

--- a/pkg/controller/middleware/auth.go
+++ b/pkg/controller/middleware/auth.go
@@ -133,9 +133,9 @@ func RequireAuth(ctx context.Context, cacher cache.Cacher, authProvider auth.Pro
 	}
 }
 
-// RequireAdmin requires the current user is a global administrator. It must
+// RequireSystemAdmin requires the current user is a global administrator. It must
 // come after RequireAuth so that a user is set on the context.
-func RequireAdmin(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
+func RequireSystemAdmin(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 	logger := logging.FromContext(ctx).Named("middleware.RequireAdminHandler")
 
 	return func(next http.Handler) http.Handler {
@@ -148,7 +148,7 @@ func RequireAdmin(ctx context.Context, h *render.Renderer) mux.MiddlewareFunc {
 				return
 			}
 
-			if !currentUser.Admin {
+			if !currentUser.SystemAdmin {
 				logger.Debugw("user is not an admin")
 				controller.Unauthorized(w, r, h)
 				return

--- a/pkg/controller/user/show.go
+++ b/pkg/controller/user/show.go
@@ -93,7 +93,7 @@ func (c *Controller) getStats(ctx context.Context, user *database.User, realm *d
 }
 
 func (c *Controller) findUser(currentUser *database.User, realm *database.Realm, id interface{}) (*database.User, error) {
-	if currentUser.Admin {
+	if currentUser.SystemAdmin {
 		return c.db.FindUser(id)
 	}
 	return realm.FindUser(c.db, id)

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -59,10 +59,10 @@ func TestPerUserRealmStats(t *testing.T) {
 	users := []*User{}
 	for userIdx, name := range []string{"Rocky", "Bullwinkle", "Boris", "Natasha"} {
 		user := &User{
-			Realms: []*Realm{realm},
-			Name:   name,
-			Email:  name + "@gmail.com",
-			Admin:  false,
+			Realms:      []*Realm{realm},
+			Name:        name,
+			Email:       name + "@gmail.com",
+			SystemAdmin: false,
 		}
 
 		if err := db.SaveUser(user, System); err != nil {

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -39,9 +39,10 @@ type User struct {
 	gorm.Model
 	Errorable
 
-	Email       string   `gorm:"type:varchar(250);unique_index"`
-	Name        string   `gorm:"type:varchar(100)"`
-	Admin       bool     `gorm:"default:false"`
+	Email       string `gorm:"type:varchar(250);unique_index"`
+	Name        string `gorm:"type:varchar(100)"`
+	SystemAdmin bool   `gorm:"column:system_admin; default:false;"`
+
 	Realms      []*Realm `gorm:"many2many:user_realms"`
 	AdminRealms []*Realm `gorm:"many2many:admin_realms"`
 
@@ -347,9 +348,9 @@ func (db *Database) SaveUser(u *User, actor Auditable) error {
 			audit := BuildAuditEntry(actor, "created user", u, 0)
 			audits = append(audits, audit)
 		} else {
-			if existing.Admin != u.Admin {
+			if existing.SystemAdmin != u.SystemAdmin {
 				audit := BuildAuditEntry(actor, "updated user system admin", u, 0)
-				audit.Diff = boolDiff(existing.Admin, u.Admin)
+				audit.Diff = boolDiff(existing.SystemAdmin, u.SystemAdmin)
 				audits = append(audits, audit)
 			}
 

--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -26,9 +26,9 @@ func TestUserLifecycle(t *testing.T) {
 
 	email := "dr@example.com"
 	user := User{
-		Email: email,
-		Name:  "Dr Example",
-		Admin: false,
+		Email:       email,
+		Name:        "Dr Example",
+		SystemAdmin: false,
 	}
 
 	if err := db.SaveUser(&user, System); err != nil {
@@ -62,13 +62,13 @@ func TestUserLifecycle(t *testing.T) {
 		if got, want := got.Name, user.Name; got != want {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
-		if got, want := got.Admin, user.Admin; got != want {
+		if got, want := got.SystemAdmin, user.SystemAdmin; got != want {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
 	}
 
 	// Update an attribute
-	user.Admin = true
+	user.SystemAdmin = true
 	if err := db.SaveUser(&user, System); err != nil {
 		t.Fatal(err)
 	}
@@ -87,7 +87,7 @@ func TestUserLifecycle(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if got, want := got.Admin, true; got != want {
+		if got, want := got.SystemAdmin, true; got != want {
 			t.Errorf("expected %#v to be %#v", got, want)
 		}
 

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -144,7 +144,7 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infow("enabled admin", "admin", admin)
 
-	super := &database.User{Email: "super@example.com", Name: "Super User", Admin: true}
+	super := &database.User{Email: "super@example.com", Name: "Super User", SystemAdmin: true}
 	if _, err := db.FindUserByEmail(super.Email); database.IsNotFound(err) {
 		if err := db.SaveUser(super, database.System); err != nil {
 			return fmt.Errorf("failed to create super: %w: %v", err, super.ErrorMessages())


### PR DESCRIPTION
Just a simple rename, but now that we're merging some functionality, I want to be clear when we say "system admin". This has also confused our partners in the past.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Rename users `admin` to `system_admin` for clarity.
```

/assign @whaught 