### PR TITLE
Include email addresses in stats export

### DIFF
--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1346,6 +1346,7 @@ func (r *Realm) UserStats(db *Database, start, stop time.Time) (RealmUserStats, 
 			$1 AS realm_id,
 			d.user_id AS user_id,
 			u.name AS name,
+			u.email AS email,
 			COALESCE(s.codes_issued, 0) AS codes_issued
 		FROM (
 			SELECT

--- a/pkg/database/realm_user_stats.go
+++ b/pkg/database/realm_user_stats.go
@@ -39,6 +39,7 @@ type RealmUserStat struct {
 	RealmID     uint
 	UserID      uint
 	Name        string
+	Email       string
 	CodesIssued uint
 }
 
@@ -52,7 +53,7 @@ func (s RealmUserStats) MarshalCSV() ([]byte, error) {
 	var b bytes.Buffer
 	w := csv.NewWriter(&b)
 
-	if err := w.Write([]string{"date", "realm_id", "user_id", "name", "codes_issued"}); err != nil {
+	if err := w.Write([]string{"date", "realm_id", "user_id", "name", "email", "codes_issued"}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
@@ -62,6 +63,7 @@ func (s RealmUserStats) MarshalCSV() ([]byte, error) {
 			strconv.FormatUint(uint64(stat.RealmID), 10),
 			strconv.FormatUint(uint64(stat.UserID), 10),
 			stat.Name,
+			stat.Email,
 			strconv.FormatUint(uint64(stat.CodesIssued), 10),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
@@ -89,6 +91,7 @@ type jsonRealmUserStatStats struct {
 type jsonRealmUserStatIssuerData struct {
 	UserID      uint   `json:"user_id"`
 	Name        string `json:"name"`
+	Email       string `json:"email"`
 	CodesIssued uint   `json:"codes_issued"`
 }
 
@@ -108,6 +111,7 @@ func (s RealmUserStats) MarshalJSON() ([]byte, error) {
 		m[stat.Date] = append(m[stat.Date], &jsonRealmUserStatIssuerData{
 			UserID:      stat.UserID,
 			Name:        stat.Name,
+			Email:       stat.Email,
 			CodesIssued: stat.CodesIssued,
 		})
 	}
@@ -153,6 +157,7 @@ func (s *RealmUserStats) UnmarshalJSON(b []byte) error {
 				RealmID:     result.RealmID,
 				UserID:      r.UserID,
 				Name:        r.Name,
+				Email:       r.Email,
 				CodesIssued: r.CodesIssued,
 			})
 		}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1211

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Include user email addresses in stats export
```
