### PR TITLE
Remove old /home route

### DIFF
--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -194,19 +194,6 @@ func Server(
 		}
 	}
 
-	// Redirect old /home path to /codes/issue. This route is no longer in use,
-	// but the redirect is preserved in case people have their browser open to the
-	// old page.
-	//
-	// TODO: remove in 0.18+.
-	{
-		sub := r.PathPrefix("/home").Subrouter()
-
-		sub.Handle("", http.RedirectHandler("/codes/issue", http.StatusPermanentRedirect)).Methods("GET")
-		sub.Handle("/", http.RedirectHandler("/codes/issue", http.StatusPermanentRedirect)).Methods("GET")
-		sub.Handle("/issue", http.RedirectHandler("/codes/issue", http.StatusPermanentRedirect)).Methods("POST")
-	}
-
 	// codes
 	{
 		sub := r.PathPrefix("/codes").Subrouter()


### PR DESCRIPTION
This route has been removed and a redirect for 2 major releases.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove old /home route
```
