### PR TITLE
Add portuguese language translations

### DIFF
--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -64,7 +64,7 @@ msgid "codes.issue.header"
 msgstr "Criar código de verificação"
 
 msgid "codes.issue.instructions"
-msgstr "Preencha o seguinte formulário para criar um código de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o códio ao paciente."
+msgstr "Preencha o seguinte formulário para criar um código de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o código ao paciente."
 
 msgid "codes.issue.diagnosis-header"
 msgstr "Diagnóstico"

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -29,7 +29,7 @@ msgid "nav.event-log"
 msgstr "Registro de eventos"
 
 msgid "nav.signing-keys"
-msgstr "Chaves assinantes"
+msgstr "Chaves de assinatura"
 
 msgid "nav.statistics"
 msgstr "Estatísticas"
@@ -67,7 +67,7 @@ msgid "codes.issue.instructions"
 msgstr "Preencha o seguinte formulário para criar um código de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o códio ao paciente."
 
 msgid "codes.issue.diagnosis-header"
-msgstr "Diagnose"
+msgstr "Diagnóstico"
 
 msgid "codes.issue.dates-header"
 msgstr "Datas"
@@ -121,7 +121,7 @@ msgid "codes.issue.backup-short-code-header"
 msgstr "Código reserva"
 
 msgid "codes.issue.backup-short-code-detail"
-msgstr "Compartilhe este código com o paciente se ele não recebeu a mensagem de texto SMS no seu celular."
+msgstr "Compartilhe este código com o paciente se ele não receber a mensagem de texto SMS no seu celular."
 
 msgid "codes.issue.generated-short-code-header"
 msgstr "O código reserva foi criado"

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -17,7 +17,7 @@ msgid "nav.bulk-issue-codes"
 msgstr "Gerar lote de códigos"
 
 msgid "nav.check-code-status"
-msgstr "Verificar estado do código"
+msgstr "Verificar status do código"
 
 msgid "nav.api-keys"
 msgstr "Chaves de API"
@@ -38,7 +38,7 @@ msgid "nav.users"
 msgstr "Usuários"
 
 msgid "nav.settings"
-msgstr "Configuração"
+msgstr "Configurações"
 
 msgid "nav.change-realm"
 msgstr "Mudar de âmbito"
@@ -64,7 +64,7 @@ msgid "codes.issue.header"
 msgstr "Criar código de verificação"
 
 msgid "codes.issue.instructions"
-msgstr "Preencha o seguinte formulário para criar um código de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o código ao paciente."
+msgstr "Preencha o seguinte formulário para criar um token de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o código ao paciente."
 
 msgid "codes.issue.diagnosis-header"
 msgstr "Diagnóstico"
@@ -103,7 +103,7 @@ msgid "codes.issue.sms-text-message-label"
 msgstr "Número de telefone do paciente"
 
 msgid "codes.issue.sms-text-message-detail"
-msgstr "Se for providenciado, o sistema enviará uma mensagem de texto contendo o código ao paciente. O número precisa ser capaz de receber mensagens de texto SMS."
+msgstr "Se for providenciado, o sistema enviará uma mensagem de texto contendo o código ao paciente. O número precisa estar habilitado para receber mensagens de texto SMS."
 
 msgid "codes.issue.create-code-button"
 msgstr "Criar código de verificação"
@@ -115,13 +115,13 @@ msgid "codes.issue.sms-verification-link-header"
 msgstr "Link de verificação de código"
 
 msgid "codes.issue.sms-verification-detail"
-msgstr "Código enviado a %s com sucesso. Oriente o paciente a verificar suas mensagens de texto no telefone onde Notificações de Exposição estiverem habilitadas."
+msgstr "Código enviado a %s com sucesso. Oriente o paciente a verificar suas mensagens de texto no telefone onde Notificações de Exposição estiverem ativadas."
 
 msgid "codes.issue.backup-short-code-header"
 msgstr "Código reserva"
 
 msgid "codes.issue.backup-short-code-detail"
