### PR TITLE
Calculate grace periods from membership date

### DIFF
--- a/pkg/controller/login/register.go
+++ b/pkg/controller/login/register.go
@@ -46,8 +46,7 @@ func (c *Controller) HandleRegisterPhone() http.Handler {
 		}
 
 		currentRealm := membership.Realm
-		currentUser := membership.User
-		mode := currentRealm.EffectiveMFAMode(currentUser)
+		mode := currentRealm.EffectiveMFAMode(membership.CreatedAt)
 		c.renderRegisterPhone(ctx, w, &mode)
 	})
 }

--- a/pkg/controller/middleware/mfa.go
+++ b/pkg/controller/middleware/mfa.go
@@ -45,7 +45,6 @@ func RequireMFA(authProvider auth.Provider, h render.Renderer) mux.MiddlewareFun
 				return
 			}
 			currentRealm := membership.Realm
-			currentUser := membership.User
 
 			mfaEnabled, err := authProvider.MFAEnabled(ctx, session)
 			if err != nil {
@@ -55,7 +54,7 @@ func RequireMFA(authProvider auth.Provider, h render.Renderer) mux.MiddlewareFun
 
 			prompted := controller.MFAPromptedFromSession(session)
 			if !mfaEnabled {
-				if mode := currentRealm.EffectiveMFAMode(currentUser); mode == database.MFARequired ||
+				if mode := currentRealm.EffectiveMFAMode(membership.CreatedAt); mode == database.MFARequired ||
 					mode == database.MFAOptionalPrompt && !prompted {
 					controller.RedirectToMFA(w, r, h)
 					return

--- a/pkg/database/membership.go
+++ b/pkg/database/membership.go
@@ -17,6 +17,7 @@ package database
 import (
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/jinzhu/gorm"
@@ -38,6 +39,12 @@ type Membership struct {
 	DefaultSMSTemplateLabel string `gorm:"type:varchar(255);"`
 
 	Permissions rbac.Permission
+
+	// CreatedAt is when the user was added to the realm. UpdatedAt is when the
+	// user's permissions were last updated. Note that UpdatedAt only applies to
+	// the membership's fields, not the user fields (e.g. email, name).
+	CreatedAt time.Time
+	UpdatedAt time.Time
 }
 
 // SaveMembership saves the membership details. Should have a userID and a realmID to identify it.

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1891,6 +1891,21 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE mobile_apps DROP COLUMN IF EXISTS disable_redirect`)
 			},
 		},
+		{
+			ID: "00081-AddTimestampsToMemberships",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE memberships ADD COLUMN IF NOT EXISTS created_at TIMESTAMP WITH TIME ZONE`,
+					`ALTER TABLE memberships ADD COLUMN IF NOT EXISTS updated_at TIMESTAMP WITH TIME ZONE`,
+					`UPDATE memberships SET created_at = NOW() WHERE created_at IS NULL`,
+					`UPDATE memberships SET updated_at = NOW() WHERE updated_at IS NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE memberships DROP COLUMN IF EXISTS created_at`,
+					`ALTER TABLE memberships DROP COLUMN IF EXISTS updated_at`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -469,14 +469,14 @@ func (r *Realm) GetLongCodeDurationHours() int {
 	return int(r.LongCodeDuration.Duration.Hours())
 }
 
-// EffectiveMFAMode returns the realm's default MFAMode but first
-// checks if the user is in the grace-period (if so, required becomes prompt).
-func (r *Realm) EffectiveMFAMode(user *User) AuthRequirement {
+// EffectiveMFAMode returns the realm's default MFAMode but first checks if the
+// time is in the grace-period (if so, required becomes prompt).
+func (r *Realm) EffectiveMFAMode(t time.Time) AuthRequirement {
 	if r == nil {
 		return MFARequired
 	}
 
-	if time.Since(user.CreatedAt) <= r.MFARequiredGracePeriod.Duration {
+	if time.Since(t) <= r.MFARequiredGracePeriod.Duration {
 		return MFAOptionalPrompt
 	}
 	return r.MFAMode

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -196,8 +196,10 @@ func (u *User) AddToRealm(db *Database, r *Realm, permissions rbac.Permission, a
 			}
 		}
 
-		conflict := fmt.Sprintf(`ON CONFLICT (user_id, realm_id) DO UPDATE
-			SET permissions = %d`, permissions)
+		conflict := `ON CONFLICT (user_id, realm_id) DO UPDATE SET
+			permissions = EXCLUDED.permissions,
+			created_at = EXCLUDED.created_at,
+			updated_at = EXCLUDED.updated_at`
 		if err := tx.
 			Set("gorm:insert_option", conflict).
 			Model(&Membership{}).


### PR DESCRIPTION
This changes the MFA grace period calculation to calculate against the date on which the user was added to the realm vs the date on which the user was created. All membership creation dates are backfilled to NOW().

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Calculate grace periods from membership date
```

/assign @whaught 
