### PR TITLE
Show raw error body if unmarshal fails

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -127,9 +127,9 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 
 	r := io.LimitReader(resp.Body, c.maxBodySize)
 	if err := json.NewDecoder(r).Decode(out); err != nil {
-		bodyBytes, rawErr := ioutil.ReadAll(resp.Body)
+		bodyBytes, rawErr := ioutil.ReadAll(r)
 		if rawErr != nil {
-			return nil, fmt.Errorf("failed to read response body %w.", rawErr)
+			return nil, fmt.Errorf("failed to read response body %w", rawErr)
 		}
 		return nil, fmt.Errorf("failed to decode JSON response: %w. Raw response: %s", err, string(bodyBytes))
 	}

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -21,6 +21,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"io/ioutil"
 	"net/http"
 	"net/url"
 	"time"
@@ -126,7 +127,11 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 
 	r := io.LimitReader(resp.Body, c.maxBodySize)
 	if err := json.NewDecoder(r).Decode(out); err != nil {
-		return nil, fmt.Errorf("failed to decode JSON response: %w", err)
+		bodyBytes, rawErr := ioutil.ReadAll(resp.Body)
+		if rawErr != nil {
+			return nil, fmt.Errorf("failed to read response body %w.", rawErr)
+		}
+		return nil, fmt.Errorf("failed to decode JSON response: %w. Raw response: %s", err, string(bodyBytes))
 	}
 	return resp, nil
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* If our e2e test receives an error that is not in the format of the expected response struct, we fail to decode it. This allows us to see the raw string within the error message.