### PR TITLE
Don't consume quota for client-provided code UUID

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -227,6 +227,8 @@ func (c *Controller) HandleIssue() http.Handler {
 			}
 		}
 
+		// If there is a client-provided UUID, check if a code has already been issued.
+		// this prevents us from consuming quota on conflict.
 		if request.UUID != "" {
 			if code, err := realm.FindVerificationCodeByUUID(c.db, request.UUID); err != nil {
 				if !database.IsNotFound(err) {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1091
Issue https://github.com/google/exposure-notifications-verification-server/pull/1069

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Try to find code by UUID before issuing one to check for conflict.
* Prevents quota-consumption for this error case.