### PR TITLE
Test for single issue code

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -7,6 +7,11 @@
 - [API Methods](#api-methods)
   - [`/api/verify`](#apiverify)
   - [`/api/certificate`](#apicertificate)
+- [Admin APIs](#admin-apis)
+  - [`/api/issue`](#apiissue)
+    - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)
+  - [`/api/batch-issue`](#apibatch-issue)
+    - [Handling batch partial success/failure](#handling-batch-partial-successfailure)
   - [`/api/checkcodestatus`](#apicheckcodestatus)
   - [`/api/expirecode`](#apiexpirecode)
   - [`/api/stats/*` (preview)](#apistats-preview)
@@ -275,6 +280,7 @@ Possible error code responses. New error codes may be added in future releases.
 | `unparsable_request`    | 400         | No    | Client sent an request the sever cannot parse                                                                   |
 | `invalid_test_type`     | 400         | No    | The client sent an accept of an unrecognized test type                                                          |
 | `missing_date`          | 400         | No    | The realm requires either a test or symptom date, but none was provided.                                        |
+| `invalid_date`          | 400         | No    | The provided test or symptom date, was older or newer than the realm allows.                                    |
 | `invalid_test_type`     | 400         | No    | The test type is not a valid test type (a string that is unknown to the server).                                |
 | `uuid_already_exists`   | 409         | No    | The UUID has already been used for an issued code                                                               |
 | `maintenance_mode   `   | 429         | Yes   | The server is temporarily down for maintenance. Wait and retry later.                                           |

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -41,7 +41,7 @@ const (
 	// this could mean a database or RPC connection drop or some other internal outage.
 	ErrInternal = "internal_server_error"
 
-	// Verify API responses
+	// Verify & Issue API responses
 
 	// ErrVerifyCodeInvalid indicates the code entered is unknown or already used.
 	ErrVerifyCodeInvalid = "code_invalid"
@@ -60,6 +60,9 @@ const (
 	ErrInvalidTestType = "invalid_test_type"
 	// ErrMissingDate indicates the realm requires a date, but none was supplied.
 	ErrMissingDate = "missing_date"
+	// ErrInvalidDate indicates the realm requires a date, but the supplied date
+	// was older or newer than the allowed date ramge.
+	ErrInvalidDate = "invalid_date"
 	// ErrUUIDAlreadyExists indicates that the UUID has already been used for an issued code.
 	ErrUUIDAlreadyExists = "uuid_already_exists"
 	// ErrMaintenanceMode indicates that the server is read-only for maintenance.

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -52,7 +52,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		if err := controller.BindJSON(w, r, &request); err != nil {
 			result.obsBlame = observability.BlameClient
 			result.obsResult = observability.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
 			return
 		}
 

--- a/pkg/controller/issueapi/issue_batch.go
+++ b/pkg/controller/issueapi/issue_batch.go
@@ -52,7 +52,7 @@ func (c *Controller) HandleBatchIssue() http.Handler {
 		if err := controller.BindJSON(w, r, &request); err != nil {
 			result.obsBlame = observability.BlameClient
 			result.obsResult = observability.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
-			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err))
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
 			return
 		}
 

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -119,7 +119,7 @@ func TestIssue(t *testing.T) {
 				SymptomDate: "1988-09-14",
 				TZOffset:    float32(tzMinOffset),
 			},
-			responseErr:    api.ErrUUIDAlreadyExists,
+			responseErr:    api.ErrInvalidDate,
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -119,7 +119,7 @@ func TestIssue(t *testing.T) {
 				SymptomDate: "1988-09-14",
 				TZOffset:    float32(tzMinOffset),
 			},
-			// fails, but no code
+			responseErr:    api.ErrUUIDAlreadyExists,
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{

--- a/pkg/controller/issueapi/logic.go
+++ b/pkg/controller/issueapi/logic.go
@@ -160,7 +160,7 @@ func (c *Controller) issue(ctx context.Context, authApp *database.AuthorizedApp,
 					obsBlame:    observability.BlameClient,
 					obsResult:   observability.ResultError(dateSettings[i].ValidateError),
 					httpCode:    http.StatusBadRequest,
-					errorReturn: api.Error(err),
+					errorReturn: api.Error(err).WithCode(api.ErrInvalidDate),
 				}, nil
 			}
 			parsedDates[i] = validatedDate

--- a/pkg/controller/issueapi/parse_date_test.go
+++ b/pkg/controller/issueapi/parse_date_test.go
@@ -1,0 +1,70 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueapi
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+)
+
+func TestDateValidation(t *testing.T) {
+	utc, err := time.LoadLocation("UTC")
+	if err != nil {
+		t.Fatalf("error loading utc")
+	}
+	var aug1 time.Time
+	aug1, err = time.ParseInLocation(project.RFC3339Date, "2020-08-01", utc)
+	if err != nil {
+		t.Fatalf("error parsing date")
+	}
+
+	tests := []struct {
+		v         string
+		max       time.Time
+		tzOffset  int
+		shouldErr bool
+		expected  string
+	}{
+		{"2020-08-01", aug1, 0, false, "2020-08-01"},
+		{"2020-08-01", aug1, 60, false, "2020-08-01"},
+		{"2020-08-01", aug1, 60 * 12, false, "2020-08-01"},
+		{"2020-07-31", aug1, 60, false, "2020-07-31"},
+		{"2020-08-01", aug1, -60, false, "2020-08-01"},
+		{"2020-07-31", aug1, -60, false, "2020-07-31"},
+		{"2020-07-30", aug1, -60, false, "2020-07-30"},
+		{"2020-07-29", aug1, -60, true, "2020-07-30"},
+	}
+	for i, test := range tests {
+		date, err := time.ParseInLocation(project.RFC3339Date, test.v, utc)
+		if err != nil {
+			t.Fatalf("[%d] error parsing date %q", i, test.v)
+		}
+		min := test.max.Add(-24 * time.Hour)
+		var newDate *time.Time
+		if newDate, err = validateDate(date, min, test.max, test.tzOffset); newDate == nil {
+			if err != nil {
+				if !test.shouldErr {
+					t.Fatalf("[%d] validateDate returned an unexpected error: %q", i, err)
+				}
+			} else {
+				t.Fatalf("[%d] expected error", i)
+			}
+		} else if s := newDate.Format(project.RFC3339Date); s != test.expected {
+			t.Fatalf("[%d] validateDate returned a different date %q != %q", i, s, test.expected)
+		}
+	}
+}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1399

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Integration test for a few failures of issue-code
* Adds an error code for symptom/test dates that are parsable but rejected - too old

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
added more test coverage of issue error cases
added error code 'invalid_date' for dates older the allowed for the realm
```
