### PR TITLE
allow short code to be in ENX SMS messages / link still required

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -224,6 +224,8 @@
           </li>
           {{end}}
           <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+          <li><code>[code]</code>The 'short' verification code can be optionally included here in the event the link isn't clickable for the user. Typically this is not needed.</li>
+          <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units). Should be included if <code>[code]</code> is used</li>
         </ul>
 
         Here is an example SMS template using EN Express.

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -369,20 +369,14 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 		if strings.Contains(r.SMSTextTemplate, SMSRegion) {
 			r.AddError("SMSTextTemplate", fmt.Sprintf("cannot contain %q - this is automatically included in %q", SMSRegion, SMSENExpressLink))
 		}
-		if strings.Contains(r.SMSTextTemplate, SMSCode) {
-			r.AddError("SMSTextTemplate", fmt.Sprintf("cannot contain %q - the long code is automatically included in %q", SMSCode, SMSENExpressLink))
-		}
-		if strings.Contains(r.SMSTextTemplate, SMSExpires) {
-			r.AddError("SMSTextTemplate", fmt.Sprintf("cannot contain %q - only the %q is allowed for expiration", SMSExpires, SMSLongExpires))
-		}
 		if strings.Contains(r.SMSTextTemplate, SMSLongCode) {
 			r.AddError("SMSTextTemplate", fmt.Sprintf("cannot contain %q - the long code is automatically included in %q", SMSLongCode, SMSENExpressLink))
 		}
 
 	} else {
 		// Check that we have exactly one of [code] or [longcode] as template substitutions.
-		if c, lc := strings.Contains(r.SMSTextTemplate, "[code]"), strings.Contains(r.SMSTextTemplate, "[longcode]"); !(c || lc) || (c && lc) {
-			r.AddError("SMSTextTemplate", "must contain exactly one of [code] or [longcode]")
+		if c, lc := strings.Contains(r.SMSTextTemplate, SMSCode), strings.Contains(r.SMSTextTemplate, SMSLongCode); !(c || lc) || (c && lc) {
+			r.AddError("SMSTextTemplate", fmt.Sprintf("must contain exactly one of %q or %q", SMSCode, SMSLongCode))
 		}
 	}
 


### PR DESCRIPTION
Fixes #1323 
Contributes towards #1296 

## Proposed Changes

* Allow the short code and short expiration to appear in the ENX test message, still requires the long link though. This is a backup in case the link isn't clickable (improper universal link registration)

**Release Note**

```release-note
Allow short code to be in the ENX SMS message.
```
