### PR TITLE
Support multiple from numbers for system SMS configs

### DIFF
--- a/cmd/server/assets/admin/sms/show.html
+++ b/cmd/server/assets/admin/sms/show.html
@@ -1,6 +1,7 @@
 {{define "admin/sms/show"}}
 
 {{$smsConfig := .smsConfig}}
+{{$smsFromNumbers := .smsFromNumbers}}
 
 <!doctype html>
 <html lang="en">
@@ -47,25 +48,113 @@
             </small>
           </div>
 
-          <div class="form-label-group">
-            <input type="tel" name="twilio_from_number" id="twilio-from-number" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioFromNumber"}} is-invalid{{end}}" autocomplete="new-password"
-              placeholder="Twilio number" {{if $smsConfig.TwilioFromNumber}}value="{{$smsConfig.TwilioFromNumber}}"{{end}} />
-            <label for="twilio-from-number">Twilio number</label>
-            {{template "errorable" $smsConfig.ErrorsFor "twilioFromNumber"}}
-            <small class="form-text text-muted">
-              This is the Twilio From Number. Get this value from the Twilio
-              console. If you plan on sending more than 100 codes per day, we
-              <strong>strongly recommend</strong> acquiring a toll free number
-              or SMS short code to reduce the chance that your message will be
-              flagged as spam.
-            </small>
+          <hr />
+
+          <p class="small form-text text-muted">
+            Below are the phone numbers from which messages can be sent.
+            Purchase these numbers using the Twilio console. After sharing the
+            system SMS configuration with a realm, they will be able to choose
+            from these phone numbers. We <strong>strongly recommend</strong>
+            acquiring a toll free number or SMS short code to reduce the chance
+            that messages will be flagged as spam.
+          </p>
+
+          <div id="twilio-from-number-template" class="d-none form-row">
+            <div class="col-sm-3">
+              <div class="form-label-group">
+                <input id="template-label" type="text" class="form-control" autocomplete="new-password" placeholder="Label" />
+                <label>Label</label>
+              </div>
+            </div>
+            <div class="col-sm-9 d-flex">
+              <div class="form-label-group w-100">
+                <input id="template-from-number" type="tel" class="form-control text-monospace" autocomplete="new-password" placeholder="Phone number" />
+                <label>From number</label>
+              </div>
+              <a href="#" class="d-inline text-secondary mt-2 ml-3">
+                <span class="oi oi-circle-x"></span>
+              </a>
+            </div>
           </div>
+
+          <div id="twilio-from-numbers-container" data-twilio-from-numbers="{{$smsFromNumbers | toJSON | toBase64}}">
+            <p class="text-center">Loading...</p>
+          </div>
+
+          <p>
+            <small>
+              <a href="#" id="add-phone-number">
+                &plus; Add phone number
+              </a>
+            </small>
+          </p>
 
           <button type="submit" class="btn btn-primary btn-block">Update system SMS config</button>
         </form>
       </div>
     </div>
   </main>
+
+  <script type="text/javascript">
+    $(function() {
+      let $container = $('#twilio-from-numbers-container');
+      let $template = $('#twilio-from-number-template');
+      let counter = 0;
+
+      function addRow(id, label, value) {
+        let $section = $template.clone();
+
+        if (id) {
+          $('<input>')
+            .attr('type', 'hidden')
+            .attr('id', `twilio-from-number-${counter}-id`)
+            .attr('name', `twilio_from_numbers.${counter}.id`)
+            .attr('value', id)
+            .appendTo($section);
+        }
+
+        $section.find('input#template-label')
+          .prop('required', true)
+          .attr('id', `twilio-from-number-${counter}-label`)
+          .attr('name', `twilio_from_numbers.${counter}.label`)
+          .attr('value', label);
+
+        $section.find('input#template-from-number')
+          .prop('required', true)
+          .attr('id', `twilio-from-number-${counter}-value`)
+          .attr('name', `twilio_from_numbers.${counter}.value`)
+          .attr('value', value);
+
+        $section.find('a').click(function(e) {
+          e.preventDefault();
+          $section.fadeOut(function() {
+            $section.remove();
+          })
+        });
+
+        $section.appendTo($container);
+        $section.removeClass('d-none');
+
+        // Increment counter for next one.
+        counter++;
+      }
+
+      $('#add-phone-number').click(function(e) {
+        e.preventDefault();
+        addRow(null, null, null);
+      });
+
+      // Load existing records.
+      $container.empty();
+      let existingRecords = $container.data('twilio-from-numbers');
+      if (existingRecords) {
+        let decoded = atob(existingRecords);
+        $.parseJSON(decoded).forEach(function(record) {
+          addRow(record.id, record.label, record.value);
+        });
+      }
+    });
+  </script>
 </body>
 </html>
 {{end}}

