### PR TITLE
Stop bulk upload if we see certain permanent errors or throttling

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -115,6 +115,13 @@
 
   <script type="text/javascript">
     let total = 0;
+    // Common error codes which should cancel the whole upload.
+    let stopUploadingCodes = [
+      '429', // too many requests
+      '403', // forbidden
+      '404', // not-found
+      '503', // unavailable
+    ];
 
     $(function() {
       let $form = $('#form');
@@ -221,14 +228,21 @@
                 $tableBody.append(row);
               }
 
-              await uploadBatch(batch).catch(err => { });
-              $startAt.val(i + 1);
-              if (cancelUpload && total > 0) {
-                flash.warning("Successfully issued " + total + " codes."
-                  + (rows.length - i) + " remaining.");
+              await uploadBatch(batch).catch(err => {
+                if (err && stopUploadingCodes.includes(err.status)) {
+                  flash.alert("Code " + err.status + " detected. Canceling remaining upload.");
+                  cancelUpload = true;
+                }
+              });
+
+              if (cancelUpload) {
+                if (total > 0) {
+                  flash.warning("Successfully issued " + total + " codes."
+                    + (rows.length - i) + " remaining.");
+                }
                 break;
               }
-
+              $startAt.val(i + 1);
               let percent = Math.floor((i + 1) * 100 / rows.length) + "%";
               $progress.width(percent);
               $progress.html(percent);

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/timeutils"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -229,7 +230,8 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		// If there is a client-provided UUID, check if a code has already been issued.
 		// this prevents us from consuming quota on conflict.
-		if request.UUID != "" {
+		rUUID := project.TrimSpaceAndNonPrintable(request.UUID)
+		if rUUID != "" {
 			if code, err := realm.FindVerificationCodeByUUID(c.db, request.UUID); err != nil {
 				if !database.IsNotFound(err) {
 					controller.InternalError(w, r, c.h, err)
@@ -305,7 +307,7 @@ func (c *Controller) HandleIssue() http.Handler {
 			IssuingUser:    user,
 			IssuingApp:     authApp,
 			RealmID:        realm.ID,
-			UUID:           request.UUID,
+			UUID:           rUUID,
 		}
 
 		code, longCode, uuid, err := codeRequest.Issue(ctx, c.config.GetCollisionRetryCount())


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1061

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Stop at 429 Too Many Requests which we give when the user runs out of codes
    * Stop a few permanent errors for good measure

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Cancel remaining bulk upload when throttled by the server
```
