### PR TITLE
Flip the cleanup code lifetime values, document, & validate

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -48,7 +48,7 @@ type CleanupConfig struct {
 	// After this time it will be recycled. The code will be zeroed out, but its status persist.
 	VerificationCodeMaxAge time.Duration `env:"VERIFICATION_CODE_MAX_AGE, default=48h"`
 	// VerificationCodeStatusMaxAge is the time after which, even the status of the code will be deleted
-	// and the entry will be purged.
+	// and the entry will be purged. This value should be greater than VerificationCodeMaxAge
 	VerificationCodeStatusMaxAge time.Duration `env:"VERIFICATION_CODE_STATUS_MAX_AGE, default=336h"`
 	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
 }
@@ -85,6 +85,11 @@ func (c *CleanupConfig) Validate() error {
 	// Audit entries need to persist for at least 7 days. The default is 30d ays.
 	if c.AuditEntryMaxAge < 7*24*time.Hour {
 		return fmt.Errorf("AUDIT_ENTRY_MAX_AGE must be at least 7 days")
+	}
+
+	if c.VerificationCodeStatusMaxAge < c.VerificationCodeMaxAge {
+		return fmt.Errorf("the code status %q is expected to live longer than the life of the code %q",
+			c.VerificationCodeStatusMaxAge.String(), c.VerificationCodeMaxAge.String())
 	}
 
 	return nil

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -40,11 +40,15 @@ type CleanupConfig struct {
 	RateLimit uint64 `env:"RATE_LIMIT,default=60"`
 
 	// Cleanup config
-	AuditEntryMaxAge             time.Duration `env:"AUDIT_ENTRY_MAX_AGE, default=720h"`
-	AuthorizedAppMaxAge          time.Duration `env:"AUTHORIZED_APP_MAX_AGE, default=336h"`
-	CleanupPeriod                time.Duration `env:"CLEANUP_PERIOD, default=15m"`
-	MobileAppMaxAge              time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
-	VerificationCodeMaxAge       time.Duration `env:"VERIFICATION_CODE_MAX_AGE, default=48h"`
+	AuditEntryMaxAge    time.Duration `env:"AUDIT_ENTRY_MAX_AGE, default=720h"`
+	AuthorizedAppMaxAge time.Duration `env:"AUTHORIZED_APP_MAX_AGE, default=336h"`
+	CleanupPeriod       time.Duration `env:"CLEANUP_PERIOD, default=15m"`
+	MobileAppMaxAge     time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
+	// VerificationCodeMaxAge is the period in which the full code should be available.
+	// After this time it will be recycled. The code will be zeroed out, but its status persist.
+	VerificationCodeMaxAge time.Duration `env:"VERIFICATION_CODE_MAX_AGE, default=48h"`
+	// VerificationCodeStatusMaxAge is the time after which, even the status of the code will be deleted
+	// and the entry will be purged.
 	VerificationCodeStatusMaxAge time.Duration `env:"VERIFICATION_CODE_STATUS_MAX_AGE, default=336h"`
 	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
 }

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -105,12 +105,12 @@ func (c *Controller) HandleCleanup() http.Handler {
 			}
 		}()
 
-		// Verification codes - purge codes from database entirerly.
+		// Verification codes - purge codes from database entirely.
 		// Their code/long_code hmac values will have been set to "".
 		func() {
 			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_CODE")
-			if count, err := c.db.PurgeVerificationCodes(c.config.VerificationCodeMaxAge); err != nil {
+			if count, err := c.db.PurgeVerificationCodes(c.config.VerificationCodeStatusMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge verification codes: %w", err))
 				result = observability.ResultError("FAILED")
 			} else {
@@ -124,7 +124,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 		func() {
 			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_CODE_RECYCLE")
-			if count, err := c.db.RecycleVerificationCodes(c.config.VerificationCodeStatusMaxAge); err != nil {
+			if count, err := c.db.RecycleVerificationCodes(c.config.VerificationCodeMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge verification codes: %w", err))
 				result = observability.ResultError("FAILED")
 			} else {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Reverses the values from code recycle / code purge
* Validates that the time for recycle is shorter than purge
* Add documentation

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure code status is retained for 14 days, but the code itself is zeroed at 48h
```
