### PR TITLE
Internationalize SMS placeholder input

### DIFF
--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -139,7 +139,7 @@
               <label for="symptomDate" class="col-sm-3">Patient phone</label>
               <div class="col-sm-9">
                 <div class="input-group">
-                  <input type="tel" id="phone" name="phone" class="form-control" placeholder="+1 (555) 555-5555" autocomplete="off" class="w-100" />
+                  <input type="tel" id="phone" name="phone" class="form-control" autocomplete="off" class="w-100" />
                 </div>
                 <small class="form-text text-muted">
                   If provided, the system will send text containing the code to the


### PR DESCRIPTION
Turns out the library does this - we just needed to remove our placeholder...

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1213

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Internationalize SMS placeholder input
```