--- a/cmd/server/assets/realmadmin/_form_sms.html
+++ b/cmd/server/assets/realmadmin/_form_sms.html
@@ -2,6 +2,7 @@
 
 {{$realm := .realm}}
 {{$smsConfig := .smsConfig}}
+{{$smsFromNumbers := .smsFromNumbers}}
 {{$countries := .countries}}
 
 <p class="mb-4">
@@ -25,14 +26,14 @@
 
     <div class="form-group form-check">
       <input type="checkbox" name="use_system_sms_config" id="use-system-sms-config" class="form-check-input" value="1" {{if $realm.UseSystemSMSConfig}} checked{{end}}
-        data-toggle="collapse" data-target="#sms-form">
+        data-toggle="collapse" data-target=".sms-system-form">
       <label class="form-check-label" for="use-system-sms-config">
         Use system SMS configuration
       </label>
     </div>
   {{end}}
 
-  <div id="sms-form" class="collapse{{if not $realm.UseSystemSMSConfig}} show{{end}}">
+  <div class="sms-system-form collapse{{if not $realm.UseSystemSMSConfig}} show{{end}}">
     <div class="form-label-group">
       <input type="text" name="twilio_account_sid" id="twilio-account-sid" class="form-control text-monospace{{if $smsConfig.ErrorsFor "twilioAccountSid"}} is-invalid{{end}}"
         placeholder="Twilio account" {{if $smsConfig.TwilioAccountSid}}value="{{$smsConfig.TwilioAccountSid}}"{{end}} />
@@ -67,8 +68,34 @@
     </div>
   </div>
 
+  <div class="sms-system-form collapse{{if $realm.UseSystemSMSConfig}} show{{end}}">
+    <div class="form-label-group">
+      <select name="sms_from_number_id" id="sms-from-number-id" class="form-control custom-select {{if $realm.ErrorsFor "smsFromNumber"}}is-invalid{{end}}">
+        <option selected disabled>From number</option>
+        {{range $smsFromNumber := $smsFromNumbers}}
+          <option value="{{$smsFromNumber.ID}}" {{selectedIf (eq $realm.SMSFromNumberID $smsFromNumber.ID)}}>{{$smsFromNumber.Label}} &nbsp;&bull;&nbsp; {{$smsFromNumber.Value}}</option>
+        {{end}}
+      </select>
+      {{template "errorable" $realm.ErrorsFor "smsFromNumber"}}
+      <small class="form-text text-muted">
+        <p>
+          This is the phone number from which text messages will originate.
+          Since you are using the system SMS configuration, you must choose one
+          of these numbers. To request a new number, contact your system
+          administrator.
+        </p>
+        <p>
+          <strong>Warning!</strong> These phone numbers may be changed if they
+          are reported as spam or repeatedly failing to deliver. The phone
+          number will always correspond to your region, but do not rely on this
+          exact phone number.
+        </p>
+      </small>
+    </div>
+  </div>
+
   <div class="form-label-group">
-    <select name="sms_country" id="sms_country" class="form-control custom-select">
+    <select name="sms_country" id="sms-country" class="form-control custom-select">
       <option selected disabled>SMS country</option>
       {{range $name, $value := $countries}}
         <option value="{{$value}}"{{if eq $realm.SMSCountry $value}} selected{{end}}>{{$name}}</option>

