### PR TITLE
Add an error table to the csv results

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -111,6 +111,23 @@
         </table>
       </div>
     </div>
+    <div class="card mb-3 shadow-sm d-none" id="error-div">
+      <div class="card-header">Errors</div>
+      <div class="card-body" >
+        <h3>Errors</h3>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th>Line</th>
+              <th>Phone number</th>
+              <th>Test date</th>
+              <th>Error message</th>
+            </tr>
+          </thead>
+          <tbody id="error-table"></tbody>
+        </table>
+      </div>
+    </div>
   </main>
 
   <script type="text/javascript">
@@ -130,6 +147,9 @@
       let $rememberCode = $('#remember-code');
       let $newCode = $('#new-code');
       let $startAt = $('#start-at');
+
+      let $errorDiv = $('#error-div');
+      let $errorTable = $('#error-table');
 
       let tzOffset = new Date().getTimezoneOffset();
       let randomString = getCookie("retryCode");
@@ -222,7 +242,7 @@
                 $tableBody.append(row);
               }
 
-              cancelUpload = await uploadWithRetries(batch, uploadBatch);
+              cancelUpload = await uploadWithRetries(batch, d => uploadBatch(d, i));
 
               if (cancelUpload) {
                 if (total > 0) {
@@ -282,33 +302,37 @@
         request["tzOffset"] = tzOffset;
         return request
       }
-    });
 
-    function uploadBatch(data) {
-      return $.ajax({
-        url: '/codes/issue',
-        type: 'POST',
-        dataType: 'json',
-        cache: false,
-        contentType: 'application/json',
-        headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
-        // TODO: at the moment we only support one-at-a-time
-        data: JSON.stringify(data[0]),
-        success: function(result) {
-          total++;
-          if (result.error) {
-            flash.error(result.error);
-          }
-        },
-        error: function(xhr, resp, text) {
-          let message = resp;
-          if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
-            message = message + ": " + xhr.responseJSON.error;
-          }
-          flash.error(message);
-        },
-      });
-    }
+      function uploadBatch(data, i) {
+        return $.ajax({
+          url: '/codes/issue',
+          type: 'POST',
+          dataType: 'json',
+          cache: false,
+          contentType: 'application/json',
+          headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
+          // TODO: at the moment we only support one-at-a-time
+          data: JSON.stringify(data[0]),
+          success: function(result) {
+            total++;
+            if (result.error) {
+              flash.error(result.error);
+            }
+          },
+          error: function(xhr, resp, text) {
+            let message = resp;
+            if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
+              message = message + ": " + xhr.responseJSON.error;
+            }
+            $errorDiv.removeClass('d-none');
+            let row = "<tr><td>" + i + "</td><td>" + data[0]["phone"] + "</td><td>" +
+                data[0]["testDate"] + "</td><td>" + message + "</td></tr>";
+            $errorTable.append(row);
+            flash.error(message);
+          },
+        });
+      }
+    });
   </script>
 </body>
 

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -268,8 +268,10 @@
               flash.alert("Successfully issued " + total + " codes.");
             }
           }
+
           $import.prop('disabled', false);
           $cancel.addClass('d-none');
+          $tableBody.empty();
         };
 
         return { start, cancel };

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -271,6 +271,7 @@
 
           $import.prop('disabled', false);
           $cancel.addClass('d-none');
+          $table.addClass('d-none');
           $tableBody.empty();
         };
 

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -271,7 +271,7 @@
           }
 
           if (totalErrs > 0) {
-            flash.error("Received errors for " + totalErrs + " entries. See error table for details.");
+            flash.error(`Received errors for ${totalErrs} entries. See error table for details.`);
           }
 
           $import.prop('disabled', false);

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -195,6 +195,9 @@
         $table.removeClass('d-none');
         $progressDiv.removeClass('d-none');
 
