### PR TITLE
Cleanup unused terraform-e2e directory

### DIFF
--- a/terraform-e2e/state.tf
+++ b/terraform-e2e/state.tf
@@ -1,5 +1,0 @@
-terraform {
-  backend "gcs" {
-    bucket = "composite-store-287220-tf-state"
-  }
-}


### PR DESCRIPTION
It was renamed to terraform-e2e-ci, was left during refactoring
