### PR TITLE
Filter user search to system admins

### DIFF
--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -39,9 +39,6 @@
         </form>
       </div>
       <div class="card-body">
-
-      {{.usertype}}
-
         <div class="table-responsive">
           <table class="table table-bordered table-striped mb-0">
             <thead>

--- a/cmd/server/assets/admin/users/index.html
+++ b/cmd/server/assets/admin/users/index.html
@@ -28,9 +28,19 @@
             <input type="search" name="q" id="search" value="{{.query}}" placeholder="Search"
               autocomplete="off" class="form-control" />
           </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="usertype" id="all" value="" {{if eq .usertype ""}}checked{{end}}>
+            <label class="form-check-label" for="all">All users</label>
+          </div>
+          <div class="form-check form-check-inline">
+            <input class="form-check-input" type="radio" name="usertype" id="sysadmin" value="sysadmin" {{if eq .usertype "sysadmin"}}checked{{end}}>
+            <label class="form-check-label" for="sysadmin">System admins</label>
+          </div>
         </form>
       </div>
       <div class="card-body">
+
+      {{.usertype}}
 
         <div class="table-responsive">
           <table class="table table-bordered table-striped mb-0">
@@ -69,6 +79,22 @@
 
   {{template "shared/pagination" .}}
   </main>
+
+  <script type="text/javascript">
+    $(function() {
+      let $sysAdmin = $('#sysadmin');
+      let $all= $('#all');
+      let $search = $('#search-form');
+
+      $sysAdmin.on('change', function() {
+        $search.submit();
+      });
+
+      $all.on('change', function() {
+        $search.submit();
+      });
+    });
+  </script>
 </body>
 </html>
 {{end}}

--- a/pkg/controller/admin/users.go
+++ b/pkg/controller/admin/users.go
@@ -23,6 +23,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	userType    = "usertype"
+	systemAdmin = "sysadmin"
+)
+
 // HandleUsersIndex renders the list of all non-system-admin users.
 func (c *Controller) HandleUsersIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -34,8 +39,9 @@ func (c *Controller) HandleUsersIndex() http.Handler {
 			return
 		}
 
+		typeFilter := r.FormValue(userType)
 		q := r.FormValue(QueryKeySearch)
-		users, paginator, err := c.db.ListUsers(pageParams, q)
+		users, paginator, err := c.db.ListUsers(pageParams, q, typeFilter == systemAdmin)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
@@ -44,6 +50,7 @@ func (c *Controller) HandleUsersIndex() http.Handler {
 		m := controller.TemplateMapFromContext(ctx)
 		m["users"] = users
 		m["query"] = q
+		m[userType] = typeFilter
 		m["paginator"] = paginator
 		c.h.RenderHTML(w, "admin/users/index", m)
 	})

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -230,7 +230,6 @@ func (u *User) Stats(db *Database, realmID uint, start, stop time.Time) ([]*User
 func (db *Database) ListUsers(p *pagination.PageParams, q string, systemAdminOnly bool) ([]*User, *pagination.Paginator, error) {
 	var users []*User
 	query := db.db.Model(&User{}).
-		Where("system_admin IS FALSE").
 		Order("LOWER(name) ASC")
 
 	if systemAdminOnly {

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -227,11 +227,15 @@ func (u *User) Stats(db *Database, realmID uint, start, stop time.Time) ([]*User
 
 // ListUsers returns a list of all users sorted by name.
 // Warning: This list may be large. Use Realm.ListUsers() to get users scoped to a realm.
-func (db *Database) ListUsers(p *pagination.PageParams, q string) ([]*User, *pagination.Paginator, error) {
+func (db *Database) ListUsers(p *pagination.PageParams, q string, systemAdminOnly bool) ([]*User, *pagination.Paginator, error) {
 	var users []*User
 	query := db.db.Model(&User{}).
 		Where("system_admin IS FALSE").
 		Order("LOWER(name) ASC")
+
+	if systemAdminOnly {
+		query = query.Where("system_admin IS TRUE")
+	}
 
 	q = project.TrimSpace(q)
 	if q != "" {


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/975

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allows the user search to toggle between all users and system admins

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Toggle for user search for all/system-admin
```
