### PR TITLE
Add test for ensuring migration numbers are up and to the right

### DIFF
--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -343,7 +343,7 @@ func runMigrations(db *Database) error {
 	}()
 
 	// Run migrations.
-	if err := db.RunMigrations(ctx); err != nil {
+	if err := db.MigrateTo(ctx, "", false); err != nil {
 		return fmt.Errorf("failed to migrate database: %v", err)
 	}
 

--- a/pkg/database/migrations_test.go
+++ b/pkg/database/migrations_test.go
@@ -1,0 +1,48 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"context"
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestMigrations_Incrementing(t *testing.T) {
+	t.Parallel()
+
+	ctx := context.Background()
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	lastID := int64(-1)
+	for _, v := range db.Migrations(ctx) {
+		parts := strings.SplitN(v.ID, "-", 2)
+		if len(parts) < 2 {
+			t.Fatalf("bad id: %v", v.ID)
+		}
+
+		idStr := parts[0]
+		id, err := strconv.ParseInt(idStr, 10, 64)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if id <= lastID {
+			t.Errorf("%s: %d is not greater than %d", v.ID, id, lastID)
+		}
+		lastID = id
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1343

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add test for ensuring database migration numbers are strictly increasing
```
