### PR TITLE
Display OS on the mobile apps index table

### DIFF
--- a/cmd/server/assets/mobileapps/index.html
+++ b/cmd/server/assets/mobileapps/index.html
@@ -49,6 +49,7 @@
             <tr>
               <th scope="col" width="40"></th>
               <th scope="col">Mobile app</th>
+              <th scope="col" width="100">OS</th>
               {{if $canWrite}}
                 <th scope="col" width="40"></th>
               {{end}}
@@ -69,6 +70,7 @@
               <td class="text-truncate">
                 <a href="/realm/mobile-apps/{{.ID}}">{{.Name}}</a>
               </td>
+              <td>{{.OS.Display}}</td>
               {{if $canWrite}}
                 <td class="text-center">
                   {{if .DeletedAt}}

--- a/cmd/server/assets/mobileapps/show.html
+++ b/cmd/server/assets/mobileapps/show.html
@@ -45,7 +45,7 @@
 
           <dt>OS</dt>
           <dd id="mobileapps-os">
-            {{.OS.Display}}
+            {{$app.OS.Display}}
           </dd>
 
           {{if (eq $app.OS .iOS)}}

--- a/cmd/server/assets/mobileapps/show.html
+++ b/cmd/server/assets/mobileapps/show.html
@@ -45,11 +45,7 @@
 
           <dt>OS</dt>
           <dd id="mobileapps-os">
-            {{if (eq $app.OS .iOS)}}
-              iOS
-            {{else if (eq $app.OS .android)}}
-              Android
-            {{end}}
+            {{.OS.Display}}
           </dd>
 
           {{if (eq $app.OS .iOS)}}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Add the OS to the mobile_apps index table
    * In real life folks seem to have the same name for their iOS app and Android. Eg. Covidwise.  It's impossible to tell which is which from the index page.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Display OS on the mobile apps index table
```
