### PR TITLE
Ensure bits don't overflow

### DIFF
--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -369,7 +369,7 @@ func (db *Database) generateAPIKeySignatures(apiKey string) ([][]byte, error) {
 // VerifyAPIKeySignature verifies the signature matches the expected value for
 // the key. It does this by computing the expected signature and then doing a
 // constant-time comparison against the provided signature.
-func (db *Database) VerifyAPIKeySignature(key string) (string, uint, error) {
+func (db *Database) VerifyAPIKeySignature(key string) (string, uint64, error) {
 	parts := strings.SplitN(key, ".", 3)
 	if len(parts) != 3 {
 		return "", 0, fmt.Errorf("invalid API key format: wrong number of parts")
@@ -409,7 +409,7 @@ func (db *Database) VerifyAPIKeySignature(key string) (string, uint, error) {
 		return "", 0, fmt.Errorf("invalid API key format")
 	}
 
-	return apiKey, uint(realmID), nil
+	return apiKey, realmID, nil
 }
 
 func (a *AuthorizedApp) AuditID() string {

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -104,7 +104,7 @@ func TestDatabase_GenerateVerifyAPIKeySignature(t *testing.T) {
 
 	db := NewTestDatabase(t)
 
-	apiKey, realmID := "abcd1234", uint(15)
+	apiKey, realmID := "abcd1234", uint64(15)
 
 	key := fmt.Sprintf("%s.%d", apiKey, realmID)
 	sig, err := db.GenerateAPIKeySignature(key)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -23,6 +23,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"math/bits"
 	"os"
 	"strconv"
 	"strings"
@@ -313,6 +314,11 @@ func callbackIncrementMetric(ctx context.Context, m *stats.Int64Measure, table s
 				raw, err := strconv.ParseUint(t, 10, 64)
 				if err != nil {
 					_ = scope.Err(fmt.Errorf("failed to parse realm_id: %w", err))
+					return
+				}
+
+				if raw >= 1<<bits.UintSize-1 {
+					_ = scope.Err(fmt.Errorf("uint overflows %d bits", bits.UintSize))
 					return
 				}
 				realmID = uint(raw)

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -236,7 +236,7 @@ func remoteIP(r *http.Request) string {
 
 // realmIDFromAPIKey extracts the realmID from the provided API key, handling v1
 // and v2 API key formats.
-func realmIDFromAPIKey(db *database.Database, apiKey string) uint {
+func realmIDFromAPIKey(db *database.Database, apiKey string) uint64 {
 	// v2 API keys encode in the realm to limit the db calls
 	_, realmID, err := db.VerifyAPIKeySignature(apiKey)
 	if err == nil {
@@ -246,7 +246,7 @@ func realmIDFromAPIKey(db *database.Database, apiKey string) uint {
 	// v1 API keys are more expensive
 	app, err := db.FindAuthorizedAppByAPIKey(apiKey)
 	if err == nil {
-		return app.RealmID
+		return uint64(app.RealmID)
 	}
 
 	return 0


### PR DESCRIPTION
All our systems are 64-bit, so uint == uint64. However, on 32-bit systems, we would overflow.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure bits don't overflow when running on 32-bit systems
```
