### PR TITLE
Separate Cloud Run Service & Revision annotations for terraform

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -97,6 +97,14 @@ resource "google_cloud_run_service" "adminapi" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "adminapi", {})
+    )
+  }
+
   template {
     spec {
       service_account_name = google_service_account.adminapi.email
@@ -136,9 +144,9 @@ resource "google_cloud_run_service" "adminapi" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "adminapi", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "adminapi", {})
       )
     }
   }
@@ -165,6 +173,8 @@ resource "google_cloud_run_service" "adminapi" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -103,6 +103,14 @@ resource "google_cloud_run_service" "apiserver" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "apiserver", {})
+    )
+  }
+
   template {
     spec {
       service_account_name = google_service_account.apiserver.email
@@ -143,9 +151,9 @@ resource "google_cloud_run_service" "apiserver" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "apiserver", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "apiserver", {})
       )
     }
   }
@@ -173,6 +181,8 @@ resource "google_cloud_run_service" "apiserver" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -97,6 +97,13 @@ resource "google_cloud_run_service" "appsync" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "appsync", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.appsync.email
@@ -137,9 +144,9 @@ resource "google_cloud_run_service" "appsync" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "appsync", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "appsync", {})
       )
     }
   }
@@ -166,6 +173,8 @@ resource "google_cloud_run_service" "appsync" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -97,6 +97,13 @@ resource "google_cloud_run_service" "cleanup" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "cleanup", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.cleanup.email
@@ -136,9 +143,9 @@ resource "google_cloud_run_service" "cleanup" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "cleanup", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "cleanup", {})
       )
     }
   }
@@ -165,6 +172,8 @@ resource "google_cloud_run_service" "cleanup" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -97,6 +97,13 @@ resource "google_cloud_run_service" "e2e-runner" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "e2e-runner", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.e2e-runner.email
@@ -137,9 +144,9 @@ resource "google_cloud_run_service" "e2e-runner" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "e2e-runner", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "e2e-runner", {})
       )
     }
   }
@@ -166,6 +173,8 @@ resource "google_cloud_run_service" "e2e-runner" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -97,6 +97,13 @@ resource "google_cloud_run_service" "modeler" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "modeler", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.modeler.email
@@ -134,9 +141,9 @@ resource "google_cloud_run_service" "modeler" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "modeler", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "modeler", {})
       )
     }
   }
@@ -164,6 +171,8 @@ resource "google_cloud_run_service" "modeler" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -117,6 +117,13 @@ resource "google_cloud_run_service" "enx-redirect" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "enx-redirect", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.enx-redirect.email
@@ -154,9 +161,9 @@ resource "google_cloud_run_service" "enx-redirect" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "enx-redirect", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "enx-redirect", {})
       )
     }
   }
@@ -186,6 +193,8 @@ resource "google_cloud_run_service" "enx-redirect" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -134,6 +134,13 @@ resource "google_cloud_run_service" "server" {
 
   autogenerate_revision_name = true
 
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "server", {})
+    )
+  }
   template {
     spec {
       service_account_name = google_service_account.server.email
@@ -178,9 +185,9 @@ resource "google_cloud_run_service" "server" {
 
     metadata {
       annotations = merge(
-        local.default_annotations,
-        var.default_annotations_overrides,
-        lookup(var.service_annotations, "server", {})
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "server", {})
       )
     }
   }
@@ -213,6 +220,8 @@ resource "google_cloud_run_service" "server" {
       template[0].metadata[0].annotations["run.googleapis.com/client-name"],
       template[0].metadata[0].annotations["run.googleapis.com/client-version"],
       template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
     ]
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -221,28 +221,62 @@ variable "enable_lb_logging" {
   EOT
 }
 
-variable "service_annotations" {
-  type    = map(map(string))
-  default = {}
-
-  description = "Per-service additional annotations."
-}
+// Note: in Cloud Run/Knative, there are two kinds of annotations.
+// - Service level annotations: applies to all revisions in the service. E.g.
+//   the ingress restriction
+//   https://cloud.google.com/run/docs/securing/ingress#yaml
+// - Revision level annotations: only applies to a new revision you want to
+//   create. E.g. the VPC connector setting
+//   https://cloud.google.com/run/docs/configuring/connecting-vpc#yaml
+//
+// Unfortunately they are just too similar and you'll have to read the doc
+// carefully to know what kind of annotation is needed to enable a feature.
+//
+// The variables below are named service_annotations and revision_annotations
+// accordingly.
 
 locals {
-  default_annotations = {
+  default_revision_annotations = {
     "autoscaling.knative.dev/maxScale" : "1",
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
     "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
   }
+  default_service_annotations = {
+    "run.googleapis.com/ingress" : "all"
+  }
 }
 
-variable "default_annotations_overrides" {
+variable "service_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service service level annotations."
+}
+
+variable "default_service_annotations_overrides" {
   type    = map(string)
   default = {}
 
   description = <<-EOT
   Annotations that applies to all services. Can be used to override
-  default_annotations.
+  default_service_annotations.
+  EOT
+}
+
+variable "revision_annotations" {
+  type    = map(map(string))
+  default = {}
+
+  description = "Per-service revision level annotations."
+}
+
+variable "default_revision_annotations_overrides" {
+  type    = map(string)
+  default = {}
+
+  description = <<-EOT
+  Annotations that applies to all services. Can be used to override
+  default_revision_annotations.
   EOT
 }
 


### PR DESCRIPTION
There are two types of annotations per Knative spec. See the inline
comment on the difference.

Part of #895 

```release-note
Breaking: To continue using the Terraform module, the following input variable is needed to avoid introducing a diff:

revision_annotations = {                                                       
    adminapi     = { "autoscaling.knative.dev/maxScale" : "1000" }
    apiserver    = { "autoscaling.knative.dev/maxScale" : "1000" }
    appsync      = { "autoscaling.knative.dev/maxScale" : "1000" }
    cleanup      = { "autoscaling.knative.dev/maxScale" : "1000" }
    e2e-runner   = { "autoscaling.knative.dev/maxScale" : "1000" }
    enx-redirect = { "autoscaling.knative.dev/maxScale" : "1000" }
    modeler      = { "autoscaling.knative.dev/maxScale" : "1000" }
} 

```
