### PR TITLE
Collect invalid codes and all token statistics

### DIFF
--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -155,7 +155,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 
 		// Do the transactional update to the database last so that if it fails, the
 		// client can retry.
-		if err := c.db.ClaimToken(authApp.RealmID, tokenID, subject); err != nil {
+		if err := c.db.ClaimToken(authApp, tokenID, subject); err != nil {
 			blame = observability.BlameClient
 			switch {
 			case errors.Is(err, database.ErrTokenExpired):

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/chromedp/chromedp"
 )
@@ -40,6 +41,14 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 	// Mint a cookie for the session.
 	cookie, err := harness.SessionCookie(session)
 	if err != nil {
+		t.Fatal(err)
+	}
+
+	authApp := &database.AuthorizedApp{
+		RealmID: realm.ID,
+		Name:    "Appy",
+	}
+	if _, err := realm.CreateAuthorizedApp(harness.Database, authApp, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
@@ -100,7 +109,7 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 
 	// Exchange the code for a verification certificate.
 	allowedTypes := api.AcceptTypes{api.TestTypeConfirmed: struct{}{}}
-	token, err := harness.Database.VerifyCodeAndIssueToken(realm.ID, code, allowedTypes, 30*time.Minute)
+	token, err := harness.Database.VerifyCodeAndIssueToken(authApp, code, allowedTypes, 30*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -95,7 +95,7 @@ func (c *Controller) HandleVerify() http.Handler {
 
 		// Exchange the short term verification code for a long term verification token.
 		// The token can be used to sign TEKs later.
-		verificationToken, err := c.db.VerifyCodeAndIssueToken(authApp.RealmID, request.VerificationCode, acceptTypes, c.config.VerificationTokenDuration)
+		verificationToken, err := c.db.VerifyCodeAndIssueToken(authApp, request.VerificationCode, acceptTypes, c.config.VerificationTokenDuration)
 		if err != nil {
 			blame = observability.BlameClient
 			switch {

--- a/pkg/database/authorized_app_stats.go
+++ b/pkg/database/authorized_app_stats.go
@@ -37,8 +37,19 @@ type AuthorizedAppStats []*AuthorizedAppStat
 // database.
 type AuthorizedAppStat struct {
 	Date            time.Time `gorm:"date; not null;"`
-	AuthorizedAppID uint      `gorm:"authorized_app_id; not null;"`
-	CodesIssued     uint      `gorm:"codes_issued; default: 0;"`
+	AuthorizedAppID uint      `gorm:"column:authorized_app_id; type:integer; not null; not null;"`
+
+	// CodesIssued is the number of codes issued. Only keys of type "admin" can
+	// issue codes. CodesClaimed and CodesInvalid are the number of codes claimed
+	// and valid, respectively. These fields are only valid for "device" API keys.
+	CodesIssued  uint `gorm:"column:codes_issued; type:integer; not null; default: 0;"`
+	CodesClaimed uint `gorm:"column:codes_claimed; type:integer; not null; default: 0;"`
+	CodesInvalid uint `gorm:"column:codes_invalid; type:integer; not null; default:0;"`
+
+	// TokensClaimed and TokensInvalid are the number of tokens exchanged for a
+	// certificate or failures. These fields are only valid for "device" API keys.
+	TokensClaimed uint `gorm:"column:tokens_claimed; type:integer; not null; default:0;"`
+	TokensInvalid uint `gorm:"column:tokens_invalid; type:integer; not null; default:0;"`
 
 	// Non-database fields, these are added via the stats lookup using the join
 	// table.

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1906,6 +1906,29 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE memberships DROP COLUMN IF EXISTS updated_at`)
 			},
 		},
+		{
+			ID: "00082-AddMoreStats",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats ADD COLUMN IF NOT EXISTS codes_invalid INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE realm_stats ADD COLUMN IF NOT EXISTS tokens_claimed INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE realm_stats ADD COLUMN IF NOT EXISTS tokens_invalid INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE authorized_app_stats ADD COLUMN IF NOT EXISTS codes_claimed INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE authorized_app_stats ADD COLUMN IF NOT EXISTS codes_invalid INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE authorized_app_stats ADD COLUMN IF NOT EXISTS tokens_claimed INTEGER NOT NULL DEFAULT 0`,
+					`ALTER TABLE authorized_app_stats ADD COLUMN IF NOT EXISTS tokens_invalid INTEGER NOT NULL DEFAULT 0`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS codes_invalid`,
+					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS tokens_claimed`,
+					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS tokens_invalid`,
+					`ALTER TABLE authorized_app_stats DROP COLUMN IF EXISTS codes_claimed`,
+					`ALTER TABLE authorized_app_stats DROP COLUMN IF EXISTS codes_invalid`,
+					`ALTER TABLE authorized_app_stats DROP COLUMN IF EXISTS tokens_claimed`,
+					`ALTER TABLE authorized_app_stats DROP COLUMN IF EXISTS tokens_invalid`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -34,11 +34,24 @@ type RealmStats []*RealmStat
 
 // RealmStat represents statistics related to a user in the database.
 type RealmStat struct {
-	Date             time.Time `gorm:"date; not null;"`
-	RealmID          uint      `gorm:"realm_id; not null;"`
-	CodesIssued      uint      `gorm:"codes_issued; default:0;"`
-	CodesClaimed     uint      `gorm:"codes_claimed; default:0;"`
-	DailyActiveUsers uint      `gorm:"daily_active_users; default:0;"`
+	Date    time.Time `gorm:"column:date; type:date; not null;"`
+	RealmID uint      `gorm:"column:realm_id; type:integer; not null;"`
+
+	// CodesIssued is the total number of codes issued. CodesClaimed are
+	// successful claims. CodesInvalid are codes that have failed to claim
+	// (expired or not found).
+	CodesIssued  uint `gorm:"column:codes_issued; type:integer; not null; default:0;"`
+	CodesClaimed uint `gorm:"column:codes_claimed; type:integer; not null; default:0;"`
+	CodesInvalid uint `gorm:"column:codes_invalid; type:integer; not null; default:0;"`
+
+	// TokensClaimed is the number of tokens exchanged for a certificate.
+	// TokensInvalid is the number of tokens which failed to exchange due to
+	// a user error.
+	TokensClaimed uint `gorm:"column:tokens_claimed; type:integer; not null; default:0;"`
+	TokensInvalid uint `gorm:"column:tokens_invalid; type:integer; not null; default:0;"`
+
+	// DailyActiveUsers is the total number of daily active users.
+	DailyActiveUsers uint `gorm:"column:daily_active_users; type:integer; not null; default:0;"`
 }
 
 // MarshalCSV returns bytes in CSV format.

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -203,6 +203,8 @@ func (db *Database) IsCodeExpired(v *VerificationCode, code string) (bool, CodeT
 	case inList(v.LongCode, possibles):
 		return !v.LongExpiresAt.After(now), CodeTypeLong, nil
 	default:
+		// This should be unreachable code because the caller looks up the
+		// verification code.
 		return true, 0, fmt.Errorf("not found")
 	}
 }

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -191,6 +191,10 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("failed to create device api key: %w", err)
 	}
 	logger.Infow("created device api key", "key", deviceAPIKey)
+	deviceAuthorizedApp, err := db.FindAuthorizedAppByAPIKey(deviceAPIKey)
+	if err != nil {
+		return fmt.Errorf("failed to lookup device api id: %w", err)
+	}
 
 	// Create some Apps
 	apps := []*database.MobileApp{
@@ -301,7 +305,7 @@ func realMain(ctx context.Context) error {
 					api.TestTypeLikely:    {},
 					api.TestTypeNegative:  {},
 				}
-				if _, err := db.VerifyCodeAndIssueToken(realm1.ID, code, accept, 24*time.Hour); err != nil {
+				if _, err := db.VerifyCodeAndIssueToken(deviceAuthorizedApp, code, accept, 24*time.Hour); err != nil {
 					return fmt.Errorf("failed to claim token: %w", err)
 				}
 			}


### PR DESCRIPTION
This adds additional statistics collection for the following data:

- `codes_invalid` - a code is expired or doesn't exist in our database
- `token_claimed` - a token successfully exchanged with a cert
- `token_invalid` - a token failed to exchange with a cert (invalid claims, etc)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Collect invalid codes and token statistics (backend only)
```
