### PR TITLE
Filter test-data from event logs

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -134,7 +134,8 @@ func realMain(ctx context.Context) error {
 	adminKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       adminKeyName + suffix,
 		APIKeyType: database.APIKeyTypeAdmin,
-	}, database.System)
+		TestApp:    true,
+	}, database.SystemTest)
 	if err != nil {
 		return fmt.Errorf("error trying to create a new Admin API Key: %w", err)
 	}
@@ -146,7 +147,7 @@ func realMain(ctx context.Context) error {
 		}
 		now := time.Now().UTC()
 		app.DeletedAt = &now
-		if err := db.SaveAuthorizedApp(app, database.System); err != nil {
+		if err := db.SaveAuthorizedApp(app, database.SystemTest); err != nil {
 			logger.Errorf("admin API key disable failed: %w", err)
 		}
 		logger.Info("successfully cleaned up e2e test admin key")
@@ -155,7 +156,8 @@ func realMain(ctx context.Context) error {
 	deviceKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       deviceKeyName + suffix,
 		APIKeyType: database.APIKeyTypeDevice,
-	}, database.System)
+		TestApp:    true,
+	}, database.SystemTest)
 	if err != nil {
 		return fmt.Errorf("error trying to create a new Device API Key: %w", err)
 	}
@@ -168,7 +170,7 @@ func realMain(ctx context.Context) error {
 		}
 		now := time.Now().UTC()
 		app.DeletedAt = &now
