### PR TITLE
fix realm from firewall for apikeys

### DIFF
--- a/pkg/controller/middleware/firewall.go
+++ b/pkg/controller/middleware/firewall.go
@@ -37,12 +37,15 @@ func ProcessFirewall(h render.Renderer, typ string) mux.MiddlewareFunc {
 
 			logger := logging.FromContext(ctx).Named("middleware.ProcessFirewall")
 
-			membership := controller.MembershipFromContext(ctx)
-			if membership == nil {
-				controller.MissingMembership(w, r, h)
-				return
+			currentRealm := controller.RealmFromContext(ctx)
+			if currentRealm == nil {
+				membership := controller.MembershipFromContext(ctx)
+				if membership == nil {
+					controller.MissingMembership(w, r, h)
+					return
+				}
+				currentRealm = membership.Realm
 			}
-			currentRealm := membership.Realm
 
 			var allowedCIDRs []string
 			switch typ {


### PR DESCRIPTION

## Proposed Changes

* load realm correctly when using apikeys in the firewall module

**Release Note**

```release-note
NONE
```
