### PR TITLE
Temporarily don't check database connection

### DIFF
--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -22,7 +22,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   period       = "60s"
 
   http_check {
-    path         = "/health?service=database"
+    path         = "/health"
     port         = "443"
     use_ssl      = true
     validate_ssl = true


### PR DESCRIPTION
This is required because Terraform configs are run from HEAD, but the previous tag (0.18.5) is not compatible with this change. We can re-add this after 0.19 is tagged and ready.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Temporarily disable database service check due to incompatibility between releases
```
