### PR TITLE
accept app_name for mobile app sync

### DIFF
--- a/pkg/clients/responses.go
+++ b/pkg/clients/responses.go
@@ -29,6 +29,7 @@ type App struct {
 // AndroidTarget holds the android metadata for an App of AppResponse.
 type AndroidTarget struct {
 	Namespace              string `json:"namespace"`
+	AppName                string `json:"app_name,omitempty"`
 	PackageName            string `json:"package_name"`
 	SHA256CertFingerprints string `json:"sha256_cert_fingerprints"`
 }

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -159,5 +159,8 @@ func (c *Controller) findAppsForRealm(
 }
 
 func generateAppName(app clients.App) string {
+	if app.AppName != "" {
+		return app.AppName
+	}
 	return app.Region + " Android App"
 }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1242

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* @flagxor added an app_name field today (although it does not yet exist in the export file). Take that as optional and prefer using that field to generating one.