### PR TITLE
Add availability SLO alerts on all Cloud Run services.

### DIFF
--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -12,6 +12,43 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  default_slo_thresholds = {
+    adminapi = {
+      availability = 0.995
+      latency      = 0
+    }
+    apiserver = {
+      availability = 0.995
+      latency      = 0
+    }
+    appsync = {
+      availability = 0.995
+      latency      = 0
+    }
+    cleanup = {
+      availability = 0.995
+      latency      = 0
+    }
+    e2e-runner = {
+      availability = 0.995
+      latency      = 0
+    }
+    enx-redirect = {
+      availability = 0.995
+      latency      = 0
+    }
+    modeler = {
+      availability = 0.995
+      latency      = 0
+    }
+    server = {
+      availability = 0.995
+      latency      = 0
+    }
+  }
+}
+
 resource "google_monitoring_custom_service" "verification-server" {
   service_id   = "verification-server"
   display_name = "Verification Server"
@@ -27,7 +64,7 @@ module "availability-slos" {
   notification-channels       = google_monitoring_notification_channel.channels
   verification-server-project = var.verification-server-project
 
-  for_each = var.slo_thresholds
+  for_each = merge(local.default_slo_thresholds, var.slo_thresholds_overrides)
 
   service-name = each.key
   goal         = each.value.availability

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -57,14 +57,9 @@ variable "alert-notification-channels" {
   description = "Notification channels"
 }
 
-variable "slo_thresholds" {
-  type = map(any)
-  default = {
-    adminapi = {
-      availability = 0.995
-      latency      = 0
-    }
-  }
+variable "slo_thresholds_overrides" {
+  type    = map(any)
+  default = {}
 }
 
 


### PR DESCRIPTION
SLO thresholds can be overriden using var.slo_thresholds_overrides

```release-note
Monitoring: Add Availability SLO alert to all Cloud Run services.
```
