### PR TITLE
Terraform for appsync

### DIFF
--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -190,7 +190,7 @@ resource "google_cloud_run_service_iam_member" "appsync-invoker" {
 resource "google_cloud_scheduler_job" "appsync-worker" {
   name             = "appsync-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 * * * *"
+  schedule         = "* 0 * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -14,7 +14,7 @@
 
 resource "google_service_account" "appsync" {
   project      = var.project
-  account_id   = "en-verification-appsync-sa"
+  account_id   = "en-ver-appsync-sa"
   display_name = "Verification App Sync"
 }
 
@@ -175,7 +175,7 @@ output "appsync_url" {
 
 resource "google_service_account" "appsync-invoker" {
   project      = data.google_project.project.project_id
-  account_id   = "en-appsync-invoker-sa"
+  account_id   = "en-appsync-invk-sa"
   display_name = "Verification appsync invoker"
 }
 

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -114,6 +114,7 @@ resource "google_cloud_run_service" "appsync" {
 
         dynamic "env" {
           for_each = merge(
+            local.appsync_config,
             local.cache_config,
             local.csrf_config,
             local.database_config,

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -114,7 +114,6 @@ resource "google_cloud_run_service" "cleanup" {
 
         dynamic "env" {
           for_each = merge(
-            local.appsync_config,
             local.cache_config,
             local.csrf_config,
             local.database_config,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 locals {
+  appsync_config = {
+    APP_SYNC_URL ="https://www.gstatic.com/exposurenotifications/apps.json"
+  }
+
   gcp_config = {
     PROJECT_ID = var.project
   }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -14,7 +14,7 @@
 
 locals {
   appsync_config = {
-    APP_SYNC_URL ="https://www.gstatic.com/exposurenotifications/apps.json"
+    APP_SYNC_URL = "https://www.gstatic.com/exposurenotifications/apps.json"
   }
 
   gcp_config = {


### PR DESCRIPTION
Fixes #https://github.com/google/exposure-notifications-verification-server/issues/1092

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add terraform config for the appsync service
    * Looks a lot like the cleanup service. Another option would to be to make this a route of cleanup.
* Adds the appropriate URL for json

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add terraform for setting up the mobile-app-sync cloud run service, scheduling, and URL config
```
