### PR TITLE
Fix potentially incorrect line numbers

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -448,7 +448,7 @@
         }
       }
 
-      function showErroredCode(request, lines, code, line) {
+      function showErroredCode(request, code, line) {
         totalErrs++;
         $receiptFailure.text(totalErrs);
         if (totalErrs == 1) {

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -485,7 +485,8 @@
           $successTable.addClass('d-none');
           $successTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") + `${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,code.uuid + '\n');
+        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
+                    + ',' + request["symptomDate"] + ",,,," + code.uuid + '\n');
         if (total > showMaxResults) {
           return
         }

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -298,6 +298,7 @@
           let template = $inputSMSTemplate.val();
           let rows = e.target.result.split('\n');
           let batch = [];
+          let batchLines = [];
           total = 0;
           totalErrs = 0;
           $tableBody.empty();
@@ -306,12 +307,14 @@
             // Clear batch that was just uploaded.
             if (batch.length >= batchSize) {
               batch = [];
+              batchLines = [];
             }
 
             // Add to batch if the next row is valid.
             let request = buildRequest(rows[i], retryCode, template);
             if (request != "") {
               batch.push(request);
+              batchLines.push(i+1);
             }
 
             // If we've hit the batch limit or end of file, upload it.
@@ -324,7 +327,7 @@
                 $tableBody.append($row);
               }
 
-              cancelUpload = await uploadWithRetries(batch, d => uploadBatch(d, i));
+              cancelUpload = await uploadWithRetries(() => uploadBatch(batch, batchLines));
 
               if (cancelUpload) {
                 if (total > 0) {
@@ -401,7 +404,7 @@
         return request
       }
 
-      function uploadBatch(data, lastRow) {
+      function uploadBatch(data, lines) {
         return $.ajax({
           url: '/codes/batch-issue',
           type: 'POST',
@@ -414,7 +417,7 @@
             if (!result.responseJSON || !result.responseJSON.codes) {
               return
             }
-            readCodes(data, result.responseJSON.codes, lastRow);
+            readCodes(data, lines, result.responseJSON.codes);
           },
           error: function(xhr, resp, text) {
             if (!xhr || !xhr.responseJSON) {
@@ -429,24 +432,23 @@
               flash.error(message);
               return
             }
-            readCodes(data, xhr.responseJSON.codes, lastRow);
+            readCodes(data, lines, xhr.responseJSON.codes);
           },
         });
       }
 
-      function readCodes(data, codes, lastRow) {
+      function readCodes(data, lines, codes) {
         for(let i = 0; i < codes.length; i++) {
           let code = codes[i]
-          let line = lastRow - codes.length + i + 1
           if (code.error) {
-            showErroredCode(data[i], code, line);
+            showErroredCode(data[i], code, lines[i]);
           } else {
-            showSuccessfulCode(data[i], code, line);
+            showSuccessfulCode(data[i], code, lines[i]);
           }
         }
       }
 
-      function showErroredCode(request, code, line) {
+      function showErroredCode(request, lines, code, line) {
         totalErrs++;
         $receiptFailure.text(totalErrs);
         if (totalErrs == 1) {
@@ -458,8 +460,7 @@
           $errorTable.addClass('d-none');
           $errorTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") +
-         `$[request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,,${code.errorCode},${code.error}\n`);
+        $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,,${code.errorCode},${code.error}\n`);
         if (totalErrs > showMaxResults) {
           return
         }
@@ -485,8 +486,7 @@
           $successTable.addClass('d-none');
           $successTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") +
-        `${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid}\n`);
+        $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid}\n`);
         if (total > showMaxResults) {
           return
         }

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -458,8 +458,8 @@
           $errorTable.addClass('d-none');
           $errorTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
-                  + ',' + request["symptomDate"] + ",,,,," + code.errorCode + ',' + code.error + '\n');
+        $save.attr("href", $save.attr("href") +
+         `$[request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,,${code.errorCode},${code.error}\n`);
         if (totalErrs > showMaxResults) {
           return
         }
@@ -485,8 +485,8 @@
           $successTable.addClass('d-none');
           $successTooMany.removeClass('d-none');
         }
-        $save.attr("href", $save.attr("href") + request["phone"] + ',' + request["testDate"]
-                    + ',' + request["symptomDate"] + ",,,," + code.uuid + '\n');
+        $save.attr("href", $save.attr("href") +
+        `${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid}\n`);
         if (total > showMaxResults) {
           return
         }

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -266,10 +266,10 @@ const stopUploadingEnum = [
   'maintenance_mode',
 ];
 
-async function uploadWithRetries(batch, uploadFn) {
+async function uploadWithRetries(uploadFn) {
   let cancel = false;
   for (let retries = 3; retries > 0; retries--) {
-    await uploadFn(batch).then(
+    await uploadFn().then(
       () => { retries = 0; }).catch(
         async function(err) {
           if (!err) {

--- a/cmd/server/assets/users/import.html
+++ b/cmd/server/assets/users/import.html
@@ -174,7 +174,7 @@
 
             // If we've hit the batch limit or end of file, upload it.
             if (batch.length >= batchSize || i == rows.length - 1 && batch.length > 0) {
-              cancelUpload = await uploadWithRetries(batch, b => uploadBatch(b, checked));
+              cancelUpload = await uploadWithRetries(() => uploadBatch(batch, checked));
               if (cancelUpload) {
                 flash.warning("Successfully added " + totalUsersAdded + " users to realm."
                   + (rows.length - i) + " remaining.");


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1459

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The code currently assumes each line is in-order and uses index to show line number. However we skip blank or empty lines of the file which results in off-by-one.
* This fixes that by keeping an array of line numbers.
* Also consolidates string calculation for the href download

```release-note
Fix off-by-one line numbers for bulk uploader
```