### PR TITLE
Prefer net split over custom indexof

### DIFF
--- a/pkg/controller/associated/index.go
+++ b/pkg/controller/associated/index.go
@@ -24,6 +24,7 @@ package associated
 import (
 	"context"
 	"fmt"
+	"net"
 	"net/http"
 	"strings"
 
@@ -45,13 +46,13 @@ type Controller struct {
 
 func (c *Controller) getRegion(r *http.Request) string {
 	// Get the hostname first
-	host := strings.ToLower(r.Host)
-	if i := strings.Index(host, ":"); i > 0 {
-		host = host[0:i]
+	baseHost := strings.ToLower(r.Host)
+	if host, _, err := net.SplitHostPort(baseHost); err == nil {
+		baseHost = host
 	}
 
 	// return the mapped region code (or default, "", if not found)
-	return c.hostnameToRegion[host]
+	return c.hostnameToRegion[baseHost]
 }
 
 func (c *Controller) HandleIos() http.Handler {

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -15,6 +15,7 @@
 package redirect
 
 import (
+	"net"
 	"net/http"
 	"strings"
 
@@ -32,8 +33,8 @@ func (c *Controller) HandleIndex() http.Handler {
 
 		// Strip of the port if that was passed along in the host header.
 		baseHost := strings.ToLower(r.Host)
-		if i := strings.Index(baseHost, ":"); i > 0 {
-			baseHost = baseHost[0:i]
+		if host, _, err := net.SplitHostPort(baseHost); err == nil {
+			baseHost = host
 		}
 
 		var hostRegion string = ""


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This should be less errorprone as net.SplitHostPort understands more complex combinations which include zone, less maintenance for us