### PR TITLE
Return 400 on Twilio errors

### DIFF
--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -265,13 +265,13 @@ func (c *Controller) issue(ctx context.Context, request *api.IssueCodeRequest) (
 				}
 
 				logger.Errorw("failed to send sms", "error", err)
-				result.obsBlame = observability.BlameServer
+				result.obsBlame = observability.BlameClient
 				result.obsResult = observability.ResultError("FAILED_TO_SEND_SMS")
 				return err
 			}
 			return nil
 		}(); err != nil {
-			result.httpCode = http.StatusInternalServerError
+			result.httpCode = http.StatusBadRequest
 			result.errorReturn = api.Errorf("failed to send sms: %s", err)
 			return result, nil
 		}


### PR DESCRIPTION
These are nearly always client errors

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1310

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return 400 (instead of 500) on Twilio errors
```