### PR TITLE
Don't enable cloudidentity twice

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -45,7 +45,6 @@ resource "google_project_service" "services" {
     "binaryauthorization.googleapis.com",
     "cloudbuild.googleapis.com",
     "cloudidentity.googleapis.com",
-    "cloudidentity.googleapis.com",
     "cloudkms.googleapis.com",
     "cloudscheduler.googleapis.com",
     "compute.googleapis.com",


### PR DESCRIPTION
This was already in the list...

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
