### PR TITLE
Return a more detailed error when bulk issue is not enabled

### DIFF
--- a/pkg/controller/issueapi/issue_batch.go
+++ b/pkg/controller/issueapi/issue_batch.go
@@ -64,7 +64,9 @@ func (c *Controller) HandleBatchIssue() http.Handler {
 
 		// Add realm so that metrics are groupable on a per-realm basis.
 		if realm := controller.RealmFromContext(ctx); !realm.AllowBulkUpload {
-			controller.Unauthorized(w, r, c.h)
+			result.obsBlame = observability.BlameClient
+			result.obsResult = observability.ResultError("BULK_ISSUE_NOT_ENABLED")
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("bulk issuing is not enabled on this realm"))
 			return
 		}
 


### PR DESCRIPTION
This confused at least one developer...

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return a more detailed error when bulk issue is not enabled
```