### PR TITLE
An odd test flake in integration_e2e

### DIFF
--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -73,7 +73,7 @@ func (c *Controller) validateToken(ctx context.Context, verToken string, publicK
 	logger := logging.FromContext(ctx).Named("certapi.validateToken")
 
 	parser := &jwt.Parser{
-		SkipClaimsValidation: true, // Manually check claims.Valid() below
+		SkipClaimsValidation: true, // we manually check claims.Valid() below
 	}
 	// Parse and validate the verification token.
 	token, err := parser.ParseWithClaims(verToken, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -72,8 +72,11 @@ func New(ctx context.Context, config *config.APIServerConfig, db *database.Datab
 func (c *Controller) validateToken(ctx context.Context, verToken string, publicKeys map[string]crypto.PublicKey) (string, *database.Subject, error) {
 	logger := logging.FromContext(ctx).Named("certapi.validateToken")
 
+	parser := &jwt.Parser{
+		SkipClaimsValidation: true, // Manually check claims.Valid() below
+	}
 	// Parse and validate the verification token.
-	token, err := jwt.ParseWithClaims(verToken, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {
+	token, err := parser.ParseWithClaims(verToken, &jwt.StandardClaims{}, func(token *jwt.Token) (interface{}, error) {
 		kidHeader := token.Header[verifyapi.KeyIDHeader]
 		kid, ok := kidHeader.(string)
 		if !ok {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* example flake: https://oss-prow.knative.dev/view/gs/oss-prow/pr-logs/pull/google_exposure-notifications-verification-server/1464/pull-en-server-release-unit/1343646210786856960
* The standard ParseWithClaims fails if !claims.Valid() but we continue on and check for that ourselves too. This resulted in the test failing with the wrong error message.
    * Why does this only fail sometimes? I am not sure. 