### PR TITLE
About link

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -52,7 +52,9 @@
             <a class="card-link" href="/{{.loginRedirect}}">&larr; Back</a>
           </div>
           {{end}}
-
+          <div class="d-flex justify-content-center pt-2">
+            <small><a class="text-muted" target="_blank" href="https://www.google.com/covid19/exposurenotifications">About exposure notifications</a></small>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Fixes #https://github.com/google/exposure-notifications-verification-server/issues/1214

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add a link to the Google marketing page  for Exposure Notifications info / spec / docs

![withabout](https://user-images.githubusercontent.com/36240966/100698181-b01aa780-334c-11eb-9cbf-45c04e76e58f.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added an 'about' link to the login page
```
