### PR TITLE
Only send welcome email for new firebase user

### DIFF
--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -101,7 +101,7 @@
       let $progress = $('#progress');
       let $sendInvites = $('#sendInvites');
 
-      let totalUsersCreated = 0;
+      let totalUsersAdded = 0;
       let upload = readFile();
 
       $table.hide();
@@ -149,7 +149,7 @@
           let checked = $sendInvites.is(":checked")
           let rows = e.target.result.split("\n");
           let batch = [];
-          totalUsersCreated = 0;
+          totalUsersAdded = 0;
           $tableBody.empty();
           let i = 0;
           for (; i < rows.length && !cancelUpload; i++) {
@@ -176,7 +176,7 @@
             if (batch.length >= batchSize || i == rows.length - 1 && batch.length > 0) {
               cancelUpload = await uploadWithRetries(batch, b => uploadBatch(b, checked));
               if (cancelUpload) {
-                flash.warning("Successfully created " + totalUsersCreated + " new users."
+                flash.warning("Successfully added " + totalUsersAdded + " users to realm."
                   + (rows.length - i) + " remaining.");
                 break;
               }
@@ -188,7 +188,7 @@
           }
 
           if (!cancelUpload) {
-            flash.alert("Successfully created " + totalUsersCreated + " new users.");
+            flash.alert("Successfully added " + totalUsersAdded + " users to realm.");
           }
           $table.fadeOut(400);
           $import.prop('disabled', false);
@@ -210,7 +210,7 @@
         headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
         contentType: 'application/json',
         success: function(result) {
-          totalUsersCreated += result.newUsers.length;
+          totalUsersAdded += result.newUsers.length;
           if (result.error) {
             flash.error(result.error);
           }

--- a/internal/auth/firebase.go
+++ b/internal/auth/firebase.go
@@ -142,23 +142,25 @@ func (f *firebaseAuth) CreateUser(ctx context.Context, name, email, pass string,
 		return false, fmt.Errorf("failed lookup firebase user: %w", err)
 	}
 
-	if user == nil {
-		// If the password is empty, generate one.
-		if pass == "" {
-			pass, err = password.Generate(24, 8, 8, false, true)
-			if err != nil {
-				return false, fmt.Errorf("failed to generate password: %w", err)
-			}
-		}
+	if user != nil {
+		return false, nil
+	}
 
-		// Create the user.
-		userToCreate := (&auth.UserToCreate{}).
-			Email(email).
-			Password(pass).
-			DisplayName(name)
-		if _, err = f.firebaseAuth.CreateUser(ctx, userToCreate); err != nil {
-			return false, fmt.Errorf("failed to create firebase user: %w", err)
+	// If the password is empty, generate one.
+	if pass == "" {
+		pass, err = password.Generate(24, 8, 8, false, true)
+		if err != nil {
+			return false, fmt.Errorf("failed to generate password: %w", err)
 		}
+	}
+
+	// Create the user.
+	userToCreate := (&auth.UserToCreate{}).
+		Email(email).
+		Password(pass).
+		DisplayName(name)
+	if _, err = f.firebaseAuth.CreateUser(ctx, userToCreate); err != nil {
+		return false, fmt.Errorf("failed to create firebase user: %w", err)
 	}
 
 	// Send the welcome email. Use the defined mailer if given, otherwise fallback

--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -114,7 +114,6 @@ func (c *Controller) HandleCreate() http.Handler {
 		flash.Alert("Successfully created user %v.", user.Name)
 		http.Redirect(w, r, fmt.Sprintf("/realm/users/%d", user.ID), http.StatusSeeOther)
 		return
-
 	})
 }
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1394

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Only send the password-reset email if the firebase user does not exist
* Count users added to realm, not created in firebase

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Users added to realm don't get password reset email - only newly created firebase users do
```
