### PR TITLE
Fully revoke signout tokens and update last_revoke_checked

### DIFF
--- a/internal/auth/auth.go
+++ b/internal/auth/auth.go
@@ -49,6 +49,11 @@ type Provider interface {
 	// ClearSession removes any information about this auth from the session.
 	ClearSession(context.Context, *sessions.Session)
 
+	// RevokeSession revokes the session in the upstream identity provider, if one
+	// exists. This is a no-op for first-party identity. RevokeSession calls
+	// ClearSession on success.
+	RevokeSession(context.Context, *sessions.Session) error
+
 	// CreateUser creates a user in the auth provider. If pass is "", the provider
 	// creates and uses a random password.
 	CreateUser(ctx context.Context, name, email, pass string, sendInvite bool, composer InviteUserEmailFunc) (bool, error)

--- a/internal/auth/local.go
+++ b/internal/auth/local.go
@@ -103,6 +103,12 @@ func (a *localAuth) ClearSession(ctx context.Context, session *sessions.Session)
 	sessionClear(session, sessionKeyLocalCookie)
 }
 
+// RevokeSession revokes the upstream session. It's a no-op for this provider.
+func (a *localAuth) RevokeSession(ctx context.Context, session *sessions.Session) error {
+	a.ClearSession(ctx, session)
+	return nil
+}
+
 // CreateUser creates a user in the upstream auth system with the given name and
 // email. It returns true if the user was created or false if the user already
 // exists.

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -280,6 +280,15 @@ func (db *Database) TouchUserRevokeCheck(u *User) error {
 		Error
 }
 
+// UntouchUserRevokeCheck removes the last revoke check, forcing it to occur on
+// next auth.
+func (db *Database) UntouchUserRevokeCheck(u *User) error {
+	return db.db.
+		Model(u).
+		UpdateColumn("last_revoke_check", nil).
+		Error
+}
+
 // PasswordChanged updates the last password change timestamp of the user.
 func (db *Database) PasswordChanged(email string, t time.Time) error {
 	q := db.db.


### PR DESCRIPTION
⚠️ We should talk about whether to actually revoke refresh tokens! Revoking the refresh token ensures a signout, and it occurs on _all_ devices. That means for local testing, if one person logs out, we all get logged out (we'll need to make our own accounts for testing auth). I think this is probably the best solution, but open to other ideas.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fully revoke signout tokens and update last_revoke_checked
```

/assign @mikehelmick 
/assign @whaught 