### PR TITLE
Show success UUIDs and provide file receipt for bulk-issue

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -129,9 +129,25 @@
         </table>
       </div>
     </div>
+
+    <div class="card mb-3 shadow-sm d-none" id="receipt-div">
+      <div class="card-header">Receipt</div>
+      <div class="card-body">
+        <a id="save" class="card-link" download="bulk-issue-log.csv" href="data:text/plain,">Save code results log</a>
+        <small class="form-text text-muted">
+          <p><span class="text-success" id="receipt-success">0</span> codes issued.
+          <span class="text-danger" id="receipt-failure">0</span> codes failed.</p>
+          The above link allows you to download a log file of the results of your bulk issuance.
+          It follows the same CSV format as input with tracking UUIDs appended for successfully issued codes or the error code and message for failures.
+          You can make corrections to lines of this file and use it to retry the upload.
+        </small>
+        <p>
+      </div>
+    </div>
+
     <div class="card mb-3 shadow-sm d-none" id="error-div">
       <div class="card-header">Errors</div>
-      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
+      <table id="error-table" class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
         <thead>
           <tr>
             <th width="60">Line</th>
@@ -140,7 +156,10 @@
             <th>Error message</th>
           </tr>
         </thead>
-        <tbody id="error-table"></tbody>
+        <tbody></tbody>
+        <div class="card-body d-none" id="error-too-many">
+          <p class="card-text">Too many code errors to display results</p>
+        </div>
       </table>
     </div>
     <div class="card mb-3 shadow-sm d-none" id="success-div">
@@ -156,7 +175,7 @@
         </thead>
         <tbody></tbody>
       </table>
-      <div class="card-body d-none" id="too-many">
+      <div class="card-body d-none" id="success-too-many">
         <p class="card-text">Too many codes issued to display results</p>
       </div>
     </div>
@@ -164,6 +183,7 @@
 
   <script type="text/javascript">
     const batchSize = 10;
+    const showMaxResults = 50;
     let total = 0;
     let totalErrs = 0;
 
@@ -183,13 +203,20 @@
       let $newCode = $('#new-code');
       let $startAt = $('#start-at');
 
+      let $receiptDiv = $('#receipt-div');
+      let $save = $('#save');
+      let $receiptSuccess = $('#receipt-success');
+      let $receiptFailure = $('#receipt-failure');
+
       let $errorDiv = $('#error-div');
       let $errorTable = $('#error-table');
+      let $errorTableBody = $('#error-table > tbody');
+      let $errorTooMany = $('#error-too-many');
 
       let $successDiv = $('#success-div');
       let $successTable = $('#success-table');
       let $successTableBody = $('#success-table > tbody');
-      let $tooMany = $('#too-many');
+      let $successTooMany = $('#success-too-many');
 
       let tzOffset = new Date().getTimezoneOffset();
       let randomString = getCookie("retryCode");
@@ -235,10 +262,16 @@
         $table.removeClass('d-none');
         $progressDiv.removeClass('d-none');
 
-        $errorDiv.addClass("d-none");
-        $errorTable.empty();
+        $receiptDiv.addClass('d-none');
+        $save.attr("href", "data:text/plain,");
+        $receiptSuccess.text(0);
+        $receiptFailure.text(0);
 
-        $tooMany.addClass('d-none');
+        $errorTooMany.addClass('d-none');
+        $errorDiv.addClass("d-none");
+        $errorTableBody.empty();
+
+        $successTooMany.addClass('d-none');
         $successDiv.addClass("d-none");
         $successTableBody.empty();
 
@@ -299,12 +332,14 @@
                 }
                 break;
               }
-              $startAt.val(i + 2);
+              $startAt.val(i + 1);
               let percent = Math.floor((i + 1) * 100 / rows.length) + "%";
               $progress.width(percent);
               $progress.html(percent);
             }
           }
+
+          $save.attr("href", $save.attr("href") + '\n');
 
           if (!cancelUpload) {
             $progress.width('100%');
@@ -349,10 +384,17 @@
           return "";
         }
 
