### PR TITLE
Remove quotes around 'all'

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -39,7 +39,7 @@ resource "google_sql_database_instance" "db-inst" {
 
     database_flags {
       name  = "pgaudit.log"
-      value = "'all'" // CloudSQL quotes this value for some reason
+      value = "all"
     }
 
     backup_configuration {


### PR DESCRIPTION
This is rather frustrating... The API returns 'all', but specifying 'all' in the API call is valid but then points the instance in a bad state trying to apply the configuration change.

<img width="1073" alt="screenshot-20201124-152152@2x" src="https://user-images.githubusercontent.com/408570/100147031-c9ad8200-2e68-11eb-86ad-ecbe918810e7.png">

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
