### PR TITLE
Create a no-op failure SMS provider

### DIFF
--- a/pkg/database/sms_config.go
+++ b/pkg/database/sms_config.go
@@ -83,7 +83,8 @@ func (db *Database) SystemSMSConfig() (*SMSConfig, error) {
 
 // SaveSMSConfig creates or updates an SMS configuration record.
 func (db *Database) SaveSMSConfig(s *SMSConfig) error {
-	if s.TwilioAccountSid == "" && s.TwilioAuthToken == "" && s.TwilioFromNumber == "" {
+	if s.ProviderType == sms.ProviderTypeTwilio &&
+		s.TwilioAccountSid == "" && s.TwilioAuthToken == "" && s.TwilioFromNumber == "" {
 		if db.db.NewRecord(s) {
 			// The fields are all blank, do not create the record.
 			return nil

--- a/pkg/sms/noop.go
+++ b/pkg/sms/noop.go
@@ -16,12 +16,13 @@ package sms
 
 import (
 	"context"
+	"errors"
 )
-
-var _ Provider = (*Noop)(nil)
 
 // Noop does nothing.
 type Noop struct{}
+
+var _ Provider = (*Noop)(nil)
 
 // NewNoop creates a new SMS sender that does nothing.
 func NewNoop(_ context.Context) (Provider, error) {
@@ -31,4 +32,22 @@ func NewNoop(_ context.Context) (Provider, error) {
 // SendSMS does nothing.
 func (p *Noop) SendSMS(_ context.Context, _, _ string) error {
 	return nil
+}
+
+// ErrNoop is the error NoopFail always returns.
+var ErrNoop error = errors.New("noop always fails")
+
+// NoopFail always fails.
+type NoopFail struct{}
+
+var _ Provider = (*NoopFail)(nil)
+
+// NewNoopFail creates a new SMS sender that only returns ErrNoop.
+func NewNoopFail(_ context.Context) (Provider, error) {
+	return &NoopFail{}, nil
+}
+
+// SendSMS does nothing.
+func (p *NoopFail) SendSMS(_ context.Context, _, _ string) error {
+	return ErrNoop
 }

--- a/pkg/sms/sms.go
+++ b/pkg/sms/sms.go
@@ -28,8 +28,9 @@ import (
 type ProviderType string
 
 const (
-	ProviderTypeNoop   ProviderType = "NOOP"
-	ProviderTypeTwilio ProviderType = "TWILIO"
+	ProviderTypeNoop     ProviderType = "NOOP"
+	ProviderTypeNoopFail ProviderType = "NOOP_FAIL"
+	ProviderTypeTwilio   ProviderType = "TWILIO"
 )
 
 // Config represents configuration for an SMS provider.
@@ -52,6 +53,8 @@ func ProviderFor(ctx context.Context, c *Config) (Provider, error) {
 	switch typ := c.ProviderType; typ {
 	case ProviderTypeNoop:
 		return NewNoop(ctx)
+	case ProviderTypeNoopFail:
+		return NewNoopFail(ctx)
 	case ProviderTypeTwilio:
 		return NewTwilio(ctx, c.TwilioAccountSid, c.TwilioAuthToken, c.TwilioFromNumber)
 	default:


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Create a no-op SMS provider that only throws an error
* This will be used later in unit test cases to assert what happens when an SMS fails
    * (Pulling out easily reviewable pieces from a larger refactor)