### PR TITLE
Use the search icon for consistency

### DIFF
--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -28,18 +28,15 @@
         <form method="GET" action="/admin/events" id="search-form">
           <div class="input-group">
             <span class="input-group-prepend">
-              <div class="input-group-text bg-transparent">
+              <button type="submit" class="input-group-text bg-transparent">
                 <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
-              </div>
+              </button>
             </span>
             <input type="datetime-local" name="from" value="{{.from}}" class="form-control">
             <span class="input-group-append">
               <span class="input-group-text bg-transparent border-left-0 border-right-0">thru</span>
             </span>
             <input type="datetime-local" name="to" value="{{.to}}" class="form-control">
-            <span class="input-group-append">
-              <input type="submit" value="Search" class="input-group-text bg-transparent">
-            </span>
           </div>
         </form>
       </div>

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -28,7 +28,7 @@
         <form method="GET" action="/admin/events" id="search-form">
           <div class="input-group">
             <span class="input-group-prepend">
-              <button type="submit" class="input-group-text bg-transparent">
+              <button type="submit" class="input-group-text bg-transparent" data-toggle="tooltip" title="Search">
                 <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
               </button>
             </span>

--- a/cmd/server/assets/realmadmin/events.html
+++ b/cmd/server/assets/realmadmin/events.html
@@ -28,11 +28,15 @@
         <form method="GET" action="/realm/events" id="search-form">
           <div class="input-group">
             <span class="input-group-prepend">
-              <input class="input-group-text bg-transparent" type="submit" value="Search"></input>
+              <button type="submit" class="input-group-text bg-transparent">
+                <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
+              </button>
             </span>
-            <input class="form-control" type="datetime-local" name="from" value="{{.from}}">
-            <div class="text-secondary pl-2 pr-2">to</div>
-            <input class="form-control" type="datetime-local" name="to" value="{{.to}}">
+            <input type="datetime-local" name="from" value="{{.from}}" class="form-control">
+            <span class="input-group-append">
+              <span class="input-group-text bg-transparent border-left-0 border-right-0">thru</span>
+            </span>
+            <input type="datetime-local" name="to" value="{{.to}}" class="form-control">
           </div>
         </form>
       </div>

--- a/cmd/server/assets/realmadmin/events.html
+++ b/cmd/server/assets/realmadmin/events.html
@@ -28,7 +28,7 @@
         <form method="GET" action="/realm/events" id="search-form">
           <div class="input-group">
             <span class="input-group-prepend">
-              <button type="submit" class="input-group-text bg-transparent">
+              <button type="submit" class="input-group-text bg-transparent" data-toggle="tooltip" title="Search">
                 <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
               </button>
             </span>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Apply the same styling to system-admin search and realm-admin search for events
* I really don't like have both the search icon and "search" button be separate (with only one clickable). This keeps the icon which is consistent with the other searches.

**Alternatives**
    * I could leave both an make both clickable
    * We could move it to the right side

![searchicon](https://user-images.githubusercontent.com/36240966/98629209-381d0c80-22cd-11eb-9dc6-dd161853ecf0.png)
