### PR TITLE
Improve UX on permissions selection

### DIFF
--- a/cmd/server/assets/users/_form.html
+++ b/cmd/server/assets/users/_form.html
@@ -1,5 +1,7 @@
 {{define "users/_form"}}
 
+{{$currentMembership := .currentMembership}}
+
 {{$user := .user}}
 {{$userMembership := .userMembership}}
 {{$permissions := .permissions}}
@@ -31,32 +33,85 @@
 
     <hr />
 
-    <h6>Permissions</h6>
+    <div class="d-flex justify-content-between">
+      <h6>Permissions</h6>
+      <small>
+        <a href="#" data-toggle="modal" data-target="#permissions-help">Learn more</a>
+      </small>
+    </div>
+
+    <div class="modal fade" id="permissions-help" data-backdrop="static" tabindex="-1" aria-hidden="true">
+      <div class="modal-dialog modal-dialog-centered">
+        <div class="modal-content">
+          <div class="modal-header">
+            <h5 class="modal-title">About permissions</h5>
+            <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+              <span aria-hidden="true">&times;</span>
+            </button>
+          </div>
+          <div class="modal-body mb-n3">
+            <p>
+              Permissions are fine-grained controls that determine what actions
+              a user can take in the system. There is a detailed description
+              under each permission which describes the set of accesses that
+              permission grants.
+            </p>
+
+            <p>
+              Some permissions automatically imply other permissions. For
+              example, the <code>UserWrite</code> permission implies the
+              <code>UserRead</code> permission. In general, you cannot grant
+              permission to write to a resource without also granting permission
+              to read it.
+            </p>
+
+            <p>
+              Finally, you can only grant a permission if you also have that
+              permission on your account. You can remove permissions that you do
+              not have, but you will not be able to add them back.
+            </p>
+          </div>
+        </div>
+      </div>
+    </div>
+
     <div id="permissions-list" class="mb-3">
       {{if (eq $currentMembership.UserID $userMembership.UserID)}}
         <small class="form-text mb-3">
           You cannot edit your own permissions.
         </small>
-      {{end}}
-      {{range $name, $permission := $permissions}}
-        <div class="custom-control custom-checkbox py-3">
-          <input type="checkbox" name="permissions" id="permission-{{$permission.Value}}"
-            class="custom-control-input" value="{{$permission.Value}}"
-            {{checkedIf ($userMembership.Can $permission)}}
-            {{disabledIf (eq $currentMembership.UserID $userMembership.UserID)}}
-            {{readonlyIf (eq $currentMembership.UserID $userMembership.UserID)}}>
-          <label class="custom-control-label w-100" for="permission-{{$permission.Value}}">
-            {{$name}}
-            <small class="form-text text-muted">
-              Can {{$permission.Description}}.
-              {{if $implied := $permission.Implied}}
-                Granting this permission will also grant {{toSentence $implied "and"}}.
+      {{else}}
+        <span id="permission-implied-warning" class="oi oi-warning small py-1 px-1 d-none" aria-hidden="true"
+          data-toggle="tooltip" data-placement="top" data-offset="75"></span>
+
+        {{range $name, $permission := $permissions}}
+          <div class="custom-control custom-checkbox py-2">
+            <input type="checkbox" name="permissions" id="permission-{{$permission.String}}"
+              class="custom-control-input" value="{{$permission.Value}}"
+              data-permission-name="{{$permission.String}}"
+              data-implied-permissions="{{joinStrings $permission.Implied ","}}"
+              {{checkedIf ($userMembership.Can $permission)}}
+              {{disabledIf ($currentMembership.Cannot $permission)}}
+              {{readonlyIf ($currentMembership.Cannot $permission)}}
+              >
+            <label class="custom-control-label w-100" id="permission-{{$permission.String}}-label"
+              for="permission-{{$permission.String}}">
+              {{$name}}
+              {{if $currentMembership.Cannot $permission}}
+                <span class="oi oi-circle-x small py-1 px-1" aria-hidden="true"
+                  data-toggle="tooltip" data-placement="top" data-offset="75" title="You lack this permission"></span>
               {{end}}
-            </small>
-          </label>
-        </div>
-      {{end}}
-    </div>
+              <small class="form-text text-muted">
+                Can {{$permission.Description}}.
+                {{if $implied := $permission.Implied}}
+                  Granting this permission will also grant {{toSentence $implied "and"}}.
+                {{end}}
+              </small>
+            </label>
+          </div>
+        {{end}}
+      </div>
+    {{end}}
 
     <button type="submit" class="btn btn-primary btn-block">
       {{if $user.ID}}
