### PR TITLE
make date required default true for new realms

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -74,9 +74,10 @@
         <label for="require-date-true" class="form-check-label">
           Required date
           <small class="form-text text-muted">
-            Require a symptom date or test date when generating a
-            verification code. Attempting to generate a verification
-            code without a date will return an error.
+            <strong>Recommended:</strong> Require a symptom date or test date
+            when generating a verification code. Attempting to generate a verification
+            code without a date will return an error. <em>Exposure notifications are 
+            more accurate when a date is provided.</em>
           </small>
         </label>
       </div>

--- a/pkg/controller/home/home_test.go
+++ b/pkg/controller/home/home_test.go
@@ -70,6 +70,8 @@ func TestHandleHome_IssueCode(t *testing.T) {
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
+	yesterday := time.Now().Add(-24 * time.Hour).Format("2006-01-02")
+
 	var code string
 	if err := chromedp.Run(taskCtx,
 		// Pre-authenticate the user.
@@ -80,6 +82,9 @@ func TestHandleHome_IssueCode(t *testing.T) {
 
 		// Wait for render.
 		chromedp.WaitVisible(`body#home`, chromedp.ByQuery),
+
+		// Add a test date of yesterday.
+		chromedp.SetValue(`input#test-date`, yesterday, chromedp.ByQuery),
 
 		// Click the issue button.
 		chromedp.Click(`#submit`, chromedp.ByQuery),

--- a/pkg/controller/home/home_test.go
+++ b/pkg/controller/home/home_test.go
@@ -66,7 +66,7 @@ func TestHandleHome_IssueCode(t *testing.T) {
 	}
 
 	// Create a browser runner.
-	browserCtx := browser.NewHeadful(t)
+	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 

--- a/pkg/controller/home/home_test.go
+++ b/pkg/controller/home/home_test.go
@@ -66,7 +66,7 @@ func TestHandleHome_IssueCode(t *testing.T) {
 	}
 
 	// Create a browser runner.
-	browserCtx := browser.New(t)
+	browserCtx := browser.NewHeadful(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
@@ -83,8 +83,9 @@ func TestHandleHome_IssueCode(t *testing.T) {
 		// Wait for render.
 		chromedp.WaitVisible(`body#home`, chromedp.ByQuery),
 
-		// Add a test date of yesterday.
+		// Add a date fields
 		chromedp.SetValue(`input#test-date`, yesterday, chromedp.ByQuery),
+		chromedp.SetValue(`input#symptom-date`, yesterday, chromedp.ByQuery),
 
 		// Click the issue button.
 		chromedp.Click(`#submit`, chromedp.ByQuery),

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -275,6 +275,7 @@ func NewRealmWithDefaults(name string) *Realm {
 		SMSTextTemplate:     "This is your Exposure Notifications Verification code: [longcode] Expires in [longexpires] hours",
 		AllowedTestTypes:    14,
 		CertificateDuration: FromDuration(15 * time.Minute),
+		RequireDate:         true, // Having dates is really important to risk scoring, encourage this by default true.
 	}
 }
 


### PR DESCRIPTION
## Proposed Changes

* Make date required the default for new realms to encourage usage of this feature.

**Release Note**


```release-note
"date required" is the default setting on NEW realms only. Existing realms not changed on upgrade.
```
