### PR TITLE
Pass in zaptest.Logger to tests

### DIFF
--- a/internal/envstest/server.go
+++ b/internal/envstest/server.go
@@ -34,6 +34,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
@@ -173,6 +174,10 @@ func NewServer(tb testing.TB, testDatabaseInstance *database.TestInstance) *Test
 	if err != nil {
 		tb.Fatal(err)
 	}
+
+	// Inject the test logger into the context instead of the default sugared
+	// logger.
+	mux = middleware.PopulateLogger(project.TestLogger(tb))(mux)
 
 	// Create a stoppable context.
 	doneCtx, cancel := context.WithCancel(ctx)

--- a/internal/envstest/unit.go
+++ b/internal/envstest/unit.go
@@ -15,7 +15,6 @@
 package envstest
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -24,6 +23,7 @@ import (
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
@@ -35,7 +35,7 @@ func ExerciseSessionMissing(t *testing.T, h http.Handler) {
 	t.Run("session_missing", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 
 		r := httptest.NewRequest("GET", "/", nil)
 		r = r.Clone(ctx)
@@ -62,7 +62,7 @@ func ExerciseMembershipMissing(t *testing.T, h http.Handler) {
 	t.Run("membership_missing", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 
 		r := httptest.NewRequest("GET", "/", nil)
@@ -90,7 +90,7 @@ func ExercisePermissionMissing(t *testing.T, h http.Handler) {
 	t.Run("permission_missing", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{})
 
@@ -118,7 +118,7 @@ func ExerciseBadPagination(t *testing.T, membership *database.Membership, h http
 	t.Run("bad_pagination", func(t *testing.T) {
 		t.Parallel()
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, membership)
 
@@ -154,7 +154,7 @@ func ExerciseIDNotFound(t *testing.T, membership *database.Membership, h http.Ha
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", h)
 
-		ctx := context.Background()
+		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, membership)
 

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -1,0 +1,40 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"context"
+	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest"
+)
+
+// TestContext returns a context with test values pre-populated.
+func TestContext(tb testing.TB) context.Context {
+	ctx := context.Background()
+	ctx = logging.WithLogger(ctx, TestLogger(tb))
+	return ctx
+}
+
+// TestLogger returns a logger configured for test. See the following link for
+// more information:
+//
+//     https://pkg.go.dev/go.uber.org/zap/zaptest
+//
+func TestLogger(tb testing.TB) *zap.SugaredLogger {
+	return zaptest.NewLogger(tb, zaptest.Level(zap.WarnLevel)).Sugar()
+}

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -88,7 +88,7 @@ func ENXRedirect(
 		wk := r.PathPrefix("/.well-known").Subrouter()
 
 		// Enable the iOS and Android redirect handler.
-		assocController, err := associated.New(ctx, cfg, db, cacher, h)
+		assocController, err := associated.New(cfg, db, cacher, h)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create associated links controller: %w", err)
 		}
@@ -97,7 +97,7 @@ func ENXRedirect(
 	}
 
 	// Handle redirects.
-	redirectController, err := redirect.New(ctx, db, cfg, cacher, h)
+	redirectController, err := redirect.New(db, cfg, cacher, h)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create redirect controller: %w", err)
 	}

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleCreate(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -53,7 +55,7 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +74,7 @@ func TestHandleCreate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +82,7 @@ func TestHandleCreate(t *testing.T) {
 		c := apikey.New(harness.Cacher, harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -112,7 +114,7 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -120,7 +122,7 @@ func TestHandleCreate(t *testing.T) {
 		c := apikey.New(harness.Cacher, harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,6 +38,7 @@ import (
 func TestHandleDisable(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -60,7 +62,7 @@ func TestHandleDisable(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +85,7 @@ func TestHandleDisable(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,7 +95,7 @@ func TestHandleDisable(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleDisable()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleEnable(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -53,7 +55,7 @@ func TestHandleEnable(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,7 +78,7 @@ func TestHandleEnable(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -86,7 +88,7 @@ func TestHandleEnable(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleEnable()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/index_test.go
+++ b/pkg/controller/apikey/index_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -36,6 +37,7 @@ import (
 func TestHandleIndex(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -51,7 +53,7 @@ func TestHandleIndex(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +75,7 @@ func TestHandleIndex(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -81,7 +83,7 @@ func TestHandleIndex(t *testing.T) {
 		c := apikey.New(harness.Cacher, harness.Database, h)
 		handler := c.HandleIndex()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,6 +38,7 @@ import (
 func TestHandleShow(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -60,7 +62,7 @@ func TestHandleShow(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -83,7 +85,7 @@ func TestHandleShow(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -93,7 +95,7 @@ func TestHandleShow(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleShow()).Methods("GET")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/stats_test.go
+++ b/pkg/controller/apikey/stats_test.go
@@ -15,13 +15,13 @@
 package apikey_test
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -34,6 +34,7 @@ import (
 func TestHandleStats(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, _, err := harness.ProvisionAndLogin()
@@ -49,7 +50,7 @@ func TestHandleStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -69,7 +70,7 @@ func TestHandleStats(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -79,7 +80,7 @@ func TestHandleStats(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleStats()).Methods("GET")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -111,7 +112,7 @@ func TestHandleStats(t *testing.T) {
 		mux.Handle("/{id}.json", c.HandleStats())
 		mux.Handle("/{id}.csv", c.HandleStats())
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -142,7 +143,7 @@ func TestHandleStats(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}.xml", c.HandleStats())
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -175,7 +176,7 @@ func TestHandleStats(t *testing.T) {
 		mux.Handle("/{id}.json", c.HandleStats())
 		mux.Handle("/{id}.csv", c.HandleStats())
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -208,7 +209,7 @@ func TestHandleStats(t *testing.T) {
 		mux.Handle("/{id}.json", c.HandleStats())
 		mux.Handle("/{id}.csv", c.HandleStats())
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleUpdate(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -61,7 +63,7 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,7 +87,7 @@ func TestHandleUpdate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -95,7 +97,7 @@ func TestHandleUpdate(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -126,7 +128,7 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -136,7 +138,7 @@ func TestHandleUpdate(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/appsync/appsync_test.go
+++ b/pkg/controller/appsync/appsync_test.go
@@ -15,9 +15,9 @@
 package appsync
 
 import (
-	"context"
 	"testing"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/clients"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -33,6 +33,8 @@ func TestMain(m *testing.M) {
 
 func TestAppSync(t *testing.T) {
 	t.Parallel()
+
+	ctx := project.TestContext(t)
 
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	config := &config.AppSyncConfig{}
@@ -80,7 +82,7 @@ func TestAppSync(t *testing.T) {
 			},
 		}
 
-		merr := c.syncApps(context.Background(), resp)
+		merr := c.syncApps(ctx, resp)
 		if e := merr.ErrorOrNil(); e != nil {
 			t.Fatalf(e.Error())
 		}

--- a/pkg/controller/associated/android.go
+++ b/pkg/controller/associated/android.go
@@ -32,8 +32,8 @@ type Target struct {
 	Fingerprints []string `json:"sha256_cert_fingerprints,omitempty"`
 }
 
-// getAndroidData finds all the android data apps.
-func (c *Controller) getAndroidData(realmID uint) ([]AndroidData, error) {
+// AndroidData finds all the android data apps.
+func (c *Controller) AndroidData(realmID uint) ([]AndroidData, error) {
 	apps, err := c.db.ListActiveApps(realmID, database.WithAppOS(database.OSTypeAndroid))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get android data: %w", err)

--- a/pkg/controller/associated/ios.go
+++ b/pkg/controller/associated/ios.go
@@ -44,8 +44,8 @@ type Appstrings struct {
 	Apps []string `json:"apps,omitempty"`
 }
 
-// getAppIds finds all the iOS app ids we know about.
-func (c *Controller) getAppIds(realmID uint) ([]string, error) {
+// iosAppIDs finds all the iOS app ids we know about.
+func (c *Controller) iosAppIDs(realmID uint) ([]string, error) {
 	apps, err := c.db.ListActiveApps(realmID, database.WithAppOS(database.OSTypeIOS))
 	if err != nil {
 		return nil, err
@@ -57,9 +57,9 @@ func (c *Controller) getAppIds(realmID uint) ([]string, error) {
 	return ret, nil
 }
 
-// getIosData gets the iOS app data.
-func (c *Controller) getIosData(realmID uint) (*IOSData, error) {
-	ids, err := c.getAppIds(realmID)
+// IOSData gets the iOS app data.
+func (c *Controller) IOSData(realmID uint) (*IOSData, error) {
+	ids, err := c.iosAppIDs(realmID)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/controller/codes/bulk_issue_test.go
+++ b/pkg/controller/codes/bulk_issue_test.go
@@ -15,7 +15,6 @@
 package codes_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -32,7 +31,8 @@ import (
 
 func TestRenderBulkIssue(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
+
+	ctx := project.TestContext(t)
 
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	realm := database.NewRealmWithDefaults("Test Realm")

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -38,7 +38,6 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Mint a cookie for the session.
 	cookie, err := harness.SessionCookie(session)
 	if err != nil {
 		t.Fatal(err)
@@ -52,7 +51,6 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	// Create a browser runner.
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
@@ -61,24 +59,15 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 
 	var code string
 	if err := chromedp.Run(taskCtx,
-		// Pre-authenticate the user.
 		browser.SetCookie(cookie),
-
-		// Visit /codes/issue.
 		chromedp.Navigate(`http://`+harness.Server.Addr()+`/codes/issue`),
-
-		// Wait for render.
 		chromedp.WaitVisible(`body#codes-issue`, chromedp.ByQuery),
 
-		// Add a date fields
 		chromedp.SetValue(`input#test-date`, yesterday, chromedp.ByQuery),
 		chromedp.SetValue(`input#symptom-date`, yesterday, chromedp.ByQuery),
-
-		// Click the issue button.
 		chromedp.Click(`#submit`, chromedp.ByQuery),
-		chromedp.WaitVisible(`#short-code`, chromedp.ByQuery),
 
-		// Get the code.
+		chromedp.WaitVisible(`#short-code`, chromedp.ByQuery),
 		chromedp.TextContent(`#short-code`, &code, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/issueapi/gen_code_test.go
+++ b/pkg/controller/issueapi/gen_code_test.go
@@ -15,12 +15,12 @@
 package issueapi_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
@@ -74,7 +74,7 @@ func TestGenerateAlphanumericCode(t *testing.T) {
 func TestCommitCode(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
 	db := testCfg.Database
 
@@ -136,8 +136,8 @@ func TestCommitCode(t *testing.T) {
 
 func TestIssueCode(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
 	db := testCfg.Database
 
@@ -168,7 +168,9 @@ func TestIssueCode(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	testCfg.RateLimiter.Set(ctx, key, 0, time.Hour)
+	if err := testCfg.RateLimiter.Set(ctx, key, 0, time.Hour); err != nil {
+		t.Fatal(err)
+	}
 
 	c := issueapi.New(testCfg.Config, db, testCfg.RateLimiter, nil)
 

--- a/pkg/controller/issueapi/handle_issue_batch_test.go
+++ b/pkg/controller/issueapi/handle_issue_batch_test.go
@@ -15,7 +15,6 @@
 package issueapi_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -30,7 +29,7 @@ import (
 func TestIssueBatch(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testSuite := testsuite.NewIntegrationSuite(t, ctx)
 	adminClient, err := testSuite.NewAdminAPIClient(ctx, t)
 	if err != nil {

--- a/pkg/controller/issueapi/handle_issue_test.go
+++ b/pkg/controller/issueapi/handle_issue_test.go
@@ -15,7 +15,6 @@
 package issueapi_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -28,7 +27,7 @@ import (
 func TestIssue(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	testSuite := testsuite.NewIntegrationSuite(t, ctx)
 	adminClient, err := testSuite.NewAdminAPIClient(ctx, t)
 	if err != nil {

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -15,7 +15,6 @@
 package issueapi_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -30,10 +29,11 @@ import (
 
 func TestIssueOne(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
 	db := testCfg.Database
+
 	realm, err := db.FindRealm(1)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/controller/issueapi/issueapi_test.go
+++ b/pkg/controller/issueapi/issueapi_test.go
@@ -16,7 +16,6 @@ package issueapi_test
 
 import (
 	"bytes"
-	"context"
 	"encoding/json"
 	"io"
 	"net/http"
@@ -24,6 +23,7 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
@@ -42,8 +42,9 @@ func TestMain(m *testing.M) {
 
 func TestIssueMalformed(t *testing.T) {
 	t.Parallel()
+
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
-	ctx := context.Background()
 
 	realm, err := testCfg.Database.FindRealm(1)
 	if err != nil {

--- a/pkg/controller/issueapi/send_sms_test.go
+++ b/pkg/controller/issueapi/send_sms_test.go
@@ -15,7 +15,6 @@
 package issueapi_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"strings"
@@ -69,8 +68,8 @@ func TestSMS_scrubPhoneNumber(t *testing.T) {
 
 func TestSMS_sendSMS(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
 	db := testCfg.Database
 

--- a/pkg/controller/issueapi/validate_code_test.go
+++ b/pkg/controller/issueapi/validate_code_test.go
@@ -15,7 +15,6 @@
 package issueapi_test
 
 import (
-	"context"
 	"net/http"
 	"testing"
 	"time"
@@ -32,8 +31,8 @@ import (
 
 func TestValidate(t *testing.T) {
 	t.Parallel()
-	ctx := context.Background()
 
+	ctx := project.TestContext(t)
 	testCfg := envstest.NewServerConfig(t, testDatabaseInstance)
 	db := testCfg.Database
 

--- a/pkg/controller/middleware/chaff_test.go
+++ b/pkg/controller/middleware/chaff_test.go
@@ -15,7 +15,6 @@
 package middleware_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -24,6 +23,7 @@ import (
 
 	"github.com/mikehelmick/go-chaff"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -85,7 +85,7 @@ func TestProcessChaff(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := project.TestContext(t)
 			ctx = controller.WithRealm(ctx, realm)
 
 			r := httptest.NewRequest("GET", "/", nil)

--- a/pkg/controller/middleware/csrf_test.go
+++ b/pkg/controller/middleware/csrf_test.go
@@ -15,7 +15,6 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -31,7 +30,8 @@ import (
 func TestConfigureCSRF(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/middleware/current_path_test.go
+++ b/pkg/controller/middleware/current_path_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 )
@@ -26,9 +27,12 @@ import (
 func TestInjectCurrentPath(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
+
 	injectCurrentPath := middleware.InjectCurrentPath()
 
 	r := httptest.NewRequest("GET", "/", nil)
+	r = r.Clone(ctx)
 	r.Header.Set("Accept", "application/json")
 
 	w := httptest.NewRecorder()

--- a/pkg/controller/middleware/debug_test.go
+++ b/pkg/controller/middleware/debug_test.go
@@ -19,11 +19,14 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 )
 
 func TestProcessDebug(t *testing.T) {
 	t.Parallel()
+
+	ctx := project.TestContext(t)
 
 	processDebug := middleware.ProcessDebug()
 
@@ -48,6 +51,7 @@ func TestProcessDebug(t *testing.T) {
 			t.Parallel()
 
 			r := httptest.NewRequest("GET", "/", nil)
+			r = r.Clone(ctx)
 			r.Header.Set("Content-Type", "text/html")
 
 			if tc.exp {

--- a/pkg/controller/middleware/email_verified_test.go
+++ b/pkg/controller/middleware/email_verified_test.go
@@ -15,13 +15,13 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -32,12 +32,12 @@ import (
 func TestRequireEmailVerified(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
 	authProvider, err := auth.NewLocal(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -151,7 +151,7 @@ func TestRequireEmailVerified(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := ctx
 			ctx = controller.WithSession(ctx, session)
 			if tc.membership != nil {
 				ctx = controller.WithMembership(ctx, tc.membership)

--- a/pkg/controller/middleware/firewall_test.go
+++ b/pkg/controller/middleware/firewall_test.go
@@ -20,6 +20,7 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -29,8 +30,7 @@ import (
 func TestProcessFirewall(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
+	ctx := project.TestContext(t)
 	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
@@ -47,24 +47,24 @@ func TestProcessFirewall(t *testing.T) {
 	}{
 		{
 			name: "no_realm",
-			ctx:  context.Background(),
+			ctx:  ctx,
 			code: 400,
 		},
 		{
 			name: "realm_in_context",
-			ctx:  controller.WithRealm(context.Background(), &database.Realm{}),
+			ctx:  controller.WithRealm(ctx, &database.Realm{}),
 			code: 200,
 		},
 		{
 			name: "membership_in_context",
-			ctx: controller.WithMembership(context.Background(), &database.Membership{
+			ctx: controller.WithMembership(ctx, &database.Membership{
 				Realm: &database.Realm{},
 			}),
 			code: 200,
 		},
 		{
 			name: "all_allowed4",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"0.0.0.0/0"},
 			}),
 			remoteAddr: "1.2.3.4",
@@ -72,7 +72,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "all_allowed6",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"::/0"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
@@ -80,7 +80,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_allowed_ip4",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "1.2.3.4",
@@ -88,7 +88,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_allowed_ip6",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"2001::/0"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
@@ -96,7 +96,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_allowed_xff",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "9.8.7.6",
@@ -105,7 +105,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_reject_ip4",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "9.8.7.6",
@@ -113,7 +113,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_reject_ip6",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"2000::/64"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
@@ -121,7 +121,7 @@ func TestProcessFirewall(t *testing.T) {
 		},
 		{
 			name: "single_reject_xff",
-			ctx: controller.WithRealm(context.Background(), &database.Realm{
+			ctx: controller.WithRealm(ctx, &database.Realm{
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "1.2.3.4",          // xff is preferred over remote ip

--- a/pkg/controller/middleware/header_test.go
+++ b/pkg/controller/middleware/header_test.go
@@ -15,11 +15,11 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
@@ -27,8 +27,7 @@ import (
 func TestRequireHeader(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
+	ctx := project.TestContext(t)
 	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
@@ -59,6 +58,7 @@ func TestRequireHeader(t *testing.T) {
 			t.Parallel()
 
 			r := httptest.NewRequest("GET", "/", nil)
+			r = r.Clone(ctx)
 			r.Header.Set("Accept", "application/json")
 			for k, v := range tc.headers {
 				r.Header.Set(k, v)
@@ -78,8 +78,7 @@ func TestRequireHeader(t *testing.T) {
 func TestRequireHeaderValues(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-
+	ctx := project.TestContext(t)
 	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
@@ -116,6 +115,7 @@ func TestRequireHeaderValues(t *testing.T) {
 			t.Parallel()
 
 			r := httptest.NewRequest("GET", "/", nil)
+			r = r.Clone(ctx)
 			r.Header.Set("Accept", "application/json")
 			for k, v := range tc.headers {
 				r.Header.Set(k, v)

--- a/pkg/controller/middleware/i18n_test.go
+++ b/pkg/controller/middleware/i18n_test.go
@@ -30,6 +30,8 @@ import (
 func TestProcessLocale(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
+
 	locales, err := i18n.Load(filepath.Join(project.Root(), "internal", "i18n", "locales"))
 	if err != nil {
 		t.Fatal(err)
@@ -73,6 +75,7 @@ func TestProcessLocale(t *testing.T) {
 			t.Parallel()
 
 			r := httptest.NewRequest("GET", "/"+tc.query, nil)
+			r = r.Clone(ctx)
 			r.Header.Set("Accept", "application/json")
 			for k, v := range tc.headers {
 				r.Header.Set(k, v)

--- a/pkg/controller/middleware/logger.go
+++ b/pkg/controller/middleware/logger.go
@@ -48,6 +48,13 @@ func PopulateLogger(originalLogger *zap.SugaredLogger) mux.MiddlewareFunc {
 
 			logger := originalLogger
 
+			// Only override the logger if it's the default logger. This is only used
+			// for testing and is intentionally a strict object equality check because
+			// the default logger is a global default in the logger package.
+			if existing := logging.FromContext(ctx); existing == logging.DefaultLogger() {
+				logger = existing
+			}
+
 			// If there's a request ID, set that on the logger.
 			if id := controller.RequestIDFromContext(ctx); id != "" {
 				logger = logger.With("request_id", id)

--- a/pkg/controller/middleware/membership_test.go
+++ b/pkg/controller/middleware/membership_test.go
@@ -15,12 +15,12 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -32,7 +32,8 @@ import (
 func TestLoadCurrentMembership(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -102,7 +103,7 @@ func TestLoadCurrentMembership(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := ctx
 			if tc.user != nil {
 				ctx = controller.WithUser(ctx, tc.user)
 			}
@@ -152,7 +153,8 @@ func TestLoadCurrentMembership(t *testing.T) {
 func TestRequireMembership(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -185,7 +187,7 @@ func TestRequireMembership(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			ctx := context.Background()
+			ctx := ctx
 			if tc.membership != nil {
 				ctx = controller.WithMembership(ctx, tc.membership)
 			}

--- a/pkg/controller/middleware/method_test.go
+++ b/pkg/controller/middleware/method_test.go
@@ -22,12 +22,14 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 )
 
 func TestMutateMethod(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	mutateMethod := middleware.MutateMethod()
 
 	cases := []struct {
@@ -63,6 +65,7 @@ func TestMutateMethod(t *testing.T) {
 			t.Parallel()
 
 			r := httptest.NewRequest("POST", "/", tc.r)
+			r = r.Clone(ctx)
 			r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 			w := httptest.NewRecorder()

--- a/pkg/controller/middleware/mfa_test.go
+++ b/pkg/controller/middleware/mfa_test.go
@@ -15,13 +15,13 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http/httptest"
 	"testing"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -32,12 +32,12 @@ import (
 func TestRequireMFA(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	ctx := context.Background()
 	authProvider, err := auth.NewLocal(ctx)
 	if err != nil {
 		t.Fatal(err)
@@ -173,7 +173,7 @@ func TestRequireMFA(t *testing.T) {
 				t.Fatal(err)
 			}
 
-			ctx := context.Background()
+			ctx := ctx
 			ctx = controller.WithSession(ctx, session)
 			if tc.membership != nil {
 				ctx = controller.WithMembership(ctx, tc.membership)

--- a/pkg/controller/middleware/request_id.go
+++ b/pkg/controller/middleware/request_id.go
@@ -30,14 +30,16 @@ func PopulateRequestID(h render.Renderer) mux.MiddlewareFunc {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			ctx := r.Context()
 
-			u, err := uuid.NewRandom()
-			if err != nil {
-				controller.InternalError(w, r, h, err)
-				return
-			}
+			if existing := controller.RequestIDFromContext(ctx); existing == "" {
+				u, err := uuid.NewRandom()
+				if err != nil {
+					controller.InternalError(w, r, h, err)
+					return
+				}
 
-			ctx = controller.WithRequestID(ctx, u.String())
-			r = r.Clone(ctx)
+				ctx = controller.WithRequestID(ctx, u.String())
+				r = r.Clone(ctx)
+			}
 
 			next.ServeHTTP(w, r)
 		})

--- a/pkg/controller/middleware/request_id_test.go
+++ b/pkg/controller/middleware/request_id_test.go
@@ -15,12 +15,12 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -29,7 +29,8 @@ import (
 func TestPopulateRequestID(t *testing.T) {
 	t.Parallel()
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -37,6 +38,7 @@ func TestPopulateRequestID(t *testing.T) {
 	populateRequestID := middleware.PopulateRequestID(h)
 
 	r := httptest.NewRequest("GET", "/", nil)
+	r = r.Clone(ctx)
 	r.Header.Set("Accept", "application/json")
 
 	w := httptest.NewRecorder()

--- a/pkg/controller/middleware/sessions_test.go
+++ b/pkg/controller/middleware/sessions_test.go
@@ -15,12 +15,12 @@
 package middleware_test
 
 import (
-	"context"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -30,16 +30,18 @@ import (
 func TestRequireSession(t *testing.T) {
 	t.Parallel()
 
-	store := sessions.NewCookieStore()
-
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	ctx := project.TestContext(t)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
+	store := sessions.NewCookieStore()
+
 	requireSession := middleware.RequireSession(store, h)
 
 	r := httptest.NewRequest("GET", "/", nil)
+	r = r.Clone(ctx)
 	r.Header.Set("Accept", "application/json")
 
 	w := httptest.NewRecorder()

--- a/pkg/controller/middleware/template_test.go
+++ b/pkg/controller/middleware/template_test.go
@@ -19,6 +19,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
@@ -27,6 +28,8 @@ import (
 func TestPopulateTemplateVariables(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
+
 	cfg := &config.ServerConfig{
 		ServerName:      "namey",
 		MaintenanceMode: true,
@@ -34,6 +37,7 @@ func TestPopulateTemplateVariables(t *testing.T) {
 	populateTemplateVariables := middleware.PopulateTemplateVariables(cfg)
 
 	r := httptest.NewRequest("GET", "/", nil)
+	r = r.Clone(ctx)
 	r.Header.Set("Accept", "application/json")
 
 	w := httptest.NewRecorder()

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleCreate(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -53,7 +55,7 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -72,7 +74,7 @@ func TestHandleCreate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -80,7 +82,7 @@ func TestHandleCreate(t *testing.T) {
 		c := mobileapps.New(harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -114,7 +116,7 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -122,7 +124,7 @@ func TestHandleCreate(t *testing.T) {
 		c := mobileapps.New(harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/mobileapps/disable_test.go
+++ b/pkg/controller/mobileapps/disable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,6 +38,7 @@ import (
 func TestHandleDisable(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -52,7 +54,7 @@ func TestHandleDisable(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,7 +77,7 @@ func TestHandleDisable(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,7 +87,7 @@ func TestHandleDisable(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleDisable()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/mobileapps/enable_test.go
+++ b/pkg/controller/mobileapps/enable_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleEnable(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -53,7 +55,7 @@ func TestHandleEnable(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -76,7 +78,7 @@ func TestHandleEnable(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -86,7 +88,7 @@ func TestHandleEnable(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleEnable()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/mobileapps/index_test.go
+++ b/pkg/controller/mobileapps/index_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -36,6 +37,7 @@ import (
 func TestHandleIndex(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -51,7 +53,7 @@ func TestHandleIndex(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +75,7 @@ func TestHandleIndex(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -81,7 +83,7 @@ func TestHandleIndex(t *testing.T) {
 		c := mobileapps.New(harness.Database, h)
 		handler := c.HandleIndex()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,6 +38,7 @@ import (
 func TestHandleShow(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -52,7 +54,7 @@ func TestHandleShow(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -75,7 +77,7 @@ func TestHandleShow(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -85,7 +87,7 @@ func TestHandleShow(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleShow()).Methods("GET")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,6 +39,7 @@ import (
 func TestHandleUpdate(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -64,7 +66,7 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -88,7 +90,7 @@ func TestHandleUpdate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -98,7 +100,7 @@ func TestHandleUpdate(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -129,7 +131,7 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -139,7 +141,7 @@ func TestHandleUpdate(t *testing.T) {
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/modeler/modeler_test.go
+++ b/pkg/controller/modeler/modeler_test.go
@@ -15,16 +15,17 @@
 package modeler
 
 import (
-	"context"
 	"testing"
 	"time"
 
+	"github.com/sethvargo/go-envconfig"
+	"github.com/sethvargo/go-limiter/memorystore"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/ratelimit"
-	"github.com/sethvargo/go-envconfig"
-	"github.com/sethvargo/go-limiter/memorystore"
 )
 
 var testDatabaseInstance *database.TestInstance
@@ -38,7 +39,7 @@ func TestMain(m *testing.M) {
 func testModeler(tb testing.TB) *Controller {
 	tb.Helper()
 
-	ctx := context.Background()
+	ctx := project.TestContext(tb)
 	db, dbConfig := testDatabaseInstance.NewDatabase(tb, nil)
 
 	config := config.Modeler{
@@ -71,7 +72,7 @@ func testModeler(tb testing.TB) *Controller {
 func TestRebuildModel(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
+	ctx := project.TestContext(t)
 	modeler := testModeler(t)
 	db := modeler.db
 

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -35,6 +36,7 @@ import (
 func TestHandleEvents(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -50,7 +52,7 @@ func TestHandleEvents(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -73,7 +75,7 @@ func TestHandleEvents(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -81,7 +83,7 @@ func TestHandleEvents(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleEvents()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -15,12 +15,12 @@
 package realmadmin_test
 
 import (
-	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -32,6 +32,7 @@ import (
 func TestHandleDisableExpress(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	_, user, _, err := harness.ProvisionAndLogin()
@@ -39,7 +40,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleDisableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -97,7 +98,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleDisableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -130,7 +131,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleDisableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -172,7 +173,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleDisableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -15,12 +15,12 @@
 package realmadmin_test
 
 import (
-	"context"
 	"net/http/httptest"
 	"strings"
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -32,6 +32,7 @@ import (
 func TestHandleEnableExpress(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	_, user, _, err := harness.ProvisionAndLogin()
@@ -39,7 +40,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -64,7 +65,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleEnableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -97,7 +98,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleEnableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -130,7 +131,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleEnableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
@@ -171,7 +172,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleEnableExpress()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -15,7 +15,6 @@
 package realmadmin_test
 
 import (
-	"context"
 	"fmt"
 	"net/http/httptest"
 	"net/url"
@@ -25,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,6 +37,7 @@ import (
 func TestHandleSettings(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, _, err := harness.ProvisionAndLogin()
@@ -45,7 +46,7 @@ func TestHandleSettings(t *testing.T) {
 	}
 	realm.AbusePreventionEnabled = true
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -67,7 +68,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -103,7 +104,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -162,7 +163,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -238,7 +239,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -324,7 +325,7 @@ func TestHandleSettings(t *testing.T) {
 				c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 				handler := c.HandleSettings()
 
-				ctx := context.Background()
+				ctx := ctx
 				ctx = controller.WithSession(ctx, &sessions.Session{})
 				ctx = controller.WithMembership(ctx, &database.Membership{
 					Realm:       realm,
@@ -373,7 +374,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -425,7 +426,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -466,7 +467,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -501,7 +502,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -545,7 +546,7 @@ func TestHandleSettings(t *testing.T) {
 		c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, h)
 		handler := c.HandleSettings()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/realmadmin/stats_test.go
+++ b/pkg/controller/realmadmin/stats_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
@@ -29,6 +30,7 @@ import (
 func TestHandleStats(t *testing.T) {
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	_, _, session, err := harness.ProvisionAndLogin()
@@ -41,7 +43,7 @@ func TestHandleStats(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/redirect/redirect_test.go
+++ b/pkg/controller/redirect/redirect_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package associated_test
+package redirect_test
 
 import (
 	"testing"

--- a/pkg/controller/user/create_test.go
+++ b/pkg/controller/user/create_test.go
@@ -26,9 +26,9 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/gorilla/sessions"
 
-	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	userpkg "github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -39,12 +39,7 @@ import (
 func TestHandleCreate(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	authProvider, err := auth.NewLocal(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, admin, session, err := harness.ProvisionAndLogin()
@@ -60,12 +55,12 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleCreate()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -79,15 +74,15 @@ func TestHandleCreate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -120,15 +115,15 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleCreate()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/user/delete_test.go
+++ b/pkg/controller/user/delete_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
-	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	userpkg "github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -38,12 +38,7 @@ import (
 func TestHandleDelete(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	authProvider, err := auth.NewLocal(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, admin, session, err := harness.ProvisionAndLogin()
@@ -71,11 +66,11 @@ func TestHandleDelete(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleDelete()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -94,17 +89,17 @@ func TestHandleDelete(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleDelete()).Methods("DELETE")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/user/index_test.go
+++ b/pkg/controller/user/index_test.go
@@ -23,9 +23,9 @@ import (
 	"time"
 
 	"github.com/chromedp/chromedp"
-	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	userpkg "github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -37,12 +37,7 @@ import (
 func TestHandleIndex(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	authProvider, err := auth.NewLocal(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -58,11 +53,11 @@ func TestHandleIndex(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleIndex()
 
 		envstest.ExerciseMembershipMissing(t, handler)
@@ -80,15 +75,15 @@ func TestHandleIndex(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleIndex()
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -23,9 +23,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/exposure-notifications-verification-server/internal/auth"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	userpkg "github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -40,12 +40,7 @@ import (
 func TestHandleUpdate(t *testing.T) {
 	t.Parallel()
 
-	ctx := context.Background()
-	authProvider, err := auth.NewLocal(ctx)
-	if err != nil {
-		t.Fatal(err)
-	}
-
+	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, admin, session, err := harness.ProvisionAndLogin()
@@ -73,12 +68,12 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 		handler := c.HandleUpdate()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -97,17 +92,17 @@ func TestHandleUpdate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
@@ -139,17 +134,17 @@ func TestHandleUpdate(t *testing.T) {
 	t.Run("validation", func(t *testing.T) {
 		t.Parallel()
 
-		h, err := render.New(context.Background(), envstest.ServerAssetsPath(), true)
+		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		c := userpkg.New(authProvider, harness.Cacher, harness.Database, h)
+		c := userpkg.New(harness.AuthProvider, harness.Cacher, harness.Database, h)
 
 		mux := mux.NewRouter()
 		mux.Handle("/{id}", c.HandleUpdate()).Methods("PUT")
 
-		ctx := context.Background()
+		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,


### PR DESCRIPTION
Now that we have many more tests, the log output is largely impossible when a single test fails.

[zaptest](https://pkg.go.dev/go.uber.org/zap/zaptest) fixes this as a special logger than only logs when `t` fails. Unfortunately that required a bit more plumbing than I had expected.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Pass in zaptest.Logger to tests
```
