### PR TITLE
Adding fr i18n file

### DIFF
--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -11,10 +11,10 @@ msgstr ""
 # ----------------
 
 msgid "nav.issue-code"
-msgstr "Emettre un code"
+msgstr "Émettre un code"
 
 msgid "nav.bulk-issue-codes"
-msgstr "Emettre des codes multiples"
+msgstr "Émettre des codes multiples"
 
 msgid "nav.check-code-status"
 msgstr "Vérifier l'état d'un code"
@@ -97,7 +97,7 @@ msgid "codes.issue.symptoms-date-label"
 msgstr "Apparition des symptômes (heure locale)"
 
 msgid "codes.issue.sms-text-message-header"
-msgstr "Message SMS (recommendé)"
+msgstr "Message SMS (recommandé)"
 
 msgid "codes.issue.sms-text-message-label"
 msgstr "Numéro de téléphone du patient"
@@ -115,7 +115,7 @@ msgid "codes.issue.sms-verification-link-header"
 msgstr "Lien de vérification SMS"
 
 msgid "codes.issue.sms-verification-detail"
-msgstr "SMS envoyé avec succès au %s. Demandez au patient de vérifier ses messages SMS sur son téléphone où Exposure Notifications est activé."
+msgstr "SMS envoyé avec succès au %s. Demandez au patient de vérifier ses messages SMS sur son téléphone où Notifications d'exposition au COVID-19 est activé."
 
 msgid "codes.issue.backup-short-code-header"
 msgstr "Code court de secours"

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -41,10 +41,10 @@ msgid "nav.settings"
 msgstr "Paramètres"
 
 msgid "nav.change-realm"
-msgstr "Changer de domaine (realm)"
+msgstr "Changer de domaine"
 
 msgid "nav.select-realm"
-msgstr "Sélectionner un domaine (realm)"
+msgstr "Sélectionner un domaine"
 
 msgid "nav.system-admin"
 msgstr "Administrateur système"

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -1,0 +1,142 @@
+msgid ""
+msgstr ""
+"Language: fr\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#
+# navigation menus
+# ----------------
+
+msgid "nav.issue-code"
+msgstr "Emettre un code"
+
+msgid "nav.bulk-issue-codes"
+msgstr "Emettre des codes multiples"
+
+msgid "nav.check-code-status"
+msgstr "Vérifier l'état d'un code"
+
+msgid "nav.api-keys"
+msgstr "Clés d'API"
+
+msgid "nav.mobile-apps"
+msgstr "Applications mobiles"
+
+msgid "nav.event-log"
+msgstr "Journal d'événements"
+
+msgid "nav.signing-keys"
+msgstr "Clés de signature"
+
+msgid "nav.statistics"
+msgstr "Statistiques"
+
+msgid "nav.users"
+msgstr "Utilisateurs"
+
+msgid "nav.settings"
+msgstr "Paramètres"
+
+msgid "nav.change-realm"
+msgstr "Changer de domaine (realm)"
+
+msgid "nav.select-realm"
+msgstr "Sélectionner un domaine (realm)"
+
+msgid "nav.system-admin"
+msgstr "Administrateur système"
+
+msgid "nav.my-account"
+msgstr "Mon compte"
+
+msgid "nav.sign-out"
+msgstr "Déconnexion"
+
+
+#
+# issue code
+# ----------
+
+msgid "codes.issue.header"
+msgstr "Créer un code de vérification"
+
+msgid "codes.issue.instructions"
+msgstr "Remplissez le formulaire suivant pour émettre un code à usage unique pour vérifier un patient. Ne soumettre ce formulaire que lorsque vous êtes prêt à transmettre le code au patient."
+
+msgid "codes.issue.diagnosis-header"
+msgstr "Diagnostic"
+
+msgid "codes.issue.dates-header"
+msgstr "Dates"
+
+msgid "codes.issue.confirmed-test"
+msgstr "Test positif"
+
+msgid "codes.issue.confirmed-test-details"
+msgstr "Résultat de test positif confirmé par une source officielle de dépistage"
+
+msgid "codes.issue.likely-test"
+msgstr "Diagnostic vraisemblable"
+
+msgid "codes.issue.likely-test-details"
+msgstr "Diagnostic clinique sans test"
+
+msgid "codes.issue.negative-test"
+msgstr "Test négatif"
+
+msgid "codes.issue.negative-test-details"
+msgstr "Résultat de test négatif confirmé par une source officielle de dépistage"
+
+msgid "codes.issue.testing-date-label"
+msgstr "Date du test (heure locale)"
+
+msgid "codes.issue.symptoms-date-label"
+msgstr "Apparition des symptômes (heure locale)"
+
+msgid "codes.issue.sms-text-message-header"
+msgstr "Message SMS (recommendé)"
+
+msgid "codes.issue.sms-text-message-label"
+msgstr "Numéro de téléphone du patient"
+
+msgid "codes.issue.sms-text-message-detail"
+msgstr "S'il est fourni, le système enverra au patient par SMS un message textuel contenant le code. Ce numéro doit être capabe de recevoir des messages SMS."
+
+msgid "codes.issue.create-code-button"
+msgstr "Créer un code de vérification"
+
+msgid "codes.issue.reset-code-button"
+msgstr "Annuler et revenir en arrière"
+
+msgid "codes.issue.sms-verification-link-header"
+msgstr "Lien de vérification SMS"
+
+msgid "codes.issue.sms-verification-detail"
+msgstr "SMS envoyé avec succès au %s. Demandez au patient de vérifier ses messages SMS sur son téléphone où Exposure Notifications est activé."
+
+msgid "codes.issue.backup-short-code-header"
+msgstr "Code court de secours"
+
+msgid "codes.issue.backup-short-code-detail"
+msgstr "Partagez ce code avec le patient s'il n'a pas recu de SMS sur son téléphone portable."
+
+msgid "codes.issue.generated-short-code-header"
+msgstr "Générer un code court"
+
+msgid "codes.issue.generated-short-code-detail"
+msgstr "Partagez ce code immédiatement avec le patient."
+
+msgid "codes.issue.uuid-header"
+msgstr "Identificateur unique"
+
+msgid "codes.issue.uuid-detail"
+msgstr "Utilisez ceci pour vérifier qu'un code a bien été saisi."
+
+msgid "codes.issue.countdown-expires-in"
+msgstr "Expire dans"
+
+msgid "codes.issue.countdown-expired"
+msgstr "EXPIRÉ"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adding fr (French) i18n file
* Used "Notifications d'exposition au COVID-19" as a translation of "Exposure Notification" for consistency. This is what an Android phone set to French shows but this should really be "Notifications d'exposition à la COVID-19" (feminine vs. masculine)
* Used properly accentuated capital letters which. On some rare but poorly-configured devices these may show as weird characters instead.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
