### PR TITLE
Show pills for realm/system admin

### DIFF
--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -44,7 +44,14 @@
             <tbody>
             {{range $users}}
               <tr>
-                <td>{{.Name}}</td>
+                <td>
+                  {{.Name}}
+                  {{if .Admin}}
+                  <span class="ml-1 badge badge-pill badge-primary">System admin</span>
+                  {{else if .IsRealmAdmin}}
+                  <span class="ml-1 badge badge-pill badge-secondary">Realm admin</span>
+                  {{end}}
+                </td>
                 <td>{{.Email}}</td>
                 <td class="text-center">
                   {{- /* cannot delete yourself */ -}}

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -48,7 +48,8 @@
                   {{.Name}}
                   {{if .SystemAdmin}}
                   <span class="ml-1 badge badge-pill badge-primary">System admin</span>
-                  {{else if .IsRealmAdmin}}
+                  {{end}}
+                  {{if .IsRealmAdmin}}
                   <span class="ml-1 badge badge-pill badge-secondary">Realm admin</span>
                   {{end}}
                 </td>

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -46,7 +46,7 @@
               <tr>
                 <td>
                   {{.Name}}
-                  {{if .Admin}}
+                  {{if .SystemAdmin}}
                   <span class="ml-1 badge badge-pill badge-primary">System admin</span>
                   {{else if .IsRealmAdmin}}
                   <span class="ml-1 badge badge-pill badge-secondary">Realm admin</span>

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -133,6 +133,10 @@ func (u *User) CanViewRealm(realmID uint) bool {
 	return false
 }
 
+func (u *User) IsRealmAdmin() bool {
+	return len(u.AdminRealms) > 0
+}
+
 func (u *User) CanAdminRealm(realmID uint) bool {
 	for _, r := range u.AdminRealms {
 		if r.ID == realmID {
@@ -235,7 +239,6 @@ func (db *Database) DeleteUser(u *User) error {
 func (db *Database) ListUsers(p *pagination.PageParams, q string) ([]*User, *pagination.Paginator, error) {
 	var users []*User
 	query := db.db.Model(&User{}).
-		Where("admin IS FALSE").
 		Order("LOWER(name) ASC")
 
 	q = project.TrimSpace(q)


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/975

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Show pills for system/realm admins in the admin console
* Now shows all users for the Users page
    * Later I'll fold in the System admin stuff and remove that tab

![pills](https://user-images.githubusercontent.com/36240966/98288080-2816cd00-1f5b-11eb-8e52-47aaa596d1e3.png)
