### PR TITLE
Capture ctx pointer when recording latency.

### DIFF
--- a/pkg/clients/e2e.go
+++ b/pkg/clients/e2e.go
@@ -77,7 +77,7 @@ func RunEndToEnd(ctx context.Context, config *config.E2ETestConfig) error {
 	// Parameterize observability.RecordLatency()
 	recordLatency := func(ctx context.Context, start time.Time, step string) {
 		stepMutator := tag.Upsert(stepTagKey, step)
-		observability.RecordLatency(ctx, start, mLatencyMs, &stepMutator, &result)
+		observability.RecordLatency(&ctx, start, mLatencyMs, &stepMutator, &result)
 	}
 
 	for i := 0; i < iterations; i++ {

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -45,7 +45,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		var blame = observability.BlameNone
 		var result = observability.ResultOK()
 
-		defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &blame, &result)
+		defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &blame, &result)
 
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -94,7 +94,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 
 		// API keys
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "API_KEYS")
 			if count, err := c.db.PurgeAuthorizedApps(c.config.AuthorizedAppMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge authorized apps: %w", err))
@@ -108,7 +108,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 		// Verification codes - purge codes from database entirely.
 		// Their code/long_code hmac values will have been set to "".
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_CODE")
 			if count, err := c.db.PurgeVerificationCodes(c.config.VerificationCodeStatusMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge verification codes: %w", err))
@@ -122,7 +122,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 		// Verification codes - recycle codes. Zero out the code/long_code values
 		// so status can be reported, but codes couldn't be recalculated or checked.
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_CODE_RECYCLE")
 			if count, err := c.db.RecycleVerificationCodes(c.config.VerificationCodeMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge verification codes: %w", err))
@@ -135,7 +135,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 
 		// Verification tokens
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_TOKEN")
 			if count, err := c.db.PurgeTokens(c.config.VerificationTokenMaxAge); err != nil {
 				result = observability.ResultError("FAILED")
@@ -148,7 +148,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 
 		// Mobile apps
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "MOBILE_APP")
 			if count, err := c.db.PurgeMobileApps(c.config.MobileAppMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge mobile apps: %w", err))
@@ -161,7 +161,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 
 		// Audit entries
 		func() {
-			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "AUDIT_ENTRY")
 			if count, err := c.db.PurgeAuditEntries(c.config.AuditEntryMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge audit entries: %w", err))

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -32,7 +32,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 
 	"go.opencensus.io/stats"
-	"go.opencensus.io/tag"
 )
 
 type dateParseSettings struct {
@@ -151,8 +150,6 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		// Add realm so that metrics are groupable on a per-realm basis.
 		ctx = observability.WithRealmID(ctx, realm.ID)
-		m := tag.FromContext(ctx)
-		logger.Infow("/api/issue tag.Map in context", "m", m.String())
 
 		// If this realm requires a date but no date was specified, return an error.
 		if realm.RequireDate && request.SymptomDate == "" && request.TestDate == "" {

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -52,7 +52,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		var blame = observability.BlameNone
 		var result = observability.ResultOK()
 
-		defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &blame)
+		defer observability.RecordLatency(&ctx, time.Now(), mLatencyMs, &result, &blame)
 
 		authApp := controller.AuthorizedAppFromContext(ctx)
 		if authApp == nil {

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -157,10 +157,10 @@ func WithBuildInfo(octx context.Context) context.Context {
 // RecordLatency calculate and record the latency.
 // Usage example:
 // func foo() {
-// 	 defer RecordLatency(ctx, time.Now(), metric, tag1, tag2)
+// 	 defer RecordLatency(&ctx, time.Now(), metric, tag1, tag2)
 //   // remaining of the function body.
 // }
-func RecordLatency(ctx context.Context, start time.Time, m *stats.Float64Measure, mutators ...*tag.Mutator) {
+func RecordLatency(ctx *context.Context, start time.Time, m *stats.Float64Measure, mutators ...*tag.Mutator) {
 	var additionalMutators []tag.Mutator
 	for _, t := range mutators {
 		additionalMutators = append(additionalMutators, *t)
@@ -168,5 +168,5 @@ func RecordLatency(ctx context.Context, start time.Time, m *stats.Float64Measure
 	// Calculate the millisecond number as float64. time.Duration.Millisecond()
 	// returns an integer.
 	latency := float64(time.Since(start)) / float64(time.Millisecond)
-	stats.RecordWithTags(ctx, additionalMutators, m.M(latency))
+	stats.RecordWithTags(*ctx, additionalMutators, m.M(latency))
 }


### PR DESCRIPTION
The realm id is usually added to ctx much later in the function body. We
need the defer of observability.RecordLatency() at the beginning of the
function body to accurately record the latency.

Fixes #1180