### PR TITLE
Give admins the ability to disable AppStore redirects

### DIFF
--- a/cmd/server/assets/mobileapps/_app.html
+++ b/cmd/server/assets/mobileapps/_app.html
@@ -2,11 +2,20 @@
 
 {{$app := .app}}
 
+<style>
+  .d-android-only, .d-app-none, .d-ios-only {
+    display: none;
+  }
+</style>
+
 <div class="form-label-group">
   <input type="text" name="name" id="name" class="form-control{{if $app.ErrorsFor "name"}} is-invalid{{end}}" value="{{$app.Name}}"
     placeholder="Application name" autofocus>
   <label for="name">Application name</label>
   {{template "errorable" $app.ErrorsFor "name"}}
+  <small class="form-text text-muted">
+    This is the name of your application.
+  </small>
 </div>
 
 <div class="form-label-group">
@@ -14,29 +23,54 @@
     placeholder="AppStore URL" autofocus>
   <label for="url">AppStore URL</label>
   {{template "errorable" $app.ErrorsFor "url"}}
+  <small class="form-text text-muted">
+    This is the URL where users can download your app. For iOS apps, this should
+    be a <a href="https://developer.apple.com/">Apple App Store URL</a>. For
+    Android apps, this should be a <a
+    href="https://support.google.com/admob/answer/3086746?hl=en">Google Play
+    Store URL</a>.
+  </small>
 </div>
+
+<div class="custom-control custom-switch mb-3">
+  <input type="checkbox" name="enable_redirect" id="enable-redirect"
+    class="custom-control-input" {{checkedIf (not $app.DisableRedirect)}}
+    {{if $app.ErrorsFor "disable_redirect"}}is-invalid{{end}}>
+  <label class="custom-control-label" for="enable-redirect">Enable AppStore redirects</label>
+  {{template "errorable" $app.ErrorsFor "disable_redirect"}}
+  <small class="form-text text-muted">
+    If a patient clicks on a verification link when they do not have the app
+    installed, the system will redirect them to the appropriate store to install
+    the application. We recommend keeping this option enabled to help increase
+    app adoption.
+  </small>
+</div>
+
+<hr>
 
 <div class="form-group">
   <select name="os" id="os" class="form-control custom-select{{if $app.ErrorsFor "os"}} is-invalid{{end}}">
     <option selected disabled>Choose platform...</option>
-    <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS Custom App</option>
-    <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android EN Express or Custom App</option>
+    <option value="{{.iOS}}" {{if (eq $app.OS .iOS)}}selected{{end}}>iOS custom app</option>
+    <option value="{{.android}}" {{if (eq $app.OS .android)}}selected{{end}}>Android EN Express or custom app</option>
   </select>
   {{template "errorable" $app.ErrorsFor "os"}}
 </div>
 
-<div id="app-id-group" class="form-label-group d-none">
+<div id="app-id-group" class="form-label-group d-app-none">
   <input type="text" name="app_id" id="app-id" class="form-control text-monospace{{if $app.ErrorsFor "app_id"}} is-invalid{{end}}" value="{{$app.AppID}}">
   <label for="app-id" id="app-id-label"></label>
   {{template "errorable" $app.ErrorsFor "app_id"}}
-  <small class="form-text text-muted d-none" id="ioshelp">
-    The iOS Mobile App configuration must be blank if you are an iOS Exposure Notifications Express (ENX) customer. This should only
-    be filled in for custom applications.
-    The iOS app id should be either a team ID or app ID prefix followed by the bundle ID. eg. ABCD1234.com.google.test.application
+  <small class="form-text text-muted d-ios-only">
+    The Application ID should be either a team ID or app ID prefix followed by
+    the bundle ID (e.g. <code>ABCD1234.com.my.app</code>).
+  </small>
+  <small class="form-text text-muted d-android-only">
+    The Package Name is the registered Android package name (e.g. <code>com.example.my.app</code>)
   </small>
 </div>
 
-<div id="sha-group" class="form-label-group d-none">
+<div id="sha-group" class="form-label-group d-android-only">
   <textarea name="sha" id="sha" class="form-control text-monospace{{if $app.ErrorsFor "sha"}} is-invalid{{end}}"
     placeholder="SHA256s (one per line)" rows="5">{{$app.SHA}}</textarea>
   <label for="sha">SHA256 from the app signing certificate (one per line) </label>
