### PR TITLE
Allow searching API keys

### DIFF
--- a/cmd/server/assets/apikeys/index.html
+++ b/cmd/server/assets/apikeys/index.html
@@ -23,8 +23,22 @@
         </a>
       </div>
 
+      <div class="card-body">
+        <form method="GET" action="/apikeys" id="search-form">
+          <div class="input-group">
+            <span class="input-group-prepend">
+              <div class="input-group-text bg-transparent">
+                <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
+              </div>
+            </span>
+            <input type="search" name="q" id="search" value="{{.query}}" placeholder="Search"
+              autocomplete="off" class="form-control" />
+          </div>
+        </form>
+      </div>
+
       {{if .apps}}
-        <table class="table table-bordered table-striped table-fixed table-inner-border-only mb-0">
+        <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
           <thead>
             <tr>
               <th scope="col" width="40"></th>

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -701,13 +701,13 @@ func (r *Realm) ListSigningKeys(db *Database) ([]*SigningKey, error) {
 	return keys, nil
 }
 
-func (r *Realm) ListAuthorizedApps(db *Database, p *pagination.PageParams) ([]*AuthorizedApp, *pagination.Paginator, error) {
+func (r *Realm) ListAuthorizedApps(db *Database, p *pagination.PageParams, scopes ...Scope) ([]*AuthorizedApp, *pagination.Paginator, error) {
 	var authApps []*AuthorizedApp
-	query := db.db.
+	query := db.db.Model(&AuthorizedApp{}).
 		Unscoped().
-		Model(&AuthorizedApp{}).
+		Scopes(scopes...).
 		Where("realm_id = ?", r.ID).
-		Order("authorized_apps.deleted_at DESC, LOWER(authorized_apps.name)")
+		Order("LOWER(authorized_apps.name)")
 
 	if p == nil {
 		p = new(pagination.PageParams)

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -52,3 +52,17 @@ func WithUserSearch(q string) Scope {
 		return db
 	}
 }
+
+// WithAuthorizedAppSearch returns a scope that adds querying for API keys by
+// name and preview, case-insensitive. It's only applicable to functions that
+// query AuthorizedApp.
+func WithAuthorizedAppSearch(q string) Scope {
+	return func(db *gorm.DB) *gorm.DB {
+		q = project.TrimSpace(q)
+		if q != "" {
+			q = `%` + q + `%`
+			return db.Where("authorized_apps.name ILIKE ? OR authorized_apps.api_key_preview ILIKE ?", q, q)
+		}
+		return db
+	}
+}


### PR DESCRIPTION
/assign @whaught 

This became obviously necessary on the e2e test project where there are thousands of keys waiting to be cleaned up.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow searching API keys
```