+        $errorDiv.addClass("d-none");
+        $errorTable.empty();
+
         if ($rememberCode.is(':checked')) {
           setCookie('retryCode',$retryCode.val(),1);
         } else {

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -250,8 +250,7 @@
 
               if (cancelUpload) {
                 if (total > 0) {
-                  flash.warning("Successfully issued " + total + " codes."
-                    + (rows.length - i) + " remaining.");
+                  flash.warning(`Successfully issued ${total} codes. ${(rows.length - i)} +  remaining.`);
                 }
                 break;
               }
@@ -266,7 +265,7 @@
             $progress.width('100%');
             $progress.html('100%');
             if (total > 0) {
-              flash.alert("Successfully issued " + total + " codes.");
+              flash.alert(`Successfully issued ${total} codes.`);
             }
           }
 

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -113,25 +113,23 @@
     </div>
     <div class="card mb-3 shadow-sm d-none" id="error-div">
       <div class="card-header">Errors</div>
-      <div class="card-body" >
-        <h3>Errors</h3>
-        <table class="table table-bordered">
-          <thead>
-            <tr>
-              <th>Line</th>
-              <th>Phone number</th>
-              <th>Test date</th>
-              <th>Error message</th>
-            </tr>
-          </thead>
-          <tbody id="error-table"></tbody>
-        </table>
-      </div>
+      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
+        <thead>
+          <tr>
+            <th>Line</th>
+            <th>Phone number</th>
+            <th>Test date</th>
+            <th>Error message</th>
+          </tr>
+        </thead>
+        <tbody id="error-table"></tbody>
+      </table>
     </div>
   </main>
 
   <script type="text/javascript">
     let total = 0;
+    let totalErrs = 0;
 
     $(function() {
       let $form = $('#form');
@@ -223,6 +221,7 @@
           let rows = e.target.result.split('\n');
           let batch = [];
           total = 0;
+          totalErrs = 0;
           $tableBody.empty();
 
           for (let i = parseInt($startAt.val()); i < rows.length && !cancelUpload; i++) {
@@ -241,8 +240,10 @@
             if (batch.length >= batchSize || i == rows.length - 1 && batch.length > 0) {
               $tableBody.empty();
               for(let r = 0; r < batch.length; r++) {
-                let row = "<tr><td>" + batch[r]["phone"] + "</td><td>" + batch[r]["testDate"] + "</td></tr>";
-                $tableBody.append(row);
+                let $row = $('<tr/>');
+                $row.append($('<td/>').text(batch[r]["phone"]));
+                $row.append($('<td/>').text(batch[r]["testDate"]));
+                $tableBody.append($row);
               }
 
               cancelUpload = await uploadWithRetries(batch, d => uploadBatch(d, i));
@@ -267,6 +268,10 @@
             if (total > 0) {
               flash.alert("Successfully issued " + total + " codes.");
             }
+          }
+
+          if (totalErrs > 0) {
+            flash.error("Received errors for " + totalErrs + " entries. See error table for details.");
           }
 
           $import.prop('disabled', false);
@@ -326,15 +331,18 @@
             }
           },
           error: function(xhr, resp, text) {
+            totalErrs++;
             let message = resp;
             if (xhr && xhr.responseJSON && xhr.responseJSON.error) {
               message = message + ": " + xhr.responseJSON.error;
             }
             $errorDiv.removeClass('d-none');
-            let row = "<tr><td>" + i + "</td><td>" + data[0]["phone"] + "</td><td>" +
-                data[0]["testDate"] + "</td><td>" + message + "</td></tr>";
-            $errorTable.append(row);
-            flash.error(message);
+            let $row = $('<tr/>');
+            $row.append($('<td/>').text(i));
+            $row.append($('<td/>').text(data[0]["phone"]));
+            $row.append($('<td/>').text(data[0]["testDate"]));
+            $row.append($('<td/>').text(message));
+            $errorTable.append($row);
           },
         });
       }


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1197

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a card for displaying errors from CSV upload

![errorstable](https://user-images.githubusercontent.com/36240966/100394772-36ed1e80-2ff3-11eb-8955-0f54e5538ccb.png)

TODO:
Show # successful above the errors?
Button to download this as text?

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Include a table of errors for CSV bulk import
```
