### PR TITLE
Keep fake success on no-user

### DIFF
--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -63,7 +63,9 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		user, err := c.db.FindUserByEmail(form.Email)
 		if err != nil {
 			if database.IsNotFound(err) {
-				flash.Error("No such user exists.")
+				// Fake success - we don't want to reveal if this is a user
+				// of our system from an unauthorized context.
+				flash.Error("Password reset email sent.")
 				c.renderResetPassword(ctx, w, form.Email)
 				return
 			}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* For security reasons we don't want to differentiate between user not-found and when we really send and email. A malicious user could use this to trawl account-existence.
* I think we accidentally "fixed" this in https://github.com/google/exposure-notifications-verification-server/pull/902
