### PR TITLE
separate batch-issue from other e2e flows

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -116,6 +116,13 @@ func realMain(ctx context.Context) error {
 		}
 	}
 
+	// Make sure realm can issue all test types and has batch issue enabled.
+	realm.AllowedTestTypes = database.TestTypeNegative | database.TestTypeConfirmed | database.TestTypeLikely
+	realm.AllowBulkUpload = true
+	if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+		return fmt.Errorf("error configuring realm for e2e runner %+v: %w: %v", realm, err, realm.ErrorMessages())
+	}
+
 	// Create new API keys
 	suffix, err := project.RandomString()
 	if err != nil {
@@ -184,6 +191,7 @@ func realMain(ctx context.Context) error {
 
 	r.HandleFunc("/default", defaultHandler(ctx, e2eConfig.TestConfig))
 	r.HandleFunc("/revise", reviseHandler(ctx, e2eConfig.TestConfig))
+	r.HandleFunc("/batch", batchIssueHandler(ctx, e2eConfig.TestConfig))
 
 	mux := http.Handler(r)
 	if e2eConfig.DevMode {
@@ -197,6 +205,21 @@ func realMain(ctx context.Context) error {
 	}
 	logger.Infow("server listening", "port", e2eConfig.Port)
 	return srv.ServeHTTPHandler(ctx, mux)
+}
+
+func batchIssueHandler(ctx context.Context, config config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {
+	logger := logging.FromContext(ctx)
+	c := &config
+	c.DoRevise = false
+	return func(w http.ResponseWriter, r *http.Request) {
+		if err := clients.RunBatchIssue(ctx, c); err != nil {
+			logger.Errorw("could not run batch issue", "error", err)
+			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
+			return
+		}
+
+		fmt.Fprint(w, "ok")
+	}
 }
 
 // Config is passed by value so that each http handler has a separate copy (since they are changing one of the)

--- a/pkg/clients/apis.go
+++ b/pkg/clients/apis.go
@@ -48,7 +48,7 @@ func IssueCode(ctx context.Context, hostname, apiKey string, request *api.IssueC
 
 // BatchIssueCode uses the ADMIN API to issue multiple verification codes.
 func BatchIssueCode(ctx context.Context, hostname, apiKey string, request *api.BatchIssueCodeRequest) (*api.BatchIssueCodeResponse, error) {
-	url := hostname + "/api/issue"
+	url := hostname + "/api/batch-issue"
 	client := &http.Client{
 		Timeout: timeout,
 	}

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -188,12 +188,39 @@ resource "google_cloud_run_service_iam_member" "e2e-runner-invoker" {
   member   = "serviceAccount:${google_service_account.e2e-runner-invoker.email}"
 }
 
+resource "google_cloud_scheduler_job" "e2e-batch-issue" {
+  name             = "e2e-batch-issue"
+  region           = var.cloudscheduler_location
+  schedule         = "0,2,12,22,32,42,52,55 * * * *"
+  time_zone        = "America/Los_Angeles"
+  attempt_deadline = "30s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.e2e-runner.status.0.url}/batch"
+    oidc_token {
+      audience              = "${google_cloud_run_service.e2e-runner.status.0.url}/batch"
+      service_account_email = google_service_account.e2e-runner-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.e2e-runner-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}
+
 resource "google_cloud_scheduler_job" "e2e-default-workflow" {
   name             = "e2e-default-workflow"
   region           = var.cloudscheduler_location
   schedule         = "0,10,20,30,40,50,55 * * * *"
   time_zone        = "America/Los_Angeles"
-  attempt_deadline = "600s"
+  attempt_deadline = "30s"
 
   retry_config {
     retry_count = 1
@@ -220,7 +247,7 @@ resource "google_cloud_scheduler_job" "e2e-revise-workflow" {
   region           = var.cloudscheduler_location
   schedule         = "0,5,15,25,35,45,55 * * * *"
   time_zone        = "America/Los_Angeles"
-  attempt_deadline = "600s"
+  attempt_deadline = "30s"
 
   retry_config {
     retry_count = 1


### PR DESCRIPTION
## Proposed Changes

* e2e runner is currently failing due to wrong path name in e2e client
* separate out batch-issue to separate handler w/ independent schedule so we can monitor separate
* ensure realm is set up correctly for bulk issue when e2e runner starts

**Release Note**

```release-note
end to end test runner now tests bulk issue in a separate handler and scheduler
```