-        // Generate a UUID by hashing phone
-        let hs  = String(CryptoJS.HmacSHA256(request["phone"], retryCode)).substr(0,36);
-        request["uuid"] = hs.substr(0,8)+ '-' + hs.substr(9,4) + '-' + hs.substr(13,4) + '-' + hs.substr(17,4) + '-' + hs.substr(21,12);
+        let uuid = ""
+        if (cols.length > 6) {
+          uuid = $("<div>").text(cols[6].trim()).html();
+        }
+        if (uuid.length != 36) {
+          // Generate a UUID by hashing phone
+          let hs  = String(CryptoJS.HmacSHA256(request["phone"], retryCode)).substr(0,36);
+          uuid = hs.substr(0,8)+ '-' + hs.substr(9,4) + '-' + hs.substr(13,4) + '-' + hs.substr(17,4) + '-' + hs.substr(21,12);
+        }
 
+        request["uuid"] = uuid
         request["smsTemplateLabel"] = template;
         request["testType"] = "confirmed";
         request["tzOffset"] = tzOffset;
@@ -406,25 +448,46 @@
 
       function showErroredCode(request, code, line) {
         totalErrs++;
-        $errorDiv.removeClass('d-none');
+        $receiptFailure.text(totalErrs);
+        if (totalErrs == 1) {
+          $receiptDiv.removeClass('d-none');
+          $errorDiv.removeClass('d-none');
+        }
+        if (totalErrs == showMaxResults + 1) {
+          $errorTableBody.empty();
+          $errorTable.addClass('d-none');
+          $errorTooMany.removeClass('d-none');
+        }
+        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
+                  + ',' + request["symptomDate"] + ",,,,," + code.errorCode + ',' + code.error + '\n');
+        if (totalErrs > showMaxResults) {
+          return
+        }
+
         let $row = $('<tr/>');
         $row.append($('<td/>').text(line));
         $row.append($('<td/>').text(request["phone"]));
         $row.append($('<td/>').text(request["testDate"]));
         $row.append($('<td/>').text(code.error));
-        $errorTable.append($row);
+        $errorTableBody.append($row);
       }
 
       function showSuccessfulCode(request, code, line) {
         total++;
+        $receiptSuccess.text(total);
         if (total == 1) {
+          $receiptDiv.removeClass('d-none');
           $successDiv.removeClass('d-none');
           $successTable.removeClass('d-none');
         }
-        if (total == 51) { // only show first 50 successes
+        if (total == showMaxResults + 1) {
           $successTableBody.empty();
           $successTable.addClass('d-none');
-          $tooMany.removeClass('d-none');
+          $successTooMany.removeClass('d-none');
+        }
+        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
+                  + ',' + request["symptomDate"] + ",,,," + code.uuid + '\n');
+        if (total > showMaxResults) {
           return
         }
 

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -421,7 +421,7 @@
           $successDiv.removeClass('d-none');
           $successTable.removeClass('d-none');
         }
-        if (total == 21) { // only show 20 successes
+        if (total == 51) { // only show first 50 successes
           $successTableBody.empty();
           $successTable.addClass('d-none');
           $tooMany.removeClass('d-none');

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -369,8 +369,8 @@
           headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
           data: JSON.stringify({'codes':data}),
           success: function(result) {
-            if (result.error) {
-              flash.error(result.error);
+            if (!result.responseJSON || !result.responseJSON.codes) {
+              return
             }
             readCodes(data, result.responseJSON.codes, lastRow);
           },

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -145,7 +145,7 @@
     </div>
     <div class="card mb-3 shadow-sm d-none" id="success-div">
       <div class="card-header">Successfully issued codes</div>
-      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
+      <table id="success-table" class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
         <thead>
           <tr>
             <th width="60">Line</th>
@@ -154,8 +154,11 @@
             <th>Tracking UUID</th>
           </tr>
         </thead>
-        <tbody id="success-table"></tbody>
+        <tbody></tbody>
       </table>
+      <div class="card-body d-none" id="too-many">
+        <p class="card-text">Too many codes issued to display results</p>
+      </div>
     </div>
   </main>
 
@@ -183,8 +186,10 @@
       let $errorDiv = $('#error-div');
       let $errorTable = $('#error-table');
 
-      let $successiv = $('#success-div');
+      let $successDiv = $('#success-div');
       let $successTable = $('#success-table');
+      let $successTableBody = $('#success-table > tbody');
+      let $tooMany = $('#too-many');
 
       let tzOffset = new Date().getTimezoneOffset();
       let randomString = getCookie("retryCode");
@@ -233,8 +238,9 @@
         $errorDiv.addClass("d-none");
         $errorTable.empty();
 
+        $tooMany.addClass('d-none');
         $successDiv.addClass("d-none");
-        $successTable.empty();
+        $successTableBody.empty();
 
         if ($rememberCode.is(':checked')) {
           setCookie('retryCode',$retryCode.val(),1);
@@ -366,15 +372,7 @@
             if (result.error) {
               flash.error(result.error);
             }
-
-            $successDiv.removeClass('d-none');
-            let codes = result.responseJSON.codes;
-            for(let i = 0; i < codes.length; i++) {
-              let code = codes[i]
-              showSuccessfulCode(code);
-            }
-
-            $successDiv.removeClass('d-none');
+            readCodes(data, result.responseJSON.codes, lastRow);
           },
           error: function(xhr, resp, text) {
             if (!xhr || !xhr.responseJSON) {
@@ -389,49 +387,54 @@
               flash.error(message);
               return
             }
-
-
-            let codes = xhr.responseJSON.codes;
-            for(let i = 0; i < codes.length; i++) {
-              let code = codes[i]
-              if (code.error) {
-                showErroredCode(code);
-              } else {
-                showSuccessfulCode(code);
-              }
-            }
+            readCodes(data, xhr.responseJSON.codes, lastRow);
           },
         });
       }
 
