### PR TITLE
externalCaseID field and SMS expansion

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -259,13 +259,14 @@
           <li><code>[enslink]</code> Inserts the EN Express link of: <code>https://{{toLower $realm.RegionCode}}.{{.enxRedirectDomain}}/v?c=[longcode]</code>
             <ul>
               <li>This domain should be registered as a universal link for both your Android and iOS applications.</li>
-              <li>Contact your server operator to verify the the verification EN Express redirect service is running and configurd correctly.</li>
+              <li>Contact your server operator to verify the the verification EN Express redirect service is running and configured correctly.</li>
             </ul>
           </li>
           {{end}}
           <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
           <li><code>[code]</code>The 'short' verification code can be optionally included here in the event the link isn't clickable for the user. Typically this is not needed.</li>
           <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units). Should be included if <code>[code]</code> is used</li>
+          <li><code>[externalcaseid]</code>The external case ID, this may be associated with the user's external case data.</li>
         </ul>
 
         Here is an example SMS template using EN Express.
@@ -302,6 +303,7 @@
         <li><code>[expires]</code>The number of minutes until the short code expires (just the number, no units).</li>
         <li><code>[longcode]</code>The 'long' verification code</li>
         <li><code>[longexpires]</code>The number of hours until the long code expires (just the number, no units).</li>
+        <li><code>[externalcaseid]</code>The external case ID, this may be associated with the user's external case data.</li>
       </ul>
 
       Here are some example SMS templates. The recommended usage is to include the long code in the SMS, and make
@@ -319,7 +321,7 @@
         </li>
         <li>
           <p>Send long code with custom URI (<code>152</code> characters with 16 digit codes and 24 hour expiration).
-            Here we assume that <code>verify.mypha.gov</code> is registred as a universal link for both your iOS
+            Here we assume that <code>verify.mypha.gov</code> is registered as a universal link for both your iOS
             and Android applications.
           </p>
           <p>

--- a/docs/realm-admin-guide.md
+++ b/docs/realm-admin-guide.md
@@ -121,7 +121,7 @@ See the help text on that page for guidance.
 
 ![sms text](images/admin/settings04.png "SMS Template")
 
