### PR TITLE
Ignore .terraform.lock.hcl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,7 +19,9 @@
 *.terraform/
 *.tfvars
 terraform/state.tf
+terraform/.terraform.lock.hcl
 terraform-e2e-ci/state.tf
+terraform-e2e-ci/.terraform.lock.hcl
 */crash.log
 
 # Local things


### PR DESCRIPTION
This file was added in terraform 0.14, it causes terraform deployment failure due to uncommitted local changes

https://www.terraform.io/docs/configuration/dependency-lock.html