### PR TITLE
Do not use show-password on sentinel forms

### DIFF
--- a/cmd/server/assets/admin/email/show.html
+++ b/cmd/server/assets/admin/email/show.html
@@ -39,16 +39,9 @@
             </div>
 
             <div class="form-label-group">
-              <div class="input-group">
-                <input type="password" name="smtp_password" id="smtp-password" class="form-control text-monospace{{if $emailConfig.ErrorsFor "smtpPassword"}} is-invalid{{end}}" autocomplete="new-password"
-                  placeholder="SMTP password" {{if $emailConfig.SMTPPassword}}value="{{passwordSentinel}}"{{end}}>
-                <label for="smtp-password">SMTP password</label>
-                <div class="input-group-append">
-                  <a class="input-group-text" data-toggle-password="smtp-password">
-                    <span class="oi oi-lock-locked" aria-hidden="true"></span>
-                  </a>
-                </div>
-              </div>
+              <input type="password" name="smtp_password" id="smtp-password" class="form-control text-monospace{{if $emailConfig.ErrorsFor "smtpPassword"}} is-invalid{{end}}" autocomplete="new-password"
+                placeholder="SMTP password" {{if $emailConfig.SMTPPassword}}value="{{passwordSentinel}}"{{end}}>
+              <label for="smtp-password">SMTP password</label>
               {{template "errorable" $emailConfig.ErrorsFor "smtpPassword"}}
               <small class="form-text text-muted">
                 This is the password for your SMTP email.

--- a/cmd/server/assets/admin/sms/show.html
+++ b/cmd/server/assets/admin/sms/show.html
@@ -38,16 +38,9 @@
           </div>
 
           <div class="form-label-group">
-            <div class="input-group">
-              <input type="password" name="twilio_auth_token" id="twilio-auth-token" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioAuthToken"}} is-invalid{{end}}" autocomplete="new-password"
-                placeholder="Twilio auth token" {{if $smsConfig.TwilioAuthToken}}value="{{passwordSentinel}}"{{end}}>
-              <label for="twilio-auth-token">Twilio auth token</label>
-              <div class="input-group-append">
-                <a class="input-group-text" data-toggle-password="twilio-auth-token">
-                  <span class="oi oi-lock-locked" aria-hidden="true"></span>
-                </a>
-              </div>
-            </div>
+            <input type="password" name="twilio_auth_token" id="twilio-auth-token" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioAuthToken"}} is-invalid{{end}}" autocomplete="new-password"
+              placeholder="Twilio auth token" {{if $smsConfig.TwilioAuthToken}}value="{{passwordSentinel}}"{{end}}>
+            <label for="twilio-auth-token">Twilio auth token</label>
             {{template "errorable" $smsConfig.ErrorsFor "twilioAuthToken"}}
             <small class="form-text text-muted">
               This is the Twilio Auth Token. Get this value from the Twilio console.


### PR DESCRIPTION
/cc @whaught 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Do not use show-password on sentinel forms
```
