### PR TITLE
Redirect back if bulk upload is not enabled

### DIFF
--- a/pkg/controller/codes/bulk_issue.go
+++ b/pkg/controller/codes/bulk_issue.go
@@ -26,6 +26,13 @@ func (c *Controller) HandleBulkIssue() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
 		membership := controller.MembershipFromContext(ctx)
 		if membership == nil {
 			controller.MissingMembership(w, r, c.h)
@@ -39,7 +46,8 @@ func (c *Controller) HandleBulkIssue() http.Handler {
 		currentRealm := membership.Realm
 
 		if !currentRealm.AllowBulkUpload {
-			controller.Unauthorized(w, r, c.h)
+			flash.Error("That feature is not enabled for your realm!")
+			controller.Back(w, r, c.h)
 			return
 		}
 

--- a/pkg/controller/codes/bulk_issue_test.go
+++ b/pkg/controller/codes/bulk_issue_test.go
@@ -17,6 +17,7 @@ package codes_test
 import (
 	"context"
 	"net/http"
+	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/project"
@@ -68,6 +69,8 @@ func TestRenderBulkIssue(t *testing.T) {
 	r := &http.Request{}
 	r = r.WithContext(ctx)
 
+	w := httptest.NewRecorder()
+
 	handleFunc := c.HandleBulkIssue()
-	handleFunc.ServeHTTP(nil, r)
+	handleFunc.ServeHTTP(w, r)
 }


### PR DESCRIPTION
This is better than unauthorized since it probably means the user just picked the wrong realm from selection (or bookmarked the page).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @whaught 