### PR TITLE
Refactor Cloud Run annotations in Terraform config.

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -135,11 +135,11 @@ resource "google_cloud_run_service" "adminapi" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "adminapi", {})
+      )
     }
   }
 

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -142,11 +142,11 @@ resource "google_cloud_run_service" "apiserver" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "apiserver", {})
+      )
     }
   }
 

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -136,11 +136,11 @@ resource "google_cloud_run_service" "appsync" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "appsync", {})
+      )
     }
   }
 

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -135,11 +135,11 @@ resource "google_cloud_run_service" "cleanup" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "cleanup", {})
+      )
     }
   }
 

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -136,11 +136,11 @@ resource "google_cloud_run_service" "e2e-runner" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "e2e-runner", {})
+      )
     }
   }
 

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -133,11 +133,11 @@ resource "google_cloud_run_service" "modeler" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "modeler", {})
+      )
     }
   }
 

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -153,11 +153,11 @@ resource "google_cloud_run_service" "enx-redirect" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "enx-redirect", {})
+      )
     }
   }
 

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -177,11 +177,11 @@ resource "google_cloud_run_service" "server" {
     }
 
     metadata {
-      annotations = {
-        "autoscaling.knative.dev/maxScale" : 1000
-        "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
-        "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
-      }
+      annotations = merge(
+        local.default_annotations,
+        var.default_annotations_overrides,
+        lookup(var.service_annotations, "server", {})
+      )
     }
   }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -221,6 +221,32 @@ variable "enable_lb_logging" {
   EOT
 }
 
+variable "service_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service additional annotations."
+}
+
+locals {
+  default_annotations = {
+    "autoscaling.knative.dev/maxScale" : "1",
+    "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
+    "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
+  }
+}
+
+variable "default_annotations_overrides" {
+  type    = map(string)
+  default = {}
+
+  description = <<-EOT
+  Annotations that applies to all services. Can be used to override
+  default_annotations.
+  EOT
+}
+
+
 terraform {
   required_version = ">= 0.14.2"
 


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/895

```release-note
Breaking: To continue using the Terraform module, the following input variable is needed to avoid introducing a diff:

service_annotations = {                                                       
    adminapi     = { "autoscaling.knative.dev/maxScale" : "1000" }
    apiserver    = { "autoscaling.knative.dev/maxScale" : "1000" }
    appsync      = { "autoscaling.knative.dev/maxScale" : "1000" }
    cleanup      = { "autoscaling.knative.dev/maxScale" : "1000" }
    e2e-runner   = { "autoscaling.knative.dev/maxScale" : "1000" }
    enx-redirect = { "autoscaling.knative.dev/maxScale" : "1000" }
    modeler      = { "autoscaling.knative.dev/maxScale" : "1000" }
} 
```
