### PR TITLE
Accept client UUID for issued-code tracking

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -171,7 +171,8 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
   "testType": "<valid test type>",
   "tzOffset": 0,
   "phone": "+CC Phone number",
-  "padding": "<bytes>"
+  "padding": "<bytes>",
+  "uuid": "string UUID",
 }
 ```
 
@@ -189,6 +190,8 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
   body to a network observer. The client should generate and insert a random
   number of base64-encoded bytes into this field. The server does not process
   the padding.
+* `uuid` is optional as request input. The server will generate a uuid on response if omitted.
+  * This is a handle which allows the issuer to track status of the issued verification code.
 
 **IssueCodeResponse**
 
@@ -308,7 +311,7 @@ curl https://example.encv.org/api/endpoint \
 
 The client should still send a real request with a real request body (the body
 will not be processed). The server will respond with a fake response that your
-client **MUST NOT** process or parse. The response will not be a valid JSON 
+client **MUST NOT** process or parse. The response will not be a valid JSON
 object.
 
 Client's should sporadically issue chaff requests to mirror real-world usage.

--- a/docs/api.md
+++ b/docs/api.md
@@ -152,6 +152,7 @@ Possible error code responses. New error codes may be added in future releases.
 | `token_invalid`         | 400         | No    | The provided token is invalid, or already used to generate a certificate |
 | `token_expired`         | 400         | No    | Code invalid or used, user may need to obtain a new code. |
 | `hmac_invalid`          | 400         | No    | The `ekeyhmac` field, when base64 decoded is not the right size (32 bytes) |
+| `uuid_already_exists`   | 409         | No    | The UUID has already been used for an issued code |
 |                         | 500         | Yes   | Internal processing error, may be successful on retry. |
 
 # Admin APIs

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -62,6 +62,8 @@ const (
 	ErrTokenExpired = "token_expired"
 	// ErrHMACInvalid indicates that the HMAC that is being signed is invalid (wrong length)
 	ErrHMACInvalid = "hmac_invalid"
+	// ErrUUIDAlreadyExists indicates that the UUID has already been used for an issued code.
+	ErrUUIDAlreadyExists = "uuid_already_exists"
 )
 
 // ErrorReturn defines the common error type.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -175,6 +175,10 @@ type IssueCodeRequest struct {
 	// (using the default of 0) are all valid. 0 is considered to be UTC.
 	TZOffset float32 `json:"tzOffset"`
 	Phone    string  `json:"phone"`
+
+	// Optional: UUID is a handle which allows the issuer to track status
+	// of the issued verification code. If omitted the server will generate the UUID.
+	UUID string `json:"uuid"`
 }
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -192,7 +192,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			return
 		}
 
-		// Set up parallel arrays to leverage the observability reporting and connect the parse / valdiation errors
+		// Set up parallel arrays to leverage the observability reporting and connect the parse / validation errors
 		// to the correct date.
 		parsedDates := make([]*time.Time, 2)
 		input := []string{request.SymptomDate, request.TestDate}
@@ -276,14 +276,6 @@ func (c *Controller) HandleIssue() http.Handler {
 			longExpiryTime = expiryTime
 		}
 
-		if request.UUID != "" {
-			_, err := realm.FindVerificationCodeByUUID(c.db, request.UUID)
-			if !database.IsNotFound(err) {
-				c.h.RenderJSON(w, http.StatusConflict, api.Errorf("code for %s already exists", request.UUID))
-				return
-			}
-		}
-
 		// Generate verification code
 		codeRequest := otp.Request{
 			DB:             c.db,
@@ -304,9 +296,15 @@ func (c *Controller) HandleIssue() http.Handler {
 		code, longCode, uuid, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())
 		if err != nil {
 			logger.Errorw("failed to issue code", "error", err)
-			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))
 			blame = observability.BlameServer
 			result = observability.ResultError("FAILED_TO_ISSUE_CODE")
+
+			// GormV1 doesn't have a good way to match db errors
+			if strings.Contains(err.Error(), database.VercodeUUIDUniqueIndex) {
+				c.h.RenderJSON(w, http.StatusConflict, api.Errorf("code for %s already exists", request.UUID))
+				return
+			}
+			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))
 			return
 		}
 

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -290,6 +290,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			IssuingUser:    user,
 			IssuingApp:     authApp,
 			RealmID:        realm.ID,
+			UUID:           request.UUID,
 		}
 
 		code, longCode, uuid, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -276,6 +276,14 @@ func (c *Controller) HandleIssue() http.Handler {
 			longExpiryTime = expiryTime
 		}
 
+		if request.UUID != "" {
+			_, err := realm.FindVerificationCodeByUUID(c.db, request.UUID)
+			if !database.IsNotFound(err) {
+				c.h.RenderJSON(w, http.StatusConflict, api.Errorf("code for %s already exists", request.UUID))
+				return
+			}
+		}
+
 		// Generate verification code
 		codeRequest := otp.Request{
 			DB:             c.db,

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -301,7 +301,8 @@ func (c *Controller) HandleIssue() http.Handler {
 
 			// GormV1 doesn't have a good way to match db errors
 			if strings.Contains(err.Error(), database.VercodeUUIDUniqueIndex) {
-				c.h.RenderJSON(w, http.StatusConflict, api.Errorf("code for %s already exists", request.UUID))
+				c.h.RenderJSON(w, http.StatusConflict,
+					api.Errorf("code for %s already exists", request.UUID).WithCode(api.ErrUUIDAlreadyExists))
 				return
 			}
 			c.h.RenderJSON(w, http.StatusInternalServerError, api.Errorf("failed to generate otp code, please try again"))

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -19,7 +19,7 @@ import (
 	"time"
 )
 
-func TestDateValidationn(t *testing.T) {
+func TestDateValidation(t *testing.T) {
 	utc, err := time.LoadLocation("UTC")
 	if err != nil {
 		t.Fatalf("error loading utc")

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -102,14 +102,16 @@ func TestIntegration(t *testing.T) {
 			}
 			hmacB64 := base64.StdEncoding.EncodeToString(hmacValue)
 
+			requestUUID := "d6ec95a3-dd42-4eef-b1ec-0f7a777c43cf"
 			issueRequest := api.IssueCodeRequest{
 				TestType:    testType,
 				SymptomDate: symptomDate,
 				TZOffset:    float32(tzMinOffset),
+				UUID:        requestUUID,
 			}
 
 			issueResp, err := adminClient.IssueCode(issueRequest)
-			if issueResp == nil || err != nil {
+			if issueResp == nil || err != nil || issueResp.UUID != requestUUID {
 				t.Fatalf("adminClient.IssueCode(%+v) = expected nil, got resp %+v, err %v", issueRequest, issueResp, err)
 			}
 

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -102,17 +102,21 @@ func TestIntegration(t *testing.T) {
 			}
 			hmacB64 := base64.StdEncoding.EncodeToString(hmacValue)
 
-			requestUUID := "d6ec95a3-dd42-4eef-b1ec-0f7a777c43cf"
 			issueRequest := api.IssueCodeRequest{
 				TestType:    testType,
 				SymptomDate: symptomDate,
 				TZOffset:    float32(tzMinOffset),
-				UUID:        requestUUID,
 			}
 
 			issueResp, err := adminClient.IssueCode(issueRequest)
-			if issueResp == nil || err != nil || issueResp.UUID != requestUUID {
+			if issueResp == nil || err != nil || issueResp.UUID == "" {
 				t.Fatalf("adminClient.IssueCode(%+v) = expected nil, got resp %+v, err %v", issueRequest, issueResp, err)
+			}
+
+			// Try to issue the same code again (same UUID)
+			issueRequest.UUID = issueResp.UUID
+			if _, err = adminClient.IssueCode(issueRequest); err == nil {
+				t.Fatalf("Expected conflict, got %s", err)
 			}
 
 			verifyRequest := api.VerifyCodeRequest{

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -99,6 +99,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 	var verificationCode database.VerificationCode
 	var err error
 	var code, longCode string
+
 	for i := uint(0); i < retryCount; i++ {
 		code, err = GenerateCode(o.ShortLength)
 		if err != nil {

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -88,6 +88,7 @@ type Request struct {
 	MaxSymptomAge  time.Duration
 	IssuingUser    *database.User
 	IssuingApp     *database.AuthorizedApp
+	UUID           string
 }
 
 // Issue will generate a verification code and save it to the database, based on
@@ -133,6 +134,7 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 			LongExpiresAt: o.LongExpiresAt,
 			IssuingUserID: issuingUserID,
 			IssuingAppID:  issuingAppID,
+			UUID:          o.UUID,
 		}
 		// If a verification code already exists, it will fail to save, and we retry.
 		if err := o.DB.SaveVerificationCode(&verificationCode, o.MaxSymptomAge); err != nil {

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -138,8 +138,11 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 			UUID:          o.UUID,
 		}
 		// If a verification code already exists, it will fail to save, and we retry.
-		if err := o.DB.SaveVerificationCode(&verificationCode, o.MaxSymptomAge); err != nil {
+		if err = o.DB.SaveVerificationCode(&verificationCode, o.MaxSymptomAge); err != nil {
 			logger.Warnf("duplicate OTP found: %v", err)
+			if strings.Contains(err.Error(), database.VercodeUUIDUniqueIndex) {
+				break // not retryable
+			}
 			continue
 		} else {
 			break // successful save, nil error, break out.

--- a/pkg/otp/code.go
+++ b/pkg/otp/code.go
@@ -99,7 +99,6 @@ func (o *Request) Issue(ctx context.Context, retryCount uint) (string, string, s
 	var verificationCode database.VerificationCode
 	var err error
 	var code, longCode string
-
 	for i := uint(0); i < retryCount; i++ {
 		code, err = GenerateCode(o.ShortLength)
 		if err != nil {

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -41,6 +41,7 @@ var allowedResponseCodes = map[int]struct{}{
 	401: {},
 	404: {},
 	405: {},
+	409: {},
 	412: {},
 	413: {},
 	429: {},


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1061

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Allow client to provide the tracking UUID for an issued code
    * Thus will allow us to pre-allocate these for the bulk-upload scenario which will help with tracking / retryability
* Backwards-compatible, if not provided the server will generate the UUID.
* Redo the UUID index as UNIQUE for enforcement

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow client-provided UUID for issuing a code
Drop and re-create UUID index as UNIQUE
```
