### PR TITLE
Document error codes table for IssueResponse

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -107,19 +107,16 @@ Exchange a verification code for a long term verification token.
 
 Possible error code responses. New error codes may be added in future releases.
 
-| ErrorCode               | HTTP Status | Retry | Meaning                                                                                                         |
-| ----------------------- | ----------- | ----- | --------------------------------------------------------------------------------------------------------------- |
-| `unparsable_request`    | 400         | No    | Client sent an request the sever cannot parse                                                                   |
-| `code_invalid`          | 400         | No    | Code invalid or used, user may need to obtain a new code.                                                       |
-| `code_expired`          | 400         | No    | Code has expired, user may need to obtain a new code.                                                           |
-| `code_not_found`        | 400         | No    | The server has no record of that code.                                                                          |
-| `invalid_test_type`     | 400         | No    | The client sent an accept of an unrecognized test type                                                          |
-| `missing_date`          | 400         | No    | The realm requires either a test or symptom date, but none was provided.                                        |
-| `uuid_already_exists`   | 409         | No    | The UUID has already been used for an issued code                                                               |
-| `maintenance_mode   `   | 429         | Yes   | The server is temporarily down for maintenance. Wait and retry later.                                           |
-| `quota_exceeded`        | 429         | Yes   | The realm has run out of its daily quota allocation for issuing codes. Wait and retry later.                    |
-| `unsupported_test_type` | 412         | No    | The code may be valid, but represents a test type the client cannot process. User may need to upgrade software. |
-|                         | 500         | Yes   | Internal processing error, may be successful on retry.                                                          |
+| ErrorCode             | HTTP Status | Retry | Meaning                                                                                      |
+| --------------------- | ----------- | ----- | -------------------------------------------------------------------------------------------- |
+| `unparsable_request`  | 400         | No    | Client sent an request the sever cannot parse                                                |
+| `code_invalid`        | 400         | No    | Code invalid or used, user may need to obtain a new code.                                    |
+| `code_expired`        | 400         | No    | Code has expired, user may need to obtain a new code.                                        |
+| `code_not_found`      | 400         | No    | The server has no record of that code.                                                       |
+| `invalid_test_type`   | 400         | No    | The client sent an accept of an unrecognized test type                                       |
+| `maintenance_mode   ` | 429         | Yes   | The server is temporarily down for maintenance. Wait and retry later.                        |
+| `quota_exceeded`      | 429         | Yes   | The realm has run out of its daily quota allocation for issuing codes. Wait and retry later. |
+|                       | 500         | Yes   | Internal processing error, may be successful on retry.                                       |
 
 ## `/api/certificate`
 
@@ -260,6 +257,20 @@ Request a verification code to be issued. Accepts [optional] symptom date and te
   network observer. The server _may_ generate and insert a random number of
   base64-encoded bytes into this field. The client should not process the
   padding.
+
+Possible error code responses. New error codes may be added in future releases.
+
+| ErrorCode               | HTTP Status | Retry | Meaning                                                                                                         |
+| ----------------------- | ----------- | ----- | --------------------------------------------------------------------------------------------------------------- |
+| `unparsable_request`    | 400         | No    | Client sent an request the sever cannot parse                                                                   |
+| `invalid_test_type`     | 400         | No    | The client sent an accept of an unrecognized test type                                                          |
+| `missing_date`          | 400         | No    | The realm requires either a test or symptom date, but none was provided.                                        |
+| `invalid_test_type`     | 400         | No    | The test type is not a valid test type (a string that is unknown to the server).                                |
+| `uuid_already_exists`   | 409         | No    | The UUID has already been used for an issued code                                                               |
+| `maintenance_mode   `   | 429         | Yes   | The server is temporarily down for maintenance. Wait and retry later.                                           |
+| `quota_exceeded`        | 429         | Yes   | The realm has run out of its daily quota allocation for issuing codes. Wait and retry later.                    |
+| `unsupported_test_type` | 412         | No    | The code may be valid, but represents a test type the client cannot process. User may need to upgrade software. |
+|                         | 500         | Yes   | Internal processing error, may be successful on retry.                                                          |
 
 ## `/api/batch-issue`
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This shows the possible error codes for Issue. Many of them are shared with Verify, but they are slightly different
    * We could dedup with a 'common error codes' table and then specific ones, but I suspect that would be confusing to readers who probably scroll to the specific API they are integrating.   

