### PR TITLE
Properly redirect to login when required

### DIFF
--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -114,6 +114,7 @@ func RedirectToLogout(w http.ResponseWriter, r *http.Request, h render.Renderer)
 	}
 
 	Unauthorized(w, r, h)
+	return
 }
 
 // Unauthorized returns an error indicating the request was unauthorized. The

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -103,6 +103,19 @@ func NotFound(w http.ResponseWriter, r *http.Request, h render.Renderer) {
 	}
 }
 
+// RedirectToLogout redirects the user to the logout page to terminate the session.
+func RedirectToLogout(w http.ResponseWriter, r *http.Request, h render.Renderer) {
+	accept := strings.Split(r.Header.Get("Accept"), ",")
+	accept = append(accept, strings.Split(r.Header.Get("Content-Type"), ",")...)
+
+	if prefixInList(accept, ContentTypeHTML) {
+		http.Redirect(w, r, "/signout", http.StatusSeeOther)
+		return
+	}
+
+	Unauthorized(w, r, h)
+}
+
 // Unauthorized returns an error indicating the request was unauthorized. The
 // system always returns 401 (even with authentication is provided but
 // authorization fails).

--- a/pkg/controller/flash/flash.go
+++ b/pkg/controller/flash/flash.go
@@ -85,6 +85,13 @@ func (f *Flash) Clear() {
 	delete(f.values, flashKeyWarning)
 }
 
+// Clone makes a copy of this flash data into the new target.
+func (f *Flash) Clone(values map[interface{}]interface{}) {
+	for k, v := range f.values {
+		values[k] = v
+	}
+}
+
 // add inserts the message into the upcoming flash for the given key.
 func (f *Flash) add(key flashKey, msg string, vars ...interface{}) {
 	var data []string

--- a/pkg/controller/login/signout.go
+++ b/pkg/controller/login/signout.go
@@ -35,6 +35,7 @@ func (c *Controller) HandleSignOut() http.Handler {
 			controller.MissingSession(w, r, c.h)
 			return
 		}
+		flash := controller.Flash(session)
 
 		// If a user is currently logged in, update their last revoked check time.
 		email, err := c.authProvider.EmailAddress(ctx, session)
@@ -65,9 +66,9 @@ func (c *Controller) HandleSignOut() http.Handler {
 			logger.Debugw("failed to revoke session", "error", err)
 		}
 
-		// Set MaxAge to -1 to expire the session.
-		session.Options.MaxAge = -1
-		controller.ClearMFAPrompted(session)
+		// Clear all session data, but copy over flashes.
+		session.Values = make(map[interface{}]interface{})
+		flash.Clone(session.Values)
 
 		m := controller.TemplateMapFromContext(ctx)
 		m.Title("Logging out...")


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1341

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Properly redirect to login page after session expiration. Previously the user would get an "Unauthorized" page.
```
