### PR TITLE
Change some error levels for certificate api

### DIFF
--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -95,7 +95,7 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 	}
 	tokenClaims, ok := token.Claims.(*jwt.StandardClaims)
 	if !ok {
-		logger.Info("invalid claims in verification token")
+		logger.Infow("invalid verification token", "error", "claims are not StandardClaims")
 		return "", nil, fmt.Errorf("invalid verification token")
 	}
 	if err := tokenClaims.Valid(); err != nil {

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -77,15 +77,15 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 		kidHeader := token.Header[verifyapi.KeyIDHeader]
 		kid, ok := kidHeader.(string)
 		if !ok {
-			message := "missing 'kid' header in token"
-			logger.Infow("invalid verification token", "error", message)
-			return nil, errors.New(message)
+			err := errors.New("missing 'kid' header in token")
+			logger.Infow("invalid verification token", "error", err)
+			return nil, err
 		}
 		publicKey, ok := publicKeys[kid]
 		if !ok {
-			message := fmt.Sprintf("no public key exists for kid %q", kid)
-			logger.Infow("invalid verification token", "error", message)
-			return nil, errors.New(message)
+			err := fmt.Errorf("no public key exists for kid %q", kid)
+			logger.Infow("invalid verification token", "error", err)
+			return nil, err
 		}
 		return publicKey, nil
 	})
@@ -104,9 +104,9 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 	}
 	if !tokenClaims.VerifyIssuer(c.config.TokenSigning.TokenIssuer, true) || !tokenClaims.VerifyAudience(c.config.TokenSigning.TokenIssuer, true) {
 		logger.Infow("invalid verification token",
-		        "error", "jwt contains invalid iss/aud",
-		        "issuer", tokenClaims.Issuer,
-		        "audience", tokenClaims.Audience)
+			"error", "jwt contains invalid iss/aud",
+			"issuer", tokenClaims.Issuer,
+			"audience", tokenClaims.Audience)
 		return "", nil, fmt.Errorf("verification token not valid")
 	}
 	subject, err := database.ParseSubject(tokenClaims.Subject)

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -103,7 +103,10 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 		return "", nil, fmt.Errorf("verification token expired")
 	}
 	if !tokenClaims.VerifyIssuer(c.config.TokenSigning.TokenIssuer, true) || !tokenClaims.VerifyAudience(c.config.TokenSigning.TokenIssuer, true) {
-		logger.Infow("jwt contains invalid iss/aud", "issuer", tokenClaims.Issuer, "audience", tokenClaims.Audience)
+		logger.Infow("invalid verification token",
+		        "error", "jwt contains invalid iss/aud",
+		        "issuer", tokenClaims.Issuer,
+		        "audience", tokenClaims.Audience)
 		return "", nil, fmt.Errorf("verification token not valid")
 	}
 	subject, err := database.ParseSubject(tokenClaims.Subject)

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -83,7 +83,7 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 		}
 		publicKey, ok := publicKeys[kid]
 		if !ok {
-			message := fmt.Sprintf("no public key for specified 'kid' not found: %q", kid)
+			message := fmt.Sprintf("no public key exists for kid %q", kid)
 			logger.Infow("invalid verification token", "error", message)
 			return nil, errors.New(message)
 		}

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -99,7 +99,7 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 		return "", nil, fmt.Errorf("invalid verification token")
 	}
 	if err := tokenClaims.Valid(); err != nil {
-		logger.Infow("JWT is invalid", "error", err)
+		logger.Infow("invalid verification token", "error", "jwt is invalid", "jwtError", err)
 		return "", nil, fmt.Errorf("verification token expired")
 	}
 	if !tokenClaims.VerifyIssuer(c.config.TokenSigning.TokenIssuer, true) || !tokenClaims.VerifyAudience(c.config.TokenSigning.TokenIssuer, true) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Change unhandled unknown errors to StatusServerInternal 500
* Log at Info for 400 level errors
* de-duplicate some double logging

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Modify error message levels for CertAPI
Change unhandled errors to StatusServerInternal
```

/hold