### PR TITLE
Support configuring regional database replicas

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -68,6 +68,13 @@ variable "database_backup_schedule" {
   description = "Cron schedule in which to do a full backup of the database to Cloud Storage."
 }
 
+variable "database_failover_replica_regions" {
+  type    = list(string)
+  default = []
+
+  description = "List of regions in which to create failover replicas. The default configuration is resistant to zonal outages. This will increase costs."
+}
+
 variable "storage_location" {
   type    = string
   default = "US"


### PR DESCRIPTION
Support regional database replicas in Terraform. The default is still none, and the existing instances are still resilient to zonal failures within a region.

When setting `database_failover_replica_regions`, each region will have a read-only replica in the selected zone. Switching that replica to primary is a manual process. 

Fixes #998

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support configuring regional database replicas.
```
