### PR TITLE
Add zapw to detect misuse of logger

### DIFF
--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -2,7 +2,8 @@ name: Code Review
 
 on:
   pull_request:
-    branches: [ 'main' ]
+    branches:
+    - 'main'
 
 jobs:
   only_user_errors:
@@ -31,7 +32,7 @@ jobs:
             -fail-on-error="false" \
             -level="warning"
 
-  controller_error_without_return:
+  controller-error-without-return:
     name: controller-returns
     runs-on: ubuntu-latest
 
@@ -60,6 +61,45 @@ jobs:
             . | \
           reviewdog -efm="%f:%l:%m" \
             -name="controller-returns" \
+            -reporter="github-pr-review" \
+            -filter-mode="diff_context" \
+            -fail-on-error="true" \
+            -level="error"
+
+  zap-logger:
+    name: zap-logger
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out code
+        uses: actions/checkout@v2
+
+      - uses: reviewdog/action-setup@v1
+
+      - uses: actions/setup-go@v2
+        with:
+          go-version: '1.15'
+
+      - uses: actions/cache@v2
+        with:
+          path: |-
+            ~/go/pkg/mod
+            ~/.cache/go-build
+          key: ${{ runner.os }}-go-${{ hashFiles('**/go.sum') }}
+          restore-keys: |
+            ${{ runner.os }}-go-
+
+      - name: Check
+        shell: bash
+        env:
+          REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
+        run: |-
+          set -eEu
+          set +o pipefail
+
+          make zapcheck 2>&1 | \
+          reviewdog -efm="%f:%l:%c: %m" \
+            -name="zap-logger" \
             -reporter="github-pr-review" \
             -filter-mode="diff_context" \
             -fail-on-error="true" \

--- a/Makefile
+++ b/Makefile
@@ -65,8 +65,8 @@ staticcheck:
 .PHONY: staticcheck
 
 zapcheck:
-	command -v zapw > /dev/null 2>&1 || GO111MODULE=off go get github.com/sethvargo/zapw/cmd/zapw
-	zapw ./...
+	@command -v zapw > /dev/null 2>&1 || GO111MODULE=off go get github.com/sethvargo/zapw/cmd/zapw
+	@zapw ./...
 
 test:
 	@go test \

--- a/Makefile
+++ b/Makefile
@@ -64,6 +64,10 @@ staticcheck:
 	@staticcheck -checks="all,-S1023" -tests $(GOFMT_FILES)
 .PHONY: staticcheck
 
