### PR TITLE
fix off by 12 error

### DIFF
--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -50,7 +50,7 @@ type AdminAPIServerConfig struct {
 	APIKeyCacheDuration time.Duration `env:"API_KEY_CACHE_DURATION,default=5m"`
 
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
-	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=660h"` // 660h is 28 days.
+	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=672h"` // 672h is 28 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	// For EN Express, the link will be

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -76,7 +76,7 @@ type ServerConfig struct {
 	// Application Config
 	ServerName          string        `env:"SERVER_NAME,default=Diagnosis Verification Server"`
 	CollisionRetryCount uint          `env:"COLLISION_RETRY_COUNT,default=6"`
-	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=660h"` // 660h is 28 days.
+	AllowedSymptomAge   time.Duration `env:"ALLOWED_PAST_SYMPTOM_DAYS,default=672h"` // 672h is 28 days.
 	EnforceRealmQuotas  bool          `env:"ENFORCE_REALM_QUOTAS, default=true"`
 
 	AssetsPath  string `env:"ASSETS_PATH, default=./cmd/server/assets"`


### PR DESCRIPTION
## Proposed Changes

* change max age from 27.5 to 28 days. Was off by 12 hours

**Release Note**

```release-note
Default max test/symptom age is 28 days 
```
