### PR TITLE
Terraform destroy first remove database from state

### DIFF
--- a/scripts/ci-terraform.sh
+++ b/scripts/ci-terraform.sh
@@ -141,6 +141,8 @@ function destroy() {
     gcloud sql instances delete ${db_inst_name} -q --project=${PROJECT_ID} || best_effort
   fi
   # Clean up states after manual DB delete
+  terraform state rm module.en.google_sql_database_instance.db-inst || best_effort
+  terraform state rm module.en.google_sql_database.db || best_effort
   terraform state rm module.en.google_sql_user.user || best_effort
   terraform state rm module.en.google_sql_ssl_cert.db-cert || best_effort
 

--- a/terraform-e2e-ci/.terraform.lock.hcl
+++ b/terraform-e2e-ci/.terraform.lock.hcl
@@ -3,7 +3,7 @@
 
 provider "registry.terraform.io/hashicorp/google" {
   version     = "3.51.0"
-  constraints = "~> 3.46"
+  constraints = "~> 3.51"
   hashes = [
     "h1:xSmUnxWTmQjfwBeWG5rMk5hzJPpqXmbpAOsnrtxZJbU=",
     "zh:378a3aa47b3a9ca096cd7a01a054e2cb1cd8118fbb8a6e4b9cf4cfe196ba9c0d",
@@ -21,7 +21,7 @@ provider "registry.terraform.io/hashicorp/google" {
 
 provider "registry.terraform.io/hashicorp/google-beta" {
   version     = "3.51.0"
-  constraints = "~> 3.46"
+  constraints = "~> 3.51"
   hashes = [
     "h1:WfwUQQEG90QdOu1wC1x2MVG+nlPV6hcagbpUFaNbroM=",
     "zh:0d2c872ae2485f9b3db5db9d8e6d47ccd22e0b41f5ca0d94610fc29b18aeae8f",


### PR DESCRIPTION
Prior to terraform0.14 this was fine, but now terraform destroy isn't happy that the database instance exists in terraform state but not physically exist in GCP