-      function showErroredCode(code) {
+      function readCodes(data, codes, lastRow) {
+        for(let i = 0; i < codes.length; i++) {
+          let code = codes[i]
+          let line = lastRow - codes.length + i + 1
+          if (code.error) {
+            showErroredCode(data[i], code, line);
+          } else {
+            showSuccessfulCode(data[i], code, line);
+          }
+        }
+      }
+
+      function showErroredCode(request, code, line) {
         totalErrs++;
         $errorDiv.removeClass('d-none');
         let $row = $('<tr/>');
-        $row.append($('<td/>').text(lastRow - l + i + 1));
-        $row.append($('<td/>').text(data[i]["phone"]));
-        $row.append($('<td/>').text(data[i]["testDate"]));
+        $row.append($('<td/>').text(line));
+        $row.append($('<td/>').text(request["phone"]));
+        $row.append($('<td/>').text(request["testDate"]));
         $row.append($('<td/>').text(code.error));
         $errorTable.append($row);
       }
 
-      function showSuccessfulCode(code) {
+      function showSuccessfulCode(request, code, line) {
         total++;
+        if (total == 1) {
+          $successDiv.removeClass('d-none');
+          $successTable.removeClass('d-none');
+        }
         if (total == 21) { // only show 20 successes
-          $successTable.empty();
-          let $tooMany = $('<p>Too many codes issued to display results</p>');
-          $successTable.append($tooMany);
+          $successTableBody.empty();
+          $successTable.addClass('d-none');
+          $tooMany.removeClass('d-none');
           return
         }
 
         let $row = $('<tr/>');
-        $row.append($('<td/>').text(lastRow - l + i + 1));
-        $row.append($('<td/>').text(data[i]["phone"]));
-        $row.append($('<td/>').text(data[i]["testDate"]));
+        $row.append($('<td/>').text(line));
+        $row.append($('<td/>').text(request["phone"]));
+        $row.append($('<td/>').text(request["testDate"]));
         $row.append($('<td/>').text(code.uuid));
-        $successTable.append($row);
+        $successTableBody.append($row);
       }
-
     });
   </script>
 </body>

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -151,7 +151,7 @@
         <thead>
           <tr>
             <th width="60">Line</th>
-            <th width="150">Phone#</th>
+            <th width="150">Phone #</th>
             <th width="130">Test date</th>
             <th>Error message</th>
           </tr>
@@ -168,7 +168,7 @@
         <thead>
           <tr>
             <th width="60">Line</th>
-            <th width="150">Phone#</th>
+            <th width="150">Phone #</th>
             <th width="130">Test date</th>
             <th>Tracking UUID</th>
           </tr>
@@ -485,8 +485,7 @@
           $successTable.addClass('d-none');
           $successTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
