### PR TITLE
Skip invitations checkbox for bulk-import

### DIFF
--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -144,6 +144,7 @@
         };
 
         let start = async function(e) {
+          let checked = $sendInvites.is(":checked")
           let rows = e.target.result.split("\n");
           let batch = [];
           totalUsersCreated = 0;
@@ -168,7 +169,7 @@
             }
 
             if (batch.length >= batchSize || i == rows.length - 1) {
-              await uploadBatch(batch).catch(err => { });
+              await uploadBatch(batch, checked).catch(err => { });
               if (cancelUpload) {
                 flash.warning("Successfully created " + totalUsersCreated + " new users."
                   + (rows.length - i) + " remaining.");
@@ -193,14 +194,13 @@
       }
     });
 
-    function uploadBatch(data) {
-      let checked = $sendInvites.is(":checked")
+    function uploadBatch(data, sendInvites) {
       return $.ajax({
         type: 'POST',
         url: '/realm/users/import',
         data: JSON.stringify({
           "users": data,
-          "sendInvites": checked,
+          "sendInvites": sendInvites,
        }),
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/json',

--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -48,6 +48,11 @@
           </div>
           <button class="btn btn-primary" type="submit" id="import" disabled>Import users</button>
           <button class="btn btn-danger" id="cancel" disabled>Cancel</button>
+
+          <div class="form-group form-check">
+            <input type="checkbox" class="form-check-input" name="sendInvites" id="sendInvites" checked>
+            <label class="form-check-label" for="sendInvites">Send invitations</label>
+          </div>
         </form>
       </div>
 
@@ -92,6 +97,7 @@
       let $tableBody = $('#csv-table-body');
       let $progressDiv = $('#progress-div');
       let $progress = $('#progress');
+      let $sendInvites = $('#sendInvites');
 
       let totalUsersCreated = 0;
       let upload = readFile();
@@ -188,10 +194,14 @@
     });
 
     function uploadBatch(data) {
+      let checked = $sendInvites.is(":checked")
       return $.ajax({
         type: 'POST',
         url: '/realm/users/import',
-        data: JSON.stringify({ "users": data }),
+        data: JSON.stringify({
+          "users": data,
+          "sendInvites": checked,
+       }),
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/json',
         success: function(result) {

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -54,7 +54,7 @@ type Provider interface {
 	CreateUser(ctx context.Context, name, email, pass string, sendInvite bool, composer InviteUserEmailFunc) (bool, error)
 
 	// SendResetPasswordEmail resets the given user's password. If the user does not exist,
-	// the underlying provider determines whether its an error or perhaps upserts
+	// the underlying provider determines whether it's an error or perhaps upserts
 	// the account.
 	SendResetPasswordEmail(ctx context.Context, email string, composer ResetPasswordEmailFunc) error
 

--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -51,10 +51,10 @@ type Provider interface {
 
 	// CreateUser creates a user in the auth provider. If pass is "", the provider
 	// creates and uses a random password.
-	CreateUser(ctx context.Context, name, email, pass string, composer InviteUserEmailFunc) (bool, error)
+	CreateUser(ctx context.Context, name, email, pass string, sendInvite bool, composer InviteUserEmailFunc) (bool, error)
 
 	// SendResetPasswordEmail resets the given user's password. If the user does not exist,
-	// the underlying provider determines whether itls an error or perhaps upserts
+	// the underlying provider determines whether its an error or perhaps upserts
 	// the account.
 	SendResetPasswordEmail(ctx context.Context, email string, composer ResetPasswordEmailFunc) error
 

--- a/internal/auth/local.go
+++ b/internal/auth/local.go
@@ -106,7 +106,11 @@ func (a *localAuth) ClearSession(ctx context.Context, session *sessions.Session)
 // CreateUser creates a user in the upstream auth system with the given name and
 // email. It returns true if the user was created or false if the user already
 // exists.
-func (a *localAuth) CreateUser(ctx context.Context, name, email, pass string, emailer InviteUserEmailFunc) (bool, error) {
+func (a *localAuth) CreateUser(ctx context.Context, name, email, pass string, sendInvite bool, emailer InviteUserEmailFunc) (bool, error) {
+	if !sendInvite {
+		return true, nil
+	}
+
 	if emailer == nil {
 		return false, fmt.Errorf("emailer is required for local auth")
 	}

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -144,7 +144,8 @@ type CSRFResponse struct {
 // This is called by the Web frontend.
 // API is served at /users/import/userbatch
 type UserBatchRequest struct {
-	Users []BatchUser `json:"users"`
+	Users       []BatchUser `json:"users"`
+	SendInvites bool        `json:"sendInvites"`
 }
 
 // BatchUser represents a single user's email/name.

--- a/pkg/controller/admin/users_operations.go
+++ b/pkg/controller/admin/users_operations.go
@@ -96,7 +96,7 @@ func (c *Controller) HandleSystemAdminCreate() http.Handler {
 			return
 		}
 
-		if _, err := c.authProvider.CreateUser(ctx, form.Email, form.Email, "", inviteComposer); err != nil {
+		if _, err := c.authProvider.CreateUser(ctx, form.Email, form.Email, "", true, inviteComposer); err != nil {
 			flash.Alert("Failed to create user: %v", err)
 			c.renderNewUser(ctx, w, user)
 		}

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -96,7 +96,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			return
 		}
 
-		if _, err := c.authProvider.CreateUser(ctx, user.Name, user.Email, "", inviteComposer); err != nil {
+		if _, err := c.authProvider.CreateUser(ctx, user.Name, user.Email, "", true, inviteComposer); err != nil {
 			flash.Alert("Failed to create user: %v", err)
 			c.renderNew(ctx, w)
 			return

--- a/pkg/controller/user/importbatch.go
+++ b/pkg/controller/user/importbatch.go
@@ -86,7 +86,7 @@ func (c *Controller) HandleImportBatch() http.Handler {
 
 			// Create the user in the auth provider. This could be a noop depending on
 			// the auth provider.
-			created, err := c.authProvider.CreateUser(ctx, user.Name, user.Email, "", inviteComposer)
+			created, err := c.authProvider.CreateUser(ctx, user.Name, user.Email, "", request.SendInvites, inviteComposer)
 			if err != nil {
 				logger.Errorw("failed to import user", "user", user.Email, "error", err)
 				batchErr = multierror.Append(batchErr, err)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allows the user to skip sending password-reset invitations when bulk-importing users
* This would be used, for example, if a state moving to ENX wants to import firebase auth (and doesn't want to send reset-passwords)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Option to skip password-reset invitations on bulk user import
```
