### PR TITLE
Recreates Spanish i18n language file

### DIFF
--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -1,0 +1,142 @@
+msgid ""
+msgstr ""
+"Language: es\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#
+# navigation menus
+# ----------------
+
+msgid "nav.issue-code"
+msgstr "Generar código"
+
+msgid "nav.bulk-issue-codes"
+msgstr "Generar lote de códigos"
+
+msgid "nav.check-code-status"
+msgstr "Revisar estatus de código"
+
+msgid "nav.api-keys"
+msgstr "Llaves de API"
+
+msgid "nav.mobile-apps"
+msgstr "Aplicaciones móviles"
+
+msgid "nav.event-log"
+msgstr "Bitácora de eventos"
+
+msgid "nav.signing-keys"
+msgstr "Llaves firmantes"
+
+msgid "nav.statistics"
+msgstr "Estadísticas"
+
+msgid "nav.users"
+msgstr "Usuarios"
+
+msgid "nav.settings"
+msgstr "Configuración"
+
+msgid "nav.change-realm"
+msgstr "Cambiar de ámbito"
+
+msgid "nav.select-realm"
+msgstr "Seleccionar ámbito"
+
+msgid "nav.system-admin"
+msgstr "Administrador de sistema"
+
+msgid "nav.my-account"
+msgstr "Mi cuenta"
+
+msgid "nav.sign-out"
+msgstr "Finalizar sesión"
+
+
+#
+# issue code
+# ----------
+
+msgid "codes.issue.header"
+msgstr "Crear código de verificación"
+
+msgid "codes.issue.instructions"
+msgstr "Complete el siguiente formulario para generar un código de un solo uso para verificar un paciente. No envíe esta forma hasta estar listo para dar el código al paciente."
+
+msgid "codes.issue.diagnosis-header"
+msgstr "Diagnóstico"
+
+msgid "codes.issue.dates-header"
+msgstr "Fechas"
+
+msgid "codes.issue.confirmed-test"
+msgstr "Prueba positiva"
+
+msgid "codes.issue.confirmed-test-details"
+msgstr "Resultado positivo confirmado de prueba proveniente de una fuente oficial"
+
+msgid "codes.issue.likely-test"
+msgstr "Diagnóstico probable"
+
+msgid "codes.issue.likely-test-details"
+msgstr "Diagnóstico clínico sin prueba"
+
+msgid "codes.issue.negative-test"
+msgstr "Prueba negativa"
+
+msgid "codes.issue.negative-test-details"
+msgstr "Resultado negativo confirmado de prueba proveniente de una fuente oficial"
+
+msgid "codes.issue.testing-date-label"
+msgstr "Fecha de prueba (hora local)"
+
+msgid "codes.issue.symptoms-date-label"
+msgstr "Inicio de síntomas (hora local)"
+
+msgid "codes.issue.sms-text-message-header"
+msgstr "Mensaje de texto SMS (recomendado)"
+
+msgid "codes.issue.sms-text-message-label"
+msgstr "Número telefónico del paciente"
+
+msgid "codes.issue.sms-text-message-detail"
+msgstr "El sistema enviará un mensaje de texto conteniendo el código al paciente a este número, si es provisto. El telefóno deberá ser capaz de recibir mensajes de texto SMS."
+
+msgid "codes.issue.create-code-button"
+msgstr "Crear código de verificación"
+
+msgid "codes.issue.reset-code-button"
+msgstr "Borrar datos y regresar"
+
+msgid "codes.issue.sms-verification-link-header"
+msgstr "Liga de verificación de SMS"
+
+msgid "codes.issue.sms-verification-detail"
+msgstr "Se ha enviado SMS a %s. Informe al paciente que revise sus mensajes en el teléfono celular donde Notificaciones de Exposición está habilitado."
+
+msgid "codes.issue.backup-short-code-header"
+msgstr "Código de respaldo"
+
+msgid "codes.issue.backup-short-code-detail"
+msgstr "Comparta este código con el paciente en caso de no haber recibido el mensaje de texto en su teléfono celular."
+
+msgid "codes.issue.generated-short-code-header"
+msgstr "Se ha generado el código de respaldo"
+
+msgid "codes.issue.generated-short-code-detail"
+msgstr "Comparta este código inmediatamente con el paciente."
+
+msgid "codes.issue.uuid-header"
+msgstr "Identificador único"
+
+msgid "codes.issue.uuid-detail"
+msgstr "Utilícese para saber si el código de verificación ha sido usado."
+
+msgid "codes.issue.countdown-expires-in"
+msgstr "Expira en"
+
+msgid "codes.issue.countdown-expired"
+msgstr "EXPIRADO"


### PR DESCRIPTION
## Proposed Changes

* Recreates Spanish i18n file with updated strings.
* Some translation comments 
    * Verified `Exposure Notifications` translation by switching iPhone to Spanish.
    * Translated `signing keys` as `llaves firmantes` this time, after plenty of feedback in a Spanish-speaking technology forum.
    * Spanish uses the same word for `realm` and `kingdom`, which is probably not a good translation. `Ámbito` is frequently used as a translation for realm in Spain, other possibilities could be `dominio` or `universo`, but each one has its own ambiguity problems.
    * `Short backup code` is a bit hard to translate; I focused more on the backup part (`código de respaldo`)

**Release Note**
```release-note
NONE
```