-                  + ',' + request["symptomDate"] + ",,,," + code.uuid + '\n');
+        $save.attr("href", $save.attr("href") + `${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,code.uuid + '\n');
         if (total > showMaxResults) {
           return
         }

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -143,6 +143,20 @@
         <tbody id="error-table"></tbody>
       </table>
     </div>
+    <div class="card mb-3 shadow-sm d-none" id="success-div">
+      <div class="card-header">Successfully issued codes</div>
+      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
+        <thead>
+          <tr>
+            <th width="60">Line</th>
+            <th width="150">Phone#</th>
+            <th width="130">Test date</th>
+            <th>Tracking UUID</th>
+          </tr>
+        </thead>
+        <tbody id="success-table"></tbody>
+      </table>
+    </div>
   </main>
 
   <script type="text/javascript">
@@ -168,6 +182,9 @@
 
       let $errorDiv = $('#error-div');
       let $errorTable = $('#error-table');
+
+      let $successiv = $('#success-div');
+      let $successTable = $('#success-table');
 
       let tzOffset = new Date().getTimezoneOffset();
       let randomString = getCookie("retryCode");
@@ -215,6 +232,9 @@
 
         $errorDiv.addClass("d-none");
         $errorTable.empty();
+
+        $successDiv.addClass("d-none");
+        $successTable.empty();
 
         if ($rememberCode.is(':checked')) {
           setCookie('retryCode',$retryCode.val(),1);
@@ -343,10 +363,18 @@
           headers: { 'X-CSRF-Token': '{{.csrfToken}}' },
           data: JSON.stringify({'codes':data}),
           success: function(result) {
-            total += data.length;
             if (result.error) {
               flash.error(result.error);
             }
+
+            $successDiv.removeClass('d-none');
+            let codes = result.responseJSON.codes;
+            for(let i = 0; i < codes.length; i++) {
+              let code = codes[i]
+              showSuccessfulCode(code);
+            }
+
+            $successDiv.removeClass('d-none');
           },
           error: function(xhr, resp, text) {
             if (!xhr || !xhr.responseJSON) {
@@ -363,25 +391,47 @@
             }
 
 
-            let l = xhr.responseJSON.codes.length;
-            for(let i = 0; i < l; i++) {
-              let code = xhr.responseJSON.codes[i]
+            let codes = xhr.responseJSON.codes;
+            for(let i = 0; i < codes.length; i++) {
+              let code = codes[i]
               if (code.error) {
-                totalErrs++;
-                $errorDiv.removeClass('d-none');
-                let $row = $('<tr/>');
-                $row.append($('<td/>').text(lastRow - l + i + 1));
-                $row.append($('<td/>').text(data[i]["phone"]));
-                $row.append($('<td/>').text(data[i]["testDate"]));
-                $row.append($('<td/>').text(code.error));
-                $errorTable.append($row);
+                showErroredCode(code);
               } else {
-                total++;
+                showSuccessfulCode(code);
               }
             }
           },
         });
       }
+
+      function showErroredCode(code) {
+        totalErrs++;
+        $errorDiv.removeClass('d-none');
+        let $row = $('<tr/>');
+        $row.append($('<td/>').text(lastRow - l + i + 1));
+        $row.append($('<td/>').text(data[i]["phone"]));
+        $row.append($('<td/>').text(data[i]["testDate"]));
+        $row.append($('<td/>').text(code.error));
+        $errorTable.append($row);
+      }
+
+      function showSuccessfulCode(code) {
+        total++;
+        if (total == 21) { // only show 20 successes
+          $successTable.empty();
+          let $tooMany = $('<p>Too many codes issued to display results</p>');
+          $successTable.append($tooMany);
+          return
+        }
+
+        let $row = $('<tr/>');
+        $row.append($('<td/>').text(lastRow - l + i + 1));
+        $row.append($('<td/>').text(data[i]["phone"]));
+        $row.append($('<td/>').text(data[i]["testDate"]));
+        $row.append($('<td/>').text(code.uuid));
+        $successTable.append($row);
+      }
+
     });
   </script>
 </body>


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1442

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Show first 50 success / error cases with uuid for bulk-issue
* After 50 we stop showing them in the card for (potentially) very large lists
    * 50 was arbitrarily chosen, but we don't want the browser to be overwhelmed in large cases
* Update a file-download link with a full CSV formatted receipt of the issuance.

![savereceipt](https://user-images.githubusercontent.com/36240966/103048155-7fd8ba00-4542-11eb-9a17-dbd46ac19ff2.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show first 50 success / error cases for bulk-issue with UUIDs
Allow download of log file for bulk-issue
```
