### PR TITLE
Test system-admin audit event search

### DIFF
--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -27,11 +27,11 @@
       <div class="card-body">
         <form method="GET" action="/admin/events" id="search-form">
           <div class="input-group">
-            <input type="datetime-local" name="from" value="{{.from}}" class="form-control">
+            <input type="datetime-local" id="from" name="from" value="{{.from}}" class="form-control">
             <span class="input-group-append">
               <span class="input-group-text bg-transparent border-left-0 border-right-0">thru</span>
             </span>
-            <input type="datetime-local" name="to" value="{{.to}}" class="form-control">
+            <input type="datetime-local" id="to" name="to" value="{{.to}}" class="form-control">
             <div class="input-group-append">
               <button type="submit" class="btn btn-primary">
                 <span class="oi oi-magnifying-glass" aria-hidden="true"></span>
@@ -43,9 +43,9 @@
       </div>
 
       {{if $events}}
-        <div class="list-group list-group-flush">
+        <div class="list-group list-group-flush" id="results">
           {{range $event := $events}}
-            <div class="list-group-item flex-column align-items-start">
+            <div class="list-group-item flex-column align-items-start" id="event">
               <div class="d-flex w-100 justify-content-between">
                 <h5 class="mb-1">{{$event.Action}}</h5>
                 <small

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -27,6 +27,9 @@ import (
 	"github.com/chromedp/chromedp"
 )
 
+// This goes to the value of a <input type="datetime-local">
+const RFC3339_PARTIAL_LOCAL = "2006-01-02T15:04:05"
+
 func TestShowAdminEvents(t *testing.T) {
 	harness := envstest.NewServer(t)
 
@@ -47,6 +50,21 @@ func TestShowAdminEvents(t *testing.T) {
 	if err := harness.Database.SaveUser(admin, database.System); err != nil {
 		t.Fatal(err)
 	}
+
+	eventTime, err := time.Parse(time.RFC3339, "2020-03-11T12:00:00Z")
+	if err != nil {
+		t.Fatal(err)
+	}
+	audit := &database.AuditEntry{
+		RealmID:       0, // system entry
+		Action:        "test action",
+		TargetID:      "testTargetID",
+		TargetDisplay: "test target",
+		ActorID:       "testActorID",
+		ActorDisplay:  "test actor",
+		CreatedAt:     eventTime,
+	}
+	harness.Database.RawDB().Save(audit)
 
 	// Log in the user.
 	session, err := harness.LoggedInSession(nil, admin.Email)
@@ -76,6 +94,22 @@ func TestShowAdminEvents(t *testing.T) {
 
 		// Wait for render.
 		chromedp.WaitVisible(`body#admin-events-index`, chromedp.ByQuery),
+
+		// Search from and hour before to and hour after our event
+		chromedp.SetValue(`#from`, eventTime.Add(-time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.SetValue(`#to`, eventTime.Add(time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.Submit(`form#search-form`, chromedp.ByQuery),
+
+		// Wait for the search result.
+		chromedp.WaitVisible(`#results #event`, chromedp.ByQuery),
+
+		// Search an hour before the event.
+		chromedp.SetValue(`#from`, eventTime.Add(-2*time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.SetValue(`#to`, eventTime.Add(-time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.Submit(`form#search-form`, chromedp.ByQuery),
+
+		// Assert no event found
+		chromedp.WaitNotPresent(`#results #event`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -28,7 +28,7 @@ import (
 )
 
 // This goes to the value of a <input type="datetime-local">
-const RFC3339_PARTIAL_LOCAL = "2006-01-02T15:04:05"
+const RFC3339PartialLocal = "2006-01-02T15:04:05"
 
 func TestShowAdminEvents(t *testing.T) {
 	harness := envstest.NewServer(t)
@@ -96,16 +96,16 @@ func TestShowAdminEvents(t *testing.T) {
 		chromedp.WaitVisible(`body#admin-events-index`, chromedp.ByQuery),
 
 		// Search from and hour before to and hour after our event
-		chromedp.SetValue(`#from`, eventTime.Add(-time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
-		chromedp.SetValue(`#to`, eventTime.Add(time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.SetValue(`#from`, eventTime.Add(-time.Hour).Format(RFC3339PartialLocal), chromedp.ByQuery),
+		chromedp.SetValue(`#to`, eventTime.Add(time.Hour).Format(RFC3339PartialLocal), chromedp.ByQuery),
 		chromedp.Submit(`form#search-form`, chromedp.ByQuery),
 
 		// Wait for the search result.
 		chromedp.WaitVisible(`#results #event`, chromedp.ByQuery),
 
 		// Search an hour before the event.
-		chromedp.SetValue(`#from`, eventTime.Add(-2*time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
-		chromedp.SetValue(`#to`, eventTime.Add(-time.Hour).Format(RFC3339_PARTIAL_LOCAL), chromedp.ByQuery),
+		chromedp.SetValue(`#from`, eventTime.Add(-2*time.Hour).Format(RFC3339PartialLocal), chromedp.ByQuery),
+		chromedp.SetValue(`#to`, eventTime.Add(-time.Hour).Format(RFC3339PartialLocal), chromedp.ByQuery),
 		chromedp.Submit(`form#search-form`, chromedp.ByQuery),
 
 		// Assert no event found


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Creates an audit event with a known time
* Searches for events in that time frame and asserts the one
* Searches and hour before and asserts no results

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Integration test for system-admin events page
```