@@ -54,29 +88,26 @@
 <script type="text/javascript">
   $(function() {
     let $selectOS = $('select#os');
-    let $appID = $('#app-id');
     let $appIDGroup = $('#app-id-group');
+    let $appIDInput = $('#app-id');
     let $appIDLabel = $('#app-id-label');
-    let $sha = $('#sha');
-    let $shaGroup = $('#sha-group');
-    let $iosHelp = $('#ioshelp');
 
     function processChange() {
-      $appIDGroup.addClass('d-none');
+      $appIDGroup.hide();
 
       let val = $selectOS.children('option:selected').val();
       if (val === '{{.iOS}}') {
-        $appID.attr('placeholder', 'Application ID');
+        $appIDInput.attr('placeholder', 'Application ID');
         $appIDLabel.html('Application ID');
-        $shaGroup.addClass('d-none');
-        $appIDGroup.removeClass('d-none');
-        $iosHelp.removeClass('d-none');
+        $('.d-android-only').hide();
+        $('.d-ios-only').show();
+        $appIDGroup.show();
       } else if (val === '{{.android}}') {
-        $appID.attr('placeholder', 'Package name');
+        $appIDInput.attr('placeholder', 'Package name');
         $appIDLabel.html('Package name');
-        $shaGroup.removeClass('d-none');
-        $appIDGroup.removeClass('d-none');
-        $iosHelp.addClass('d-none');
+        $('.d-android-only').show();
+        $('.d-ios-only').hide();
+        $appIDGroup.show();
       }
     }
 

--- a/cmd/server/assets/mobileapps/show.html
+++ b/cmd/server/assets/mobileapps/show.html
@@ -40,6 +40,9 @@
           <dt>AppStore link</dt>
           <dd id="mobileapps-url"><a href="{{$app.URL}}" rel="noreferrer" target="_blank">{{$app.URL}}</a></dd>
 
+          <dt>Enable AppStore redirect</dt>
+          <dd>{{not $app.DisableRedirect}}</dd>
+
           <dt>OS</dt>
           <dd id="mobileapps-os">
             {{if (eq $app.OS .iOS)}}

--- a/pkg/controller/mobileapps/create.go
+++ b/pkg/controller/mobileapps/create.go
@@ -80,17 +80,19 @@ func (c *Controller) HandleCreate() http.Handler {
 
 func bindCreateForm(r *http.Request, app *database.MobileApp) error {
 	type FormData struct {
-		Name  string          `form:"name"`
-		URL   string          `form:"url"`
-		OS    database.OSType `form:"os"`
-		AppID string          `form:"app_id"`
-		SHA   string          `form:"sha"`
+		Name           string          `form:"name"`
+		URL            string          `form:"url"`
+		EnableRedirect bool            `form:"enable_redirect"`
+		OS             database.OSType `form:"os"`
+		AppID          string          `form:"app_id"`
+		SHA            string          `form:"sha"`
 	}
 
 	var form FormData
 	err := controller.BindForm(nil, r, &form)
 	app.Name = form.Name
 	app.URL = form.URL
+	app.DisableRedirect = !form.EnableRedirect
 	app.OS = form.OS
 	app.AppID = form.AppID
 	app.SHA = form.SHA

--- a/pkg/controller/mobileapps/update.go
+++ b/pkg/controller/mobileapps/update.go
@@ -93,17 +93,19 @@ func (c *Controller) HandleUpdate() http.Handler {
 
 func bindUpdateForm(r *http.Request, app *database.MobileApp) error {
 	type FormData struct {
-		Name  string          `form:"name"`
-		URL   string          `form:"url"`
-		OS    database.OSType `form:"os"`
-		AppID string          `form:"app_id"`
-		SHA   string          `form:"sha"`
+		Name           string          `form:"name"`
+		URL            string          `form:"url"`
+		EnableRedirect bool            `form:"enable_redirect"`
+		OS             database.OSType `form:"os"`
+		AppID          string          `form:"app_id"`
+		SHA            string          `form:"sha"`
 	}
 
 	var form FormData
 	err := controller.BindForm(nil, r, &form)
 	app.Name = form.Name
 	app.URL = form.URL
+	app.DisableRedirect = !form.EnableRedirect
 	app.OS = form.OS
 	app.AppID = form.AppID
 	app.SHA = form.SHA

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -183,6 +183,7 @@ func TestHandleUpdate(t *testing.T) {
 			chromedp.WaitVisible(`body#mobileapps-edit`, chromedp.ByQuery),
 
 			chromedp.SetValue(`input#name`, "Updated name", chromedp.ByQuery),
+			chromedp.RemoveAttribute(`input#enable-redirect`, "checked", chromedp.ByQuery),
 			chromedp.Click(`#submit`, chromedp.ByQuery),
 
 			chromedp.WaitVisible(`body#mobileapps-show`, chromedp.ByQuery),
@@ -197,6 +198,9 @@ func TestHandleUpdate(t *testing.T) {
 
 		if got, want := record.Name, "Updated name"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
+		}
+		if got, want := record.DisableRedirect, true; got != want {
+			t.Errorf("expected %t to be %t", got, want)
 		}
 	})
 }

--- a/pkg/controller/redirect/appstore.go
+++ b/pkg/controller/redirect/appstore.go
@@ -36,8 +36,14 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 		return nil, fmt.Errorf("failed to get Android Apps: %w", err)
 	}
 	if len(androidApps) > 0 {
-		androidURL = androidApps[0].URL
-		androidAppID = androidApps[0].AppID
+		// Find the first app that has redirects enabled.
+		for _, app := range androidApps {
+			if !app.DisableRedirect {
+				androidURL = app.URL
+				androidAppID = app.AppID
+				break
+			}
+		}
 	}
 
 	// Pick first iOS app (in the realm) for Store redirect.
@@ -47,7 +53,13 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 		return nil, fmt.Errorf("failed to get iOS Apps: %w", err)
 	}
 	if len(iosApps) > 0 {
-		iosURL = iosApps[0].URL
+		// Find the first app that has redirects enabled.
+		for _, app := range iosApps {
+			if !app.DisableRedirect {
+				iosURL = app.URL
+				break
+			}
+		}
 	}
 
 	return &AppStoreData{

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -79,12 +79,12 @@ func (c *Controller) HandleIndex() http.Handler {
 			return
 		}
 
-		if sendto, success := decideRedirect(hostRegion, r.UserAgent(), *r.URL, data); success {
+		if sendto, success := decideRedirect(hostRegion, r.UserAgent(), r.URL, realm.EnableENExpress, data); success {
 			http.Redirect(w, r, sendto, http.StatusSeeOther)
 			return
 		}
 
-		logger.Infow("not a mobile user agent",
+		logger.Infow("no matching metadata for redirect",
 			"host", r.Host,
 			"userAgent", r.UserAgent())
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1879,6 +1879,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return nil
 			},
 		},
+		{
+			ID: "00080-AddDisableRedirectToMobileApps",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE mobile_apps ADD COLUMN IF NOT EXISTS disable_redirect BOOL DEFAULT false NOT NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE mobile_apps DROP COLUMN IF EXISTS disable_redirect`)
+			},
+		},
 	}
 }
 
@@ -1899,4 +1910,14 @@ func (db *Database) MigrateTo(ctx context.Context, target string, rollback bool)
 		return m.MigrateTo(target)
 	}
 	return m.Migrate()
+}
+
+// multiExec is a helper that executes the given sql clauses against the tx.
+func multiExec(tx *gorm.DB, sqls ...string) error {
+	for _, sql := range sqls {
+		if err := tx.Exec(sql).Error; err != nil {
+			return fmt.Errorf("failed to execute %q: %w", sql, err)
+		}
+	}
+	return nil
 }

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -63,6 +63,10 @@ type MobileApp struct {
 	URL    string  `gorm:"-"`
 	URLPtr *string `gorm:"column:url; type:text"`
 
+	// DisableRedirect disables URL redirection in the redirector service for this
+	// app.
+	DisableRedirect bool `gorm:"column:disable_redirect; type:bool; default:false; not null"`
+
 	// OS is the type of the application we're using (eg, iOS, Android).
 	OS OSType `gorm:"column:os; type:int;"`
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1463

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Give admins the ability to disable AppStore redirects for apps
```

/assign @whaught 

/cc @mikehelmick 