-msgstr "Compartilhe este código com o paciente se ele não receber a mensagem de texto SMS no seu celular."
+msgstr "Compartilhe este código com o paciente se ele não receber a mensagem de texto SMS no celular."
 
 msgid "codes.issue.generated-short-code-header"
 msgstr "O código reserva foi criado"

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -1,0 +1,142 @@
+msgid ""
+msgstr ""
+"Language: pt\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+#
+# navigation menus
+# ----------------
+
+msgid "nav.issue-code"
+msgstr "Gerar código"
+
+msgid "nav.bulk-issue-codes"
+msgstr "Gerar lote de códigos"
+
+msgid "nav.check-code-status"
+msgstr "Verificar estado do código"
+
+msgid "nav.api-keys"
+msgstr "Chaves de API"
+
+msgid "nav.mobile-apps"
+msgstr "Aplicativos móveis"
+
+msgid "nav.event-log"
+msgstr "Registro de eventos"
+
+msgid "nav.signing-keys"
+msgstr "Chaves assinantes"
+
+msgid "nav.statistics"
+msgstr "Estatísticas"
+
+msgid "nav.users"
+msgstr "Usuários"
+
+msgid "nav.settings"
+msgstr "Configuração"
+
+msgid "nav.change-realm"
+msgstr "Mudar de âmbito"
+
+msgid "nav.select-realm"
+msgstr "Selecionar âmbito"
+
+msgid "nav.system-admin"
+msgstr "Administrador de sistema"
+
+msgid "nav.my-account"
+msgstr "Minha conta"
+
+msgid "nav.sign-out"
+msgstr "Sair"
+
+
+#
+# issue code
+# ----------
+
+msgid "codes.issue.header"
+msgstr "Criar código de verificação"
+
+msgid "codes.issue.instructions"
+msgstr "Preencha o seguinte formulário para criar um código de uso único para verificar um paciente. Não envie este formulário até estar pronto para repassar o códio ao paciente."
+
+msgid "codes.issue.diagnosis-header"
+msgstr "Diagnose"
+
+msgid "codes.issue.dates-header"
+msgstr "Datas"
+
+msgid "codes.issue.confirmed-test"
+msgstr "Teste positivo"
+
+msgid "codes.issue.confirmed-test-details"
+msgstr "Resultado positivo confirmado vindo de uma fonte oficial"
+
+msgid "codes.issue.likely-test"
+msgstr "Diagnóstico provável"
+
+msgid "codes.issue.likely-test-details"
+msgstr "Dignóstico clínico sem teste"
+
+msgid "codes.issue.negative-test"
+msgstr "Teste negativo"
+
+msgid "codes.issue.negative-test-details"
+msgstr "Resultado positivo confirmado vindo de uma fonte oficial"
+
+msgid "codes.issue.testing-date-label"
+msgstr "Data do teste (horário local)"
+
+msgid "codes.issue.symptoms-date-label"
+msgstr "Início de sintomas (horário local)"
+
+msgid "codes.issue.sms-text-message-header"
+msgstr "Mensagem de texto SMS (recomendado)"
+
+msgid "codes.issue.sms-text-message-label"
+msgstr "Número de telefone do paciente"
+
+msgid "codes.issue.sms-text-message-detail"
+msgstr "Se for providenciado, o sistema enviará uma mensagem de texto contendo o código ao paciente. O número precisa ser capaz de receber mensagens de texto SMS."
+
+msgid "codes.issue.create-code-button"
+msgstr "Criar código de verificação"
+
+msgid "codes.issue.reset-code-button"
+msgstr "Apagar dados e voltar"
+
+msgid "codes.issue.sms-verification-link-header"
+msgstr "Link de verificação de código"
+
+msgid "codes.issue.sms-verification-detail"
+msgstr "Código enviado a %s com sucesso. Oriente o paciente a verificar suas mensagens de texto no telefone onde Notificações de Exposição estiverem habilitadas."
+
+msgid "codes.issue.backup-short-code-header"
+msgstr "Código reserva"
+
+msgid "codes.issue.backup-short-code-detail"
+msgstr "Compartilhe este código com o paciente se ele não recebeu a mensagem de texto SMS no seu celular."
+
+msgid "codes.issue.generated-short-code-header"
+msgstr "O código reserva foi criado"
+
+msgid "codes.issue.generated-short-code-detail"
+msgstr "Compartilhe este código com o paciente imediatamente."
+
+msgid "codes.issue.uuid-header"
+msgstr "Código único"
+
+msgid "codes.issue.uuid-detail"
+msgstr "Use para saber se o código de verificação foi utilizado."
+
+msgid "codes.issue.countdown-expires-in"
+msgstr "Expira em"
+
+msgid "codes.issue.countdown-expired"
+msgstr "EXPIRADO"


### PR DESCRIPTION

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adding Portuguese language translations.
* Small concern - ISO 639-1 doesn't differentiate between Brazilian and European Portuguese. I did Brazilian Portuguese, but I suspect there would be some differences in these phrases.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Added Portuguese translations.
```
