### PR TITLE
Ensure external_issuer_id column exists

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1715,6 +1715,16 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return tx.DropTable(&ExternalIssuerStat{}).Error
 			},
 		},
+		{
+			ID: "00070-AddExternalIssuerIDToVerificationCode",
+			Migrate: func(tx *gorm.DB) error {
+				sql := `ALTER TABLE verification_codes ADD COLUMN IF NOT EXISTS issuing_external_id VARCHAR(255)`
+				return tx.Exec(sql).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.DropTable(&ExternalIssuerStat{}).Error
+			},
+		},
 	})
 }
 

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -76,18 +76,18 @@ type VerificationCode struct {
 	// IssuingUserID is the ID of the user in the database that created this
 	// verification code. This is only populated if the code was created via the
 	// UI.
-	IssuingUserID uint
+	IssuingUserID uint `gorm:"column:issuing_user_id; type:integer;"`
 
 	// IssuingAppID is the ID of the app in the database that created this
 	// verification code. This is only populated if the code was created via the
 	// API.
-	IssuingAppID uint
+	IssuingAppID uint `gorm:"column:issuing_app_id; type:integer;"`
 
 	// IssuingExternalID is an optional ID to an external system that created this
 	// verification code. This is only populated if the code was created via the
 	// API AND the API caller supplied it in the request. This ID has no meaning
 	// in this system. It can be up to 255 characters in length.
-	IssuingExternalID string
+	IssuingExternalID string `gorm:"column:issuing_external_id; type:varchar(255);"`
 }
 
 // TableName sets the VerificationCode table name


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix missing column in migration for verification code statistics
```
