### PR TITLE
Reset recaptcha on expire

### DIFF
--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -106,6 +106,12 @@
         'submit-register', {
           'size': 'invisible',
           'callback': (response) => onSignInSubmit(),
+          'expired-callback': e => {
+            grecaptcha.reset(window.recaptchaWidgetId);
+          },
+          'error-callback': e => {
+            grecaptcha.reset(window.recaptchaWidgetId);
+          },
         },
       );
 
@@ -244,7 +250,6 @@
       });
 
       $pinClose.on('click', function(event) {
-        grecaptcha.reset(window.recaptchaWidgetId);
         $submit.prop('disabled', false);
         $registerDiv.show();
         $pinDiv.addClass('d-none');

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -410,6 +410,12 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
   window.recaptchaVerifier = new firebase.auth.RecaptchaVerifier(
     'recaptcha-container', {
     'size': 'invisible',
+    'expired-callback': e => {
+      window.recaptchaVerifier.reset();
+    },
+    'error-callback': e => {
+      window.recaptchaVerifier.reset();
+    },
   });
 
   $loginForm.on('submit', function(event) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We already reset the recaptcha on flows where we `catch` an error post-sms send. This adds it for the recaptcha callbacks that occur when it expires (if you leave the page sitting open for a long time).

I'm still trying to track down connection issues with recaptcha on not-localhost. Firebase automatically handles the recaptcha keys and I'm wondering how that works with the custom domain - I'll try to find more information there.

