### PR TITLE
Link to system admin from realm select

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -91,30 +91,28 @@ aria-expanded="false" aria-label="Toggle navigation">
       {{if .currentRealm }}
       {{if .currentUser.CanAdminRealm .currentRealm.ID}}
       <h6 class="dropdown-header">Manage realm</h6>
-      <a class="dropdown-item" href="/apikeys">API keys</a>
-      <a class="dropdown-item" href="/mobile-apps">Mobile apps</a>
-      <a class="dropdown-item" href="/realm/events">Event log</a>
-      <a class="dropdown-item" href="/realm/keys">Signing keys</a>
-      <a class="dropdown-item" href="/realm/stats">Statistics</a>
-      <a class="dropdown-item" href="/users">Users</a>
-      <a class="dropdown-item" href="/realm/settings#general">Settings</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/apikeys"}}active{{end}}" href="/apikeys">API keys</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/mobile-apps"}}active{{end}}" href="/mobile-apps">Mobile apps</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/realm/events"}}active{{end}}" href="/realm/events">Event log</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/realm/keys"}}active{{end}}" href="/realm/keys">Signing keys</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/realm/stats"}}active{{end}}" href="/realm/stats">Statistics</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/users"}}active{{end}}" href="/users">Users</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/realm/settings"}}active{{end}}" href="/realm/settings#general">Settings</a>
       <div class="dropdown-divider"></div>
       {{end}}
       {{end}}
 
       {{if .currentUser.SystemAdmin}}
-      {{if not (.currentPath.IsDir "/admin")}}
       <h6 class="dropdown-header">System admin</h6>
-      <a class="dropdown-item" href="/admin/realms">Launch</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/admin"}}active{{end}}" href="/admin/realms">System admin</a>
       <div class="dropdown-divider"></div>
-      {{end}}
       {{end}}
 
       <h6 class="dropdown-header">Actions</h6>
       {{if gt (len .currentUser.Realms) 1}}
-      <a class="dropdown-item" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/login/select-realm"}}active{{end}}" href="/login/select-realm">{{if .currentRealm}}Change realm{{else}}Select realm{{end}}</a>
       {{end}}
-      <a class="dropdown-item" href="/account">My account</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/account"}}active{{end}}" href="/account">My account</a>
       <a class="dropdown-item" href="/signout">Sign out</a>
     </div>
   </li>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -103,9 +103,11 @@ aria-expanded="false" aria-label="Toggle navigation">
       {{end}}
 
       {{if .currentUser.SystemAdmin}}
+      {{if not (.currentPath.IsDir "/admin")}}
       <h6 class="dropdown-header">System admin</h6>
       <a class="dropdown-item" href="/admin/realms">Launch</a>
       <div class="dropdown-divider"></div>
+      {{end}}
       {{end}}
 
       <h6 class="dropdown-header">Actions</h6>

--- a/cmd/server/assets/login/select-realm.html
+++ b/cmd/server/assets/login/select-realm.html
@@ -72,12 +72,12 @@
     {{if $currentUser.SystemAdmin}}
     <div class="card mb-3 shadow-sm">
       <div class="card-header text-bold text-white admin-header">
-        Admin
+        System admin
       </div>
       <div class="list-group-item p-0">
         <a href="/admin" class="w-100 d-flex flex-row justify-content-between align-items-center align-self-center list-group-item-action px-4 py-3">
           <div>
-            <p class="mb-1">System admin console</p>
+            <p class="mb-1">Go to system admin</p>
           </div>
           <div>
             <span class="oi oi-arrow-right" aria-hidden="true"></span>

--- a/cmd/server/assets/login/select-realm.html
+++ b/cmd/server/assets/login/select-realm.html
@@ -2,6 +2,7 @@
 
 {{$csrfField := .csrfField}}
 {{$realms := .realms}}
+{{$currentUser := .currentUser}}
 {{$currentRealm := .currentRealm}}
 
 <!doctype html>
@@ -67,6 +68,24 @@
         </div>
       {{end}}
     </div>
+
+    {{if $currentUser.SystemAdmin}}
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header text-bold text-white admin-header">
+        Admin
+      </div>
+      <div class="list-group-item p-0">
+        <a href="/admin" class="w-100 d-flex flex-row justify-content-between align-items-center align-self-center list-group-item-action px-4 py-3">
+          <div>
+            <p class="mb-1">System admin console</p>
+          </div>
+          <div>
+            <span class="oi oi-arrow-right" aria-hidden="true"></span>
+          </div>
+        </a>
+      </div>
+    </div>
+    {{end}}
   </main>
 </body>
 </html>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Link directly to system-admin page from realm-select
   * Note that if the admin is not a member of any realms, we go straight to admin already. https://github.com/google/exposure-notifications-verification-server/blob/f76a3cea09d53d076a47a204ce9c948e183c8f35/pkg/controller/login/select.go#L50

* Remove "launch admin" from navigation if already there

![straighttoadmin](https://user-images.githubusercontent.com/36240966/98307479-b0589a80-1f7a-11eb-83b2-573c069022f1.png)

