### PR TITLE
change SMS max length

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -203,7 +203,13 @@
       The SMS message will be constructed based on the template you provide. The overall
       length of of the SMS message should not exceed 160 characters, or your message will need to be split
       in transit and may not be joined correctly. There are some special strings that you can use
-      to substitute items.
+      to substitute items.<br/>
+      
+      If your choose to exceed 160 characters, your message will be broken up into
+      individual messages of 153 characters and reconstructed at the mobile device.  The user may be
+      charged for each individual message. The overall maximum length of an SMS Template is {{.maxSMSTemplate}}
+      characters before expansion.
+      <br/>
       {{if $realm.EnableENExpress}}
         Your SMS template <em>MUST</em> contain <code>[enslink]</code>.
         <ul>

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -452,6 +452,8 @@ func (c *Controller) renderSettings(
 	m["longCodeHours"] = longCodeHours
 	m["enxRedirectDomain"] = c.config.GetENXRedirectDomain()
 
+	m["maxSMSTemplate"] = database.SMSTemplateMaxLength
+
 	m["quotaLimit"] = quotaLimit
 	m["quotaRemaining"] = quotaRemaining
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1736,6 +1736,17 @@ func (db *Database) getMigrations(ctx context.Context) *gormigrate.Gormigrate {
 				return tx.Exec(sql).Error
 			},
 		},
+		{
+			ID: "00072-ChangeSMSTemplateType",
+			Migrate: func(tx *gorm.DB) error {
+				logger.Debugw("changing type of SMS Template text")
+				return tx.Exec("ALTER TABLE realms ALTER COLUMN sms_text_template TYPE text").Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				// No rollback for this, as there is no reason to do so.
+				return nil
+			},
+		},
 	})
 }
 


### PR DESCRIPTION
## Proposed Changes

* change SMS template to not be size constrained at the database
* up template max to 800 in software
* check expanded length

**Release Note**

```release-note
The SMS Template max size is being doubled from 400 to 800.
```
