### PR TITLE
Cleanup codes/ paths

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/codestatus"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -159,9 +159,9 @@ func realMain(ctx context.Context) error {
 		issueapiController := issueapi.New(ctx, cfg, db, limiterStore, h)
 		sub.Handle("/issue", issueapiController.HandleIssue()).Methods("POST")
 
-		codeStatusController := codestatus.NewAPI(ctx, cfg, db, h)
-		sub.Handle("/checkcodestatus", codeStatusController.HandleCheckCodeStatus()).Methods("POST")
-		sub.Handle("/expirecode", codeStatusController.HandleExpireAPI()).Methods("POST")
+		codesController := codes.NewAPI(ctx, cfg, db, h)
+		sub.Handle("/checkcodestatus", codesController.HandleCheckCodeStatus()).Methods("POST")
+		sub.Handle("/expirecode", codesController.HandleExpireAPI()).Methods("POST")
 	}
 
 	srv, err := server.New(cfg.Port)

--- a/cmd/server/assets/admin/_nav.html
+++ b/cmd/server/assets/admin/_nav.html
@@ -11,7 +11,7 @@
         {{if .currentRealm}}
         <ul class="navbar-nav mr-auto">
           <li class="nav-item">
-            <a class="nav-link" href="/code/issue">&larr; Back to {{.currentRealm.Name}} </a>
+            <a class="nav-link" href="/codes/issue">&larr; Back to {{.currentRealm.Name}} </a>
           </li>
         </ul>
         {{end}}

--- a/cmd/server/assets/codestatus/index.html
+++ b/cmd/server/assets/codestatus/index.html
@@ -23,51 +23,46 @@
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Code status</div>
       <div class="card-body">
-        <form class="floating-form">
+        <form class="floating-form" action="/codes/status" id="form-check-status">
           <div class="form-group">
-            <div class="form-label-group ">
+            <div class="form-label-group">
               <input type="text" id="uuid" name="uuid"
                 class='form-control text-monospace{{if $code.ErrorsFor "uuid"}} is-invalid{{end}}'
                 value="{{$code.UUID}}" placeholder="UUID" autocomplete="off" required autofocus>
               <label for="uuid">UUID</label>
-              {{if $code.ErrorsFor "uuid"}}
-              <div class="invalid-feedback">
-                {{joinStrings ($code.ErrorsFor "uuid") ", "}}
-              </div>
-              {{end}}
+              {{template "errorable" $code.ErrorsFor "uuid"}}
               <small class="form-text text-muted">
                 Identifier given from the Issue Code form.
               </small>
             </div>
-          </form>
+          </div>
 
-          <button class="btn btn-primary btn-block" id="check">Check status</button>
-        </div>
+          <input type="submit" value="Check status" class="btn btn-primary btn-block">
+        </form>
       </div>
     </div>
 
     <div class="card mb-3 shadow-sm">
       <div class="card-header">Your recently issued codes</div>
-      <div class="card-body">
-        <div class="list-group">
-          {{range $code := .recentCodes}}
-          <a href="/code/show/{{$code.UUID}}" class="list-group-item list-group-item-action">
-            {{$code.UUID}}<br />
+      <div class="list-group list-group-flush">
+        {{range $code := .recentCodes}}
+          <a href="/codes/{{$code.UUID}}" class="list-group-item list-group-item-action">
+            <span class="text-monospace">{{$code.UUID}}</span>
+            <br />
             <small
               data-timestamp="{{$code.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}"
               data-toggle="tooltip" title="{{$code.CreatedAt.Format "2006-02-01 15:04 UTC"}}">
               {{$code.CreatedAt.Format "2006-02-01 15:04"}}
             </small>
           </a>
-          {{end}}
-        </div>
+        {{end}}
       </div>
     </div>
   </main>
 
   <script type="text/javascript">
     $(function() {
-      let $check= $('#check');
+      let $form = $('#form-check-status');
       let $uuid = $('#uuid');
 
       let allowedChars = new RegExp("[0-9a-fA-F]");
@@ -89,9 +84,9 @@
         $uuid.val(r);
       });
 
-      $check.click(function(e) {
+      $form.submit(function(e) {
         e.preventDefault();
-        window.location.assign("/code/show/"+$uuid.val());
+        window.location.assign("/codes/"+$uuid.val());
       });
     });
   </script>

--- a/cmd/server/assets/codestatus/show.html
+++ b/cmd/server/assets/codestatus/show.html
@@ -25,7 +25,7 @@
       <div class="list-group list-group-flush">
         <div class="list-group-item">
           <h5 class="mb-1">UUID</h5>
