### PR TITLE
Use first available membership for password reset

### DIFF
--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -87,8 +87,13 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 			// Use the first membership available. This will help get the user a realm-localized template.
 			// For most users the expected number of memberships is 1.
 			membership, err = user.SelectFirstMembership(c.db)
-			if err != nil && !database.IsNotFound(err) {
-				logger.Warnw("failed retrieving membership", "error", err)
+			if err != nil {
+				if !database.IsNotFound(err) {
+					logger.Infof("No membership found for %s", user.Email)
+				} else {
+					controller.InternalError(w, r, c.h, err)
+					return
+				}
 			}
 		}
 

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -84,14 +84,11 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 
 		// This is likely - most users reset password from un-authed context.
 		if membership == nil {
-			memberships, err := user.ListMemberships(c.db)
-			if err != nil {
-				logger.Warnw("failed retrieving memberships", "error", err)
-			}
 			// Use the first membership available. This will help get the user a realm-localized template.
 			// For most users the expected number of memberships is 1.
-			if len(memberships) > 0 {
-				membership = memberships[0]
+			membership, err = user.SelectFirstMembership(c.db)
+			if err != nil {
+				logger.Warnw("failed retrieving membership", "error", err)
 			}
 		}
 

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -88,7 +88,7 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 			// For most users the expected number of memberships is 1.
 			membership, err = user.SelectFirstMembership(c.db)
 			if err != nil {
-				if !database.IsNotFound(err) {
+				if database.IsNotFound(err) {
 					logger.Infof("No membership found for %s", user.Email)
 				} else {
 					controller.InternalError(w, r, c.h, err)

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -86,7 +86,7 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		if membership == nil {
 			// Use the first membership available. This will help get the user a realm-localized template.
 			// For most users the expected number of memberships is 1.
-			membership, err = user.SelectFirstMembership(c.db)
+			membership, err = user.SelectFirstMembershipOrNil(c.db)
 			if err != nil {
 				logger.Warnw("failed retrieving membership", "error", err)
 			}

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -86,8 +86,8 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		if membership == nil {
 			// Use the first membership available. This will help get the user a realm-localized template.
 			// For most users the expected number of memberships is 1.
-			membership, err = user.SelectFirstMembershipOrNil(c.db)
-			if err != nil {
+			membership, err = user.SelectFirstMembership(c.db)
+			if err != nil && !database.IsNotFound(err) {
 				logger.Warnw("failed retrieving membership", "error", err)
 			}
 		}

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"net/http"
 
+	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -45,6 +46,7 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+		logger := logging.FromContext(ctx).Named("HandleSubmitResetPassword")
 
 		session := controller.SessionFromContext(ctx)
 		if session == nil {
@@ -79,6 +81,20 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		var resetComposer auth.ResetPasswordEmailFunc
 
 		membership := controller.MembershipFromContext(ctx)
+
+		// This is likely - most users reset password from un-authed context.
+		if membership == nil {
+			memberships, err := user.ListMemberships(c.db)
+			if err != nil {
+				logger.Warnw("failed retrieving memberships", "error", err)
+			}
+			// Use the first membership available. This will help get the user a realm-localized template.
+			// For most users the expected number of memberships is 1.
+			if len(memberships) > 0 {
+				membership = memberships[0]
+			}
+		}
+
 		// Build the emailer.
 		if membership != nil {
 			resetComposer, err = controller.SendPasswordResetEmailFunc(ctx, c.db, c.h, user.Email, membership.Realm)

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -145,7 +145,7 @@ func (u *User) ListMemberships(db *Database) ([]*Membership, error) {
 }
 
 // SelectFirstMembership selects the first memberships for this user.
-func (u *User) SelectFirstMembership(db *Database) (*Membership, error) {
+func (u *User) SelectFirstMembershipOrNil(db *Database) (*Membership, error) {
 	var membership *Membership
 
 	if err := db.db.
@@ -158,7 +158,7 @@ func (u *User) SelectFirstMembership(db *Database) (*Membership, error) {
 		First(&membership).
 		Error; err != nil {
 		if IsNotFound(err) {
-			return membership, nil
+			return nil, nil
 		}
 		return nil, err
 	}

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -145,9 +145,8 @@ func (u *User) ListMemberships(db *Database) ([]*Membership, error) {
 }
 
 // SelectFirstMembership selects the first memberships for this user.
-func (u *User) SelectFirstMembershipOrNil(db *Database) (*Membership, error) {
+func (u *User) SelectFirstMembership(db *Database) (*Membership, error) {
 	var membership *Membership
-
 	if err := db.db.
 		Preload("Realm").
 		Preload("User").
@@ -157,9 +156,6 @@ func (u *User) SelectFirstMembershipOrNil(db *Database) (*Membership, error) {
 		Order("realms.name").
 		First(&membership).
 		Error; err != nil {
-		if IsNotFound(err) {
-			return nil, nil
-		}
 		return nil, err
 	}
 	return membership, nil

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -144,6 +144,27 @@ func (u *User) ListMemberships(db *Database) ([]*Membership, error) {
 	return memberships, nil
 }
 
+// SelectFirstMembership selects the first memberships for this user.
+func (u *User) SelectFirstMembership(db *Database) (*Membership, error) {
+	var membership *Membership
+
+	if err := db.db.
+		Preload("Realm").
+		Preload("User").
+		Model(&Membership{}).
+		Where("user_id = ?", u.ID).
+		Joins("JOIN realms ON realms.id = memberships.realm_id").
+		Order("realms.name").
+		First(&membership).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return membership, nil
+		}
+		return nil, err
+	}
+	return membership, nil
+}
+
 // FindMembership finds the corresponding membership for the given realm ID, if
 // one exists. If not does not exist, an error is returned that satisfies
 // IsNotFound.


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Password reset occurs from a context that has no auth set and we allow realms to localize the email templates if using their own SMTP server
* Select the first available membership realm for password reset so the user can get a localized email.
    * Not idea for members of many realms, but that is not expected for most users 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Select a realm-localized template for reset password
```
