### PR TITLE
Change rate calculating window of StackdriverExportFailed alert.

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -209,7 +209,7 @@ resource "google_monitoring_alert_policy" "StackdriverExportFailed" {
       query    = <<-EOT
       fetch
       cloud_run_revision::logging.googleapis.com/user/stackdriver_export_error_count
-      | align rate(1m)
+      | align rate(5m)
       | group_by [resource.service_name], [val: sum(value.stackdriver_export_error_count)]
       # Any export error for more than 5min should alert.
       | condition val > 0


### PR DESCRIPTION
The rate window should be larger than the interval of the errors.
Currently we export to stackdriver every 2min, meaning if the export is
constantly failing, our calculated error rate with 1min window will have
the rate oscillating between 0 and 1, and thus we would never get an
alert with our alerting duration (each time the value reaches 0 the
timer to trigger the alert is reset).

Changing this to 5min window means the condition is "on" as soon as
there's a single export error and last at least 5min. The alert is
firing if the condition is "on" for >15min.