### PR TITLE
Add implied permissions - write permissions need read permissions to be useful

### DIFF
--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -72,7 +72,7 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 		}
 		permission = permission | update
 	}
-	// Ensure impled permissions. The actor must also have the impled permissions by definition.
+	// Ensure implied permissions. The actor must also have the implied permissions by definition.
 	for has, needs := range requiredPermission {
 		// If granted has, ensure that we have all needs.
 		if Can(permission, has) {

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -74,6 +74,7 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 	}
 	// Ensure impled permissions. The actor must also have the impled permissions by definition.
 	for has, needs := range requiredPermission {
+		// If granted has, ensure that we have all needs.
 		if Can(permission, has) {
 			for _, required := range needs {
 				permission = permission | required

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -83,6 +83,11 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 	return permission, nil
 }
 
+// ImpliedBy returns any permissions that
+func ImpliedBy(permission Permission) []Permission {
+	return impliedBy[permission]
+}
+
 // PermissionNames returns the list of permissions included in the given
 // permission.
 func PermissionNames(p Permission) []string {
@@ -166,7 +171,22 @@ var (
 		MobileAppWrite: {MobileAppRead},
 		UserWrite:      {UserRead},
 	}
+
+	// This is the inverse of the above map, set by the init() func.
+	// Done in code to ensure it always stays in sync with requiredPermission.
+	impliedBy = make(map[Permission][]Permission)
 )
+
+func init() {
+	for has, needs := range requiredPermission {
+		for _, perm := range needs {
+			if _, ok := impliedBy[perm]; !ok {
+				impliedBy[perm] = make([]Permission, 0, 1)
+			}
+			impliedBy[perm] = append(impliedBy[perm], has)
+		}
+	}
+}
 
 // --
 // Legacy permissions

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -177,6 +177,9 @@ var (
 	impliedBy = make(map[Permission][]Permission)
 )
 
+// Note: there are multiple init functions in this file. They are organized to be
+// near the thing they are initializing.
+// Yes, go allows multiple init functions in the same module.
 func init() {
 	for has, needs := range requiredPermission {
 		for _, perm := range needs {

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -84,7 +84,8 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 	return permission, nil
 }
 
-// ImpliedBy returns any permissions that
+// ImpliedBy returns any permissions that cause this permission to be added automatically.
+// The return may be nil.
 func ImpliedBy(permission Permission) []Permission {
 	return impliedBy[permission]
 }

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -72,6 +72,14 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 		}
 		permission = permission | update
 	}
+	// Ensure impled permissions. The actor must also have the impled permissions by definition.
+	for has, needs := range requiredPermission {
+		if Can(permission, has) {
+			for _, required := range needs {
+				permission = permission | required
+			}
+		}
+	}
 	return permission, nil
 }
 
@@ -143,6 +151,21 @@ const (
 	// Users
 	UserRead  = 1 << iota
 	UserWrite = 1 << iota
+)
+
+// --
+// Required / Implied permissions.
+// Write permissions require subordinate read.
+// --
+
+var (
+	// requiredPermissions is not exported since maps cannot be constant.
+	requiredPermission = map[Permission][]Permission{
+		APIKeyWrite:    {APIKeyRead},
+		SettingsWrite:  {SettingsRead},
+		MobileAppWrite: {MobileAppRead},
+		UserWrite:      {UserRead},
+	}
 )
 
 // --


### PR DESCRIPTION
Fixes #1408 

## Proposed Changes

* All write permissions automatically add required read permissions if they are not set.

**Release Note**

```release-note
Setting write permissions automatically add required read permissions.
```
