### PR TITLE
Add triage steps for StackdriverExportFailed alert

### DIFF
--- a/docs/playbooks/alerts/StackdriverExportFailed.md
+++ b/docs/playbooks/alerts/StackdriverExportFailed.md
@@ -7,3 +7,23 @@ on the export metrics.
 
 NOTE: metric export may spontanously fail. If the failure rate is low it's
 likely the threshold is too sensitive.
+
+## Triage steps
+
+You can use the following query to get the rate of errors:
+
+```
+fetch cloud_run_revision
+| metric 'logging.googleapis.com/user/stackdriver_export_error_count'
+| align rate(1m)
+| every 1m
+| group_by [resource.revision_name, resource.service_name],
+    [row_count: row_count()]
+```
+
+If the error can be correlated to a new release, reach out to the Slack
+channel and ping the dev team for help.
+
+If it's not correlated to a release, chances are the issue is on Google
+Cloud Monitoring's end. Open a ticket with the Cloud Support team and
+ping Slack channel to raise awareness.


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1203
