### PR TITLE
Only trust Referer from same domain

### DIFF
--- a/pkg/controller/middleware/secure.go
+++ b/pkg/controller/middleware/secure.go
@@ -27,6 +27,7 @@ func SecureHeaders(devMode bool, serverType string) mux.MiddlewareFunc {
 		FrameDeny:            serverType == "html",
 		HostsProxyHeaders:    []string{"X-Forwarded-Host"},
 		IsDevelopment:        devMode,
+		ReferrerPolicy:       "strict-origin-when-cross-origin",
 		SSLProxyHeaders:      map[string]string{"X-Forwarded-Proto": "https"},
 		SSLRedirect:          !devMode,
 		STSIncludeSubdomains: true,


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only trust HTTP Referer from same origin domain
```
