### PR TITLE
Wait for Redis connections to become available

### DIFF
--- a/pkg/cache/config.go
+++ b/pkg/cache/config.go
@@ -59,6 +59,7 @@ func CacherFor(ctx context.Context, c *Config, keyFunc KeyFunc) (Cacher, error) 
 			IdleTimeout: c.Redis.IdleTimeout,
 			MaxIdle:     c.Redis.MaxIdle,
 			MaxActive:   c.Redis.MaxActive,
+			WaitTimeout: c.Redis.WaitTimeout,
 		})
 	default:
 		return nil, fmt.Errorf("unknown cacher type: %v", typ)

--- a/pkg/redis/config.go
+++ b/pkg/redis/config.go
@@ -29,4 +29,8 @@ type Config struct {
 	IdleTimeout time.Duration `env:"REDIS_IDLE_TIMEOUT, default=1m"`
 	MaxIdle     int           `env:"REDIS_MAX_IDLE, default=16"`
 	MaxActive   int           `env:"REDIS_MAX_ACTIVE, default=64"`
+
+	// WaitTimeout is the maximum amount of time to wait for a connection to
+	// become available.
+	WaitTimeout time.Duration `env:"REDIS_WAIT_TIMEOUT, default=1s"`
 }


### PR DESCRIPTION
Configurable via an envvar. Default is 1s.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Wait for Redis connections to become available
```

/assign @mikehelmick 