### PR TITLE
Recover from panics in main

### DIFF
--- a/cmd/adminapi/main.go
+++ b/cmd/adminapi/main.go
@@ -44,6 +44,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/apiserver/main.go
+++ b/cmd/apiserver/main.go
@@ -45,6 +45,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/appsync/main.go
+++ b/cmd/appsync/main.go
@@ -41,6 +41,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -42,6 +42,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -54,6 +54,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -41,6 +41,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/migrate/main.go
+++ b/cmd/migrate/main.go
@@ -46,6 +46,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/modeler/main.go
+++ b/cmd/modeler/main.go
@@ -45,6 +45,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 

--- a/cmd/server/main.go
+++ b/cmd/server/main.go
@@ -44,6 +44,13 @@ func main() {
 		With("build_tag", buildinfo.BuildTag)
 	ctx = logging.WithLogger(ctx, logger)
 
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
 	err := realMain(ctx)
 	done()
 


### PR DESCRIPTION
This commit adds panic recovery, logs the error, then exits non-zero. Note that the container still exits with logger.Fatal, we just ensure the log is captured first.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Recover from panics in main
```

/assign @whaught 