### PR TITLE
Move /users to /realm/users

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -96,7 +96,7 @@ aria-expanded="false" aria-label="Toggle navigation">
       <a class="dropdown-item {{if .currentPath.IsDir "/realm/events"}}active{{end}}" href="/realm/events">Event log</a>
       <a class="dropdown-item {{if .currentPath.IsDir "/realm/keys"}}active{{end}}" href="/realm/keys">Signing keys</a>
       <a class="dropdown-item {{if .currentPath.IsDir "/realm/stats"}}active{{end}}" href="/realm/stats">Statistics</a>
-      <a class="dropdown-item {{if .currentPath.IsDir "/users"}}active{{end}}" href="/users">Users</a>
+      <a class="dropdown-item {{if .currentPath.IsDir "/realm/users"}}active{{end}}" href="/realm/users">Users</a>
       <a class="dropdown-item {{if .currentPath.IsDir "/realm/settings"}}active{{end}}" href="/realm/settings#general">Settings</a>
       <div class="dropdown-divider"></div>
       {{end}}

--- a/cmd/server/assets/login/account.html
+++ b/cmd/server/assets/login/account.html
@@ -73,7 +73,7 @@
 
             {{- /* system admins can remove themselves from realms */ -}}
             {{if $user.SystemAdmin}}
-            <a href="/users/{{.ID}}" class="d-block text-danger float-right" data-method="DELETE"
+            <a href="/realm/users/{{.ID}}" class="d-block text-danger float-right" data-method="DELETE"
               data-confirm="Are you sure you want to leave {{.Name}}?">
               <span class="oi oi-account-logout" aria-hidden="true"></span>
               Leave realm

--- a/cmd/server/assets/users/_form.html
+++ b/cmd/server/assets/users/_form.html
@@ -4,10 +4,10 @@
 {{$user := .user}}
 
 {{if $user.ID}}
-<form method="POST" action="/users/{{$user.ID}}">
+<form method="POST" action="/realm/users/{{$user.ID}}">
   <input type="hidden" name="_method" value="PATCH">
   {{else}}
-  <form method="POST" action="/users">
+  <form method="POST" action="/realm/users">
     {{end}}
 
     {{ .csrfField }}

--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -67,7 +67,7 @@
         </table>
       </div>
     </div>
-    <a class=" card-link" href="/users">&larr; All users</a>
+    <a class=" card-link" href="/realm/users">&larr; All users</a>
   </main>
 
   <script type="text/javascript">
