### PR TITLE
Allow the issuer to select an SMS template

### DIFF
--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -249,6 +249,7 @@
     let $form;
       let $inputTestDate;
       let $inputSymptomDate;
+      let $inputSMSTemplate;
       let $inputPhone;
       let $buttonSubmit;
       let $buttonReset;
@@ -271,6 +272,7 @@
       $form = $('form#issue');
         $inputTestDate = $('input#test-date');
         $inputSymptomDate = $('input#symptom-date');
+        $inputSMSTemplate = $('select#sms-template');
         $inputPhone = $('input#phone');
         $buttonSubmit = $('button#submit');
         $buttonReset = $('button#reset');
@@ -322,6 +324,7 @@
         data.tzOffset = new Date().getTimezoneOffset();
 
         {{if $hasSMSConfig}}
+        data['SMSTemplateLabel'] = $inputSMSTemplate.val();
         data['phone'] = iti.getNumber();
         {{end}}
 

--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -128,7 +128,7 @@
               <label for="sms-template" class="col-sm-6 col-md-4 col-lg-3">{{t $.locale "codes.issue.sms-template-label"}}</label>
               <div class="col-sm-6 col-md-8 col-lg-9">
                 <div class="input-group">
-                  <select class="form-control" name="sms-template">
+                  <select class="form-control" id="sms-template">
                     <option value="Default SMS template">Default SMS template</option>
                     {{range $k, $v := $currentRealm.SMSTextAlternateTemplates}}
                     <option value="{{$k}}">{{$k}}</option>

--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -324,7 +324,7 @@
         data.tzOffset = new Date().getTimezoneOffset();
 
         {{if $hasSMSConfig}}
-        data['SMSTemplateLabel'] = $inputSMSTemplate.val();
+        data['smsTemplateLabel'] = $inputSMSTemplate.val();
         data['phone'] = iti.getNumber();
         {{end}}
 

--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -123,8 +123,26 @@
         <div class="card mb-3 shadow-sm">
           <div class="card-header">{{t $.locale "codes.issue.sms-text-message-header"}}</div>
           <div class="card-body">
+            {{if $currentRealm.SMSTextAlternateTemplates}}
             <div class="row form-group">
-              <label for="symptomDate" class="col-sm-6 col-md-4 col-lg-3">{{t $.locale "codes.issue.sms-text-message-label"}}</label>
+              <label for="sms-template" class="col-sm-6 col-md-4 col-lg-3">{{t $.locale "codes.issue.sms-template-label"}}</label>
+              <div class="col-sm-6 col-md-8 col-lg-9">
+                <div class="input-group">
+                  <select class="form-control" name="sms-template">
+                    <option value="Default SMS template">Default SMS template</option>
+                    {{range $k, $v := $currentRealm.SMSTextAlternateTemplates}}
+                    <option value="{{$k}}">{{$k}}</option>
+                    {{end}}
+                  </select>
+                </div>
+                <small class="form-text text-muted">
+                  {{t $.locale "codes.issue.sms-template-detail"}}
+                </small>
+              </div>
+            </div>
+            {{end}}
+            <div class="row form-group">
+              <label for="phone" class="col-sm-6 col-md-4 col-lg-3">{{t $.locale "codes.issue.sms-text-message-label"}}</label>
               <div class="col-sm-6 col-md-8 col-lg-9">
                 <div class="input-group">
                   <input type="tel" id="phone" name="phone" class="form-control" autocomplete="off" class="w-100" />

--- a/docs/api.md
+++ b/docs/api.md
@@ -190,6 +190,7 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
   "testType": "<valid test type>",
   "tzOffset": 0,
   "phone": "+CC Phone number",
+  "SMSTemplateLabel": "my sms template",
   "padding": "<bytes>",
   "uuid": "string UUID",
   "externalIssuerID": "external-ID",
@@ -207,6 +208,10 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
 * `phone`
   * Phone number to send the SMS to. If a phone number is provided, but the SMS text
     message fails to send, the API will return a 4xx client error.
+* `SMSTemplateLabel`
+  * If the realm has more than one SMS template defined, this may be optionally specify
+    the label of the message template which the server should compose. If omitted, the
+    default template will be used.
 * `padding` is a _recommended_ field that obfuscates the size of the request
   body to a network observer. The client should generate and insert a random
   number of base64-encoded bytes into this field. The server does not process

--- a/docs/api.md
+++ b/docs/api.md
@@ -190,7 +190,7 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
   "testType": "<valid test type>",
   "tzOffset": 0,
   "phone": "+CC Phone number",
