### PR TITLE
Fix and test for regression for long code expiry

### DIFF
--- a/pkg/controller/codes/expire.go
+++ b/pkg/controller/codes/expire.go
@@ -47,7 +47,7 @@ func (c *Controller) HandleExpireAPI() http.Handler {
 		c.h.RenderJSON(w, http.StatusOK,
 			&api.ExpireCodeResponse{
 				ExpiresAtTimestamp:     code.ExpiresAt.UTC().Unix(),
-				LongExpiresAtTimestamp: code.ExpiresAt.UTC().Unix(),
+				LongExpiresAtTimestamp: code.LongExpiresAt.UTC().Unix(),
 			})
 	})
 }

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -105,8 +105,7 @@ func TestIssueOne(t *testing.T) {
 				t.Errorf("did not receive expected errorCode. got %q, want %q", resp.ErrorCode, tc.responseErr)
 			}
 
-			// success case
-			if tc.responseErr == "" && resp.ExpiresAt == resp.LongExpiresAt {
+			if tc.responseErr == "" && tc.request.Phone != "" && resp.ExpiresAt == resp.LongExpiresAt {
 				t.Errorf("Long expiry should be longer than short when a phone is provided.")
 			}
 		})

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 )
 
 func TestIssueOne(t *testing.T) {
@@ -40,6 +41,14 @@ func TestIssueOne(t *testing.T) {
 	}
 	ctx = controller.WithRealm(ctx, realm)
 
+	smsConfig := &database.SMSConfig{
+		RealmID:      realm.ID,
+		ProviderType: sms.ProviderType(sms.ProviderTypeNoop),
+	}
+	if err := db.SaveSMSConfig(smsConfig); err != nil {
+		t.Fatal(err)
+	}
+
 	existingCode := &database.VerificationCode{
 		RealmID:       realm.ID,
 		Code:          "00000001",
@@ -47,7 +56,7 @@ func TestIssueOne(t *testing.T) {
 		Claimed:       true,
 		TestType:      "confirmed",
 		ExpiresAt:     time.Now().Add(time.Hour),
-		LongExpiresAt: time.Now().Add(time.Hour),
+		LongExpiresAt: time.Now().Add(24 * time.Hour),
 	}
 	if err := db.SaveVerificationCode(existingCode, realm); err != nil {
 		t.Fatal(err)
@@ -65,6 +74,7 @@ func TestIssueOne(t *testing.T) {
 			request: api.IssueCodeRequest{
 				TestType:    "confirmed",
 				SymptomDate: symptomDate,
+				Phone:       "+15005550006",
 			},
 			httpStatusCode: http.StatusOK,
 		},
@@ -93,6 +103,11 @@ func TestIssueOne(t *testing.T) {
 			}
 			if resp.ErrorCode != tc.responseErr {
 				t.Errorf("did not receive expected errorCode. got %q, want %q", resp.ErrorCode, tc.responseErr)
+			}
+
+			// success case
+			if tc.responseErr == "" && resp.ExpiresAt == resp.LongExpiresAt {
+				t.Errorf("Long expiry should be longer than short when a phone is provided.")
 			}
 		})
 	}

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -42,7 +42,6 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, request *api.Iss
 		ExpiresAt:         now.Add(realm.CodeDuration.Duration),
 		LongExpiresAt:     now.Add(realm.LongCodeDuration.Duration),
 	}
-
 	if membership := controller.MembershipFromContext(ctx); membership != nil {
 		vCode.IssuingUserID = membership.UserID
 	}

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -42,6 +42,7 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, request *api.Iss
 		ExpiresAt:         now.Add(realm.CodeDuration.Duration),
 		LongExpiresAt:     now.Add(realm.LongCodeDuration.Duration),
 	}
+
 	if membership := controller.MembershipFromContext(ctx); membership != nil {
 		vCode.IssuingUserID = membership.UserID
 	}
@@ -72,7 +73,8 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, request *api.Iss
 	// Verify SMS configuration if phone was provided
 	var smsProvider sms.Provider
 	if request.Phone != "" {
-		smsProvider, err := realm.SMSProvider(c.db)
+		var err error
+		smsProvider, err = realm.SMSProvider(c.db)
 		if err != nil {
 			logger.Errorw("failed to get sms provider", "error", err)
 			return nil, &IssueResult{

--- a/pkg/database/duration.go
+++ b/pkg/database/duration.go
@@ -24,7 +24,7 @@ import (
 var _ sql.Scanner = (*DurationSeconds)(nil)
 var _ driver.Valuer = (*DurationSeconds)(nil)
 
-// DurationSeconds is a custom type for writing and reating a time.Duration to be stored
+// DurationSeconds is a custom type for writing and reading a time.Duration to be stored
 // as seconds in the database.
 type DurationSeconds struct {
 	Duration time.Duration


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* A shadowed variable causes smsProvider to be nil and therefore LongCodeExpiry is set to the short expiry
    * Added a test case to prevent regression
   
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix for long code expiry being set to short code expiry
```
