### PR TITLE
Switch to older associated domain format

### DIFF
--- a/docs/link_handling.md
+++ b/docs/link_handling.md
@@ -48,15 +48,8 @@ Sample iOS universal link metadata
 	"applinks": {
 		"details": [
 			{
-				"appIDs": [
-					"com.google.test.application"
-				],
-				"components": [
-					{
-						"/": "/*",
-						"comment": "handle all urls"
-					}
-				]
+				"appID": "com.google.test.application",
+				"paths": ["*"]
 			}
 		]
 	}

--- a/pkg/controller/associated/ios.go
+++ b/pkg/controller/associated/ios.go
@@ -37,7 +37,7 @@ type Applinks struct {
 }
 
 type Detail struct {
-	AppId string   `json:"appID,omitempty"`
+	AppID string   `json:"appID,omitempty"`
 	Paths []string `json:"components,omitempty"`
 }
 
@@ -77,7 +77,7 @@ func (c *Controller) getIosData(region string) (*IOSData, error) {
 	details := make([]Detail, len(ids))
 	for i, id := range ids {
 		details[i] = Detail{
-			AppId: id,
+			AppID: id,
 			Paths: []string{"*"},
 		}
 	}

--- a/pkg/controller/associated/ios.go
+++ b/pkg/controller/associated/ios.go
@@ -37,15 +37,8 @@ type Applinks struct {
 }
 
 type Detail struct {
-	AppIds     []string    `json:"appIDs,omitempty"`
-	Components []Component `json:"components,omitempty"`
-}
-
-type Component struct {
-	Path    string `json:"/,omitempty"`
-	Param   string `json:"?,omitempty"`
-	Exclude *bool  `json:"exclude,omitempty"`
-	Comment string `json:"comment,omitempty"`
+	AppId string   `json:"appID,omitempty"`
+	Paths []string `json:"components,omitempty"`
 }
 
 type Appstrings struct {
@@ -81,14 +74,17 @@ func (c *Controller) getIosData(region string) (*IOSData, error) {
 		return nil, nil
 	}
 
+	details := make([]Detail, len(ids))
+	for i, id := range ids {
+		details[i] = Detail{
+			AppId: id,
+			Paths: []string{"*"},
+		}
+	}
+
 	return &IOSData{
 		Applinks: Applinks{
-			Details: []Detail{{
-				AppIds: ids,
-				Components: []Component{
-					{Path: "/*", Comment: "handle all urls"},
-				}},
-			},
+			Details: details,
 		},
 	}, nil
 }


### PR DESCRIPTION
Fixes #https://github.com/google/exposure-notifications-verification-server/issues/1299

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Use the older format for iOS Associated Domains
/hold to see if we can get confirmation from Apple on this (docs are confusing)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch to older Associated Domains format for iOS
```
