### PR TITLE
Extract adminapi and apiserver routes into internal/

### DIFF
--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -62,8 +62,10 @@
             {{range $name, $permission := $permissions}}
               <li class="small">
                 {{if $userMembership.Can $permission}}
+                  <span class="sr-only">{{$user.Name}} can {{$name}}</span>
                   <span class="oi oi-circle-check text-success mr-1" aria-hidden="true"></span>
                 {{else}}
+                  <span class="sr-only">{{$user.Name}} cannot {{$name}}</span>
                   <span class="oi oi-circle-x text-muted mr-1" aria-hidden="true"></span>
                 {{end}}
                 {{$name}}

--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -1,0 +1,115 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit/limitware"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/sethvargo/go-limiter"
+
+	"github.com/gorilla/mux"
+)
+
+// AdminAPI defines routes for the adminapi service.
+func AdminAPI(
+	ctx context.Context,
+	cfg *config.AdminAPIServerConfig,
+	db *database.Database,
+	cacher cache.Cacher,
+	limiterStore limiter.Store,
+) (http.Handler, error) {
+	// Create the router
+	r := mux.NewRouter()
+
+	// Common observability context
+	ctx, obs := middleware.WithObservability(ctx)
+	r.Use(obs)
+
+	// Create the renderer
+	h, err := render.New(ctx, "", cfg.DevMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create renderer: %w", err)
+	}
+
+	// Request ID injection
+	populateRequestID := middleware.PopulateRequestID(h)
+	r.Use(populateRequestID)
+
+	// Logger injection.
+	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
+	r.Use(populateLogger)
+
+	httplimiter, err := limitware.NewMiddleware(ctx, limiterStore,
+		limitware.APIKeyFunc(ctx, db, "adminapi:ratelimit:", cfg.RateLimit.HMACKey),
+		limitware.AllowOnError(false))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create limiter middleware: %w", err)
+	}
+	rateLimit := httplimiter.Handle
+
+	// Install common security headers
+	r.Use(middleware.SecureHeaders(cfg.DevMode, "json"))
+
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug()
+	r.Use(processDebug)
+
+	// Install the rate limiting first. In this case, we want to limit by key
+	// first to reduce the chance of a database lookup.
+	r.Use(rateLimit)
+
+	// Other common middlewares
+	requireAPIKey := middleware.RequireAPIKey(cacher, db, h, []database.APIKeyType{
+		database.APIKeyTypeAdmin,
+	})
+	processFirewall := middleware.ProcessFirewall(h, "adminapi")
+
+	// Health route
+	r.Handle("/health", controller.HandleHealthz(ctx, &cfg.Database, h)).Methods("GET")
+
+	// API routes
+	{
+		sub := r.PathPrefix("/api").Subrouter()
+		sub.Use(requireAPIKey)
+		sub.Use(processFirewall)
+
+		issueapiController := issueapi.New(ctx, cfg, db, limiterStore, h)
+		sub.Handle("/issue", issueapiController.HandleIssue()).Methods("POST")
+		sub.Handle("/batch-issue", issueapiController.HandleBatchIssue()).Methods("POST")
+
+		codesController := codes.NewAPI(ctx, cfg, db, h)
+		sub.Handle("/checkcodestatus", codesController.HandleCheckCodeStatus()).Methods("POST")
+		sub.Handle("/expirecode", codesController.HandleExpireAPI()).Methods("POST")
+	}
+
+	// Wrap the main router in the mutating middleware method. This cannot be
+	// inserted as middleware because gorilla processes the method before
+	// middleware.
+	mux := http.NewServeMux()
+	mux.Handle("/", middleware.MutateMethod()(r))
+	return mux, nil
+}

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -1,0 +1,161 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package routes
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/keys"
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/certapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/verifyapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit/limitware"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/mikehelmick/go-chaff"
+	"github.com/sethvargo/go-limiter"
+
+	"github.com/gorilla/mux"
+)
+
+// APIServer defines routes for the apiserver service.
+func APIServer(
+	ctx context.Context,
+	cfg *config.APIServerConfig,
+	db *database.Database,
+	cacher cache.Cacher,
+	limiterStore limiter.Store,
+	tokenSigner keys.KeyManager,
+	certificateSigner keys.KeyManager,
+) (http.Handler, error) {
+	// Create the router
+	r := mux.NewRouter()
+
+	// Common observability context
+	ctx, obs := middleware.WithObservability(ctx)
+	r.Use(obs)
+
+	// Create the renderer
+	h, err := render.New(ctx, "", cfg.DevMode)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create renderer: %w", err)
+	}
+
+	// Request ID injection
+	populateRequestID := middleware.PopulateRequestID(h)
+	r.Use(populateRequestID)
+
+	// Logger injection.
+	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
+	r.Use(populateLogger)
+
+	// Note that rate limiting is installed _after_ the chaff middleware because
+	// we do not want chaff requests to count towards rate-limiting quota.
+	httplimiter, err := limitware.NewMiddleware(ctx, limiterStore,
+		limitware.APIKeyFunc(ctx, db, "apiserver:ratelimit:", cfg.RateLimit.HMACKey),
+		limitware.AllowOnError(false))
+	if err != nil {
+		return nil, fmt.Errorf("failed to create limiter middleware: %w", err)
+	}
+	rateLimit := httplimiter.Handle
+
+	// Install common security headers
+	r.Use(middleware.SecureHeaders(cfg.DevMode, "json"))
+
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug()
+	r.Use(processDebug)
+
+	// Other common middlewares
+	requireAPIKey := middleware.RequireAPIKey(cacher, db, h, []database.APIKeyType{
+		database.APIKeyTypeDevice,
+	})
+	processFirewall := middleware.ProcessFirewall(h, "apiserver")
+
+	// Health route
+	r.Handle("/health", controller.HandleHealthz(ctx, &cfg.Database, h)).Methods("GET")
+
+	// Make verify chaff tracker.
+	verifyChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeVerifyResponse), chaff.DefaultCapacity)
+	if err != nil {
+		return nil, fmt.Errorf("error creating verify chaffer: %v", err)
+	}
+	defer verifyChaffTracker.Close()
+
+	// Make cert chaff tracker.
+	certChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeCertificateResponse), chaff.DefaultCapacity)
+	if err != nil {
+		return nil, fmt.Errorf("error creating cert chaffer: %v", err)
+	}
+	defer certChaffTracker.Close()
+
+	{
+		sub := r.PathPrefix("/api/verify").Subrouter()
+		sub.Use(requireAPIKey)
+		sub.Use(processFirewall)
+		sub.Use(middleware.ProcessChaff(db, verifyChaffTracker))
+		sub.Use(rateLimit)
+
+		// POST /api/verify
+		verifyapiController, err := verifyapi.New(ctx, cfg, db, h, tokenSigner)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create verify api controller: %w", err)
+		}
+		sub.Handle("", verifyapiController.HandleVerify()).Methods("POST")
+	}
+
+	{
+		sub := r.PathPrefix("/api/certificate").Subrouter()
+		sub.Use(requireAPIKey)
+		sub.Use(processFirewall)
+		sub.Use(middleware.ProcessChaff(db, certChaffTracker))
+		sub.Use(rateLimit)
+
+		// POST /api/certificate
+		certapiController, err := certapi.New(ctx, cfg, db, cacher, certificateSigner, h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create certapi controller: %w", err)
+		}
+		sub.Handle("", certapiController.HandleCertificate()).Methods("POST")
+	}
+
+	// Wrap the main router in the mutating middleware method. This cannot be
+	// inserted as middleware because gorilla processes the method before
+	// middleware.
+	mux := http.NewServeMux()
+	mux.Handle("/", middleware.MutateMethod()(r))
+	return mux, nil
+}
+
+// makePadFromChaff makes a Padding structure from chaff data.
+// Note, the random chaff data will be longer than necessary, so we shorten it.
+func makePadFromChaff(s string) api.Padding {
+	return api.Padding(s)
+}
+
+func encodeVerifyResponse(s string) interface{} {
+	return api.VerifyCodeResponse{Padding: makePadFromChaff(s)}
+}
+
+func encodeCertificateResponse(s string) interface{} {
+	return api.VerificationCertificateResponse{Padding: makePadFromChaff(s)}
+}

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -62,6 +62,7 @@ func TestUpdate(t *testing.T) {
 	defer done()
 
 	for _, permission := range rbac.PermissionMap() {
+		permission := permission
 		target := fmt.Sprintf(`input#permission-%d`, permission)
 
 		if err := chromedp.Run(taskCtx,
@@ -75,7 +76,7 @@ func TestUpdate(t *testing.T) {
 			chromedp.WaitVisible(`body#users-edit`, chromedp.ByQuery),
 
 			// Fill out the form.
-			chromedp.Click(target, chromedp.ByQuery),
+			chromedp.RemoveAttribute(target, "checked", chromedp.ByQuery),
 			chromedp.Submit(`form#user-form`, chromedp.ByQuery),
 
 			// Wait for render.
@@ -105,6 +106,7 @@ func TestUpdate(t *testing.T) {
 
 	// Now add permissions back
 	for _, permission := range rbac.PermissionMap() {
+		permission := permission
 		target := fmt.Sprintf(`input#permission-%d`, permission)
 
 		if err := chromedp.Run(taskCtx,
@@ -118,7 +120,7 @@ func TestUpdate(t *testing.T) {
 			chromedp.WaitVisible(`body#users-edit`, chromedp.ByQuery),
 
 			// Fill out the form.
-			chromedp.Click(target, chromedp.ByQuery),
+			chromedp.SetAttributeValue(target, "checked", "true", chromedp.ByQuery),
 			chromedp.Submit(`form#user-form`, chromedp.ByQuery),
 
 			// Wait for render.


### PR DESCRIPTION
No changes, just moving these around so we can use them more easily in tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
