### PR TITLE
Document date format

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -42,7 +42,7 @@
               The CSV file must be of the format <code>phone,date</code>. Each
               entry must appear on its own line, and phone numbers must be in
               <a href="https://www.twilio.com/docs/glossary/what-e164" target="_blank">E.164</a>
-              format.
+              format and dates in <a href="https://www.iso.org/iso-8601-date-and-time-format.html" target="_blank">ISO 8601</a>.
             </small>
           </div>
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Dates should be in ISO 8601.
* This question was asked over email, therefore it's nonobvious and should be there in the text.
