### PR TITLE
Skip twilio for fake phones in dev mode

### DIFF
--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -109,3 +109,7 @@ func (c *AdminAPIServerConfig) GetRateLimitConfig() *ratelimit.Config {
 func (c *AdminAPIServerConfig) ObservabilityExporterConfig() *observability.Config {
 	return &c.Observability
 }
+
+func (c *AdminAPIServerConfig) DevMode() bool {
+	return c.DevMode
+}

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -28,4 +28,6 @@ type IssueAPIConfig interface {
 	GetEnforceRealmQuotas() bool
 	GetRateLimitConfig() *ratelimit.Config
 	GetENXRedirectDomain() string
+
+	DevMode() bool
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -153,6 +153,10 @@ func (c *ServerConfig) ObservabilityExporterConfig() *observability.Config {
 	return &c.Observability
 }
 
+func (c *AdminAPIServerConfig) DevMode() bool {
+	return c.DevMode
+}
+
 // FirebaseConfig represents configuration specific to firebase auth.
 type FirebaseConfig struct {
 	APIKey          string `env:"FIREBASE_API_KEY,required"`

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -310,7 +310,10 @@ func (c *Controller) HandleIssue() http.Handler {
 		}
 
 		if request.Phone != "" && smsProvider != nil {
-			if err := func() error {
+			// +1XXX55501XX is reserved for fictitious use. Just log for dev mode.
+			if c.config.DevMode() && request.Phone[:2] == "+1" && request.Phone[5:5] == "55501" {
+				logger.Infow("dev mode example number detected", "phone", request.Phone)
+			} else if err := func() error {
 				defer observability.RecordLatency(ctx, time.Now(), mSMSLatencyMs, &blame, &result)
 				message := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain())
 				if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -310,8 +310,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		}
 
 		if request.Phone != "" && smsProvider != nil {
-			// +1XXX55501XX is reserved for fictitious use. Just log for dev mode.
-			if c.config.DevMode() && request.Phone[:2] == "+1" && request.Phone[5:5] == "55501" {
+			if c.config.DevMode() && isFictitious(request.Phone) {
 				logger.Infow("dev mode example number detected", "phone", request.Phone)
 			} else if err := func() error {
 				defer observability.RecordLatency(ctx, time.Now(), mSMSLatencyMs, &blame, &result)
@@ -346,6 +345,11 @@ func (c *Controller) HandleIssue() http.Handler {
 				LongExpiresAtTimestamp: longExpiryTime.UTC().Unix(),
 			})
 	})
+}
+
+// isFictitious returns true if the number is part of +1XXX55501XX, reserved for fictitious use.
+func isFictitious(p string) bool {
+	return len(p) == 12 && p[:2] == "+1" && p[5:5] == "55501"
 }
 
 func (c *Controller) getAuthorizationFromContext(r *http.Request) (*database.AuthorizedApp, *database.User, error) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Expose DevMode to IssueConfig
* Detect phones in the [fictional range](https://en.wikipedia.org/wiki/555_(telephone_number)) and just log when in dev mode

I'm trying to make a fake CSV to test some bulk-issue scenarios.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow no-op for SMS from fictional +1XXX55501XX numbers in dev mode for testing
```