-The fields `[region]`, `[code]`, `[expires]`, `[longcode]`, and `[longexpires]` may be included with brackets
+The fields `[region]`, `[code]`, `[expires]`, `[longcode]`, `[longexpires]`, and `[externalcaseid]` may be included with brackets
 which will be programmatically substituted with values. It is recommended that the text of this SMS be composed
 in such a way that is respectful to the patient and does not reveal details about their diagnosis to potential onlookers of the phone's notifications with further information presented in-app.
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -197,18 +197,28 @@ type IssueCodeRequest struct {
 	// of the issued verification code. If omitted the server will generate the UUID.
 	UUID string `json:"uuid"`
 
-	// ExternalIssuerID is a optional information supplied by the API caller to
+	// ExternalIssuerID is optional information supplied by the API caller to
 	// uniquely identify the entity making this request. This is useful where
 	// callers are using a single API key behind an ERP, or when callers are using
 	// the verification server as an API with a different authentication system.
 	// This field is optional.
-
+	//
 	// The information provided is stored exactly as-is. If the identifier is
 	// uniquely identifying PII (such as an email address, employee ID, SSN, etc),
 	// the caller should apply a cryptographic hash before sending that data. The
 	// system does not sanitize or encrypt these external IDs, it is the caller's
 	// responsibility to do so.
 	ExternalIssuerID string `json:"externalIssuerID"`
+
+	// ExternalCaseID is an optional identifier that the API caller can provide
+	// which may be expanded in the SMS sent to patients. This aid users of this
+	// system in coordinating with patients and their own data.
+	//
+	// The information provided is stored exactly as-is. The system does not sanitize
+	// or encrypt these external IDs, it is the caller's responsibility to do so.
+	// PII of the patient should never be used as their caseID (such as an
+	// email address, employee ID, SSN, etc).
+	ExternalCaseID string `json:"externalCaseID"`
 }
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -77,7 +77,7 @@ func (c *Controller) SendSMS(ctx context.Context, request *api.IssueCodeRequest,
 	logger := logging.FromContext(ctx).Named("issueapi.sendSMS")
 	smsStart := time.Now()
 	err = func() error {
-		message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+		message, err := realm.BuildSMSText(result.VerCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
 		if err != nil {
 			result.obsResult = observability.ResultError("FAILED_TO_BUILD_SMS")
 			return err

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -38,6 +38,7 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, request *api.Iss
 	vCode := &database.VerificationCode{
 		RealmID:           realm.ID,
 		IssuingExternalID: request.ExternalIssuerID,
+		ExternalCaseID:    request.ExternalCaseID,
 		TestType:          strings.ToLower(request.TestType),
 		ExpiresAt:         now.Add(realm.CodeDuration.Duration),
 		LongExpiresAt:     now.Add(realm.LongCodeDuration.Duration),

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1650,7 +1650,8 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return tx.Exec(sql).Error
 			},
 			Rollback: func(tx *gorm.DB) error {
-				return tx.DropTable(&ExternalIssuerStat{}).Error
+				sql := `ALTER TABLE verification_codes DROP COLUMN IF EXISTS issuing_external_id`
+				return tx.Exec(sql).Error
 			},
 		},
 		{
@@ -1877,6 +1878,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					}
 				}
 				return nil
+			},
+		},
+		{
+			ID: "00080-AddExternalCaseIDToVerificationCode",
+			Migrate: func(tx *gorm.DB) error {
+				sql := `ALTER TABLE verification_codes ADD COLUMN IF NOT EXISTS external_case_id VARCHAR(255)`
+				return tx.Exec(sql).Error
+			},
+			Rollback: func(tx *gorm.DB) error {
+				sql := `ALTER TABLE verification_codes DROP COLUMN IF EXISTS external_case_id`
+				return tx.Exec(sql).Error
 			},
 		},
 	}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -104,12 +104,13 @@ const (
 	maxCodeDuration     = time.Hour
 	maxLongCodeDuration = 24 * time.Hour
 
-	SMSRegion        = "[region]"
-	SMSCode          = "[code]"
-	SMSExpires       = "[expires]"
-	SMSLongCode      = "[longcode]"
-	SMSLongExpires   = "[longexpires]"
-	SMSENExpressLink = "[enslink]"
+	SMSRegion         = "[region]"
+	SMSCode           = "[code]"
+	SMSExpires        = "[expires]"
+	SMSLongCode       = "[longcode]"
+	SMSLongExpires    = "[longexpires]"
+	SMSENExpressLink  = "[enslink]"
+	SMSExternalCaseID = "[externalcaseid]"
 
 	SMSTemplateMaxLength    = 800
 	SMSTemplateExpansionMax = 918
@@ -442,10 +443,13 @@ func (r *Realm) validateSMSTemplate(label, t string) {
 	}
 
 	// Check expansion length based on settings.
-	fakeCode := fmt.Sprintf(fmt.Sprintf("\\%0%d\\%d", r.CodeLength), 0)
-	fakeLongCode := fmt.Sprintf(fmt.Sprintf("\\%0%d\\%d", r.LongCodeLength), 0)
+	fakeVerCode := &VerificationCode{
+		Code:           fmt.Sprintf(fmt.Sprintf("\\%0%d\\%d", r.CodeLength), 0),
+		LongCode:       fmt.Sprintf(fmt.Sprintf("\\%0%d\\%d", r.LongCodeLength), 0),
+		ExternalCaseID: "123456abcdef",
+	}
 	enxDomain := os.Getenv("ENX_REDIRECT_DOMAIN")
-	expandedSMSText, err := r.BuildSMSText(fakeCode, fakeLongCode, enxDomain, label)
+	expandedSMSText, err := r.BuildSMSText(fakeVerCode, enxDomain, label)
 	if err != nil {
 		r.AddError("smsTextTemplate", fmt.Sprintf("SMS template expansion failed: %s", err))
 		r.AddError(label, fmt.Sprintf("SMS template expansion failed: %s", err))
@@ -494,7 +498,7 @@ func (r *Realm) FindVerificationCodeByUUID(db *Database, uuid string) (*Verifica
 }
 
 // BuildSMSText replaces certain strings with the right values.
-func (r *Realm) BuildSMSText(code, longCode string, enxDomain, templateLabel string) (string, error) {
+func (r *Realm) BuildSMSText(verCode *VerificationCode, enxDomain, templateLabel string) (string, error) {
 	text := r.SMSTextTemplate
 	if templateLabel != "" && templateLabel != DefaultTemplateLabel && r.SMSTextAlternateTemplates != nil {
 		if t, has := r.SMSTextAlternateTemplates[templateLabel]; has && t != nil && *t != "" {
@@ -515,10 +519,11 @@ func (r *Realm) BuildSMSText(code, longCode string, enxDomain, templateLabel str
 				SMSLongCode))
 	}
 	text = strings.ReplaceAll(text, SMSRegion, r.RegionCode)
-	text = strings.ReplaceAll(text, SMSCode, code)
+	text = strings.ReplaceAll(text, SMSCode, verCode.Code)
 	text = strings.ReplaceAll(text, SMSExpires, fmt.Sprintf("%d", r.GetCodeDurationMinutes()))
-	text = strings.ReplaceAll(text, SMSLongCode, longCode)
+	text = strings.ReplaceAll(text, SMSLongCode, verCode.LongCode)
 	text = strings.ReplaceAll(text, SMSLongExpires, fmt.Sprintf("%d", r.GetLongCodeDurationHours()))
+	text = strings.ReplaceAll(text, SMSExternalCaseID, verCode.ExternalCaseID)
 
 	return text, nil
 }

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -396,7 +396,11 @@ func TestRealm_BuildSMSText(t *testing.T) {
 	realm.SMSTextTemplate = "This is your Exposure Notifications Verification code: [enslink] Expires in [longexpires] hours"
 	realm.RegionCode = "US-WA"
 
-	got, err := realm.BuildSMSText("12345678", "abcdefgh12345678", "en.express", "")
+	verCode := &VerificationCode{
+		Code:     "12345678",
+		LongCode: "abcdefgh12345678",
+	}
+	got, err := realm.BuildSMSText(verCode, "en.express", "")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -405,8 +409,12 @@ func TestRealm_BuildSMSText(t *testing.T) {
 		t.Errorf("SMS text wrong, want: %q got %q", want, got)
 	}
 
+	verCode = &VerificationCode{
+		Code:     "654321",
+		LongCode: "asdflkjasdlkfjl",
+	}
 	realm.SMSTextTemplate = "State of Wonder, COVID-19 Exposure Verification code [code]. Expires in [expires] minutes. Act now!"
-	got, err = realm.BuildSMSText("654321", "asdflkjasdlkfjl", "", "")
+	got, err = realm.BuildSMSText(verCode, "", "")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/sms_config_test.go
+++ b/pkg/database/sms_config_test.go
@@ -41,6 +41,12 @@ func TestSMSConfig_Lifecycle(t *testing.T) {
 		}
 	}
 
+	if has, err := realm.HasSMSConfig(db); err != nil {
+		t.Fatal(err)
+	} else if has {
+		t.Fatal("expected no SMS config for realm")
+	}
+
 	// Create SMS config on the realm
 	smsConfig := &SMSConfig{
 		RealmID:          realm.ID,
@@ -57,6 +63,12 @@ func TestSMSConfig_Lifecycle(t *testing.T) {
 	realm, err = db.FindRealm(realm.ID)
 	if err != nil {
 		t.Fatal(err)
+	}
+
+	if has, err := realm.HasSMSConfig(db); err != nil {
+		t.Fatal(err)
+	} else if !has {
+		t.Fatal("expected realm to have SMS config")
 	}
 
 	// Load the SMS config

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -88,12 +88,21 @@ type VerificationCode struct {
 	// API AND the API caller supplied it in the request. This ID has no meaning
 	// in this system. It can be up to 255 characters in length.
 	IssuingExternalID string `gorm:"column:issuing_external_id; type:varchar(255);"`
+
+	// ExternalCaseID is an optional ID to an external system that may be used
+	// in SMS expansions to coordinate with the patient with issuer data that is
+	// external to this system.
+	ExternalCaseID string `gorm:"column:external_case_id; type:varchar(255);"`
 }
 
 // BeforeSave is used by callbacks.
 func (v *VerificationCode) BeforeSave(tx *gorm.DB) error {
 	if len(v.IssuingExternalID) > 255 {
 		v.AddError("issuingExternalID", "cannot exceed 255 characters")
+	}
+
+	if len(v.ExternalCaseID) > 255 {
+		v.AddError("externalCaseID", "cannot exceed 255 characters")
 	}
 
 	if msgs := v.ErrorMessages(); len(msgs) > 0 {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1321

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a new field to issue request that allows for a transparent string to be included with the issunace
*  Allow SMS expansion of this caseID field
*  **I'm worried about PII**
    * Alternative is to only show our UUID: https://github.com/google/exposure-notifications-verification-server/pull/1464 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add externalCaseID field to issue request
Allow externalCaseID in SMS expansion
```
