### PR TITLE
Simplify latency alerting

### DIFF
--- a/terraform/alerting/module.latency-alert/main.tf
+++ b/terraform/alerting/module.latency-alert/main.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.

--- a/terraform/alerting/module.latency-alert/main.tf
+++ b/terraform/alerting/module.latency-alert/main.tf
@@ -1,0 +1,57 @@
+# Copyright 2020 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+locals {
+  playbook_prefix = "https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/slo"
+}
+
+# latency alert
+# alert if mean latency is over $threshold for $duration
+resource "google_monitoring_alert_policy" "latency-alert" {
+  count        = var.enabled ? 1 : 0
+  project      = var.project
+  display_name = "LatencyOverThreshold-${var.service_name}"
+  combiner     = "AND"
+  enabled      = var.enabled
+
+  conditions {
+    display_name = "Latency over ${var.threshold / 1000} seconds for ${var.duration / 1000 / 60} minutes"
+    condition_monitoring_query_language {
+      duration = "${var.duration / 1000}s"
+      query    = <<-EOT
+        fetch https_lb_rule
+        | metric 'loadbalancing.googleapis.com/https/total_latencies'
+        | filter (resource.backend_name == '${var.service_name}')
+        | group_by 1m,
+            [value_total_latencies_percentile: percentile(value.total_latencies, 99)]
+        | every 1m
+        | group_by [],
+            [val:
+            mean(value_total_latencies_percentile)]
+        | condition val > ${var.threshold} 'ms'
+      EOT
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${local.playbook_prefix}/FastLatencyBudgetBurn.md"
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [for x in values(var.notification_channels) : x.id]
+
+}

--- a/terraform/alerting/module.latency-alert/variables.tf
+++ b/terraform/alerting/module.latency-alert/variables.tf
@@ -41,6 +41,6 @@ variable "threshold" {
 
 variable "duration" {
   type        = number
-  description = "Duration of alert evaluation"
+  description = "Duration of alert evaluation (in ms)"
 }
 

--- a/terraform/alerting/module.latency-alert/variables.tf
+++ b/terraform/alerting/module.latency-alert/variables.tf
@@ -1,0 +1,32 @@
+variable "custom_service_id" {
+  type = string
+}
+
+variable "service_name" {
+  type = string
+}
+
+variable "enabled" {
+  type        = bool
+  description = "Whether to enable this alert"
+}
+
+variable "notification_channels" {
+  type        = map(any)
+  description = "Notification channels"
+}
+
+variable "project" {
+  type = string
+}
+
+variable "threshold" {
+  type        = number
+  description = "Latency threshold (in ms)."
+}
+
+variable "duration" {
+  type        = number
+  description = "Duration of alert evaluation"
+}
+

--- a/terraform/alerting/module.latency-alert/variables.tf
+++ b/terraform/alerting/module.latency-alert/variables.tf
@@ -1,3 +1,17 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
 variable "custom_service_id" {
   type = string
 }

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -16,7 +16,7 @@ locals {
   default_per_service_slo = {
     enable_alert           = false
     availability_goal      = 0.995
-    enable_latency_slo     = false
+    enable_latency_slo     = false # disabled by default due to low request volume; use latency alert for those
     latency_goal           = 0.95
     latency_threshold      = 60000 # 60 seconds, in ms
     enable_latency_alert   = false
@@ -26,8 +26,7 @@ locals {
   service_configs = {
     adminapi = merge(local.default_per_service_slo,
       { enable_alert         = true,
-        enable_latency_alert = true,
-        enable_latency_slo   = false,
+        enable_latency_alert = true
     latency_threshold = 6000 })
     apiserver = merge(local.default_per_service_slo,
       { enable_alert         = true,
@@ -94,7 +93,6 @@ module "latency-slos" {
 
   project = var.project
 
-  # enabled               = var.https-forwarding-rule != ""
   notification_channels = google_monitoring_notification_channel.channels
 
   for_each = merge(local.service_configs, var.slo_thresholds_overrides)

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -14,27 +14,36 @@
 
 locals {
   default_per_service_slo = {
-    enable_alert      = false
-    availability_goal = 0.995
-    latency_goal      = 0.95
-    latency_threshold = 60000 # in ms
+    enable_alert            = false
+    availability_goal       = 0.995
+    enable_latency_slo      = false
+    latency_goal            = 0.95
+    latency_threshold       = 60000 # 60 seconds, in ms
+    enable_latency_alert    = false
+    latency_alert_duration  = 300000 # 5 minutes, in ms
+    
   }
   service_configs = {
     adminapi = merge(local.default_per_service_slo,
       { enable_alert = true,
+    enable_latency_alert = true,
+    enable_latency_slo = false,
     latency_threshold = 6000 })
     apiserver = merge(local.default_per_service_slo,
       { enable_alert = true,
+    enable_latency_alert = true,
     latency_threshold = 2000 })
     appsync    = local.default_per_service_slo
     cleanup    = local.default_per_service_slo
     e2e-runner = local.default_per_service_slo
     enx-redirect = merge(local.default_per_service_slo,
       { enable_alert = true,
+    enable_latency_alert = true,
     latency_threshold = 2000 })
     modeler = local.default_per_service_slo
     server = merge(local.default_per_service_slo,
       { enable_alert = true,
+    enable_latency_alert = true,
     latency_threshold = 2000 })
   }
 }
@@ -49,6 +58,20 @@ module "services" {
   display_name      = each.key
   latency_threshold = each.value.latency_threshold
   latency_goal      = each.value.latency_goal
+}
+
+module "latency-alerts" {
+  source = "./module.latency-alert"
+
+  notification_channels = google_monitoring_notification_channel.channels
+
+  project = var.project
+  for_each          = merge(local.service_configs, var.slo_thresholds_overrides)
+  custom_service_id = each.key
+  enabled           = each.value.enable_latency_alert
+  service_name      = each.key
+  threshold         = each.value.latency_threshold
+  duration          = each.value.latency_alert_duration
 }
 
 module "availability-slos" {
@@ -71,11 +94,12 @@ module "latency-slos" {
 
   project = var.project
 
-  enabled               = var.https-forwarding-rule != ""
+  # enabled               = var.https-forwarding-rule != ""
   notification_channels = google_monitoring_notification_channel.channels
 
   for_each = merge(local.service_configs, var.slo_thresholds_overrides)
 
+  enabled           = each.value.enable_latency_slo
   custom_service_id = each.key
   service_name      = each.key
   goal              = each.value.latency_goal

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -14,36 +14,36 @@
 
 locals {
   default_per_service_slo = {
-    enable_alert            = false
-    availability_goal       = 0.995
-    enable_latency_slo      = false
-    latency_goal            = 0.95
-    latency_threshold       = 60000 # 60 seconds, in ms
-    enable_latency_alert    = false
-    latency_alert_duration  = 300000 # 5 minutes, in ms
-    
+    enable_alert           = false
+    availability_goal      = 0.995
+    enable_latency_slo     = false
+    latency_goal           = 0.95
+    latency_threshold      = 60000 # 60 seconds, in ms
+    enable_latency_alert   = false
+    latency_alert_duration = 300000 # 5 minutes, in ms
+
   }
   service_configs = {
     adminapi = merge(local.default_per_service_slo,
-      { enable_alert = true,
-    enable_latency_alert = true,
-    enable_latency_slo = false,
+      { enable_alert         = true,
+        enable_latency_alert = true,
+        enable_latency_slo   = false,
     latency_threshold = 6000 })
     apiserver = merge(local.default_per_service_slo,
-      { enable_alert = true,
-    enable_latency_alert = true,
+      { enable_alert         = true,
+        enable_latency_alert = true,
     latency_threshold = 2000 })
     appsync    = local.default_per_service_slo
     cleanup    = local.default_per_service_slo
     e2e-runner = local.default_per_service_slo
     enx-redirect = merge(local.default_per_service_slo,
-      { enable_alert = true,
-    enable_latency_alert = true,
+      { enable_alert         = true,
+        enable_latency_alert = true,
     latency_threshold = 2000 })
     modeler = local.default_per_service_slo
     server = merge(local.default_per_service_slo,
-      { enable_alert = true,
-    enable_latency_alert = true,
+      { enable_alert         = true,
+        enable_latency_alert = true,
     latency_threshold = 2000 })
   }
 }
@@ -65,7 +65,7 @@ module "latency-alerts" {
 
   notification_channels = google_monitoring_notification_channel.channels
 
-  project = var.project
+  project           = var.project
   for_each          = merge(local.service_configs, var.slo_thresholds_overrides)
   custom_service_id = each.key
   enabled           = each.value.enable_latency_alert

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -16,7 +16,7 @@ locals {
   default_per_service_slo = {
     enable_alert      = false
     availability_goal = 0.995
-    latency_goal      = 0.99
+    latency_goal      = 0.95
     latency_threshold = 60000 # in ms
   }
   service_configs = {
@@ -25,13 +25,13 @@ locals {
     latency_threshold = 6000 })
     apiserver = merge(local.default_per_service_slo,
       { enable_alert = true,
-    latency_threshold = 400 })
+    latency_threshold = 2000 })
     appsync    = local.default_per_service_slo
     cleanup    = local.default_per_service_slo
     e2e-runner = local.default_per_service_slo
     enx-redirect = merge(local.default_per_service_slo,
       { enable_alert = true,
-    latency_threshold = 400 })
+    latency_threshold = 2000 })
     modeler = local.default_per_service_slo
     server = merge(local.default_per_service_slo,
       { enable_alert = true,


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* loosened default latency SLO target
* added latency-alert module
* added per-service toggles for latency alerts
* added per-service toggles for latency SLOs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Latency alerting done via threshold, rather than SLO
```
