### PR TITLE
Allow uuid expansion in sms text

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -259,13 +259,15 @@
           <li><code>[enslink]</code> Inserts the EN Express link of: <code>https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode]</code>
             <ul>
               <li>This domain should be registered as a universal link for both your Android and iOS applications.</li>
-              <li>Contact your server operator to verify the the verification EN Express redirect service is running and configurd correctly.</li>
+              <li>Contact your server operator to verify the the verification EN Express redirect service is running and configured correctly.</li>
             </ul>
           </li>
           {{end}}
           <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
           <li><code>[code]</code>The 'short' verification code can be optionally included here in the event the link isn't clickable for the user. Typically this is not needed.</li>
           <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units). Should be included if <code>[code]</code> is used</li>
+          <li><code>[uuid]</code>The tracking uuid of the code, this may be associated with the user's case data, and
+            issuers may use this to confirm that a code has been claimed by the user.</li>
         </ul>
 
         Here is an example SMS template using EN Express.
@@ -302,6 +304,8 @@
         <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units).</li>
         <li><code>[longcode]</code>The 'long' verification code</li>
         <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+        <li><code>[uuid]</code>The tracking uuid of the code, this may be associated with the user's case data, and
+          issuers may use this to confirm that a code has been claimed by the user.</li>
       </ul>
 
       Here are some example SMS templates. The recommended usage is to include the long code in the SMS, and make
@@ -319,7 +323,7 @@
         </li>
         <li>
           <p>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration).
-            Here we assume that <code>verify.mypha.gov</code> is registred as a universal link for both your iOS
+            Here we assume that <code>verify.mypha.gov</code> is registered as a universal link for both your iOS
             and Android applications.
           </p>
           <p>

--- a/docs/realm-admin-guide.md
+++ b/docs/realm-admin-guide.md
@@ -121,7 +121,7 @@ See the help text on that page for guidance.
 
 ![sms text](images/admin/settings04.png "SMS Template")
 
-The fields `[region]`, `[code]`, `[expires]`, `[longcode]`, and `[longexpires]` may be included with brackets
+The fields `[region]`, `[code]`, `[expires]`, `[longcode]`, `[longexpires]`, and `[uuid]` may be included with brackets
 which will be programmatically substituted with values. It is recommended that the text of this SMS be composed
 in such a way that is respectful to the patient and does not reveal details about their diagnosis to potential onlookers of the phone's notifications with further information presented in-app.
 

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -77,7 +77,7 @@ func (c *Controller) SendSMS(ctx context.Context, request *api.IssueCodeRequest,
 	logger := logging.FromContext(ctx).Named("issueapi.sendSMS")
 	smsStart := time.Now()
 	err = func() error {
-		message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+		message, err := realm.BuildSMSText(result.VerCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
 		if err != nil {
 			result.obsResult = observability.ResultError("FAILED_TO_BUILD_SMS")
 			return err

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -396,7 +396,11 @@ func TestRealm_BuildSMSText(t *testing.T) {
 	realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
 	realm.RegionCode = "US-WA"
 
-	got, err := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express", "")
+	verCode := &VerificationCode{
+		Code:     "12345678",
+		LongCode: "abcdefgh12345678",
+	}
+	got, err := realm.BuildSMSText(verCode, "en.express", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -406,7 +410,11 @@ func TestRealm_BuildSMSText(t *testing.T) {
 	}
 
 	realm.SMSTextTemplate = "State of Wonder, COVID-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
-	got, err = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "", "")
+	verCode = &VerificationCode{
+		Code:     "654321",
+		LongCode: "asdflkjasdlkfjl",
+	}
+	got, err = realm.BuildSMSText(verCode, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/sms_config_test.go
+++ b/pkg/database/sms_config_test.go
@@ -41,6 +41,12 @@ func TestSMSConfig_Lifecycle(t *testing.T) {
 		}
 	}
 
+	if has, err := realm.HasSMSConfig(db); err != nil {
+		t.Fatal(err)
+	} else if has {
+		t.Fatal("expected no SMS config for realm")
+	}
+
 	// Create SMS config on the realm
 	smsConfig := &SMSConfig{
 		RealmID:          realm.ID,
@@ -57,6 +63,12 @@ func TestSMSConfig_Lifecycle(t *testing.T) {
 	realm, err = db.FindRealm(realm.ID)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if has, err := realm.HasSMSConfig(db); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Fatal("expected realm to have SMS config")
 	}
 
 	// Load the SMS config


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1321

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Although not included by default, realms may configure their SMS template to expand UUID into the text. This might allow case-workers to track a UUID from their case file, to our system, to the text. They can follow up with the user with that identifier to confirm that the token has been claimed.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow code UUID in SMS expansion
```