--- a/pkg/controller/realmadmin/settings.go
+++ b/pkg/controller/realmadmin/settings.go
@@ -66,6 +66,7 @@ func (c *Controller) HandleSettings() http.Handler {
 		SMS                bool   `form:"sms"`
 		UseSystemSMSConfig bool   `form:"use_system_sms_config"`
 		SMSCountry         string `form:"sms_country"`
+		SMSFromNumberID    uint   `form:"sms_from_number_id"`
 		TwilioAccountSid   string `form:"twilio_account_sid"`
 		TwilioAuthToken    string `form:"twilio_auth_token"`
 		TwilioFromNumber   string `form:"twilio_from_number"`
@@ -170,6 +171,7 @@ func (c *Controller) HandleSettings() http.Handler {
 		if form.SMS {
 			realm.UseSystemSMSConfig = form.UseSystemSMSConfig
 			realm.SMSCountry = form.SMSCountry
+			realm.SMSFromNumberID = form.SMSFromNumberID
 		}
 
 		// Email
@@ -393,6 +395,13 @@ func (c *Controller) renderSettings(
 		}
 	}
 
+	// Look up the sms from numbers.
+	smsFromNumbers, err := c.db.SMSFromNumbers()
+	if err != nil {
+		controller.InternalError(w, r, c.h, err)
+		return
+	}
+
 	// Don't pass through the system config to the template - we don't want to
 	// risk accidentally rendering its ID or values since the realm should never
 	// see these values. However, we have to go lookup the actual SMS config
@@ -434,6 +443,7 @@ func (c *Controller) renderSettings(
 	m.Title("Realm settings")
 	m["realm"] = realm
 	m["smsConfig"] = smsConfig
+	m["smsFromNumbers"] = smsFromNumbers
 	m["emailConfig"] = emailConfig
 	m["countries"] = database.Countries
 	m["testTypes"] = map[string]database.TestType{

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -618,6 +618,22 @@ func float64Diff(old, new float64) string {
 	return stringDiff(strconv.FormatFloat(old, 'f', 4, 64), strconv.FormatFloat(new, 'f', 4, 64))
 }
 
+// uintValue gets the value of the uint pointer, returning 0 for nil.
+func uintValue(v *uint) uint {
+	if v == nil {
+		return 0
+	}
+	return *v
+}
+
+// uintPtr converts the uint value to a pointer, returning nil for 0.
+func uintPtr(v uint) *uint {
+	if v == 0 {
+		return nil
+	}
+	return &v
+}
+
 func uintDiff(old, new uint) string {
 	return stringDiff(strconv.FormatUint(uint64(old), 10), strconv.FormatUint(uint64(new), 10))
 }

--- a/pkg/database/sms_config.go
+++ b/pkg/database/sms_config.go
@@ -51,11 +51,15 @@ type SMSConfig struct {
 
 func (s *SMSConfig) BeforeSave(tx *gorm.DB) error {
 	// Twilio config is all or nothing
-	if (s.TwilioAccountSid != "" || s.TwilioAuthToken != "" || s.TwilioFromNumber != "") &&
-		(s.TwilioAccountSid == "" || s.TwilioAuthToken == "" || s.TwilioFromNumber == "") {
+	if (s.TwilioAccountSid != "" || s.TwilioAuthToken != "") &&
+		(s.TwilioAccountSid == "" || s.TwilioAuthToken == "") {
 		s.AddError("twilioAccountSid", "all must be specified or all must be blank")
 		s.AddError("twilioAuthToken", "all must be specified or all must be blank")
-		s.AddError("twilioFromNumber", "all must be specified or all must be blank")
+	}
+
+	if s.IsSystem {
+		// Do not persist from numbers for system configs
+		s.TwilioFromNumber = ""
 	}
 
 	if len(s.Errors()) > 0 {

--- a/pkg/database/sms_from_number.go
+++ b/pkg/database/sms_from_number.go
@@ -1,0 +1,111 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/jinzhu/gorm"
+)
+
+// SMSFromNumber represents a source number which can send SMS messages. The
+// table only contains the system SMS from numbers.
+type SMSFromNumber struct {
+	Errorable
+
+	ID    uint   `gorm:"primary_key;" json:"id,omitempty"`
+	Label string `gorm:"column:label;" json:"label"`
+	Value string `gorm:"column:value;" json:"value"`
+}
+
+func (s *SMSFromNumber) BeforeSave(tx *gorm.DB) error {
+	if s.Label == "" {
+		s.AddError("label", "cannot be blank")
+	}
+
+	if s.Value == "" {
+		s.AddError("value", "cannot be blank")
+	}
+
+	if len(s.Errors()) > 0 {
+		return fmt.Errorf("sms from number validation failed: %s", strings.Join(s.ErrorMessages(), ", "))
+	}
+	return nil
+}
+
+// SMSFromNumbers returns the list of SMS from numbers in the system.
+func (db *Database) SMSFromNumbers(scopes ...Scope) ([]*SMSFromNumber, error) {
+	var numbers []*SMSFromNumber
+
+	if err := db.db.
+		Model(&SMSFromNumber{}).
+		Scopes(scopes...).
+		Order("label ASC").
+		Find(&numbers).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return numbers, nil
+		}
+		return nil, err
+	}
+	return numbers, nil
+}
+
+// FindSMSFromNumber finds the given SMS from number by ID.
+func (db *Database) FindSMSFromNumber(id interface{}) (*SMSFromNumber, error) {
+	var number SMSFromNumber
+	if err := db.db.
+		Model(&SMSFromNumber{}).
+		Where("id = ?", id).
+		First(&number).
+		Error; err != nil {
+		return nil, err
+	}
+	return &number, nil
+}
+
+// CreateOrUpdateSMSFromNumbers takes the list of SMS numbers and creates new
+// records, updates existing records, and deletes records that are not present
+// in the list.
+func (db *Database) CreateOrUpdateSMSFromNumbers(numbers []*SMSFromNumber) error {
+	ids := make([]uint, 0, len(numbers))
+
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		for _, number := range numbers {
+			if number.ID == 0 {
+				if err := tx.Model(&SMSFromNumber{}).Create(number).Error; err != nil {
+					return fmt.Errorf("failed to create %s: %w", number.Label, err)
+				}
+			} else {
+				if err := tx.Model(&SMSFromNumber{}).Update(number).Error; err != nil {
+					return fmt.Errorf("failed to update %s: %w", number.Label, err)
+				}
+			}
+
+			ids = append(ids, number.ID)
+		}
+
+		del := tx.Unscoped()
+		if len(ids) > 0 {
+			del = del.Where("id NOT IN (?)", ids)
+		}
+		if err := del.Delete(&SMSFromNumber{}).Error; err != nil {
+			return fmt.Errorf("failed to delete old sms numbers: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/pkg/database/sms_from_number_test.go
+++ b/pkg/database/sms_from_number_test.go
@@ -1,0 +1,90 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestSMSFromNumber_BeforeSave(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	t.Run("label", func(t *testing.T) {
+		t.Parallel()
+
+		var n SMSFromNumber
+		n.Label = ""
+		_ = n.BeforeSave(db.RawDB())
+
+		errs := n.ErrorsFor("label")
+		if len(errs) < 1 {
+			t.Fatal("expected error")
+		}
+	})
+
+	t.Run("value", func(t *testing.T) {
+		t.Parallel()
+
+		var n SMSFromNumber
+		n.Value = ""
+		_ = n.BeforeSave(db.RawDB())
+
+		errs := n.ErrorsFor("value")
+		if len(errs) < 1 {
+			t.Fatal("expected error")
+		}
+	})
+}
+
+func TestSMSFromNumbers(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	if err := db.CreateOrUpdateSMSFromNumbers([]*SMSFromNumber{
+		{
+			Label: "zzz",
+			Value: "222-222-2222",
+		},
+		{
+			Label: "aaa",
+			Value: "111-111-1111",
+		},
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	smsFromNumbers, err := db.SMSFromNumbers()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var labels []string
+	var values []string
+	for _, v := range smsFromNumbers {
+		labels = append(labels, v.Label)
+		values = append(values, v.Value)
+	}
+
+	if got, want := labels, []string{"aaa", "zzz"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v to be %v", got, want)
+	}
+	if got, want := values, []string{"111-111-1111", "222-222-2222"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("expected %v to be %v", got, want)
+	}
+}

--- a/pkg/render/render.go
+++ b/pkg/render/render.go
@@ -18,6 +18,8 @@ package render
 import (
 	"bytes"
 	"context"
+	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	htmltemplate "html/template"
 	"os"
@@ -188,6 +190,8 @@ func templateFuncs() htmltemplate.FuncMap {
 		"stringContains":   strings.Contains,
 		"toLower":          strings.ToLower,
 		"toUpper":          strings.ToUpper,
+		"toJSON":           json.Marshal,
+		"toBase64":         base64.StdEncoding.EncodeToString,
 		"safeHTML":         safeHTML,
 		"selectedIf":       selectedIf,
 		"readonlyIf":       readonlyIf,

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -109,6 +109,21 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infow("created realm", "realm", realm2)
 
+	// Create some system sms from numbers
+	if err := db.CreateOrUpdateSMSFromNumbers([]*database.SMSFromNumber{
+		{
+			Label: "USA",
+			Value: "111-111-1111",
+		},
+		{
+			Label: "Mexico",
+			Value: "55-1234-5678",
+		},
+	}); err != nil {
+		return fmt.Errorf("failed to create sms from numbers: %w", err)
+	}
+	logger.Infow("created sms from numbers")
+
 	// Create users
 	user := &database.User{Email: "user@example.com", Name: "Demo User"}
 	if _, err := db.FindUserByEmail(user.Email); database.IsNotFound(err) {


### PR DESCRIPTION
This gives system administrators the ability to define a list of available SMS phone numbers. When the system SMS configuration is shared with a realm, the realm can choose the phone number from which they want to send messages.

Not pictured: the 6 hours I spent fighting gorm.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1291

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support multiple 'from' numbers for system SMS configs
```
