### PR TITLE
Only show 5 next/prev pages

### DIFF
--- a/pkg/database/pagination.go
+++ b/pkg/database/pagination.go
@@ -21,6 +21,12 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
+const (
+	// maxPrevPages and maxNextPages control the "window" to show.
+	maxPrevPages = 5
+	maxNextPages = 5
+)
+
 // Paginate is a helper that paginates a gorm query into the given result. In
 // addition to reflecting into the provided result, it returns a pagination
 // struct.
@@ -65,14 +71,14 @@ func PaginateFn(query *gorm.DB, page, limit uint64, populateFn func(query *gorm.
 	if current := offset + limit; current < total {
 		remaining := total - current
 		nextPages = uint64(math.Ceil(float64(remaining) / float64(limit)))
-		if nextPages > 10 {
-			nextPages = 5
+		if nextPages > maxNextPages {
+			nextPages = maxNextPages
 		}
 	}
 
 	prevPages := page - 1
-	if prevPages > 10 {
-		prevPages = 5
+	if prevPages > maxPrevPages {
+		prevPages = maxPrevPages
 	}
 
 	var paginator pagination.Paginator

--- a/pkg/database/pagination.go
+++ b/pkg/database/pagination.go
@@ -66,13 +66,13 @@ func PaginateFn(query *gorm.DB, page, limit uint64, populateFn func(query *gorm.
 		remaining := total - current
 		nextPages = uint64(math.Ceil(float64(remaining) / float64(limit)))
 		if nextPages > 10 {
-			nextPages = 10
+			nextPages = 5
 		}
 	}
 
 	prevPages := page - 1
 	if prevPages > 10 {
-		prevPages = 10
+		prevPages = 5
 	}
 
 	var paginator pagination.Paginator


### PR DESCRIPTION
10 rolls off the page when there's a lot of pages.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only show 5 next/prev pages in pagination.
```
