### PR TITLE
Use regular mux for testing not-found scenarios

### DIFF
--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -17,15 +17,21 @@ package apikey_test
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 )
 
 func TestHandleDisable(t *testing.T) {
@@ -61,47 +67,37 @@ func TestHandleDisable(t *testing.T) {
 	t.Run("not_found", func(t *testing.T) {
 		t.Parallel()
 
-		authApp := &database.AuthorizedApp{
-			RealmID: realm.ID,
-			Name:    "Not found app",
-		}
-		if _, err := realm.CreateAuthorizedApp(harness.Database, authApp, database.SystemTest); err != nil {
-			t.Fatal(err)
-		}
-
-		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 10*time.Second)
-		defer done()
-
-		// Click "confirm" when it pops up.
-		confirmErrCh := envstest.AutoConfirmDialogs(taskCtx, true)
-
-		target := fmt.Sprintf(`a#disable-apikey-%d`, authApp.ID)
-
-		if err := chromedp.Run(taskCtx,
-			browser.SetCookie(cookie),
-			chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/apikeys`),
-			chromedp.WaitVisible(`body#apikeys-index`, chromedp.ByQuery),
-
-			chromedp.SetAttributeValue(target, "href", "/realm/apikeys/100/disable", chromedp.ByQuery),
-			chromedp.Click(target, chromedp.ByQuery),
-
-			chromedp.WaitVisible(`body#unauthorized`, chromedp.ByQuery),
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := <-confirmErrCh; err != nil {
-			t.Fatal(err)
-		}
-
-		// Still enabled
-		record, err := harness.Database.FindAuthorizedApp(authApp.ID)
+		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := record.DeletedAt; got != nil {
-			t.Errorf("expected %v to be nil", got)
+		c := apikey.New(harness.Cacher, harness.Database, h)
+
+		mux := mux.NewRouter()
+		mux.Handle("/{id}", c.HandleDisable())
+
+		ctx := context.Background()
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       &database.Realm{},
+			User:        &database.User{},
+			Permissions: rbac.APIKeyWrite,
+		})
+
+		r := httptest.NewRequest("GET", "/100", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		mux.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 401; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "unauthorized"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -17,15 +17,21 @@ package apikey_test
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 	"github.com/jinzhu/gorm"
 )
 
@@ -62,51 +68,37 @@ func TestHandleEnable(t *testing.T) {
 	t.Run("not_found", func(t *testing.T) {
 		t.Parallel()
 
-		now := time.Now().UTC().Add(-5 * time.Second)
-		authApp := &database.AuthorizedApp{
-			RealmID: realm.ID,
-			Name:    "Not found app",
-			Model: gorm.Model{
-				DeletedAt: &now,
-			},
-		}
-		if _, err := realm.CreateAuthorizedApp(harness.Database, authApp, database.SystemTest); err != nil {
-			t.Fatal(err)
-		}
-
-		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 10*time.Second)
-		defer done()
-
-		// Click "confirm" when it pops up.
-		confirmErrCh := envstest.AutoConfirmDialogs(taskCtx, true)
-
-		target := fmt.Sprintf(`a#enable-apikey-%d`, authApp.ID)
-
-		if err := chromedp.Run(taskCtx,
-			browser.SetCookie(cookie),
-			chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/apikeys`),
-			chromedp.WaitVisible(`body#apikeys-index`, chromedp.ByQuery),
-
-			chromedp.SetAttributeValue(target, "href", "/realm/apikeys/100/enable", chromedp.ByQuery),
-			chromedp.Click(target, chromedp.ByQuery),
-
-			chromedp.WaitVisible(`body#unauthorized`, chromedp.ByQuery),
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := <-confirmErrCh; err != nil {
-			t.Fatal(err)
-		}
-
-		// Still disabled
-		record, err := harness.Database.FindAuthorizedApp(authApp.ID)
+		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got := record.DeletedAt; got == nil {
-			t.Errorf("expected %v to not be nil", got)
+		c := apikey.New(harness.Cacher, harness.Database, h)
+
+		mux := mux.NewRouter()
+		mux.Handle("/{id}", c.HandleEnable())
+
+		ctx := context.Background()
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       &database.Realm{},
+			User:        &database.User{},
+			Permissions: rbac.APIKeyWrite,
+		})
+
+		r := httptest.NewRequest("GET", "/100", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		mux.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 401; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "unauthorized"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -17,6 +17,7 @@ package apikey_test
 import (
 	"context"
 	"fmt"
+	"net/http/httptest"
 	"strings"
 	"testing"
 	"time"
@@ -24,9 +25,13 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 )
 
 func TestHandleShow(t *testing.T) {
@@ -62,16 +67,37 @@ func TestHandleShow(t *testing.T) {
 	t.Run("not_found", func(t *testing.T) {
 		t.Parallel()
 
-		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 10*time.Second)
-		defer done()
-
-		if err := chromedp.Run(taskCtx,
-			browser.SetCookie(cookie),
-			chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/apikeys/100`),
-			chromedp.WaitVisible(`body#unauthorized`, chromedp.ByQuery),
-		); err != nil {
+		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		if err != nil {
 			t.Fatal(err)
+		}
+		c := apikey.New(harness.Cacher, harness.Database, h)
+
+		mux := mux.NewRouter()
+		mux.Handle("/{id}", c.HandleShow())
+
+		ctx := context.Background()
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       &database.Realm{},
+			User:        &database.User{},
+			Permissions: rbac.APIKeyWrite,
+		})
+
+		r := httptest.NewRequest("GET", "/100", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		mux.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 401; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "unauthorized"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
 		}
 	})
 


### PR DESCRIPTION
This gives us more control over the response assertions.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