-  "SMSTemplateLabel": "my sms template",
+  "smsTemplateLabel": "my sms template",
   "padding": "<bytes>",
   "uuid": "string UUID",
   "externalIssuerID": "external-ID",
@@ -208,7 +208,7 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
 * `phone`
   * Phone number to send the SMS to. If a phone number is provided, but the SMS text
     message fails to send, the API will return a 4xx client error.
-* `SMSTemplateLabel`
+* `smsTemplateLabel`
   * If the realm has more than one SMS template defined, this may be optionally specify
     the label of the message template which the server should compose. If omitted, the
     default template will be used.

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -102,6 +102,12 @@ msgstr "SMS Textnachricht (empfohlen)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Patienten Telefonnummer"
 
+msgid "codes.issue.sms-template-label"
+msgstr "SMS Vorlage"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "Der Patient erhält eine SMS mit der ausgewählten Nachrichtenvorlage."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "Das System sendet dem Patienten eine Textnachricht mit dem Verifizierungscode. Die eingetragene Telefonnummer muss Textnachrichten erhalten können."
 

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -102,6 +102,12 @@ msgstr "SMS text message (recommended)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Patient phone number"
 
+msgid "codes.issue.sms-template-label"
+msgstr "SMS template"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "The patient will receive an SMS with the selected message template."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "If provided, the system will send a text message containing the code to the patient. This must be a phone number capable of receiving SMS text messages."
 

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -102,6 +102,12 @@ msgstr "Mensaje de texto SMS (recomendado)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Número telefónico del paciente"
 
+msgid "codes.issue.sms-template-label"
+msgstr "Plantilla de SMS"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "El paciente recibirá un SMS con la plantilla de mensaje seleccionada."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "El sistema enviará un mensaje de texto conteniendo el código al paciente a este número, si es provisto. El telefóno deberá ser capaz de recibir mensajes de texto SMS."
 

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -102,6 +102,12 @@ msgstr "Message SMS (recommandé)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Numéro de téléphone du patient"
 
+msgid "codes.issue.sms-template-label"
+msgstr "Modèle de SMS"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "Le patient recevra un SMS avec le modèle de message sélectionné."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "S'il est fourni, le système enverra au patient par SMS un message textuel contenant le code. Ce numéro doit être capabe de recevoir des messages SMS."
 

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -102,6 +102,12 @@ msgstr "Messaggio di testo SMS (consigliato)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Numero di telefono del paziente"
 
+msgid "codes.issue.sms-template-label"
+msgstr "Modello SMS"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "Il paziente riceverà un SMS con il modello di messaggio selezionato."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "Se fornito, il sistema inviera' un messaggio di testo con il codice al paziente. Il telefono deve essere in grado di ricevere messaggi di testo SMS."
 

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -102,6 +102,12 @@ msgstr "SMSテキストメッセージ(推奨)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "患者の電話番号"
 
+msgid "codes.issue.sms-template-label"
+msgstr "SMSテンプレート"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "患者は、選択したメッセージテンプレートを含むSMSを受信します"
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "電話番号が提供されれば、システムは患者にコードを記述したテキストメッセージを送信します。SMSテキストメッセージを受信できる電話番号が必要です。"
 

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -102,6 +102,12 @@ msgstr "Mensagem de texto SMS (recomendado)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Número de telefone do paciente"
 
+msgid "codes.issue.sms-template-label"
+msgstr "Modelo de SMS"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "O paciente receberá um SMS com o modelo de mensagem selecionado."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "Se for providenciado, o sistema enviará uma mensagem de texto contendo o código ao paciente. O número precisa estar habilitado para receber mensagens de texto SMS."
 

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -102,6 +102,12 @@ msgstr "SMS kısa mesaj (önerilen)"
 msgid "codes.issue.sms-text-message-label"
 msgstr "Hastanın telefon numarası"
 