-		if err := db.SaveAuthorizedApp(app, database.System); err != nil {
+		if err := db.SaveAuthorizedApp(app, database.SystemTest); err != nil {
 			logger.Errorf("device API key disable failed: %w", err)
 		}
 		logger.Info("successfully cleaned up e2e test device key")
@@ -199,7 +201,7 @@ func realMain(ctx context.Context) error {
 	return srv.ServeHTTPHandler(ctx, handlers.CombinedLoggingHandler(os.Stdout, r))
 }
 
-// Config is passed by value so that each http hadndler has a separate copy (since they are changing one of the)
+// Config is passed by value so that each http handler has a separate copy (since they are changing one of the)
 // config elements. Previous versions of those code had a race condition where the "DoRevise" status
 // could be changed while a handler was executing.
 func defaultHandler(ctx context.Context, config config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -120,7 +120,7 @@ func realMain(ctx context.Context) error {
 		}
 		realm = database.NewRealmWithDefaults(realmName)
 		realm.RegionCode = realmRegionCode
-		if err := db.SaveRealm(realm, database.System); err != nil {
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 			return fmt.Errorf("failed to create realm %+v: %w: %v", realm, err, realm.ErrorMessages())
 		}
 	}

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -36,6 +36,7 @@
         <form method="GET" action="/admin/events" id="search-form">
           <!--
             hidden query to filter on test events values are:
+               "?include_test=false" // Filters out test events. Default if omitted.
                "?include_test=only" // shows only test events
                "?include_test=all" // shows all test and non-test events
            -->

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -60,7 +60,7 @@
           </div>
           <div class="form-check">
             <input type="checkbox" class="form-check-input" name="include_test" id="include-test" value="true" {{if .include_test}}{{if eq .include_test "true"}}checked{{end}}{{end}}>
-            <label class="form-check-label" for="includ-test">Include test</label>
+            <label class="form-check-label" for="include-test">Include test</label>
           </div>
         </form>
       </div>

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -58,6 +58,10 @@
               </button>
             </div>
           </div>
+          <div class="form-check">
+            <input type="checkbox" class="form-check-input" name="include_test" id="include-test" value="true" {{if .include_test}}{{if eq .include_test "true"}}checked{{end}}{{end}}>
+            <label class="form-check-label" for="includ-test">Include test</label>
+          </div>
         </form>
       </div>
 

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -34,6 +34,12 @@
 
       <div class="card-body">
         <form method="GET" action="/admin/events" id="search-form">
+          <!--
+            hidden query to filter on test events values are:
+               "?include_test=only" // shows only test events
+               "?include_test=all" // shows all test and non-test events
+           -->
+          <input type="hidden" name="include_test" {{if .from_test}}value="{{.include_test}}"{{end}}>
           <div class="input-group">
             <span class="input-group-prepend">
               <select name="realm_id" class="text-truncate custom-select dropdown-toggle border-right-0" style="border-radius:0.25rem 0 0 0.25rem;">
@@ -57,10 +63,6 @@
                 <span class="sr-only">Search</span>
               </button>
             </div>
-          </div>
-          <div class="form-check">
-            <input type="checkbox" class="form-check-input" name="include_test" id="include-test" value="true" {{if .include_test}}{{if eq .include_test "true"}}checked{{end}}{{end}}>
-            <label class="form-check-label" for="include-test">Include test</label>
           </div>
         </form>
       </div>

--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -40,7 +40,7 @@
                "?include_test=only" // shows only test events
                "?include_test=all" // shows all test and non-test events
            -->
-          <input type="hidden" name="include_test" {{if .from_test}}value="{{.include_test}}"{{end}}>
+          <input type="hidden" name="include_test" value="{{if .from_test}}{{.include_test}}{{else}}false{{end}}">
           <div class="input-group">
             <span class="input-group-prepend">
               <select name="realm_id" class="text-truncate custom-select dropdown-toggle border-right-0" style="border-radius:0.25rem 0 0 0.25rem;">

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -43,8 +43,9 @@ func TestShowAdminCaches(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/email_test.go
+++ b/pkg/controller/admin/email_test.go
@@ -43,8 +43,9 @@ func TestShowAdminEmail(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/events.go
+++ b/pkg/controller/admin/events.go
@@ -35,6 +35,9 @@ const (
 
 	// QueryRealmIDSearch is the query key to filter by realmID.
 	QueryRealmIDSearch = "realm_id"
+
+	// QueryIncludeTest is the query key to include test events.
+	QueryIncludeTest = "include_test"
 )
 
 // HandleEventsShow shows event logs.
@@ -53,6 +56,9 @@ func (c *Controller) HandleEventsShow() http.Handler {
 		scopes := []database.Scope{}
 		scopes = append(scopes, database.WithAuditTime(from, to))
 		realmID := project.TrimSpace(r.FormValue(QueryRealmIDSearch))
+
+		includeTest := r.FormValue(QueryIncludeTest)
+		scopes = append(scopes, database.WithIncludeTest(includeTest == "true"))
 
 		// Add realm filter if applicable
 		var realm *database.Realm
@@ -83,17 +89,18 @@ func (c *Controller) HandleEventsShow() http.Handler {
 			return
 		}
 
-		c.renderEvents(ctx, w, events, paginator, from, to, realm)
+		c.renderEvents(ctx, w, events, paginator, from, to, includeTest, realm)
 	})
 }
 
 func (c *Controller) renderEvents(ctx context.Context, w http.ResponseWriter,
-	events []*database.AuditEntry, paginator *pagination.Paginator, from, to string, realm *database.Realm) {
+	events []*database.AuditEntry, paginator *pagination.Paginator, from, to, includeTest string, realm *database.Realm) {
 	m := controller.TemplateMapFromContext(ctx)
 	m["events"] = events
 	m["paginator"] = paginator
 	m[QueryFromSearch] = from
 	m[QueryToSearch] = to
+	m[QueryIncludeTest] = includeTest
 	m["realm"] = realm
 	c.h.RenderHTML(w, "admin/events/index", m)
 }

--- a/pkg/controller/admin/events.go
+++ b/pkg/controller/admin/events.go
@@ -58,7 +58,9 @@ func (c *Controller) HandleEventsShow() http.Handler {
 		realmID := project.TrimSpace(r.FormValue(QueryRealmIDSearch))
 
 		includeTest := r.FormValue(QueryIncludeTest)
-		scopes = append(scopes, database.WithIncludeTest(includeTest == "true"))
+		if includeTest != "true" {
+			scopes = append(scopes, database.WithAuditFromTest(false))
+		}
 
 		// Add realm filter if applicable
 		var realm *database.Realm

--- a/pkg/controller/admin/events.go
+++ b/pkg/controller/admin/events.go
@@ -59,8 +59,7 @@ func (c *Controller) HandleEventsShow() http.Handler {
 
 		includeTest := r.FormValue(QueryIncludeTest)
 		switch includeTest {
-		case "":
-		case "false":
+		case "", "false":
 			// by default, don't show test events
 			scopes = append(scopes, database.WithAuditFromTest(false))
 		case "only":

--- a/pkg/controller/admin/events.go
+++ b/pkg/controller/admin/events.go
@@ -60,6 +60,7 @@ func (c *Controller) HandleEventsShow() http.Handler {
 		includeTest := r.FormValue(QueryIncludeTest)
 		switch includeTest {
 		case "":
+		case "false":
 			// by default, don't show test events
 			scopes = append(scopes, database.WithAuditFromTest(false))
 		case "only":

--- a/pkg/controller/admin/events.go
+++ b/pkg/controller/admin/events.go
@@ -36,7 +36,7 @@ const (
 	// QueryRealmIDSearch is the query key to filter by realmID.
 	QueryRealmIDSearch = "realm_id"
 
-	// QueryIncludeTest is the query key to include test events.
+	// QueryIncludeTest is the query key to filter on events from test or not.
 	QueryIncludeTest = "include_test"
 )
 
@@ -58,8 +58,15 @@ func (c *Controller) HandleEventsShow() http.Handler {
 		realmID := project.TrimSpace(r.FormValue(QueryRealmIDSearch))
 
 		includeTest := r.FormValue(QueryIncludeTest)
-		if includeTest != "true" {
+		switch includeTest {
+		case "":
+			// by default, don't show test events
 			scopes = append(scopes, database.WithAuditFromTest(false))
+		case "only":
+			// only test events
+			scopes = append(scopes, database.WithAuditFromTest(true))
+		default:
+			// Any other string shows both test and non-test events
 		}
 
 		// Add realm filter if applicable

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -46,8 +46,9 @@ func TestShowAdminEvents(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/mobile_apps_test.go
+++ b/pkg/controller/admin/mobile_apps_test.go
@@ -43,8 +43,9 @@ func TestShowAdminMobileApps(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
@@ -56,7 +57,7 @@ func TestShowAdminMobileApps(t *testing.T) {
 		SHA:     "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 		AppID:   "app2",
 	}
-	if err := harness.Database.SaveMobileApp(app, database.System); err != nil {
+	if err := harness.Database.SaveMobileApp(app, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -45,8 +45,9 @@ func TestShowAdminRealms(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/sms_test.go
+++ b/pkg/controller/admin/sms_test.go
@@ -43,8 +43,9 @@ func TestShowAdminSMS(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/admin/users_test.go
+++ b/pkg/controller/admin/users_test.go
@@ -43,8 +43,9 @@ func TestAdminUsers(t *testing.T) {
 		SystemAdmin: true,
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -43,8 +43,9 @@ func TestHandleCreate(t *testing.T) {
 		Name:        "Admin",
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -45,8 +45,9 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 		Name:        "Admin",
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -43,8 +43,9 @@ func TestHandleCreate(t *testing.T) {
 		Name:        "Admin",
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/modeler/modeler_test.go
+++ b/pkg/controller/modeler/modeler_test.go
@@ -70,7 +70,7 @@ func TestRebuildModel(t *testing.T) {
 	// Create the realm.
 	realm := database.NewRealmWithDefaults("Statsylvania")
 	realm.AbusePreventionEnabled = true
-	if err := db.SaveRealm(realm, database.System); err != nil {
+	if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/controller/user/search_test.go
+++ b/pkg/controller/user/search_test.go
@@ -43,8 +43,9 @@ func TestHandleSearch(t *testing.T) {
 		Name:        "Admin",
 		Realms:      []*database.Realm{realm},
 		AdminRealms: []*database.Realm{realm},
+		TestUser:    true,
 	}
-	if err := harness.Database.SaveUser(admin, database.System); err != nil {
+	if err := harness.Database.SaveUser(admin, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
@@ -65,11 +66,12 @@ func TestHandleSearch(t *testing.T) {
 
 	// Create another user.
 	user := &database.User{
-		Email:  "user@example.com",
-		Name:   "User",
-		Realms: []*database.Realm{realm},
+		Email:    "user@example.com",
+		Name:     "User",
+		Realms:   []*database.Realm{realm},
+		TestUser: true,
 	}
-	if err := harness.Database.SaveUser(user, database.System); err != nil {
+	if err := harness.Database.SaveUser(user, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/database/audit_entry.go
+++ b/pkg/database/audit_entry.go
@@ -61,6 +61,9 @@ type AuditEntry struct {
 
 	// CreatedAt is when the entry was created.
 	CreatedAt time.Time
+
+	// FromTest marks the entry as originating from an Auditable where IsTest is true.
+	FromTest bool `gorm:"type:boolean; default: false"`
 }
 
 // SaveAuditEntry saves the audit entry.

--- a/pkg/database/audit_entry.go
+++ b/pkg/database/audit_entry.go
@@ -63,7 +63,7 @@ type AuditEntry struct {
 	CreatedAt time.Time
 
 	// FromTest marks the entry as originating from an Auditable where IsTest is true.
-	FromTest bool `gorm:"type:boolean; default: false"`
+	FromTest bool `gorm:"type:boolean; default: false;"`
 }
 
 // SaveAuditEntry saves the audit entry.

--- a/pkg/database/auditable.go
+++ b/pkg/database/auditable.go
@@ -22,6 +22,9 @@ type Auditable interface {
 
 	// AuditDisplay returns how this resource should appear in audit logs.
 	AuditDisplay() string
+
+	// IsTest marks this as a test resource for log filtering.
+	IsTest() bool
 }
 
 // BuildAuditEntry builds an AuditEntry from the given parameters. For actions
@@ -34,5 +37,6 @@ func BuildAuditEntry(actor Auditable, action string, target Auditable, realmID u
 	e.Action = action
 	e.TargetID = target.AuditID()
 	e.TargetDisplay = target.AuditDisplay()
+	e.FromTest = target.IsTest()
 	return &e
 }

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -84,7 +84,7 @@ type AuthorizedApp struct {
 
 	// TestApp marks this as a test app which may be used to ignore or filter
 	// data (such as audit logs) from this class of app.
-	TestApp bool `gorm:"type:boolean; default: false"`
+	TestApp bool `gorm:"type:boolean; default: false;"`
 }
 
 // BeforeSave runs validations. If there are errors, the save fails.

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -59,7 +59,7 @@ var _ Auditable = (*AuthorizedApp)(nil)
 // verification codes and perform token exchanges.
 // This is controlled via a generated API key.
 //
-// Admin Keys are able to issue diagnosis keys and are not able to perticipate
+// Admin Keys are able to issue diagnosis keys and are not able to participate
 // the verification protocol.
 type AuthorizedApp struct {
 	gorm.Model
@@ -81,6 +81,10 @@ type AuthorizedApp struct {
 
 	// APIKeyType is the API key type.
 	APIKeyType APIKeyType `gorm:"column:api_key_type; type:integer; not null;"`
+
+	// TestApp marks this as a test app which may be used to ignore or filter
+	// data (such as audit logs) from this class of app.
+	TestApp bool `gorm:"type:boolean; default: false"`
 }
 
 // BeforeSave runs validations. If there are errors, the save fails.
@@ -107,6 +111,10 @@ func (a *AuthorizedApp) IsAdminType() bool {
 
 func (a *AuthorizedApp) IsDeviceType() bool {
 	return a.APIKeyType == APIKeyTypeDevice
+}
+
+func (a *AuthorizedApp) IsTest() bool {
+	return a.TestApp
 }
 
 // Realm returns the associated realm for this app.

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -36,7 +36,7 @@ func TestDatabase_CreateFindAPIKey(t *testing.T) {
 		APIKeyType: APIKeyTypeAdmin,
 	}
 
-	apiKey, err := realm.CreateAuthorizedApp(db, authApp, System)
+	apiKey, err := realm.CreateAuthorizedApp(db, authApp, SystemTest)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1706,6 +1706,11 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					`UPDATE authorized_apps SET test_app = FALSE WHERE test_app IS NULL`,
 					`ALTER TABLE authorized_apps ALTER COLUMN test_app SET DEFAULT FALSE`,
 					`ALTER TABLE authorized_apps ALTER COLUMN test_app SET NOT NULL`,
+
+					`ALTER TABLE users ADD COLUMN IF NOT EXISTS test_userBOOL`,
+					`UPDATE users SET test_user = FALSE WHERE test_user IS NULL`,
+					`ALTER TABLE users ALTER COLUMN test_user SET DEFAULT FALSE`,
+					`ALTER TABLE users ALTER COLUMN test_user SET NOT NULL`,
 				}
 
 				for _, sql := range sqls {
@@ -1719,6 +1724,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				sqls := []string{
 					`ALTER TABLE audit_entries DROP COLUMN IF EXISTS from_test`,
 					`ALTER TABLE authorized_apps DROP COLUMN IF EXISTS test_app`,
+					`ALTER TABLE users DROP COLUMN IF EXISTS test_user`,
 				}
 
 				for _, sql := range sqls {

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1707,7 +1707,7 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 					`ALTER TABLE authorized_apps ALTER COLUMN test_app SET DEFAULT FALSE`,
 					`ALTER TABLE authorized_apps ALTER COLUMN test_app SET NOT NULL`,
 
-					`ALTER TABLE users ADD COLUMN IF NOT EXISTS test_userBOOL`,
+					`ALTER TABLE users ADD COLUMN IF NOT EXISTS test_user BOOL`,
 					`UPDATE users SET test_user = FALSE WHERE test_user IS NULL`,
 					`ALTER TABLE users ALTER COLUMN test_user SET DEFAULT FALSE`,
 					`ALTER TABLE users ALTER COLUMN test_user SET NOT NULL`,

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -286,6 +286,11 @@ func (a *MobileApp) AuditDisplay() string {
 	return fmt.Sprintf("%s (%s)", a.Name, a.OS.Display())
 }
 
+// IsTest returns if this Auditable is a test resource.
+func (a *MobileApp) IsTest() bool {
+	return false // Test MobileApp not yet supported.
+}
+
 func (a *MobileApp) AfterFind(tx *gorm.DB) error {
 	a.URL = stringValue(a.URLPtr)
 	return nil

--- a/pkg/database/mobile_app_test.go
+++ b/pkg/database/mobile_app_test.go
@@ -154,12 +154,12 @@ func TestMobileApp_List(t *testing.T) {
 		db := NewTestDatabase(t)
 
 		realm1 := NewRealmWithDefaults("realm1")
-		if err := db.SaveRealm(realm1, System); err != nil {
+		if err := db.SaveRealm(realm1, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
 		realm2 := NewRealmWithDefaults("realm2")
-		if err := db.SaveRealm(realm2, System); err != nil {
+		if err := db.SaveRealm(realm2, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
@@ -170,7 +170,7 @@ func TestMobileApp_List(t *testing.T) {
 			OS:      OSTypeIOS,
 			AppID:   "app1",
 		}
-		if err := db.SaveMobileApp(app1, System); err != nil {
+		if err := db.SaveMobileApp(app1, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
@@ -182,7 +182,7 @@ func TestMobileApp_List(t *testing.T) {
 			SHA:     "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 			AppID:   "app2",
 		}
-		if err := db.SaveMobileApp(app2, System); err != nil {
+		if err := db.SaveMobileApp(app2, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -880,6 +880,10 @@ func (r *Realm) AuditDisplay() string {
 	return r.Name
 }
 
+func (r *Realm) IsTest() bool {
+	return false // Test Realm not yet supported
+}
+
 func (db *Database) SaveRealm(r *Realm, actor Auditable) error {
 	if r == nil {
 		return fmt.Errorf("provided realm is nil")

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -55,7 +55,7 @@ func TestPerUserRealmStats(t *testing.T) {
 
 	// Create a new realm
 	realm := NewRealmWithDefaults("test")
-	if err := db.SaveRealm(realm, System); err != nil {
+	if err := db.SaveRealm(realm, SystemTest); err != nil {
 		t.Fatalf("error saving realm: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestPerUserRealmStats(t *testing.T) {
 			SystemAdmin: false,
 		}
 
-		if err := db.SaveUser(user, System); err != nil {
+		if err := db.SaveUser(user, SystemTest); err != nil {
 			t.Fatalf("[%v] error creating user: %v", name, err)
 		}
 		users = append(users, user)
@@ -117,12 +117,12 @@ func TestRealm_FindMobileApp(t *testing.T) {
 		db := NewTestDatabase(t)
 
 		realm1 := NewRealmWithDefaults("realm1")
-		if err := db.SaveRealm(realm1, System); err != nil {
+		if err := db.SaveRealm(realm1, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
 		realm2 := NewRealmWithDefaults("realm2")
-		if err := db.SaveRealm(realm2, System); err != nil {
+		if err := db.SaveRealm(realm2, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
@@ -133,7 +133,7 @@ func TestRealm_FindMobileApp(t *testing.T) {
 			OS:      OSTypeIOS,
 			AppID:   "app1",
 		}
-		if err := db.SaveMobileApp(app1, System); err != nil {
+		if err := db.SaveMobileApp(app1, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
@@ -144,7 +144,7 @@ func TestRealm_FindMobileApp(t *testing.T) {
 			OS:      OSTypeIOS,
 			AppID:   "app2",
 		}
-		if err := db.SaveMobileApp(app2, System); err != nil {
+		if err := db.SaveMobileApp(app2, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 
@@ -179,7 +179,7 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 	db.config.MaxCertificateSigningKeyVersions = 2
 
 	realm1 := NewRealmWithDefaults("realm1")
-	if err := db.SaveRealm(realm1, System); err != nil {
+	if err := db.SaveRealm(realm1, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -76,6 +76,16 @@ func WithAuditRealmID(r uint) Scope {
 	}
 }
 
+// WithIncludeTest returns a scope that adds querying for Audit events originating from test.
+func WithIncludeTest(includeTest bool) Scope {
+	return func(db *gorm.DB) *gorm.DB {
+		if !includeTest {
+			return db.Where("audit_entries.from_test = false")
+		}
+		return db
+	}
+}
+
 // WithAuthorizedAppSearch returns a scope that adds querying for API keys by
 // name and preview, case-insensitive. It's only applicable to functions that
 // query AuthorizedApp.

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -79,7 +79,7 @@ func WithAuditRealmID(r uint) Scope {
 // WithAuditFromTest returns a scope that adds querying for Audit events originating from test.
 func WithAuditFromTest(includeTest bool) Scope {
 	return func(db *gorm.DB) *gorm.DB {
-		return db.Where("audit_entries.from_test = false")
+		return db.Where("audit_entries.from_test = ?", includeTest)
 	}
 }
 

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -76,13 +76,10 @@ func WithAuditRealmID(r uint) Scope {
 	}
 }
 
-// WithIncludeTest returns a scope that adds querying for Audit events originating from test.
-func WithIncludeTest(includeTest bool) Scope {
+// WithAuditFromTest returns a scope that adds querying for Audit events originating from test.
+func WithAuditFromTest(includeTest bool) Scope {
 	return func(db *gorm.DB) *gorm.DB {
-		if !includeTest {
-			return db.Where("audit_entries.from_test = false")
-		}
-		return db
+		return db.Where("audit_entries.from_test = false")
 	}
 }
 

--- a/pkg/database/system.go
+++ b/pkg/database/system.go
@@ -27,3 +27,25 @@ func (s *system) AuditID() string {
 func (s *system) AuditDisplay() string {
 	return "System"
 }
+
+func (s *system) IsTest() bool {
+	return false
+}
+
+// SystemTest represents the system and actions it has taken. It's not stored in the
+// database.
+var SystemTest Auditable = new(systemTest)
+
+type systemTest struct{}
+
+func (s *systemTest) AuditID() string {
+	return "system_test:1"
+}
+
+func (s *systemTest) AuditDisplay() string {
+	return "SystemTest"
+}
+
+func (s *systemTest) IsTest() bool {
+	return true
+}

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -279,7 +279,7 @@ func TestIssueToken(t *testing.T) {
 			db := NewTestDatabase(t)
 
 			realm := NewRealmWithDefaults(fmt.Sprintf("TestIssueToken/%s", tc.Name))
-			if err := db.SaveRealm(realm, System); err != nil {
+			if err := db.SaveRealm(realm, SystemTest); err != nil {
 				t.Fatal(err)
 			}
 

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -48,6 +48,9 @@ type User struct {
 
 	LastRevokeCheck    time.Time
 	LastPasswordChange time.Time
+
+	// TestUser marks the user as originating from a test.
+	TestUser bool `gorm:"type:boolean; default: false;"`
 }
 
 // PasswordChanged returns password change time or account creation time if unset.
@@ -307,7 +310,7 @@ func (u *User) AuditDisplay() string {
 
 // IsTest returns if this Auditable is a test resource.
 func (u *User) IsTest() bool {
-	return false // Test User not yet supported.
+	return u.TestUser
 }
 
 // DeleteUser deletes the user entry.

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -305,6 +305,11 @@ func (u *User) AuditDisplay() string {
 	return fmt.Sprintf("%s (%s)", u.Name, u.Email)
 }
 
+// IsTest returns if this Auditable is a test resource.
+func (u *User) IsTest() bool {
+	return false // Test User not yet supported.
+}
+
 // DeleteUser deletes the user entry.
 func (db *Database) DeleteUser(u *User, actor Auditable) error {
 	if u == nil {

--- a/pkg/database/user_test.go
+++ b/pkg/database/user_test.go
@@ -31,7 +31,7 @@ func TestUserLifecycle(t *testing.T) {
 		SystemAdmin: false,
 	}
 
-	if err := db.SaveUser(&user, System); err != nil {
+	if err := db.SaveUser(&user, SystemTest); err != nil {
 		t.Fatalf("error creating user: %v", err)
 	}
 
@@ -69,7 +69,7 @@ func TestUserLifecycle(t *testing.T) {
 
 	// Update an attribute
 	user.SystemAdmin = true
-	if err := db.SaveUser(&user, System); err != nil {
+	if err := db.SaveUser(&user, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/testsuite/e2e.go
+++ b/pkg/testsuite/e2e.go
@@ -69,7 +69,7 @@ func NewE2ESuite(tb testing.TB, ctx context.Context) *E2ESuite {
 		}
 		realm = database.NewRealmWithDefaults(realmName)
 		realm.RegionCode = realmRegionCode
-		if err := db.SaveRealm(realm, database.System); err != nil {
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 			tb.Fatalf("failed to create realm %+v: %v: %v", realm, err, realm.ErrorMessages())
 		}
 	}
@@ -83,7 +83,7 @@ func NewE2ESuite(tb testing.TB, ctx context.Context) *E2ESuite {
 	adminKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       adminKeyName + suffix,
 		APIKeyType: database.APIKeyTypeAdmin,
-	}, database.System)
+	}, database.SystemTest)
 	if err != nil {
 		tb.Fatalf("error trying to create a new Admin API Key: %v", err)
 	}
@@ -91,7 +91,7 @@ func NewE2ESuite(tb testing.TB, ctx context.Context) *E2ESuite {
 	deviceKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       deviceKeyName + suffix,
 		APIKeyType: database.APIKeyTypeDevice,
-	}, database.System)
+	}, database.SystemTest)
 	if err != nil {
 		tb.Fatalf("error trying to create a new Device API Key: %v", err)
 	}

--- a/pkg/testsuite/integration.go
+++ b/pkg/testsuite/integration.go
@@ -76,7 +76,7 @@ func NewIntegrationSuite(tb testing.TB, ctx context.Context) *IntegrationSuite {
 		}
 		realm = database.NewRealmWithDefaults(realmName)
 		realm.RegionCode = realmRegionCode
-		if err := db.SaveRealm(realm, database.System); err != nil {
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 			tb.Fatalf("failed to create realm %+v: %v: %v", realm, err, realm.ErrorMessages())
 		}
 	}
@@ -90,7 +90,7 @@ func NewIntegrationSuite(tb testing.TB, ctx context.Context) *IntegrationSuite {
 	adminKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       adminKeyName + suffix,
 		APIKeyType: database.APIKeyTypeAdmin,
-	}, database.System)
+	}, database.SystemTest)
 	if err != nil {
 		tb.Fatalf("error trying to create a new Admin API Key: %v", err)
 	}
@@ -98,7 +98,7 @@ func NewIntegrationSuite(tb testing.TB, ctx context.Context) *IntegrationSuite {
 	deviceKey, err := realm.CreateAuthorizedApp(db, &database.AuthorizedApp{
 		Name:       deviceKeyName + suffix,
 		APIKeyType: database.APIKeyTypeDevice,
-	}, database.System)
+	}, database.SystemTest)
 	if err != nil {
 		tb.Fatalf("error trying to create a new Device API Key: %v", err)
 	}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1153

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a bit to authorized_app and audit_entry to mark data as test data
* Creates a SystemTest audit actor
* Updates e2e test to use the above
* No support for test User, MobileApp, or Realm (we can do that later if needed).
* Adds a checkbox to event log in system admin to include test events (off by default)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Mark e2e test audit events as 'test' and filter them out by default
```