@@ -69,17 +124,56 @@
 
   <script type="text/javascript">
     $(function() {
-      {{range $name, $permission := $permissions}}
-        {{if $implied := $permission.Implied}}
-          $('input#permission-{{$permission.Value}}').change(function() {
-            if($(this).prop('checked')) {
-              {{range $implied}}
-                $('input#permission-{{.Value}}').prop('checked', true);
-              {{end}}
-            }
-          });
-        {{end}}
-      {{end}}
+      let $permissionImpliedWarning = $('#permission-implied-warning');
+
+      $('input[name=permissions]')
+        .each(toggleState)
+        .change(toggleState);
+
+      function toggleState() {
+        let $this = $(this);
+
+        // Do nothing if disabled
+        if($this.prop('disabled')) {
+          return;
+        }
+
+        let permissionName = $this.data('permissionName');
+        let impliedPermissions = ($this.data('impliedPermissions') || '').split(',');
+
+        let impliedPermissionsList = [];
+        for(i = 0; i < impliedPermissions.length; i++) {
+          let permission = impliedPermissions[i].trim();
+          if(permission) {
+            impliedPermissionsList.push(permission);
+          }
+        }
+
+        let inputs = impliedPermissionsList.map(function(permission) {
+          return `input[data-permission-name="${permission}"]`;
+        }).join(',');
+        let labels = impliedPermissionsList.map(function(permission) {
+          return `label#permission-${permission}-label`;
+        }).join(',');
+
+        if($this.prop('checked')) {
+          $(inputs)
+            .prop('checked', true)
+            .prop('disabled', true);
+
+          let $warning = $permissionImpliedWarning.clone()
+            .removeClass('d-none')
+            .attr('title', `Implied by ${permissionName}`)
+            .tooltip();
+
+          $(labels).find('small.form-text').before($warning);
+        } else {
+          $(inputs)
+            .prop('disabled', false)
+
+          $(labels).find('span.oi').remove();
+        }
+      }
     });
   </script>
 {{end}}

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -63,12 +63,12 @@ func TestUpdate(t *testing.T) {
 
 	for _, permission := range rbac.NamePermissionMap {
 		permission := permission
-		targets := []string{fmt.Sprintf(`input#permission-%d`, permission)}
+		targets := []string{fmt.Sprintf(`input#permission-%s`, permission)}
 
 		// We also need to remove permissions that imply this permission, or it will
 		// be added back in.
 		for _, superPerm := range rbac.ImpliedBy(permission) {
-			targets = append(targets, fmt.Sprintf(`input#permission-%d`, superPerm))
+			targets = append(targets, fmt.Sprintf(`input#permission-%s`, superPerm))
 		}
 
 		// Build the actions as an array prior to run since super-permissions actions aren't known until runtime.
@@ -87,6 +87,7 @@ func TestUpdate(t *testing.T) {
 		for _, target := range targets {
 			actions = append(actions, chromedp.RemoveAttribute(target, "checked", chromedp.ByQuery))
 		}
+
 		actions = append(actions, chromedp.Submit(`form#user-form`, chromedp.ByQuery))
 
 		// Wait for render.
@@ -109,7 +110,7 @@ func TestUpdate(t *testing.T) {
 	// Now add permissions back
 	for _, permission := range rbac.NamePermissionMap {
 		permission := permission
-		target := fmt.Sprintf(`input#permission-%d`, permission)
+		target := fmt.Sprintf(`input#permission-%s`, permission)
 
 		if err := chromedp.Run(taskCtx,
 			// Pre-authenticate the user.

--- a/pkg/database/membership.go
+++ b/pkg/database/membership.go
@@ -109,3 +109,8 @@ func (m *Membership) Can(p rbac.Permission) bool {
 	}
 	return rbac.Can(m.Permissions, p)
 }
+
+// Cannot returns the opposite of Can
+func (m *Membership) Cannot(p rbac.Permission) bool {
+	return !m.Can(p)
+}


### PR DESCRIPTION
- Add help text that explains permissions and how they work

- Add membership.Cannot, which makes templates easier

- Checking a permission with implied permissions automatically checks
the implied ones and adds a little notice

- Don't allow the current user to select permissions that they lack
(this was already enforced server-side)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improve UX on permissions selection
```
