### PR TITLE
Add statistics endpoints to adminapi

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -12,8 +12,8 @@
     <a href="#" data-toggle="modal" data-target="#realm-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/realm/stats.csv" class="mr-1">CSV</a>
-      <a href="/realm/stats.json">JSON</a>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json">JSON</a>
     </span>
   </small>
 </div>
@@ -59,7 +59,7 @@
 
   function drawRealmCharts() {
     $.ajax({
-      url: '/realm/stats.json',
+      url: '/stats/realm.json',
       dataType: 'json',
     })
     .done(function(data, status, xhr) {

--- a/cmd/server/assets/realmadmin/_stats_daily_active_users.html
+++ b/cmd/server/assets/realmadmin/_stats_daily_active_users.html
@@ -12,8 +12,8 @@
     <a href="#" data-toggle="modal" data-target="#daily-active-users-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/realm/stats.csv" class="mr-1">CSV</a>
-      <a href="/realm/stats.json">JSON</a>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json">JSON</a>
     </span>
   </small>
 </div>
@@ -55,7 +55,7 @@
 
   function drawDailyActiveUsersChart() {
     $.ajax({
-      url: '/realm/stats.json',
+      url: '/stats/realm.json',
       dataType: 'json',
     })
     .done(function(data, status, xhr) {

--- a/cmd/server/assets/realmadmin/_stats_external_issuers.html
+++ b/cmd/server/assets/realmadmin/_stats_external_issuers.html
@@ -14,8 +14,8 @@
     <a href="#" data-toggle="modal" data-target="#per-external-issuer-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/realm/stats.csv?scope=external" class="mr-1">CSV</a>
-      <a href="/realm/stats.json?scope=external">JSON</a>
+      <a href="/stats/realm-external-issuer.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm-external-issuer.json">JSON</a>
     </span>
   </small>
 </div>
@@ -68,7 +68,7 @@
 
   function drawExternalIssuersTable() {
     $.ajax({
-      url: '/realm/stats.json',
+      url: '/stats/realm-external-issuer.json',
       data: { scope: 'external' },
       dataType: 'json',
     })

--- a/cmd/server/assets/realmadmin/_stats_users.html
+++ b/cmd/server/assets/realmadmin/_stats_users.html
@@ -14,8 +14,8 @@
     <a href="#" data-toggle="modal" data-target="#per-user-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/realm/stats.csv?scope=user" class="mr-1">CSV</a>
-      <a href="/realm/stats.json?scope=user">JSON</a>
+      <a href="/stats/realm-user.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm-user.json">JSON</a>
     </span>
   </small>
 </div>
@@ -60,7 +60,7 @@
 
   function drawUsersTable() {
     $.ajax({
-      url: '/realm/stats.json',
+      url: '/stats/realm-user.json',
       data: { scope: 'user' },
       dataType: 'json',
     })

--- a/docs/api.md
+++ b/docs/api.md
@@ -448,6 +448,27 @@ Expires an unclaimed code. If the code has been claimed an error is returned.
 The timestamps are updated to the new expiration time (which will be in the
 past).
 
+
+## `/api/stats/*` (preview)
+
+**The statistics API are currently in preview. They are not covered by our
+backwards-compatibility promise and the APIs are subject to change without
+notice!**
+
+This path includes realm-level statistics for the past 30 days.
+
+-   `/api/stats/realm.{csv,json}` - Daily statistics for the realm, including
+    codes issued, codes claimed, and daily active users (if enabled).
+
+-   `/api/stats/realm-user.{csv,json}` - Daily statistics for codes issued by
+    realm user. These statistics only include codes issued by humans logged into
+    the verification system.
+
+-   `/api/stats/realm-external-issuser.{csv,json}` - Daily statistics for codes
+    issued by external issuers. These statistics only include codes issued by
+    the API where an `externalIssuer` field was provided.
+
+
 # Chaffing requests
 
 In addition to "real" requests, the server also accepts chaff (fake) requests.

--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -26,6 +26,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/stats"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit/limitware"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -104,6 +105,18 @@ func AdminAPI(
 		codesController := codes.NewAPI(ctx, cfg, db, h)
 		sub.Handle("/checkcodestatus", codesController.HandleCheckCodeStatus()).Methods("POST")
 		sub.Handle("/expirecode", codesController.HandleExpireAPI()).Methods("POST")
+
+		{
+			sub := sub.PathPrefix("/stats").Subrouter()
+
+			statsController := stats.New(ctx, cacher, db, h)
+			sub.Handle("/realm.csv", statsController.HandleRealmStats(stats.StatsTypeCSV)).Methods("GET")
+			sub.Handle("/realm.json", statsController.HandleRealmStats(stats.StatsTypeJSON)).Methods("GET")
+			sub.Handle("/realm-user.csv", statsController.HandleRealmUserStats(stats.StatsTypeCSV)).Methods("GET")
+			sub.Handle("/realm-user.json", statsController.HandleRealmUserStats(stats.StatsTypeJSON)).Methods("GET")
+			sub.Handle("/realm-external-issuer.csv", statsController.HandleRealmExternalIssuerStats(stats.StatsTypeCSV)).Methods("GET")
+			sub.Handle("/realm-external-issuer.json", statsController.HandleRealmExternalIssuerStats(stats.StatsTypeJSON)).Methods("GET")
+		}
 	}
 
 	// Wrap the main router in the mutating middleware method. This cannot be

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/stats"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit/limitware"
@@ -261,6 +262,21 @@ func Server(
 		userRoutes(sub, userController)
 	}
 
+	// stats
+	{
+		sub := r.PathPrefix("/stats").Subrouter()
+		sub.Use(requireAuth)
+		sub.Use(loadCurrentMembership)
+		sub.Use(requireMembership)
+		sub.Use(processFirewall)
+		sub.Use(requireVerified)
+		sub.Use(requireMFA)
+		sub.Use(rateLimit)
+
+		statsController := stats.New(ctx, cacher, db, h)
+		statsRoutes(sub, statsController)
+	}
+
 	// realms
 	{
 		sub := r.PathPrefix("/realm").Subrouter()
@@ -376,14 +392,22 @@ func realmkeysRoutes(r *mux.Router, c *realmkeys.Controller) {
 	r.Handle("/keys/activate", c.HandleActivate()).Methods("POST")
 }
 
+// statsRoutes are the statistics routes, rooted at /stats.
+func statsRoutes(r *mux.Router, c *stats.Controller) {
+	r.Handle("/realm.csv", c.HandleRealmStats(stats.StatsTypeCSV)).Methods("GET")
+	r.Handle("/realm.json", c.HandleRealmStats(stats.StatsTypeJSON)).Methods("GET")
+	r.Handle("/realm-user.csv", c.HandleRealmUserStats(stats.StatsTypeCSV)).Methods("GET")
+	r.Handle("/realm-user.json", c.HandleRealmUserStats(stats.StatsTypeJSON)).Methods("GET")
+	r.Handle("/realm-external-issuer.csv", c.HandleRealmExternalIssuerStats(stats.StatsTypeCSV)).Methods("GET")
+	r.Handle("/realm-external-issuer.json", c.HandleRealmExternalIssuerStats(stats.StatsTypeJSON)).Methods("GET")
+}
+
 // realmadminRoutes are the realm admin routes.
 func realmadminRoutes(r *mux.Router, c *realmadmin.Controller) {
 	r.Handle("/settings", c.HandleSettings()).Methods("GET", "POST")
 	r.Handle("/settings/enable-express", c.HandleEnableExpress()).Methods("POST")
 	r.Handle("/settings/disable-express", c.HandleDisableExpress()).Methods("POST")
 	r.Handle("/stats", c.HandleStats()).Methods("GET")
-	r.Handle("/stats.csv", c.HandleStats()).Methods("GET")
-	r.Handle("/stats.json", c.HandleStats()).Methods("GET")
 	r.Handle("/events", c.HandleEvents()).Methods("GET")
 }
 

--- a/internal/routes/server_test.go
+++ b/internal/routes/server_test.go
@@ -215,6 +215,41 @@ func TestRoutes_realmkeysRoutes(t *testing.T) {
 	}
 }
 
+func TestRoutes_statsRoutes(t *testing.T) {
+	t.Parallel()
+
+	m := mux.NewRouter()
+	statsRoutes(m, nil)
+
+	cases := []struct {
+		req  *http.Request
+		vars map[string]string
+	}{
+		{
+			req: httptest.NewRequest("GET", "/realm.csv", nil),
+		},
+		{
+			req: httptest.NewRequest("GET", "/realm.json", nil),
+		},
+		{
+			req: httptest.NewRequest("GET", "/realm-user.csv", nil),
+		},
+		{
+			req: httptest.NewRequest("GET", "/realm-user.json", nil),
+		},
+		{
+			req: httptest.NewRequest("GET", "/realm-external-issuer.csv", nil),
+		},
+		{
+			req: httptest.NewRequest("GET", "/realm-external-issuer.json", nil),
+		},
+	}
+
+	for _, tc := range cases {
+		testRoute(t, m, tc.req, tc.vars)
+	}
+}
+
 func TestRoutes_realmadminRoutes(t *testing.T) {
 	t.Parallel()
 
@@ -239,12 +274,6 @@ func TestRoutes_realmadminRoutes(t *testing.T) {
 		},
 		{
 			req: httptest.NewRequest("GET", "/stats", nil),
-		},
-		{
-			req: httptest.NewRequest("GET", "/stats.json", nil),
-		},
-		{
-			req: httptest.NewRequest("GET", "/stats.csv", nil),
 		},
 		{
 			req: httptest.NewRequest("GET", "/events", nil),

--- a/pkg/controller/middleware/membership.go
+++ b/pkg/controller/middleware/membership.go
@@ -81,7 +81,7 @@ func LoadCurrentMembership(cacher cache.Cacher, db *database.Database, h render.
 				return
 			}
 
-			// Save the membership on the context.
+			// Save the membership and realm on the context.
 			ctx = controller.WithMembership(ctx, membership)
 			r = r.Clone(ctx)
 

--- a/pkg/controller/stats/realm.go
+++ b/pkg/controller/stats/realm.go
@@ -12,31 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmadmin
+// Package stats produces statistics.
+package stats
 
 import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
-func (c *Controller) HandleStats() http.Handler {
+// HandleRealmStats renders statistics for the current realm.
+func (c *Controller) HandleRealmStats(typ StatsType) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		membership := controller.MembershipFromContext(ctx)
-		if membership == nil {
-			controller.MissingMembership(w, r, c.h)
-			return
-		}
-		if !membership.Can(rbac.StatsRead) {
+		currentRealm, ok := authorizeFromContext(ctx)
+		if !ok {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
 
-		m := controller.TemplateMapFromContext(ctx)
-		m.Title("Realm stats")
-		c.h.RenderHTML(w, "realmadmin/stats", m)
+		stats, err := currentRealm.StatsCached(ctx, c.db, c.cacher)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		switch typ {
+		case StatsTypeCSV:
+			c.h.RenderCSV(w, http.StatusOK, csvFilename("realm-stats"), stats)
+			return
+		case StatsTypeJSON:
+			c.h.RenderJSON(w, http.StatusOK, stats)
+			return
+		default:
+			controller.NotFound(w, r, c.h)
+			return
+		}
 	})
 }

--- a/pkg/controller/stats/realm_user.go
+++ b/pkg/controller/stats/realm_user.go
@@ -12,31 +12,42 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmadmin
+// Package stats produces statistics.
+package stats
 
 import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
-func (c *Controller) HandleStats() http.Handler {
+// HandleRealmUserStats renders statistics for the current realm.
+func (c *Controller) HandleRealmUserStats(typ StatsType) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		membership := controller.MembershipFromContext(ctx)
-		if membership == nil {
-			controller.MissingMembership(w, r, c.h)
-			return
-		}
-		if !membership.Can(rbac.StatsRead) {
+		currentRealm, ok := authorizeFromContext(ctx)
+		if !ok {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
 
-		m := controller.TemplateMapFromContext(ctx)
-		m.Title("Realm stats")
-		c.h.RenderHTML(w, "realmadmin/stats", m)
+		stats, err := currentRealm.UserStatsCached(ctx, c.db, c.cacher)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		switch typ {
+		case StatsTypeCSV:
+			c.h.RenderCSV(w, http.StatusOK, csvFilename("user-stats"), stats)
+			return
+		case StatsTypeJSON:
+			c.h.RenderJSON(w, http.StatusOK, stats)
+			return
+		default:
+			controller.NotFound(w, r, c.h)
+			return
+		}
 	})
 }

--- a/pkg/controller/stats/stats.go
+++ b/pkg/controller/stats/stats.go
@@ -1,0 +1,76 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package stats produces statistics.
+package stats
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+// StatsType represents a type of stat.
+type StatsType int64
+
+const (
+	_ StatsType = iota
+	StatsTypeCSV
+	StatsTypeJSON
+)
+
+// Controller is a stats controller.
+type Controller struct {
+	cacher cache.Cacher
+	db     *database.Database
+	h      render.Renderer
+}
+
+// New creates a new stats controller.
+func New(ctx context.Context, cacher cache.Cacher, db *database.Database, h render.Renderer) *Controller {
+	return &Controller{
+		cacher: cacher,
+		db:     db,
+		h:      h,
+	}
+}
+
+// authorizeFromContext attempts to pull authorization from the context. It
+// returns false if authorization failed.
+func authorizeFromContext(ctx context.Context) (*database.Realm, bool) {
+	membership := controller.MembershipFromContext(ctx)
+	if membership != nil && membership.Can(rbac.StatsRead) {
+		return membership.Realm, true
+	}
+
+	realm := controller.RealmFromContext(ctx)
+	if realm != nil {
+		return realm, true
+	}
+
+	return nil, false
+}
+
+// csvFilename returns the formatted filename for now.
+func csvFilename(name string) string {
+	nowFormatted := time.Now().Format(project.RFC3339Squish)
+	return fmt.Sprintf("%s-%s.csv", nowFormatted, name)
+}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -487,7 +487,7 @@ func TestRealm_UserStats(t *testing.T) {
 		}
 	}
 
-	stats, err := realm.UserStats(db, startDate, endDate)
+	stats, err := realm.UserStats(db)
 	if err != nil {
 		t.Fatalf("error getting stats: %v", err)
 	}


### PR DESCRIPTION
Part of #1390

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add statistics endpoints to adminapi
```

/assign @mikehelmick 