### PR TITLE
Clearer outer error message for batch API

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -291,7 +291,7 @@ This API is *not atomic* and does not follow the [typical guidelines for a batch
 messages.
 
 The server attempts to issue every code in the batch. If errors are encountered, each item in `codes` will contain the error details for
-the corresponding code. The overall request will get the error status code and message of the first seen error, although some codes may have
+the corresponding code. The overall request will get the error status code of the first seen error, although some codes may have
 succeeded.
 
 eg.


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1350

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Switch the outer error message of the batch-issue API to describe success/fail and how to view individual errors
    * Should be clearer and guide developers to not trust the outer message and dive into individual failures. Especially if they don't see the docs.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Clearer outer error message for batch issue API
```
