### PR TITLE
Enable and configure pgaudit

### DIFF
--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -571,8 +571,8 @@ func getFieldString(scope *gorm.Scope, name string) (*gorm.Field, string, bool) 
 	return field, typ, true
 }
 
-// withRetries is a helper for creating a fibonacci backoff with capped retries,
-// useful for retrying database queries.
+// withRetries is a helper for creating a backoff with capped retries, useful
+// for retrying database queries.
 func withRetries(ctx context.Context, f retry.RetryFunc) error {
 	b, err := retry.NewConstant(500 * time.Millisecond)
 	if err != nil {

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -35,6 +35,10 @@ import (
 	"github.com/sethvargo/go-envconfig"
 )
 
+const (
+	defaultPostgresImageRef = "postgres:13-alpine"
+)
+
 var (
 	approxTime = cmp.Options{cmpopts.EquateApproxTime(time.Second)}
 )
@@ -207,7 +211,7 @@ func generateKeys(tb testing.TB, qty, length int) []envconfig.Base64Bytes {
 func postgresRepo(tb testing.TB) (string, string) {
 	postgresImageRef := os.Getenv("CI_POSTGRES_IMAGE")
 	if postgresImageRef == "" {
-		postgresImageRef = "postgres:13-alpine"
+		postgresImageRef = defaultPostgresImageRef
 	}
 
 	parts := strings.SplitN(postgresImageRef, ":", 2)

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1695,6 +1695,15 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return tx.Exec("ALTER TABLE realms DROP COLUMN IF EXISTS allow_bulk_upload").Error
 			},
 		},
+		{
+			ID: "00068-EnablePGAudit",
+			Migrate: func(tx *gorm.DB) error {
+				if err := tx.Exec(`CREATE EXTENSION pgaudit`).Error; err != nil {
+					logger.Warnw("failed to enable pgaudit", "error", err)
+				}
+				return nil
+			},
+		},
 	})
 }
 

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -32,6 +32,16 @@ resource "google_sql_database_instance" "db-inst" {
       value = var.database_max_connections
     }
 
+    database_flags {
+      name  = "cloudsql.enable_pgaudit"
+      value = "on"
+    }
+
+    database_flags {
+      name  = "pgaudit.log"
+      value = "all"
+    }
+
     backup_configuration {
       enabled    = true
       location   = var.database_backup_location

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -39,7 +39,7 @@ variable "database_version" {
   type    = string
   default = "POSTGRES_13"
 
-  description = "Version of the database to use. Must be at least 12 or higher."
+  description = "Version of the database to use. Must be at least 13 or higher."
 }
 
 variable "database_disk_size_gb" {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1150

This enables pgaudit, but the migration succeeds if the extension isn't available (e.g. in dev/test) with a warning.

**Release Note**

```release-note
**Warning!** - Enable and configure pgaudit. You **must** run the Terraform configuration changes _before_ deploying this commit with migrations.
```
