### PR TITLE
Don't serve session cookie over javascript, restrict retry storage to 24h

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -176,7 +176,7 @@
         $progressDiv.removeClass('d-none');
 
         if ($rememberCode.is(':checked')) {
-          setCookie('retryCode',$retryCode.val(),14);
+          setCookie('retryCode',$retryCode.val(),1);
         } else {
           setCookie('retryCode','',-1);
         }

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -65,6 +65,7 @@ func Server(
 	sessions.Options.MaxAge = int(cfg.SessionDuration.Seconds())
 	sessions.Options.Secure = !cfg.DevMode
 	sessions.Options.SameSite = http.SameSiteStrictMode
+	sessions.Options.HttpOnly = true
 
 	// Create the router
 	r := mux.NewRouter()


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Don't serve session cookie over javascript, restrict retry storage to 24h
```