+msgid "codes.issue.sms-template-label"
+msgstr "SMS şablonu"
+
+msgid "codes.issue.sms-template-detail"
+msgstr "Hasta, seçilen mesaj şablonunu içeren bir SMS alacaktır."
+
 msgid "codes.issue.sms-text-message-detail"
 msgstr "Bu alan doldurulursa, sistem üretilen kodu hastaya kısa mesaj (SMS) olarak atacaktır. O yüzden bu numara SMS alabilen bir numara olmalıdır."
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -188,7 +188,7 @@ type IssueCodeRequest struct {
 	// (using the default of 0) are all valid. 0 is considered to be UTC.
 	TZOffset         float32 `json:"tzOffset"`
 	Phone            string  `json:"phone"`
-	SMSTemplateLabel string  `json:"SMSTemplateLabel"`
+	SMSTemplateLabel string  `json:"smsTemplateLabel"`
 
 	// Optional: UUID is a handle which allows the issuer to track status
 	// of the issued verification code. If omitted the server will generate the UUID.

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -186,8 +186,9 @@ type IssueCodeRequest struct {
 	TestType    string `json:"testType"`
 	// Offset in minutes of the user's timezone. Positive, negative, 0, or omitted
 	// (using the default of 0) are all valid. 0 is considered to be UTC.
-	TZOffset float32 `json:"tzOffset"`
-	Phone    string  `json:"phone"`
+	TZOffset         float32 `json:"tzOffset"`
+	Phone            string  `json:"phone"`
+	SMSTemplateLabel string  `json:"SMSTemplateLabel"`
 
 	// Optional: UUID is a handle which allows the issuer to track status
 	// of the issued verification code. If omitted the server will generate the UUID.

--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -262,7 +262,7 @@ func (c *Controller) issue(ctx context.Context, authApp *database.AuthorizedApp,
 
 			message, err := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
 			if err != nil {
-				logger.Errorw("failed to compose SMS", "error", err)
+				logger.Warnw("failed to compose SMS", "error", err)
 				return err
 			}
 

--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -262,7 +262,6 @@ func (c *Controller) issue(ctx context.Context, authApp *database.AuthorizedApp,
 
 			message, err := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
 			if err != nil {
-				logger.Warnw("failed to compose SMS", "error", err)
 				return err
 			}
 

--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -260,7 +260,11 @@ func (c *Controller) issue(ctx context.Context, authApp *database.AuthorizedApp,
 		if err := func() error {
 			defer observability.RecordLatency(ctx, time.Now(), mSMSLatencyMs, &result.obsBlame, &result.obsResult)
 
-			message := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+			message, err := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+			if err != nil {
+				logger.Errorw("failed to compose SMS", "error", err)
+				return err
+			}
 
 			if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
 				// Delete the token

--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -260,7 +260,7 @@ func (c *Controller) issue(ctx context.Context, authApp *database.AuthorizedApp,
 		if err := func() error {
 			defer observability.RecordLatency(ctx, time.Now(), mSMSLatencyMs, &result.obsBlame, &result.obsResult)
 
-			message := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain())
+			message := realm.BuildSMSText(code, longCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
 
 			if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
 				// Delete the token

--- a/pkg/controller/middleware/csrf.go
+++ b/pkg/controller/middleware/csrf.go
@@ -56,7 +56,7 @@ func ConfigureCSRF(ctx context.Context, config *config.ServerConfig, h render.Re
 	}
 }
 
-// handleCSRFError is an http.HandlerFunc that can be installed inthe gorilla csrf
+// handleCSRFError is an http.HandlerFunc that can be installed in the gorilla csrf
 // protect middleware. It will respond w/ a JSON object containing error: on API
 // requests and a signout redirect to other requests.
 func handleCSRFError(ctx context.Context, h render.Renderer) http.Handler {

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -34,14 +34,20 @@ func TestSMS(t *testing.T) {
 	realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
 	realm.RegionCode = "US-WA"
 
-	got, _ := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express", "")
+	got, err := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express", "")
+	if err != nil {
+		t.Fatalf("failed to buildSMS, %v", err)
+	}
 	want := "This is your Exposure Notifications Verification code: https://us-wa.en.express/v?c=abcdefgh12345678 Expires in 24 hours"
 	if got != want {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 
 	realm.SMSTextTemplate = "State of Wonder, COVID-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
-	got, _ = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "", "")
+	got, err = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "", "")
+	if err != nil {
+		t.Fatalf("failed to buildSMS, %v", err)
+	}
 	want = "State of Wonder, COVID-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
 	if got != want {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -34,14 +34,14 @@ func TestSMS(t *testing.T) {
 	realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
 	realm.RegionCode = "US-WA"
 
-	got := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express")
+	got, _ := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express", "")
 	want := "This is your Exposure Notifications Verification code: https://us-wa.en.express/v?c=abcdefgh12345678 Expires in 24 hours"
 	if got != want {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 
 	realm.SMSTextTemplate = "State of Wonder, COVID-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
-	got = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "")
+	got, _ = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "", "")
 	want = "State of Wonder, COVID-19 Exposure Verification code 654321. Expires in 15 minutes. Act now!"
 	if got != want {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1320

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If more than one SMS template is defined, allow the user to pick one
* Add a field to the issue API and compose with the given template

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow user to select an SMS template on code-issue. Add template label field to issueAPI.
```
