### PR TITLE
Keep uint as uint64 for observability

### DIFF
--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -68,7 +68,7 @@ func WithRealm(ctx context.Context, r *database.Realm) context.Context {
 	m := TemplateMapFromContext(ctx)
 	m["currentRealm"] = r
 	ctx = WithTemplateMap(ctx, m)
-	ctx = observability.WithRealmID(ctx, r.ID)
+	ctx = observability.WithRealmID(ctx, uint64(r.ID))
 
 	return context.WithValue(ctx, contextKeyRealm, r)
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -23,7 +23,6 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
-	"math/bits"
 	"os"
 	"strconv"
 	"strings"
@@ -287,40 +286,34 @@ func callbackIncrementMetric(ctx context.Context, m *stats.Int64Measure, table s
 		if ok && field.Field.CanInterface() && field.Field.Interface() != nil {
 			realmIDRaw := field.Field.Interface()
 
-			var realmID uint
+			var realmID uint64
 			switch t := realmIDRaw.(type) {
 			case uint:
-				realmID = t
+				realmID = uint64(t)
 			case uint8:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case uint16:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case uint32:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case uint64:
-				realmID = uint(t)
+				realmID = t
 			case int:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case int8:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case int16:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case int32:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case int64:
-				realmID = uint(t)
+				realmID = uint64(t)
 			case string:
-				raw, err := strconv.ParseUint(t, 10, 64)
-				if err != nil {
+				var err error
+				if realmID, err = strconv.ParseUint(t, 10, 64); err != nil {
 					_ = scope.Err(fmt.Errorf("failed to parse realm_id: %w", err))
 					return
 				}
-
-				if raw >= 1<<bits.UintSize-1 {
-					_ = scope.Err(fmt.Errorf("uint overflows %d bits", bits.UintSize))
-					return
-				}
-				realmID = uint(raw)
 			default:
 				_ = scope.Err(fmt.Errorf("realm_id is of unknown type %v", t))
 				return

--- a/pkg/observability/observability.go
+++ b/pkg/observability/observability.go
@@ -112,8 +112,8 @@ func APITagKeys() []tag.Key {
 
 // WithRealmID creates a new context with the realm id attached to the
 // observability context.
-func WithRealmID(octx context.Context, realmID uint) context.Context {
-	realmIDStr := strconv.FormatUint(uint64(realmID), 10)
+func WithRealmID(octx context.Context, realmID uint64) context.Context {
+	realmIDStr := strconv.FormatUint(realmID, 10)
 	ctx, err := tag.New(octx, tag.Upsert(RealmTagKey, realmIDStr))
 	if err != nil {
 		logger := logging.FromContext(octx).Named("observability.WithRealmID")


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fixes CodeQL isse: https://github.com/google/exposure-notifications-verification-server/security/code-scanning/8?query=ref%3Arefs%2Fheads%2Fmain
* Instead of converting a parsed uint64 to uint, just keep it around as uint64. No overflow logic needed