### PR TITLE
Update alerts.tf

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -290,7 +290,7 @@ resource "google_monitoring_alert_policy" "fast_burn" {
 resource "google_monitoring_alert_policy" "slow_burn" {
   project      = var.verification-server-project
   display_name = "SlowErrorBudgetBurn"
-  combiner     = "OR"
+  combiner     = "AND"
   enabled      = "true"
   # create only if using GCLB, which means there's an SLO created
   count = var.https-forwarding-rule == "" ? 0 : 1


### PR DESCRIPTION
Fix SlowBurn alert trigger conditions to AND, so the alert will only fire when both 30 minutes and 6 hours alerts are firing.

