### PR TITLE
Generate an audit entry when quota is bumped

### DIFF
--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -16,6 +16,7 @@ package realmadmin
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"time"
 
@@ -341,6 +342,13 @@ func (c *Controller) HandleSettings() http.Handler {
 				return
 			}
 			if err := c.limiter.Burst(ctx, key, burst); err != nil {
+				controller.InternalError(w, r, c.h, err)
+				return
+			}
+
+			msg := fmt.Sprintf("added %d quota capacity", burst)
+			audit := database.BuildAuditEntry(currentUser, msg, realm, realm.ID)
+			if err := c.db.SaveAuditEntry(audit); err != nil {
 				controller.InternalError(w, r, c.h, err)
 				return
 			}

--- a/pkg/database/audit_entry.go
+++ b/pkg/database/audit_entry.go
@@ -63,6 +63,11 @@ type AuditEntry struct {
 	CreatedAt time.Time
 }
 
+// SaveAuditEntry saves the audit entry.
+func (db *Database) SaveAuditEntry(a *AuditEntry) error {
+	return db.db.Save(a).Error
+}
+
 // PurgeAuditEntries will delete audit entries which were created longer than
 // maxAge ago.
 func (db *Database) PurgeAuditEntries(maxAge time.Duration) (int64, error) {


### PR DESCRIPTION
Fixes #926

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Generate an audit entry when quota is increased
```