-          <p class="mb-1 text-monospace">{{.code.UUID}}</p>
+          <p class="mb-1 text-monospace user-select-all">{{.code.UUID}}</p>
         </div>
         <div class="list-group-item">
           <h5 class="mb-1">{{.code.IssuerType}}</h5>
@@ -53,7 +53,7 @@
         {{end}}
         {{if .code.Expires}}
         <div class="list-group-item">
-          <a href="/code/{{.code.UUID}}/expire" class="btn btn-danger d-block" data-method="PATCH" data-confirm="Are you sure you want to expire this code?">
+          <a href="/codes/{{.code.UUID}}/expire" class="btn btn-danger d-block" data-method="PATCH" data-confirm="Are you sure you want to expire this code?">
             Invalidate code now
           </a>
         </div>
@@ -61,7 +61,7 @@
       </div>
     </div>
 
-    <a href="/code/status" class="card-link">&larr; Enter another code</a>
+    <a href="/codes/status" class="card-link">&larr; Enter another code</a>
   </main>
 
   {{template "codescripts" .}}

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -55,10 +55,10 @@
         {{if .currentRealm}}
         <ul class="nav mr-auto flex-column flex-md-row">
           <li class="nav-item">
-            <a class="nav-link {{if .currentPath.IsDir "/code/issue"}}active{{end}}" href="/code/issue">Issue code</a>
+            <a class="nav-link {{if .currentPath.IsDir "/codes/issue"}}active{{end}}" href="/codes/issue">Issue code</a>
           </li>
           <li class="nav-item">
-            <a class="nav-link {{if .currentPath.IsDir "/code/status"}}active{{end}}" href="/code/status">Check code status</a>
+            <a class="nav-link {{if .currentPath.IsDir "/codes/status"}}active{{end}}" href="/codes/status">Check code status</a>
           </li>
         </ul>
         {{end}}