+zapcheck:
+	command -v zapw > /dev/null 2>&1 || GO111MODULE=off go get github.com/sethvargo/zapw/cmd/zapw
+	zapw ./...
+
 test:
 	@go test \
 		-count=1 \

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -213,7 +213,7 @@ func batchIssueHandler(ctx context.Context, config config.E2ETestConfig) func(ht
 	c.DoRevise = false
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := clients.RunBatchIssue(ctx, c); err != nil {
-			logger.Errorw("could not run batch issue", "error", err)
+			logger.Errorw("could not run batch issue", "error", err, "hi")
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -231,7 +231,7 @@ func defaultHandler(ctx context.Context, config config.E2ETestConfig) func(http.
 	c.DoRevise = false
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			logger.Errorw("could not run default end to end", "error", err)
+			logger.Errorw("could not run default end to end", "error", err, 5, "hi")
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -213,7 +213,7 @@ func batchIssueHandler(ctx context.Context, config config.E2ETestConfig) func(ht
 	c.DoRevise = false
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := clients.RunBatchIssue(ctx, c); err != nil {
-			logger.Errorw("could not run batch issue", "error", err, "hi")
+			logger.Errorw("could not run batch issue", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}
@@ -231,7 +231,7 @@ func defaultHandler(ctx context.Context, config config.E2ETestConfig) func(http.
 	c.DoRevise = false
 	return func(w http.ResponseWriter, r *http.Request) {
 		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			logger.Errorw("could not run default end to end", "error", err, 5, "hi")
+			logger.Errorw("could not run default end to end", "error", err)
 			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
 			return
 		}

--- a/go.mod
+++ b/go.mod
@@ -38,6 +38,7 @@ require (
 	github.com/gorilla/securecookie v1.1.1
 	github.com/gorilla/sessions v1.2.1
 	github.com/gorilla/websocket v1.4.2 // indirect
+	github.com/gostaticanalysis/analysisutil v0.6.1 // indirect
 	github.com/hashicorp/go-memdb v1.2.1 // indirect
 	github.com/hashicorp/go-msgpack v1.1.5 // indirect
 	github.com/hashicorp/go-multierror v1.1.0
@@ -68,6 +69,7 @@ require (
 	github.com/sethvargo/go-redisstore v0.3.0-opencensus
 	github.com/sethvargo/go-retry v0.1.0
 	github.com/sethvargo/go-signalcontext v0.1.0
+	github.com/sethvargo/zapw v0.1.0
 	github.com/smartystreets/assertions v1.0.0 // indirect
 	github.com/stretchr/objx v0.3.0 // indirect
 	github.com/timakin/bodyclose v0.0.0-20200424151742-cb6215831a94
@@ -79,7 +81,7 @@ require (
 	golang.org/x/sys v0.0.0-20201221093633-bc327ba9c2f0 // indirect
 	golang.org/x/text v0.3.4
 	golang.org/x/time v0.0.0-20201208040808-7e3f01d25324
-	golang.org/x/tools v0.0.0-20201222163215-f2e330f49058
+	golang.org/x/tools v0.0.0-20201226215659-b1c90890d22a
 	google.golang.org/api v0.36.0
 	google.golang.org/genproto v0.0.0-20201214200347-8c77b98c765d
 	gopkg.in/gormigrate.v1 v1.6.0

--- a/go.sum
+++ b/go.sum
@@ -684,6 +684,10 @@ github.com/gorilla/websocket v1.4.2 h1:+/TMaTYc4QFitKJxsQ7Yye35DkWvkdLcvGKqM+x0U
 github.com/gorilla/websocket v1.4.2/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3 h1:JVnpOZS+qxli+rgVl98ILOXVNbW+kb5wcxeGx8ShUIw=
 github.com/gostaticanalysis/analysisutil v0.0.0-20190318220348-4088753ea4d3/go.mod h1:eEOZF4jCKGi+aprrirO9e7WKB3beBRtWgqGunKl6pKE=
+github.com/gostaticanalysis/analysisutil v0.6.1 h1:/1JkoHe4DVxur+0wPvi26FoQfe1E3ZGqIXS3aaSLiaw=
+github.com/gostaticanalysis/analysisutil v0.6.1/go.mod h1:18U/DLpRgIUd459wGxVHE0fRgmo1UgHDcbw7F5idXu0=
+github.com/gostaticanalysis/comment v1.4.1 h1:xHopR5L2lRz6OsjH4R2HG5wRhW9ySl3FsHIvi5pcXwc=
+github.com/gostaticanalysis/comment v1.4.1/go.mod h1:ih6ZxzTHLdadaiSnF5WY3dxUoXfXAlTaRzuaNDlSado=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible h1:AQwinXlbQR2HvPjQZOmDhRqsv5mZf+Jb1RnSLxcqZcI=
 github.com/gotestyourself/gotestyourself v2.2.0+incompatible/go.mod h1:zZKM6oeNM8k+FRljX1mnzVYeS8wiGgQyvST1/GafPbY=
 github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:FecbI9+v66THATjSRHfNgh1IVFe/9kFxbXtjV0ctIMA=
@@ -1403,6 +1407,8 @@ github.com/sethvargo/go-retry v0.1.0 h1:8sPqlWannzcReEcYjHSNw9becsiYudcwTD7CasGj
 github.com/sethvargo/go-retry v0.1.0/go.mod h1:JzIOdZqQDNpPkQDmcqgtteAcxFLtYpNF/zJCM1ysDg8=
 github.com/sethvargo/go-signalcontext v0.1.0 h1:3IU7HOlmRXF0PSDf85C4nJ/zjYDjF+DS+LufcKfLvyk=
 github.com/sethvargo/go-signalcontext v0.1.0/go.mod h1:PXu9UmR2f7mmp8kEwgkKmaDbxq/PbqixkiC66WIkkWE=
+github.com/sethvargo/zapw v0.1.0 h1:mld/WxYO+9GSEtY+UKMkz5I3HQYm4uaaGdMWhiKgrm4=
+github.com/sethvargo/zapw v0.1.0/go.mod h1:R5PgP+vnMnhUny+JcfcvWKfiif/WJ0X23MfmS/dJKqM=
 github.com/shirou/gopsutil v2.20.9+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
 github.com/shirou/gopsutil v3.20.12-0.20201210134652-afe0c04c5d5a+incompatible h1:uvFOXu1W/nsxgfbLu0jGTad6j0PbFDsXkwxK/rqT/AA=
 github.com/shirou/gopsutil v3.20.12-0.20201210134652-afe0c04c5d5a+incompatible/go.mod h1:5b4v6he4MtMOwMlS0TUMTu2PcXUg8+E1lC7eC3UO/RA=
@@ -1899,6 +1905,7 @@ golang.org/x/tools v0.0.0-20200806022845-90696ccdc692/go.mod h1:njjCfa9FT2d7l9Bc
 golang.org/x/tools v0.0.0-20200814230902-9882f1d1823d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200817023811-d00afeaade8f/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200818005847-188abfa75333/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
+golang.org/x/tools v0.0.0-20200820010801-b793a1359eac/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200825202427-b303f430e36d/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200828161849-5deb26317202/go.mod h1:njjCfa9FT2d7l9Bc6FUM5FLjQPp3cFF28FI3qnDFljA=
 golang.org/x/tools v0.0.0-20200904185747-39188db58858/go.mod h1:Cj7w3i3Rnn0Xh82ur9kSqwfTHTeVxaDqrfMjpcNT6bE=
@@ -1911,8 +1918,8 @@ golang.org/x/tools v0.0.0-20201208233053-a543418bbed2 h1:vEtypaVub6UvKkiXZ2xx9QI
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201217235154-5b06639e575e h1:E9Tsxve7zGyxn3wehkwL3jSudihvp4PBgkZOHFR/ojc=
 golang.org/x/tools v0.0.0-20201217235154-5b06639e575e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
-golang.org/x/tools v0.0.0-20201222163215-f2e330f49058 h1:zSPRinxiz6krIAZie/STjID5lW/bkAvl+xz2cquNQEA=
-golang.org/x/tools v0.0.0-20201222163215-f2e330f49058/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20201226215659-b1c90890d22a h1:pdfjQ7VswBeGam3EpuEJ4e8EAb7JgaubV570LO/SIQM=
+golang.org/x/tools v0.0.0-20201226215659-b1c90890d22a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=

--- a/tools/tools.go
+++ b/tools/tools.go
@@ -19,6 +19,7 @@ package tools
 
 import (
 	_ "github.com/client9/misspell/cmd/misspell"
+	_ "github.com/sethvargo/zapw/cmd/zapw"
 	_ "github.com/timakin/bodyclose"
 	_ "golang.org/x/tools/cmd/goimports"
 	_ "honnef.co/go/tools/cmd/staticcheck"


### PR DESCRIPTION
This leverages a static analysis tool I wrote to find and alert when we misuse the logger.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add zapw to detect misuse of logger
```

/hold