### PR TITLE
Make daily active stats collection a realm configurable

### DIFF
--- a/cmd/server/assets/realmadmin/_form_general.html
+++ b/cmd/server/assets/realmadmin/_form_general.html
@@ -15,11 +15,7 @@
     <input type="text" name="name" id="name" class="form-control{{if $realm.ErrorsFor "name"}} is-invalid{{end}}"
       value="{{$realm.Name}}" placeholder="Name" required autofocus />
     <label for="name">Name</label>
-    {{if $realm.ErrorsFor "name"}}
-    <div class="invalid-feedback">
-      {{joinStrings ($realm.ErrorsFor "name") ", "}}
-    </div>
-    {{end}}
+    {{template "errorable" $realm.ErrorsFor "name"}}
     <small class="form-text text-muted">
       The realm name is displayed on the realm selection page and in the header
       when selected. Choose a descriptive name that your team will recognize.
@@ -31,11 +27,7 @@
     <input type="text" name="region_code" id="region-code" class="form-control text-uppercase{{if $realm.ErrorsFor "regionCode"}} is-invalid{{end}}"
       value="{{$realm.RegionCode}}" placeholder="Region code" />
     <label for="region-code">Region code</label>
-    {{if $realm.ErrorsFor "regionCode"}}
-    <div class="invalid-feedback">
-      {{joinStrings ($realm.ErrorsFor "regionCode") ", "}}
-    </div>
-    {{end}}
+    {{template "errorable" $realm.ErrorsFor "regionCode"}}
     <small class="form-text text-muted">
       The region code is displayed on the realm selection page and in the header
       when selection. It is also used when the creating deep link SMS for
@@ -54,16 +46,27 @@
     <textarea name="welcome_message" id="welcome-message" class="form-control text-monospace{{if $realm.ErrorsFor "welcomeMessage"}} is-invalid{{end}}"
       rows="5" placeholder="Welcome message">{{$realm.WelcomeMessage}}</textarea>
     <label for="welcome-message">Welcome message</label>
-    {{if $realm.ErrorsFor "welcomeMessage"}}
-    <div class="invalid-feedback">
-      {{joinStrings ($realm.ErrorsFor "welcomeMessage") ", "}}
-    </div>
-    {{end}}
+    {{template "errorable" $realm.ErrorsFor "welcomeMessage"}}
     <small class="form-text text-muted">
       The welcome message is displayed to your team after selecting this realm.
       This field supports the common <a
       href="https://daringfireball.net/projects/markdown/syntax">markdown</a>
-      stanard.
+      standard.
+    </small>
+  </div>
+
+  <div class="custom-control custom-checkbox">
+    <input type="checkbox" name="daily_active_users_enabled" id="daily-active-users-enabled"
+      class="custom-control-input" {{checkedIf $realm.DailyActiveUsersEnabled}}>
+    <label class="custom-control-label" for="daily-active-users-enabled">Enable daily active user counting</label>
+    {{template "errorable" $realm.ErrorsFor "dailyActiveUsersEnabled"}}
+    <small class="form-text text-muted">
+      Enable server-side collection of reported daily active users. You must
+      also <a
+      href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md#chaffing-requests"
+      target="_BLANK" rel="noopener">enable this functionality</a> on your iOS
+      and Android applications. This will also add a new dashboard to the
+      statistics page.
     </small>
   </div>
 

--- a/pkg/controller/middleware/chaff.go
+++ b/pkg/controller/middleware/chaff.go
@@ -57,7 +57,7 @@ func ProcessChaff(db *database.Database, t *chaff.Tracker) mux.MiddlewareFunc {
 				currentRealm := controller.RealmFromContext(ctx)
 				if currentRealm == nil {
 					logger.Error("missing current realm in context")
-				} else {
+				} else if currentRealm.DailyActiveUsersEnabled {
 					// Increment DAU asynchronously and out-of-band for the request. These
 					// statistics are best-effort and we don't want to block or delay
 					// rendering to populate stats.

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -54,10 +54,11 @@ func init() {
 }
 
 type formData struct {
-	General        bool   `form:"general"`
-	Name           string `form:"name"`
-	RegionCode     string `form:"region_code"`
-	WelcomeMessage string `form:"welcome_message"`
+	General                 bool   `form:"general"`
+	Name                    string `form:"name"`
+	RegionCode              string `form:"region_code"`
+	WelcomeMessage          string `form:"welcome_message"`
+	DailyActiveUsersEnabled bool   `form:"daily_active_users_enabled"`
 
 	Codes                     bool               `form:"codes"`
 	AllowedTestTypes          database.TestType  `form:"allowed_test_types"`
@@ -165,6 +166,7 @@ func (c *Controller) HandleSettings() http.Handler {
 			currentRealm.Name = form.Name
 			currentRealm.RegionCode = form.RegionCode
 			currentRealm.WelcomeMessage = form.WelcomeMessage
+			currentRealm.DailyActiveUsersEnabled = form.DailyActiveUsersEnabled
 		}
 
 		// Codes

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1842,6 +1842,15 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return tx.Exec(`ALTER TABLE realms DROP COLUMN IF EXISTS alternate_sms_templates`).Error
 			},
 		},
+		{
+			ID: "00078-AddEnableDailyActiveUsersToRealm",
+			Migrate: func(tx *gorm.DB) error {
+				return tx.Exec(`ALTER TABLE realms ADD COLUMN IF NOT EXISTS daily_active_users_enabled BOOL DEFAULT false NOT NULL`).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return tx.Exec(`ALTER TABLE realms DROP COLUMN IF EXISTS daily_active_users_enabled`).Error
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -258,6 +258,10 @@ type Realm struct {
 	// before triggering abuse protections.
 	AbusePreventionLimitFactor float32 `gorm:"type:numeric(6, 3); not null; default:1.0"`
 
+	// DailyActiveUsersEnabled determines if the realm collects and displays daily
+	// active user metrics.
+	DailyActiveUsersEnabled bool `gorm:"type:boolean; not null; default: false;"`
+
 	// Relations to items that belong to a realm.
 	Codes  []*VerificationCode `gorm:"PRELOAD:false; SAVE_ASSOCIATIONS:false; ASSOCIATION_AUTOUPDATE:false, ASSOCIATION_SAVE_REFERENCE:false"`
 	Tokens []*Token            `gorm:"PRELOAD:false; SAVE_ASSOCIATIONS:false; ASSOCIATION_AUTOUPDATE:false, ASSOCIATION_SAVE_REFERENCE:false"`


### PR DESCRIPTION
Part of #1393

There's some HTML changes to the stats page that need to happen, but I'll do that in the next PR because it'll be a bunch of whitespace changes. This is the 🍖.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make daily active stats collection a realm configurable
```

/assign @whaught 