### PR TITLE
Limit number of non-deleted KMS signing keys on a realm

### DIFF
--- a/cmd/server/assets/realmkeys.html
+++ b/cmd/server/assets/realmkeys.html
@@ -68,10 +68,21 @@
                 <ol>
                   <li>Creating a new key.</li>
                   <li>Communicating that key version and public key to your <em>exposure notifications key server</em> operator.</li>
-                  <li>Activiating the new key in this system.</li>
+                  <li>Activating the new key in this system.</li>
                 </ol>
               </span>
-              <button type="submit" class="btn btn-primary btn-block">Create new signing key version</button>
+
+              {{if ge (len .realmKeys) .maximumKeyVersions }}
+                <div class="alert alert-warning">
+                  <span class="oi oi-warning" aria-hidden="true"></span>
+                  There is a limit of {{.maximumKeyVersions}} available key versions.
+                </div>
+                <button class="btn btn-primary btn-block disabled" disabled>
+                  Create new signing key version
+                </button>
+              {{else}}
+                <button type="submit" class="btn btn-primary btn-block">Create new signing key version</button>
+              {{end}}
             </div>
           </div>
         </form>

--- a/pkg/controller/realmkeys/render.go
+++ b/pkg/controller/realmkeys/render.go
@@ -42,6 +42,9 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 
 		m["realmKeys"] = keys
 
+		maximumKeyVersions := c.db.MaxCertificateSigningKeyVersions()
+		m["maximumKeyVersions"] = maximumKeyVersions
+
 		publicKeys := make(map[string]string)
 		// Go through and load / parse all of the public keys for the realm.
 		for _, k := range keys {

--- a/pkg/controller/realmkeys/save.go
+++ b/pkg/controller/realmkeys/save.go
@@ -24,7 +24,7 @@ func (c *Controller) HandleSave() http.Handler {
 	type FormData struct {
 		Issuer         string `form:"certificateIssuer"`
 		Audience       string `form:"certificateAudience"`
-		DuratingString string `form:"certificateDuration"`
+		DurationString string `form:"certificateDuration"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -60,7 +60,7 @@ func (c *Controller) HandleSave() http.Handler {
 		realm.CertificateIssuer = form.Issuer
 		realm.CertificateAudience = form.Audience
 		// AsString delgates the duration parsing and validation to the model.
-		realm.CertificateDuration.AsString = form.DuratingString
+		realm.CertificateDuration.AsString = form.DurationString
 
 		if err := c.db.SaveRealm(realm, currentUser); err != nil {
 			flash.Error("Failed to update realm: %v", err)

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -55,6 +55,11 @@ type Config struct {
 	// created on.
 	CertificateSigningKeyRing string `env:"CERTIFICATE_SIGNING_KEYRING"`
 
+	// MaxCertificateSigningKeyVersions is the maximum number of certificate
+	// signing key versions per realm. This is enforced at the database layer, not
+	// the upstream KMS.
+	MaxCertificateSigningKeyVersions int64 `env:"MAX_CERTIFICATE_SIGNING_KEY_VERSIONS, default=5"`
+
 	// EncryptionKey is the reference to an encryption/decryption key to use when
 	// for application-layer encryption before values are persisted to the
 	// database.

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -91,6 +91,11 @@ func (db *Database) SupportsPerRealmSigning() bool {
 	return db.signingKeyManager != nil
 }
 
+// MaxCertificateSigningKeyVersions returns the configured maximum.
+func (db *Database) MaxCertificateSigningKeyVersions() int64 {
+	return db.config.MaxCertificateSigningKeyVersions
+}
+
 func (db *Database) KeyManager() keys.KeyManager {
 	return db.keyManager
 }


### PR DESCRIPTION
Fixes #993

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Limit number of non-deleted KMS signing keys on a realm (default: 5, configurable)
```

/assign @mikehelmick 

I went with 5 instead of 3 because the cost differential is ~$0.12 and I'd rather never be in the way of the end-user.