@@ -177,7 +177,7 @@
     function uploadBatch(data) {
       return $.ajax({
         type: 'POST',
-        url: '/users/import',
+        url: '/realm/users/import',
         data: JSON.stringify({ "users": data }),
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/json',

--- a/cmd/server/assets/users/index.html
+++ b/cmd/server/assets/users/index.html
@@ -22,16 +22,16 @@
       <div class="card-header">
         <span class="oi oi-person mr-2 ml-n1" aria-hidden="true"></span>
         Users
-        <a href="/users/new" class="float-right mr-n1 text-secondary" data-toggle="tooltip" title="New user">
+        <a href="/realm/users/new" class="float-right mr-n1 text-secondary" data-toggle="tooltip" title="New user">
           <span class="oi oi-plus small" aria-hidden="true"></span>
         </a>
-        <a href="/users/import" class="float-right mr-3 text-secondary" data-toggle="tooltip" title="Bulk import users">
+        <a href="/realm/users/import" class="float-right mr-3 text-secondary" data-toggle="tooltip" title="Bulk import users">
           <span class="oi oi-data-transfer-upload" aria-hidden="true"></span>
         </a>
       </div>
 
       <div class="card-body">
-        <form method="GET" action="/users" id="search-form">
+        <form method="GET" action="/realm/users" id="search-form">
           <div class="input-group">
             <span class="input-group-prepend">
               <div class="input-group-text bg-transparent">
@@ -57,7 +57,7 @@
             {{range $users}}
             <tr id="user-{{.ID}}">
               <td>
-                <a href="/users/{{.ID}}">{{.Name}}</a>
+                <a href="/realm/users/{{.ID}}">{{.Name}}</a>
                 {{if .CanAdminRealm $currentRealm.ID}}
                   <span class="ml-1 badge badge-pill badge-primary">Admin</span>
                 {{end}}
@@ -68,7 +68,7 @@
               <td class="text-center">
                 {{if not (eq .ID $currentUser.ID)}}
                 {{- /* cannot delete yourself */ -}}
-                <a href="/users/{{.ID}}" class="d-block text-danger" data-method="DELETE"
+                <a href="/realm/users/{{.ID}}" class="d-block text-danger" data-method="DELETE"
                   data-confirm="Are you sure you want to remove '{{.Name}}'?" data-toggle="tooltip"
                   title="Remove this user">
                   <span class="oi oi-trash" aria-hidden="true"></span>

--- a/cmd/server/assets/users/new.html
+++ b/cmd/server/assets/users/new.html
@@ -26,7 +26,7 @@
         {{template "users/_form" .}}
       </div>
     </div>
-    <a class="card-link" href="/users" id="all-users">&larr; All users</a>
+    <a class="card-link" href="/realm/users" id="all-users">&larr; All users</a>
   </main>
 </body>
 

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -18,7 +18,7 @@
 
     <h1>{{$user.Name}}</h1>
     <p class="float-right">
-      <a href="/users/{{$user.ID}}/edit">Edit</a>
+      <a href="/realm/users/{{$user.ID}}/edit">Edit</a>
     </p>
     <p>
       Here is information about the user.
@@ -46,7 +46,7 @@
           {{end}}
         </div>
 
-        <a href="/users/{{$user.ID}}/reset-password" data-method="POST" class="btn btn-primary btn-block">Send password reset</a>
+        <a href="/realm/users/{{$user.ID}}/reset-password" data-method="POST" class="btn btn-primary btn-block">Send password reset</a>
       </div>
     </div>
 
@@ -82,7 +82,7 @@
       </div>
     </div>
 
-    <a class="card-link" href="/users">&larr; All users</a>
+    <a class="card-link" href="/realm/users">&larr; All users</a>
   </main>
 
   {{if $stats}}

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -270,7 +270,7 @@ func Server(
 
 	// users
 	{
-		userSub := r.PathPrefix("/users").Subrouter()
+		userSub := r.PathPrefix("/realm/users").Subrouter()
 		userSub.Use(requireAuth)
 		userSub.Use(loadCurrentRealm)
 		userSub.Use(requireRealm)

--- a/pkg/controller/user/delete.go
+++ b/pkg/controller/user/delete.go
@@ -61,7 +61,7 @@ func (c *Controller) HandleDelete() http.Handler {
 		// themselves from the system admin panel.
 		if user.ID == currentUser.ID {
 			flash.Error("Failed to remove user from realm: cannot remove self")
-			http.Redirect(w, r, "/users", http.StatusSeeOther)
+			http.Redirect(w, r, "/realm/users", http.StatusSeeOther)
 			return
 		}
 
@@ -69,7 +69,7 @@ func (c *Controller) HandleDelete() http.Handler {
 
 		if err := c.db.SaveUser(user, currentUser); err != nil {
 			flash.Error("Failed to remove user from realm: %v", err)
-			http.Redirect(w, r, "/users", http.StatusSeeOther)
+			http.Redirect(w, r, "/realm/users", http.StatusSeeOther)
 			return
 		}
 
@@ -83,6 +83,6 @@ func (c *Controller) HandleDelete() http.Handler {
 		}
 
 		flash.Alert("Successfully removed user %v from realm", user.Email)
-		http.Redirect(w, r, "/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/realm/users", http.StatusSeeOther)
 	})
 }

--- a/pkg/controller/user/search_test.go
+++ b/pkg/controller/user/search_test.go
@@ -85,7 +85,7 @@ func TestHandleSearch(t *testing.T) {
 		browser.SetCookie(cookie),
 
 		// Visit /apikeys/new.
-		chromedp.Navigate(`http://`+harness.Server.Addr()+`/users`),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/users`),
 
 		// Wait for render.
 		chromedp.WaitVisible(`body#users-index`, chromedp.ByQuery),

--- a/pkg/controller/user/update.go
+++ b/pkg/controller/user/update.go
@@ -101,7 +101,7 @@ func (c *Controller) HandleUpdate() http.Handler {
 		}
 
 		flash.Alert("Successfully updated user '%v'", form.Name)
-		http.Redirect(w, r, "/users", http.StatusSeeOther)
+		http.Redirect(w, r, "/realm/users", http.StatusSeeOther)
 	})
 }
 


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1026

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

We have 

1. `/realm/settings`
2. `/realm/stats`
3. `/realm/keys`
4. `/realm/events`

but

1. `/users`
2. `/apikeys`
3. `/mobileapps`
4. `/home`
5. `/code/stats`

This relocates `/users` to `/realm/users` but I'm also putting this out for a discussion of what we want our paths to look like

/hold

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Move /users to /realm/users
```
