### PR TITLE
Ping db on health instead of opening new connection

### DIFF
--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -93,7 +93,7 @@ func AdminAPI(
 	processFirewall := middleware.ProcessFirewall(h, "adminapi")
 
 	// Health route
-	r.Handle("/health", controller.HandleHealthz(ctx, &cfg.Database, h)).Methods("GET")
+	r.Handle("/health", controller.HandleHealthz(db, h)).Methods("GET")
 
 	// API routes
 	{

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -94,7 +94,7 @@ func APIServer(
 	processFirewall := middleware.ProcessFirewall(h, "apiserver")
 
 	// Health route
-	r.Handle("/health", controller.HandleHealthz(ctx, &cfg.Database, h)).Methods("GET")
+	r.Handle("/health", controller.HandleHealthz(db, h)).Methods("GET")
 
 	// Make verify chaff tracker.
 	verifyChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeVerifyResponse), chaff.DefaultCapacity)

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -69,7 +69,7 @@ func ENXRedirect(
 	r.Use(processDebug)
 
 	// Handle health.
-	r.Handle("/health", controller.HandleHealthz(ctx, nil, h)).Methods("GET")
+	r.Handle("/health", controller.HandleHealthz(db, h)).Methods("GET")
 
 	// iOS and Android include functionality to associate data between web-apps
 	// and device apps. Things like handoff between websites and apps, or

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -154,7 +154,7 @@ func Server(
 
 	{
 		sub := r.PathPrefix("").Subrouter()
-		sub.Handle("/health", controller.HandleHealthz(ctx, &cfg.Database, h)).Methods("GET")
+		sub.Handle("/health", controller.HandleHealthz(db, h)).Methods("GET")
 	}
 
 	{

--- a/pkg/testsuite/integration.go
+++ b/pkg/testsuite/integration.go
@@ -279,7 +279,7 @@ func (s *IntegrationSuite) newAdminAPIServer(ctx context.Context, tb testing.TB)
 		tb.Fatalf("failed to create the limit store %v", err)
 	}
 
-	adminRouter.Handle("/health", controller.HandleHealthz(ctx, &s.cfg.AdminAPISrvConfig.Database, h)).Methods("GET")
+	adminRouter.Handle("/health", controller.HandleHealthz(s.DB, h)).Methods("GET")
 
 	{
 		sub := adminRouter.PathPrefix("/api").Subrouter()
@@ -339,7 +339,7 @@ func (s *IntegrationSuite) newAPIServer(ctx context.Context, tb testing.TB) *htt
 	// Install common security headers
 	apiRouter.Use(middleware.SecureHeaders(s.cfg.APISrvConfig.DevMode, "json"))
 
-	apiRouter.Handle("/health", controller.HandleHealthz(ctx, &s.cfg.APISrvConfig.Database, h)).Methods("GET")
+	apiRouter.Handle("/health", controller.HandleHealthz(s.DB, h)).Methods("GET")
 
 	{
 		sub := apiRouter.PathPrefix("/api").Subrouter()

--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -22,7 +22,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   period       = "60s"
 
   http_check {
-    path         = "/health"
+    path         = "/health?service=database"
     port         = "443"
     use_ssl      = true
     validate_ssl = true


### PR DESCRIPTION
The previous logic relied on creating a new database connection. This would be a different database connection from the one the rest of the app is using, and could lead to false successes. This changes the health endpoint to use the same db that the other handlers use.

Additionally, since it's just a ping now (instead of a full config parsing), the limit is increased from 1/min to 1/sec. The response code when the limit is exceeded is now a 429 instead of silently falling through to 200.

Finally, the monitoring uptime checks are updated to use this endpoint instead of the generic /health. It's safe to say that the service is "down" if it cannot connect to the database.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ping db on /health instead of opening new connection
```

/assign @yegle 
/assign @whaught 