--- a/cmd/server/assets/home.html
+++ b/cmd/server/assets/home.html
@@ -342,7 +342,7 @@
 
     function getCode(data) {
       $.ajax({
-        url: '/code/issue',
+        url: '/codes/issue',
         type: 'POST',
         dataType: 'json',
         cache: false,

--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -58,7 +58,7 @@
               </form>
 
 
-              <a id="skip" href="/code/issue" class="float-right mt-3 card-link {{if eq .mfaMode.String "required"}}d-none{{end}}">
+              <a id="skip" href="/codes/issue" class="float-right mt-3 card-link {{if eq .mfaMode.String "required"}}d-none{{end}}">
                 Skip for now
               </a>
             </div>
@@ -303,7 +303,7 @@
             contentType: 'application/x-www-form-urlencoded',
             success: function(returnData) {
               {{if .isPrompt}}
-              window.location.assign('/code/issue');
+              window.location.assign('/codes/issue');
               {{else}}
               flash.clear();
               flash.alert('SMS authentication enrolled successfully.');

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -46,7 +46,7 @@
 
               {{if .currentRealm}}
               {{if ne .currentRealm.EmailVerifiedMode.String "required"}}
-              <a id="skip" class="card-link float-right mt-3" href="/code/issue">Skip for now</a>
+              <a id="skip" class="card-link float-right mt-3" href="/codes/issue">Skip for now</a>
               {{end}}
               {{end}}
             </div>
@@ -73,7 +73,7 @@
       if (user.emailVerified) {
         flash.clear();
         flash.alert("Your email address is already verified.");
-        window.location.assign("/code/issue");
+        window.location.assign("/codes/issue");
         return;
       }
 

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/codestatus"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/home"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/jwks"
@@ -229,8 +229,8 @@ func Server(
 		issueapiController := issueapi.New(ctx, cfg, db, limiterStore, h)
 		sub.Handle("/issue", issueapiController.HandleIssue()).Methods("POST")
 
-		codestatusController := codestatus.NewServer(ctx, cfg, db, h)
-		codestatusRoutes(sub, codestatusController)
+		codesController := codes.NewServer(ctx, cfg, db, h)
+		codesRoutes(sub, codesController)
 	}
 
 	// mobileapp
@@ -335,8 +335,8 @@ func Server(
 	return mux, nil
 }
 
-// codestatusRoutes are the routes for checking code statuses.
-func codestatusRoutes(r *mux.Router, c *codestatus.Controller) {
+// codesRoutes are the routes for checking codes.
+func codesRoutes(r *mux.Router, c *codes.Controller) {
 	r.Handle("/status", c.HandleIndex()).Methods("GET")
 	r.Handle("/{uuid}", c.HandleShow()).Methods("GET")
 	r.Handle("/{uuid}/expire", c.HandleExpirePage()).Methods("PATCH")

--- a/internal/routes/server_test.go
+++ b/internal/routes/server_test.go
@@ -38,7 +38,7 @@ func TestRoutes_codestatusRoutes(t *testing.T) {
 			req: httptest.NewRequest("GET", "/status", nil),
 		},
 		{
-			req: httptest.NewRequest("GET", "/show/aaa-aaa-aaa-aaa", nil),
+			req: httptest.NewRequest("GET", "/aaa-aaa-aaa-aaa", nil),
 		},
 		{
 			req: httptest.NewRequest("PATCH", "/aaa-aaa-aaa-aaa/expire", nil),

--- a/internal/routes/server_test.go
+++ b/internal/routes/server_test.go
@@ -24,11 +24,11 @@ import (
 	"github.com/gorilla/mux"
 )
 
-func TestRoutes_codestatusRoutes(t *testing.T) {
+func TestRoutes_codesRoutes(t *testing.T) {
 	t.Parallel()
 
 	m := mux.NewRouter()
-	codestatusRoutes(m, nil)
+	codesRoutes(m, nil)
 
 	cases := []struct {
 		req  *http.Request

--- a/pkg/controller/codes/api.go
+++ b/pkg/controller/codes/api.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package codestatus
+package codes
 
 import (
 	"net/http"

--- a/pkg/controller/codes/controller.go
+++ b/pkg/controller/codes/controller.go
@@ -12,9 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package codestatus defines a web controller for the code status page of the verification
-// server. This view allows users to view the status of previously-issued OTP codes.
-package codestatus
+// Package codes defines a web controller for the code status page of the
+// verification server. This view allows users to view the status of
+// previously-issued OTP codes.
+package codes
 
 import (
 	"context"

--- a/pkg/controller/codes/expire.go
+++ b/pkg/controller/codes/expire.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package codestatus defines a web controller for the code status page of the verification
-// server. This view allows users to view the status of previously-issued OTP codes.
-package codestatus
+package codes
 
 import (
 	"net/http"

--- a/pkg/controller/codes/index.go
+++ b/pkg/controller/codes/index.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package codestatus defines a web controller for the code status page of the verification
-// server. This view allows users to view the status of previously-issued OTP codes.
-package codestatus
+package codes
 
 import (
 	"context"

--- a/pkg/controller/codes/logic.go
+++ b/pkg/controller/codes/logic.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package codestatus defines a web controller for the code status page of the verification
-// server. This view allows users to view the status of previously-issued OTP codes.
-package codestatus
+package codes
 
 import (
 	"fmt"
@@ -29,7 +27,7 @@ import (
 func (c *Controller) CheckCodeStatus(r *http.Request, uuid string) (*database.VerificationCode, int, *api.ErrorReturn) {
 	ctx := r.Context()
 
-	logger := logging.FromContext(ctx).Named("codestatus.CheckCodeStatus")
+	logger := logging.FromContext(ctx).Named("codes.CheckCodeStatus")
 
 	authApp, user, err := c.getAuthorizationFromContext(r)
 	if err != nil {

--- a/pkg/controller/codes/show.go
+++ b/pkg/controller/codes/show.go
@@ -12,9 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package codestatus defines a web controller for the code status page of the verification
-// server. This view allows users to view the status of previously-issued OTP codes.
-package codestatus
+package codes
 
 import (
 	"context"

--- a/pkg/controller/codestatus/show.go
+++ b/pkg/controller/codestatus/show.go
@@ -18,6 +18,7 @@ package codestatus
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"strings"
 
@@ -69,6 +70,14 @@ func (c *Controller) HandleShow() http.Handler {
 			if err := c.renderStatus(ctx, w, realm, currentUser, &code); err != nil {
 				controller.InternalError(w, r, c.h, err)
 			}
+			return
+		}
+
+		// The code was valid, but it's not in the correct UUID format. This ensures
+		// two different links don't point to the same resource.
+		if code.UUID != vars["uuid"] {
+			u := fmt.Sprintf("/codes/%s", code.UUID)
+			http.Redirect(w, r, u, http.StatusSeeOther)
 			return
 		}
 

--- a/pkg/controller/home/home_test.go
+++ b/pkg/controller/home/home_test.go
@@ -77,8 +77,8 @@ func TestHandleHome_IssueCode(t *testing.T) {
 		// Pre-authenticate the user.
 		browser.SetCookie(cookie),
 
-		// Visit /code/issue.
-		chromedp.Navigate(`http://`+harness.Server.Addr()+`/code/issue`),
+		// Visit /codes/issue.
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/codes/issue`),
 
 		// Wait for render.
 		chromedp.WaitVisible(`body#home`, chromedp.ByQuery),

--- a/pkg/controller/login/change_password.go
+++ b/pkg/controller/login/change_password.go
@@ -61,6 +61,6 @@ func (c *Controller) HandleSubmitChangePassword() http.Handler {
 		}
 
 		flash.Alert("Successfully changed password.")
-		http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+		http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 	})
 }

--- a/pkg/controller/login/login.go
+++ b/pkg/controller/login/login.go
@@ -26,13 +26,13 @@ func (c *Controller) HandleLogin() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		// If there's a firebase cookie in the session, try to redirect to /code/issue. If
+		// If there's a firebase cookie in the session, try to redirect to /codes/issue. If
 		// the cookie is invalid, the auth middleware will pick it up, delete the
 		// cookie from the session, and kick them back here.
 		session := controller.SessionFromContext(ctx)
 		if session != nil {
 			if err := c.authProvider.CheckRevoked(ctx, session); err == nil {
-				http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+				http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 				return
 			}
 		}

--- a/pkg/controller/login/select.go
+++ b/pkg/controller/login/select.go
@@ -58,7 +58,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 			// The user is already logged in and the current realm matches the
 			// expected realm - just redirect.
 			if controller.RealmIDFromSession(session) == realm.ID {
-				http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+				http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 				return
 			}
 
@@ -70,7 +70,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 			flash.Clear()
 
 			controller.StoreSessionRealm(session, realm)
-			http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 			return
 		default:
 			// Continue below
@@ -104,7 +104,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 		}
 
 		controller.StoreSessionRealm(session, realm)
-		http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+		http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 	})
 }
 

--- a/pkg/controller/user/delete.go
+++ b/pkg/controller/user/delete.go
@@ -78,7 +78,7 @@ func (c *Controller) HandleDelete() http.Handler {
 		if user.ID == currentUser.ID {
 			flash.Alert("Successfully removed you from the realm")
 			controller.ClearSessionRealm(session)
-			http.Redirect(w, r, "/code/issue", http.StatusSeeOther)
+			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
 			return
 		}
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -230,6 +230,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				logger.Debugw("creating default realm")
 				// Create the default realm with all of the default settings.
 				defaultRealm := NewRealmWithDefaults("Default")
+				defaultRealm.RequireDate = false
 				if err := tx.FirstOrCreate(defaultRealm).Error; err != nil {
 					return err
 				}

--- a/pkg/testsuite/integration.go
+++ b/pkg/testsuite/integration.go
@@ -26,7 +26,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/certapi"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/codestatus"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/verifyapi"
@@ -174,9 +174,9 @@ func (s *IntegrationSuite) newAdminAPIServer(ctx context.Context, tb testing.TB)
 		issueapiController := issueapi.New(ctx, &s.cfg.AdminAPISrvConfig, s.db, limiterStore, h)
 		sub.Handle("/issue", issueapiController.HandleIssue()).Methods("POST")
 
-		codeStatusController := codestatus.NewAPI(ctx, &s.cfg.AdminAPISrvConfig, s.db, h)
-		sub.Handle("/checkcodestatus", codeStatusController.HandleCheckCodeStatus()).Methods("POST")
-		sub.Handle("/expirecode", codeStatusController.HandleExpireAPI()).Methods("POST")
+		codesController := codes.NewAPI(ctx, &s.cfg.AdminAPISrvConfig, s.db, h)
+		sub.Handle("/checkcodestatus", codesController.HandleCheckCodeStatus()).Methods("POST")
+		sub.Handle("/expirecode", codesController.HandleExpireAPI()).Methods("POST")
 	}
 
 	srv, err := server.New(s.cfg.AdminAPISrvConfig.Port)


### PR DESCRIPTION
Also a few nits:

- Fixes the HTML nesting on code lookup form
- Redirects a good UUID in the wrong format/casing to the correct URL

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

The /home -> /code was never deployed, so we don't need to do a /code -> /codes redirect.