### PR TITLE
Terrafrom smoke test: stricter db name matching so it won't mess up

### DIFF
--- a/scripts/ci-terraform.sh
+++ b/scripts/ci-terraform.sh
@@ -136,7 +136,7 @@ function destroy() {
   local db_inst_name
   # Fetching databases from previous terraform deployment output is not always reliable,
   # especially when previous terraform deployment failed. So grepping from terraform state instead.
-  db_inst_name="$(terraform state show module.en.google_sql_database_instance.db-inst | grep -Eo 'terraform-[a-zA-Z0-9]+' | uniq)" || best_effort
+  db_inst_name="$(terraform state show module.en.google_sql_database_instance.db-inst | grep -Eo 'name.*=.*"terraform-[a-zA-Z0-9]+"' | grep -Eo 'terraform-[a-zA-Z0-9]+' | uniq)" || best_effort
   if [[ -n "${db_inst_name}" ]]; then
     gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID}
   fi


### PR DESCRIPTION
This had been tested and this grep worked