### PR TITLE
Make e2e-runner dashboard more useful.

### DIFF
--- a/terraform/alerting/verification-server/dashboards/e2e.yaml
+++ b/terraform/alerting/verification-server/dashboards/e2e.yaml
@@ -1,8 +1,8 @@
-displayName: e2e
+displayName: End-to-End Dashboard
 gridLayout:
-  columns: "2"
+  columns: "1"
   widgets:
-    - title: /api/issue/request count by result
+    - title: e2e-runner requests
       xyChart:
         chartOptions:
           mode: COLOR
@@ -11,11 +11,11 @@ gridLayout:
             timeSeriesQuery:
               timeSeriesQueryLanguage: >
                 generic_task ::
-                custom.googleapis.com/opencensus/en-verification-server/api/issue/request_count
-                | align rate()
+                custom.googleapis.com/opencensus/en-verification-server/e2e/request_count
+                | align rate(1m)
                 | every 1m
-                | [metric.result]
-    - title: /api/verify/request count by result
+                | [metric.step, metric.test_type, metric.result]
+    - title: e2e-runner failed requests
       xyChart:
         chartOptions:
           mode: COLOR
@@ -24,7 +24,21 @@ gridLayout:
             timeSeriesQuery:
               timeSeriesQueryLanguage: >
                 generic_task ::
-                custom.googleapis.com/opencensus/en-verification-server/api/verify/request_count
-                | align rate()
+                custom.googleapis.com/opencensus/en-verification-server/e2e/request_count
+                | filter metric.result == "NOT_OK"
+                | align rate(1m)
                 | every 1m
-                | [metric.result]
+                | [metric.step, metric.test_type, metric.result]
+    - title: e2e-runner request latency
+      xyChart:
+        chartOptions:
+          mode: COLOR
+        dataSets:
+          - plotType: LINE
+            timeSeriesQuery:
+              timeSeriesQueryLanguage: >
+                generic_task ::
+                custom.googleapis.com/opencensus/en-verification-server/e2e/request_latency
+                | align delta(1m)
+                | every 1m
+                | [metric.step], [val: percentile(value.request_latency, 99)]

--- a/terraform/alerting/verification-server/metrics.tf
+++ b/terraform/alerting/verification-server/metrics.tf
@@ -15,7 +15,7 @@
 resource "google_monitoring_metric_descriptor" "api--issue--request_count" {
   project      = var.verification-server-project
   description  = "Count of code issue requests"
-  display_name = "OpenCensus/en-verification-server/api/issue/request_count"
+  display_name = "/api/issue/request_count"
   type         = "custom.googleapis.com/opencensus/en-verification-server/api/issue/request_count"
   metric_kind  = "CUMULATIVE"
   value_type   = "INT64"
@@ -29,7 +29,7 @@ resource "google_monitoring_metric_descriptor" "api--issue--request_count" {
 resource "google_monitoring_metric_descriptor" "api--verify--request_count" {
   project      = var.verification-server-project
   description  = "Count of verify requests"
-  display_name = "OpenCensus/en-verification-server/api/verify/request_count"
+  display_name = "/api/verify/request_count"
   type         = "custom.googleapis.com/opencensus/en-verification-server/api/verify/request_count"
   metric_kind  = "CUMULATIVE"
   value_type   = "INT64"
@@ -44,7 +44,7 @@ resource "google_monitoring_metric_descriptor" "api--verify--request_count" {
 resource "google_monitoring_metric_descriptor" "api--issue--realm_token_latest" {
   project      = var.verification-server-project
   description  = "Latest realm token count"
-  display_name = "OpenCensus/en-verification-server/api/issue/realm_token_latest"
+  display_name = "/api/issue/realm_token_latest"
   type         = "custom.googleapis.com/opencensus/en-verification-server/api/issue/realm_token_latest"
   metric_kind  = "GAUGE"
   value_type   = "INT64"
@@ -58,7 +58,7 @@ resource "google_monitoring_metric_descriptor" "api--issue--realm_token_latest" 
 resource "google_monitoring_metric_descriptor" "ratelimit--limitware--request_count" {
   project      = var.verification-server-project
   description  = "requests seen by middleware"
-  display_name = "OpenCensus/en-verification-server/ratelimit/limitware/request_count"
+  display_name = "/ratelimit/limitware/request_count"
   type         = "custom.googleapis.com/opencensus/en-verification-server/ratelimit/limitware/request_count"
   metric_kind  = "CUMULATIVE"
   value_type   = "INT64"
@@ -72,7 +72,7 @@ resource "google_monitoring_metric_descriptor" "ratelimit--limitware--request_co
 resource "google_monitoring_metric_descriptor" "e2e--request_count" {
   project      = var.verification-server-project
   description  = "Count of e2e requests"
-  display_name = "OpenCensus/en-verification-server/e2e/request_count"
+  display_name = "/e2e/request_count"
   type         = "custom.googleapis.com/opencensus/en-verification-server/e2e/request_count"
   metric_kind  = "CUMULATIVE"
   value_type   = "INT64"


### PR DESCRIPTION
- Include request count and latency charts
- Inculde request count chart with filter on failed requests.