### PR TITLE
Return on controller error

### DIFF
--- a/pkg/controller/realmadmin/show.go
+++ b/pkg/controller/realmadmin/show.go
@@ -28,7 +28,7 @@ import (
 
 var cacheTimeout = 5 * time.Minute
 
-// ResultType specfies which type of renderer you want.
+// ResultType specifies which type of renderer you want.
 type ResultType int
 
 const (
@@ -84,18 +84,21 @@ func (c *Controller) HandleShow(result ResultType) http.Handler {
 		realm := controller.RealmFromContext(ctx)
 		if realm == nil {
 			controller.MissingRealm(w, r, c.h)
+			return
 		}
 
 		// Get the realm stats.
 		stats, err := c.getRealmStats(ctx, realm, now, past)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 
 		// Also get the per-user stats.
 		userStats, err := c.getUserStats(ctx, realm, now, past)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 
 		switch result {


### PR DESCRIPTION
@jeremyfaller found this as part of https://github.com/google/exposure-notifications-verification-server/pull/1159, but we might spend more time on that, and I'd like to get this part of the fix into the next release.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Stop processing after the controller returns an error in admin statistics pages.
```

/assign @whaught 