### PR TITLE
block verify and throw up a banner

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -40,6 +40,11 @@
 
 {{/* defines the top navigation bar */}}
 {{define "navbar"}}
+{{if .maintenanceMode}}
+<div class="alert alert-danger" role="alert">
+  The server is undergoing maintenance and is read-only. Requests to issue new codes will fail.
+</div>
+{{end}}
 <header class="mb-3">
   {{if .currentRealm}}
   <div href="/" class="d-block px-3 py-2 text-center text-bold text-white bg-primary">

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -40,15 +40,15 @@
 
 {{/* defines the top navigation bar */}}
 {{define "navbar"}}
-{{if .maintenanceMode}}
-<div class="alert alert-danger" role="alert">
-  The server is undergoing maintenance and is read-only. Requests to issue new codes will fail.
-</div>
-{{end}}
 <header class="mb-3">
   {{if .currentRealm}}
   <div href="/" class="d-block px-3 py-2 text-center text-bold text-white bg-primary">
     {{.currentRealm.Name}}{{if .currentRealm.RegionCode}} - {{.currentRealm.RegionCode}}{{end}}
+  </div>
+  {{end}}
+  {{if .maintenanceMode}}
+  <div class="alert alert-danger" role="alert">
+    The server is undergoing maintenance and is read-only. Requests to issue new codes will fail.
   </div>
   {{end}}
 

--- a/pkg/config/api_server_config.go
+++ b/pkg/config/api_server_config.go
@@ -39,6 +39,9 @@ type APIServerConfig struct {
 	// production environments.
 	DevMode bool `env:"DEV_MODE"`
 
+	// If MaintenanceMode is true, the server is temporarily read-only and will not issue codes.
+	MaintenanceMode bool `env:"MAINTENANCE_MODE"`
+
 	Port string `env:"PORT,default=8080"`
 
 	APIKeyCacheDuration time.Duration `env:"API_KEY_CACHE_DURATION,default=5m"`

--- a/pkg/controller/middleware/template.go
+++ b/pkg/controller/middleware/template.go
@@ -37,6 +37,7 @@ func PopulateTemplateVariables(config *config.ServerConfig) mux.MiddlewareFunc {
 			m["title"] = config.ServerName
 			m["buildID"] = buildinfo.BuildID
 			m["buildTag"] = buildinfo.BuildTag
+			m["maintenanceMode"] = config.MaintenanceMode
 
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -39,6 +39,12 @@ import (
 
 func (c *Controller) HandleVerify() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if c.config.MaintenanceMode {
+			c.h.RenderJSON(w, http.StatusTooManyRequests,
+				api.Errorf("server is read-only for maintenance").WithCode(api.ErrMaintenanceMode))
+			return
+		}
+
 		ctx := observability.WithBuildInfo(r.Context())
 
 		logger := logging.FromContext(ctx).Named("verifyapi.HandleVerify")


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1139

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Blocks request to verify
* Puts up a scary banner when in maintenance mode

![scary](https://user-images.githubusercontent.com/36240966/99597475-e6e7d980-29ac-11eb-8b6c-e41f7a3279b4.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Maintenance mode block issue and verify requests. Adds a banner to the header.
```
