### PR TITLE
Quote pgaudit all for Cloud SQL

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -39,7 +39,7 @@ resource "google_sql_database_instance" "db-inst" {
 
     database_flags {
       name  = "pgaudit.log"
-      value = "all"
+      value = "'all'" // CloudSQL quotes this value for some reason
     }
 
     backup_configuration {


### PR DESCRIPTION
The API accepts "all", but then saves it as "'all'" which causes a diff in Terraform.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
