### PR TITLE
Late load recaptcha - only require for 2nd factor SMS

### DIFF
--- a/cmd/server/assets/login/login.html
+++ b/cmd/server/assets/login/login.html
@@ -62,6 +62,8 @@
         </div>
       </div>
     </div>
+
+    <div id="recaptcha-container" class="center-block"></div>
   </main>
 
   {{template "loginscripts" .}}

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -408,10 +408,9 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
   let selectedFactorIndex = 0;
 
   window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
-    'submit', {
+    'recaptcha-container', {
     'size': 'invisible',
   });
-  window.recaptchaVerifier.render();
 
   $loginForm.on('submit', function(event) {
     event.preventDefault();
@@ -474,6 +473,7 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
       onLoginSuccess();
     }).catch(function(error) {
       if (error.code == 'auth/multi-factor-auth-required') {
+        window.recaptchaVerifier.render();
         resolver = error.resolver;
         populatePinText(resolver.hints);
         populateFactors(resolver.hints);

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -387,6 +387,7 @@ function decorateInvalid($element) {
 function loginScripts(hasCurrentUser, onLoginSuccess) {
   let $loginDiv = $('#login-div');
   let $submit = $('#submit');
+  let $loginForm = $('#login-form');
   let $email = $('#email');
   let $password = $('#password');
 
@@ -409,9 +410,13 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
   window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
     'submit', {
     'size': 'invisible',
-    'callback': (response) => onSignInSubmit(),
   });
   window.recaptchaVerifier.render();
+
+  $loginForm.on('submit', function(event) {
+    event.preventDefault();
+    onSignInSubmit();
+  });
 
   $pinForm.on('submit', function(event) {
     event.preventDefault();
@@ -435,7 +440,6 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
   });
 
   $pinClose.on('click', function(event) {
-    window.recaptchaVerifier.reset();
     event.preventDefault();
     $submit.prop('disabled', false);
     $factors.empty();
@@ -498,12 +502,10 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
           flash.error('Unsupported 2nd factor authentication type.');
         }
       } else if (error.code == 'auth/too-many-requests') {
-        window.recaptchaVerifier.reset();
         flash.clear();
         flash.error(error.message);
         $submit.prop('disabled', false);
       } else {
-        window.recaptchaVerifier.reset();
         console.error(error);
         flash.clear();
         flash.error("Sign-in failed. Please try again.");
@@ -734,7 +736,7 @@ function initBulkUploadUI() {
   $successTooMany = $('#success-too-many');
 
   let now = new Date();
-  $save.attr('download', `bulk-issue-log-${now.toISOString().split('T')[0]}.csv`);
+  $save.attr('download', `${now.toISOString().split('T')[0]}-bulk-issue-log.csv`);
 }
 
 function resetBulkUploadUI() {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1305

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Previously we protected the entire login flow with recaptcha, but it is only required for SMS send. Unfortunately the recaptcha reset-on-failure does not appear to work (on not-localhost).
Instead we load the recaptcha an only render it after successful sign-in with username/password for the SMS send.  

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Don't load captcha unless SMS factor needed
```
