### PR TITLE
Only warn on missing regions

### DIFF
--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -81,7 +81,13 @@ func (c *Controller) syncApps(ctx context.Context, apps *clients.AppsResponse) *
 	for _, app := range apps.Apps {
 		realm, err := c.findRealmForApp(app, realms)
 		if err != nil {
-			merr = multierror.Append(merr, fmt.Errorf("unable to lookup realm for region %q: %w", app.Region, err))
+			if database.IsNotFound(err) {
+				logger.Warnw("no app corresponds to region, skipping",
+					"app", app.AndroidTarget.AppName,
+					"region", app.Region)
+			} else {
+				merr = multierror.Append(merr, fmt.Errorf("unable to lookup realm for region %q: %w", app.Region, err))
+			}
 			continue
 		}
 


### PR DESCRIPTION
This can happen if apps aren't using our server, or in integration and test environments where not all regions are registered.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only warn on missing regions for appsync.
```
