### PR TITLE
Add an "Error Budget Burn" playbook page

### DIFF
--- a/docs/playbooks/alerts/FastErrorBudgetBurn.md
+++ b/docs/playbooks/alerts/FastErrorBudgetBurn.md
@@ -1,23 +1,7 @@
 # Fast Error Budget Alert
 
-This alert fires when 2% of the error budget, as determined by the availability SLO, is consumed in an hour.
+This alert fires when 2% of the error budget, as determined by the
+availability SLO, is consumed in an hour.
 
-* First check if the site is up
-   * Check if https://encv.org/ loads (or appropriate domain for this environment)
-   * Check if you can login
-   * If you can, admins aren't affected
-   * If you can't login everyone is affected
-* Post in chat that you've got the alert
-   * Communicate to your team that you are actively looking at this alert to lower confusion.
-* Look at services dashboard
-   * Load https://console.cloud.google.com/monitoring/services
-   * Look at the Verification Server service and determine its health
-   * Look at the e2e-runner service request logs. This is a service executing code issue and key upload logic and may contain more information on what's going on
-   * Look for servers with elevated 5xx
-   * Look at request logs, you can navigate by hand or use the following query
-
-```
-resource.type="cloud_run_revision"
-resource.labels.service_name="e2e-runner"
-severity=ERROR
-```
+Please refer to the [ErrorBudgetBurn](./_ErrorBudgetBurn.md) page for
+triage steps.

--- a/docs/playbooks/alerts/SlowErrorBudgetBurn.md
+++ b/docs/playbooks/alerts/SlowErrorBudgetBurn.md
@@ -1,23 +1,7 @@
 # Fast Error Budget Alert
 
-This alert fires when 5% of the error budget, as determined by the availability SLO, is consumed in 6 hours.
+This alert fires when 5% of the error budget, as determined by the
+availability SLO, is consumed in 6 hours.
 
-* First check if the site is up
-   * Check if https://encv.org/ loads (or appropriate domain for this environment)
-   * Check if you can login
-   * If you can, admins aren't affected
-   * If you can't login everyone is affected
-* Post in chat that you've got the alert
-   * Communicate to your team that you are actively looking at this alert to lower confusion.
-* Look at services dashboard
-   * Load https://console.cloud.google.com/monitoring/services
-   * Look at the Verification Server service and determine its health
-   * Look at the e2e-runner service request logs. This is a service executing code issue and key upload logic and may contain more information on what's going on
-   * Look for servers with elevated 5xx
-   * Look at request logs, you can navigate by hand or use the following query
-
-```
-resource.type="cloud_run_revision"
-resource.labels.service_name="e2e-runner"
-severity=ERROR
-```
+Please refer to the [ErrorBudgetBurn](./_ErrorBudgetBurn.md) page for
+triage steps.

--- a/docs/playbooks/alerts/_ErrorBudgetBurn.md
+++ b/docs/playbooks/alerts/_ErrorBudgetBurn.md
@@ -1,0 +1,39 @@
+# Error Budget Burn
+
+This playbook applies to both
+[FastErrorBudgetBurn](./FastErrorBudgetBurn.md) and
+[SlowErrorBudgetBurn](./SlowErrorBudgetBurn.md).
+
+Our SLO is defined in
+[../../terraform/alerting/slos.tf](../../terraform/alerting/slos.tf).
+
+The error budget start burning when 5xx error are returned.
+
+## Triage steps
+
+First thing first, communicate to the internal chat to raise awareness.
+
+Use the following MQL queries to see which service is returning 5xx
+errors:
+
+```
+fetch cloud_run_revision
+| metric 'run.googleapis.com/request_count'
+| filter (metric.response_code_class == '5xx')
+| align rate(1m)
+| every 1m
+```
+
+(NB: we currently only have SLO defined for `apiserver` service so this
+step may not be necessary)
+
+While at this, you can also add a "group by" to check whether the error
+is correlated to a new release.
+
+Use the following log filter to determine what went wrong:
+
+```
+resource.type="cloud_run_revision"
+resource.labels.service_name="${SERVICE_NAME}"
+severity=ERROR
+```

--- a/docs/playbooks/alerts/_ErrorBudgetBurn.md
+++ b/docs/playbooks/alerts/_ErrorBudgetBurn.md
@@ -4,8 +4,7 @@ This playbook applies to both
 [FastErrorBudgetBurn](./FastErrorBudgetBurn.md) and
 [SlowErrorBudgetBurn](./SlowErrorBudgetBurn.md).
 
-Our SLO is defined in
-[../../terraform/alerting/slos.tf](../../terraform/alerting/slos.tf).
+Our SLO is defined in [slos.tf](../../../terraform/alerting/slos.tf).
 
 The error budget start burning when 5xx error are returned.
 

--- a/docs/playbooks/playbook_test.go
+++ b/docs/playbooks/playbook_test.go
@@ -25,8 +25,10 @@ import (
 )
 
 const (
-	alertTF       = "../../terraform/alerting/alerts.tf"
-	playbooksGlob = "./alerts/*.md"
+	alertTF = "../../terraform/alerting/alerts.tf"
+
+	// Ignore files not starting with an upper case letter.
+	playbooksGlob = "./alerts/[A-Z]*.md"
 )
 
 var alertPolicySchema = hcl.BodySchema{


### PR DESCRIPTION
We don't need two separate pages as the triage process would be the
same.