### PR TITLE
Don't allow admin API keys to read stats

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -27,9 +27,8 @@ two types of API keys:
     _certificates_.
 
 -   `ADMIN` - Intended for public health authority internal applications to
-    integrate with this server. This API key type can also retrieve statistics
-    about the realm. **We strongly advise putting additional protections in
-    place such as an external proxy authentication.**
+    integrate with this server. **We strongly advise putting additional
+    protections in place such as an external proxy authentication.**
 
 -   `STATS` - Intended for public health authorities to gather automated
     statistics.

--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -88,7 +88,6 @@ func AdminAPI(
 		database.APIKeyTypeAdmin,
 	})
 	requireStatsAPIKey := middleware.RequireAPIKey(cacher, db, h, []database.APIKeyType{
-		database.APIKeyTypeAdmin,
 		database.APIKeyTypeStats,
 	})
 	processFirewall := middleware.ProcessFirewall(h, "adminapi")


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @mikehelmick 