### PR TITLE
Introduce advanced search and bulk permissions

### DIFF
--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -85,7 +85,7 @@ jobs:
           set +o pipefail
 
           YEAR=$(date +"%Y")
-          find . -type f -name '*.go' -exec awk 'FNR==1{if ($0!~"Copyright ${YEAR}") print FILENAME ":1:missing copyright or invalid copyright year";}' '{}' + | \
+          find . -type f -name '*.go' -exec awk 'FNR==1{if ($0!~"Copyright '"${YEAR}"'") print FILENAME ":1:missing copyright or invalid copyright year";}' '{}' + | \
           reviewdog -efm="%f:%l:%m" \
             -name="copyright-check" \
             -reporter="github-pr-review" \

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -112,6 +112,11 @@ $(function() {
     $this.text(date.toLocaleString());
   });
 
+  // Disable propagation on links in menus if they are marked as such.
+  $(document).on('click', 'div.dropdown-menu .keep-open', function(e) {
+    e.stopPropagation();
+  });
+
   // Toast shows alerts/flash messages.
   $(".toast").toast("show");
 

--- a/cmd/server/assets/users/index.html
+++ b/cmd/server/assets/users/index.html
@@ -2,6 +2,7 @@
 
 {{$csrfField := .csrfField}}
 {{$memberships := .memberships}}
+{{$permissions := .permissions}}
 
 {{$currentMembership := .currentMembership}}
 {{$canWrite := $currentMembership.Can rbac.UserWrite}}
@@ -11,6 +12,17 @@
 
 <head>
   {{template "head" .}}
+
+  <style>
+    .dropdown-hover:hover {
+      background-color: #f8f9fa;
+    }
+
+    .custom-control-label.py-2::before,
+    .custom-control-label.py-2::after {
+      top: 0.72rem;
+    }
+  </style>
 </head>
 
 <body id="users-index" class="tab-content">
@@ -45,49 +57,183 @@
               </button>
             </div>
           </div>
+          <small class="float-right mt-2">
+            <a href="#" data-toggle="modal" data-target="#advanced-search-modal">Advanced</a>
+          </small>
         </form>
       </div>
 
+      <div class="modal fade" id="advanced-search-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
+        <div class="modal-dialog modal-dialog-centered">
+          <div class="modal-content">
+            <div class="modal-header">
+              <h5 class="modal-title">Advanced search</h5>
+              <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+                <span aria-hidden="true">&times;</span>
+              </button>
+            </div>
+            <div class="modal-body mb-n3">
+              <p>
+                The default search uses fuzzy matching on the name and email
+                fields for a user. For example, a search for
+                <code>"admin"</code> would match both "Admin user" and
+                "admin@example.com". All searches are case-insensitive.
+              </p>
+
+              <p>
+                The system also supports advanced querying via prefixing:
+              </p>
+              <ul>
+                <li><code>name:</code> searches for users with that name</li>
+                <li><code>email:</code> searches for users with that email</li>
+                <li><code>can:</code> searches for users with that permission</li>
+                <li><code>cannot:</code> searches for users without that permission</li>
+              </ul>
+
+              <p>
+                Multiple advanced queries are considered compound requirements.
+                For example, the following query searches for all users which
+                have a name matching <code>"fred"</code> who lack the
+                <code>"APIKeyRead"</code>
+                permission.
+              </p>
+              <p>
+                <pre class="border border-muted bg-light rounded p-2"><code>name:fred cannot:APIKeyRead</code></pre>
+              </p>
+
+              <hr>
+
+              <p>
+                The syntax also supports modifiers, including:
+              </p>
+
+              <ul>
+                <li><code>|</code> means OR</li>
+                <li><code>*</code> means repeated 0 or more times</li>
+                <li><code>+</code> means repeated 1 or more times</li>
+                <li><code>?</code> means repeated 0 or 1 time</li>
+                <li><code>{n}</code> means repeated exactly n times</li>
+                <li><code>{n,}</code> means repeated n or more times</li>
+                <li><code>{n,m}</code> means repeated between n and m times</li>
+              </ul>
+
+              <p>
+                This searches for users who have the name
+                <code>"fred"</code> or <code>"jones"</code>:
+              </p>
+              <p>
+                <pre class="border border-muted bg-light rounded p-2"><code>name:fred|jones</code></pre>
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {{if $memberships}}
-        <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
-          <thead>
-            <tr>
-              <th scope="col">Name</th>
-              <th scope="col" width="300">Email</th>
-              {{if $canWrite}}
-                <th scope="col" width="40"></th>
-              {{end}}
-            </tr>
-          </thead>
-          <tbody>
-            {{range $membership := $memberships}}
-            {{$user := $membership.User}}
-            <tr id="user-{{$user.ID}}">
-              <td>
-                <a href="/realm/users/{{$user.ID}}">{{$user.Name}}</a>
-              </td>
-              <td>
-                {{$user.Email}}
-              </td>
-              {{if $canWrite}}
+        <form method="POST" id="users-form">
+          {{$csrfField}}
+          <div class="float-left d-flex ml-3 pl-1 mt-n4 mb-3 pb-1">
+            <div class="dropdown">
+              <button disabled id="add-permissions-button" class="btn btn-sm btn-secondary dropdown-toggle" type="button" data-toggle="dropdown">
+                Add permissions
+              </button>
+              <div class="dropdown-menu">
+                {{range $name, $permission := $permissions}}
+                  <div class="custom-control custom-checkbox keep-open dropdown-hover">
+                    <input type="checkbox" name="permission" id="add-permission-{{$name}}"
+                      class="custom-control-input" value="{{$permission.Value}}"
+                      {{disabledIf ($currentMembership.Cannot $permission)}}
+                      {{readonlyIf ($currentMembership.Cannot $permission)}}
+                    >
+                    <label for="add-permission-{{$name}}" class="custom-control-label user-select-none d-block ml-3 py-2">
+                      {{$name}}
+                      {{if $currentMembership.Cannot $permission}}
+                        <span class="oi oi-circle-x small py-1 px-1" aria-hidden="true"
+                          data-toggle="tooltip" data-placement="top" data-offset="75" title="You lack this permission"></span>
+                      {{end}}
+                    </label>
+                  </div>
+                {{end}}
+                <div class="dropdown-divider"></div>
+                <div class="mx-3 my-2">
+                  <input type="submit" value="Add permissions" formaction="/realm/users/bulk-permissions/add"
+                    id="add-permissions-submit" class="btn btn-primary btn-block mx-0 mt-3" style="min-width:275px;">
+                </div>
+              </div>
+            </div>
+
+            <div class="dropdown">
+              <button disabled id="remove-permissions-button" class="btn btn-sm btn-secondary dropdown-toggle ml-2" type="button" data-toggle="dropdown">
+                Remove permissions
+              </button>
+              <div class="dropdown-menu">
+                {{range $name, $permission := $permissions}}
+                  <div class="custom-control custom-checkbox keep-open dropdown-hover">
+                    <input type="checkbox" name="permission" id="remove-permission-{{$name}}" class="custom-control-input" value="{{$permission.Value}}">
+                    <label for="remove-permission-{{$name}}" class="custom-control-label user-select-none d-block ml-3 py-2">{{$name}}</label>
+                  </div>
+                {{end}}
+                <div class="dropdown-divider"></div>
+                <div class="mx-3 my-2">
+                  <input type="submit" value="Remove permissions" formaction="/realm/users/bulk-permissions/remove"
+                    id="remove-permissions-submit" class="btn btn-primary btn-block mx-0 mt-3" style="min-width:275px;">
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <table class="table table-bordered table-striped table-fixed table-inner-border-only border-top mb-0">
+            <thead>
+              <tr>
+                <th scope="col" width="40">
+                  <div class="custom-control custom-checkbox mr-0">
+                    <input type="checkbox" id="select-user-all" class="custom-control-input">
+                    <label class="custom-control-label" for="select-user-all"></label>
+                  </div>
+                </th>
+                <th scope="col">Name</th>
+                <th scope="col" width="300">Email</th>
+                {{if $canWrite}}
+                  <th scope="col" width="40"></th>
+                {{end}}
+              </tr>
+            </thead>
+            <tbody>
+              {{range $membership := $memberships}}
+              {{$user := $membership.User}}
+              <tr id="user-{{$user.ID}}">
                 <td class="text-center">
-                  {{if not (eq $membership.UserID $currentMembership.UserID)}}
-                  {{- /* cannot delete yourself */ -}}
-                  <a href="/realm/users/{{$user.ID}}" id="delete-user-{{$user.ID}}"
-                    class="d-block text-danger"
-                    data-method="DELETE"
-                    data-confirm="Are you sure you want to remove '{{$user.Name}}'?"
-                    data-toggle="tooltip"
-                    title="Remove this user">
-                    <span class="oi oi-trash" aria-hidden="true"></span>
-                  </a>
-                  {{end}}
+                  <div class="custom-control custom-checkbox mr-0">
+                    <input type="checkbox" name="user_id" id="select-user-{{$user.ID}}" class="custom-control-input" value="{{$user.ID}}">
+                    <label class="custom-control-label" for="select-user-{{$user.ID}}"></label>
+                  </div>
                 </td>
+                <td>
+                  <a href="/realm/users/{{$user.ID}}">{{$user.Name}}</a>
+                </td>
+                <td>
+                  {{$user.Email}}
+                </td>
+                {{if $canWrite}}
+                  <td class="text-center">
+                    {{if not (eq $membership.UserID $currentMembership.UserID)}}
+                    {{- /* cannot delete yourself */ -}}
+                    <a href="/realm/users/{{$user.ID}}" id="delete-user-{{$user.ID}}"
+                      class="d-block text-danger"
+                      data-method="DELETE"
+                      data-confirm="Are you sure you want to remove '{{$user.Name}}'?"
+                      data-toggle="tooltip"
+                      title="Remove this user">
+                      <span class="oi oi-trash" aria-hidden="true"></span>
+                    </a>
+                    {{end}}
+                  </td>
+                {{end}}
+              </tr>
               {{end}}
-            </tr>
-            {{end}}
-          </tbody>
-        </table>
+            </tbody>
+          </table>
+        </form>
       {{else}}
         <p class="card-body text-center mb-0">
           <em>There are no users{{if .query}} that match the query{{end}}.</em>
@@ -97,6 +243,44 @@
 
     {{template "shared/pagination" .}}
   </main>
+
+  <script type="text/javascript">
+    $(function() {
+      let $selectUserAll = $('#select-user-all');
+      let $addPermissionsButton = $('#add-permissions-button');
+      let $addPermissionsSubmit = $('#add-permissions-submit');
+      let $removePermissionsButton = $('#remove-permissions-button');
+      let $removePermissionsSubmit = $('#remove-permissions-submit');
+
+      function updateUI() {
+        let checked = $('#users-form input[name=user_id]:checkbox:checked').length;
+
+        if (checked > 0) {
+          let users = 'users';
+          if (checked === 1) {
+            users = 'user';
+          }
+
+          $addPermissionsButton.prop('disabled', false);
+          $addPermissionsSubmit.val(`Add permissions to ${checked} ${users}`);
+          $removePermissionsButton.prop('disabled', false);
+          $removePermissionsSubmit.val(`Remove permissions from ${checked} ${users}`);
+        } else {
+          $addPermissionsButton.prop('disabled', true);
+          $removePermissionsButton.prop('disabled', true);
+        }
+      }
+
+      $('#users-form input[name=user_id]:checkbox').change(updateUI);
+
+      $selectUserAll.change(function() {
+        $('#users-form input[name=user_id]:checkbox').attr('checked', $selectUserAll.is(':checked'));
+        updateUI();
+      });
+
+      updateUI();
+    });
+  </script>
 </body>
 
 </html>

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -373,6 +373,8 @@ func userRoutes(r *mux.Router, c *user.Controller) {
 	r.Handle("/export.csv", c.HandleExport()).Methods("GET")
 	r.Handle("/import", c.HandleImport()).Methods("GET")
 	r.Handle("/import", c.HandleImportBatch()).Methods("POST")
+	r.Handle("/bulk-permissions/add", c.HandleBulkPermissions(database.BulkPermissionActionAdd)).Methods("POST")
+	r.Handle("/bulk-permissions/remove", c.HandleBulkPermissions(database.BulkPermissionActionRemove)).Methods("POST")
 	r.Handle("/{id:[0-9]+}/edit", c.HandleUpdate()).Methods("GET")
 	r.Handle("/{id:[0-9]+}", c.HandleShow()).Methods("GET")
 	r.Handle("/{id:[0-9]+}", c.HandleUpdate()).Methods("PATCH")

--- a/pkg/controller/user/bulk_permissions.go
+++ b/pkg/controller/user/bulk_permissions.go
@@ -1,0 +1,103 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package user
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+)
+
+func (c *Controller) HandleBulkPermissions(action database.BulkPermissionAction) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+		flash := controller.Flash(session)
+
+		currentMembership := controller.MembershipFromContext(ctx)
+		if currentMembership == nil {
+			controller.MissingMembership(w, r, c.h)
+			return
+		}
+		if !currentMembership.Can(rbac.UserWrite) {
+			controller.Unauthorized(w, r, c.h)
+			return
+		}
+		currentUser := currentMembership.User
+		currentRealm := currentMembership.Realm
+
+		bulkPermission := &database.BulkPermission{
+			RealmID: currentRealm.ID,
+		}
+		if err := bindBulkPermissions(r, currentMembership, bulkPermission, action); err != nil {
+			flash.Error("Failed to process bulk permissions: %s", err.Error())
+			controller.Back(w, r, c.h)
+			return
+		}
+
+		// Bulk add permissions.
+		if err := bulkPermission.Apply(c.db, currentUser); err != nil {
+			if database.IsValidationError(err) {
+				flash.Error("Failed to apply bulk permissions: %s", err.Error())
+				controller.Back(w, r, c.h)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		flash.Alert("Successfully updated permissions")
+		controller.Back(w, r, c.h)
+		return
+	})
+}
+
+func bindBulkPermissions(r *http.Request, currentMembership *database.Membership, bulkPermission *database.BulkPermission, action database.BulkPermissionAction) error {
+	type FormData struct {
+		UserIDs     []uint            `form:"user_id"`
+		Permissions []rbac.Permission `form:"permission"`
+	}
+
+	var form FormData
+	formErr := controller.BindForm(nil, r, &form)
+	bulkPermission.Action = action
+	bulkPermission.UserIDs = form.UserIDs
+
+	var rbacErr error
+	switch action {
+	case database.BulkPermissionActionAdd:
+		// For adding permissions, authorize against the membership.
+		bulkPermission.Permissions, rbacErr = rbac.CompileAndAuthorize(currentMembership.Permissions, form.Permissions)
+	case database.BulkPermissionActionRemove:
+		// It's valid to remove permissions that the current user does not have (so
+		// long as they have permission to manage users).
+		for _, v := range form.Permissions {
+			bulkPermission.Permissions = bulkPermission.Permissions | v
+		}
+	}
+
+	if formErr != nil {
+		return formErr
+	}
+	return rbacErr
+}

--- a/pkg/database/bulk_permission.go
+++ b/pkg/database/bulk_permission.go
@@ -1,0 +1,135 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/jinzhu/gorm"
+)
+
+// BulkPermissionAction is the permission action to take.
+type BulkPermissionAction uint8
+
+const (
+	_ BulkPermissionAction = iota
+	BulkPermissionActionAdd
+	BulkPermissionActionRemove
+)
+
+// BulkPermission represents a bulk permission operation. This is not actually a
+// table in the database.
+type BulkPermission struct {
+	Errorable
+
+	RealmID     uint
+	UserIDs     []uint
+	Permissions rbac.Permission
+	Action      BulkPermissionAction
+}
+
+// Apply converges the bulk operation. If a user isn't in the realm, no action
+// is taken.
+//
+// For add operations, if the user already has the permission, no action is
+// taken. For remove opreations, if the user does not have the permission, no
+// action is taken.
+//
+// Other permissions not in the list are unchanged.
+func (b *BulkPermission) Apply(db *Database, actor Auditable) error {
+	// Bulk update is all-or-nothing, so do everything in a transaction.
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		// Fetch all current memberships - this is required for re-building implied
+		// permissions and auditing.
+		var memberships []*Membership
+		if err := tx.
+			Set("gorm:query_option", "FOR UPDATE").
+			Model(&Membership{}).
+			Where("realm_id = ?", b.RealmID).
+			Where("user_id IN (?)", b.UserIDs).
+			Find(&memberships).
+			Error; err != nil {
+			if IsNotFound(err) {
+				return nil
+			}
+			return err
+		}
+
+		// Process each membership individually.
+		for _, membership := range memberships {
+			// Users cannot update their own permissions.
+			if user, ok := actor.(*User); ok && membership.UserID == user.ID {
+				continue
+			}
+
+			// Compute new permissions.
+			newPerms, existingPerms := membership.Permissions, membership.Permissions
+			switch b.Action {
+			case BulkPermissionActionAdd:
+				newPerms = newPerms | b.Permissions
+			case BulkPermissionActionRemove:
+				newPerms = newPerms &^ b.Permissions
+
+				// Re-compute implied permissions. This handles an edge case where
+				// someone removes an implied permission but not the implying
+				// permission. For example, if someone bulk-removed a Read but not
+				// Write, memberships with Write should still retain read because its
+				// implied.
+				//
+				// There's also a weird security edge case here in that we do not check
+				// if the actor has this permission. In this case, the membership
+				// already had the permission, so even if the actor doesn't have said
+				// permission, it's not privilege escalation.
+				newPerms = rbac.AddImplied(newPerms)
+			}
+
+			// It's possible that no permissions have changed, in which case we don't
+			// need to save the record or create an audit entry.
+			if newPerms == existingPerms {
+				continue
+			}
+
+			// Save the membership.
+			if err := tx.
+				Model(&Membership{}).
+				Where("realm_id = ?", membership.RealmID).
+				Where("user_id = ?", membership.UserID).
+				Update("permissions", newPerms).
+				Error; err != nil {
+				return fmt.Errorf("failed to save membership: %w", err)
+			}
+
+			// Audit if permissions were changed.
+			audit := BuildAuditEntry(actor, "updated user permissions", actor, membership.RealmID)
+			audit.Diff = stringSliceDiff(rbac.PermissionNames(existingPerms), rbac.PermissionNames(newPerms))
+			if err := tx.Save(audit).Error; err != nil {
+				return fmt.Errorf("failed to save audit: %w", err)
+			}
+
+			// Cascade updated_at on user
+			if err := tx.
+				Model(&User{}).
+				Where("id = ?", membership.UserID).
+				UpdateColumn("updated_at", time.Now().UTC()).
+				Error; err != nil {
+				return fmt.Errorf("failed to update user updated_at: %w", err)
+			}
+		}
+
+		return nil
+	})
+}

--- a/pkg/database/bulk_permission_test.go
+++ b/pkg/database/bulk_permission_test.go
@@ -1,0 +1,163 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+)
+
+func TestBulkPermission_Apply(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name          string
+		existingPerms rbac.Permission
+		changePerms   rbac.Permission
+		action        BulkPermissionAction
+		expPerms      rbac.Permission
+	}{
+		// Add
+		{
+			name:        "adds_one",
+			changePerms: rbac.CodeIssue,
+			action:      BulkPermissionActionAdd,
+			expPerms:    rbac.CodeIssue,
+		},
+		{
+			name:        "adds_many",
+			changePerms: rbac.CodeIssue | rbac.APIKeyRead,
+			action:      BulkPermissionActionAdd,
+			expPerms:    rbac.CodeIssue | rbac.APIKeyRead,
+		},
+		{
+			name:          "adds_already_has",
+			existingPerms: rbac.CodeIssue | rbac.APIKeyRead,
+			changePerms:   rbac.CodeIssue | rbac.APIKeyRead,
+			action:        BulkPermissionActionAdd,
+			expPerms:      rbac.CodeIssue | rbac.APIKeyRead,
+		},
+		{
+			name:          "adds_already_has_subset",
+			existingPerms: rbac.CodeIssue,
+			changePerms:   rbac.CodeIssue | rbac.APIKeyRead,
+			action:        BulkPermissionActionAdd,
+			expPerms:      rbac.CodeIssue | rbac.APIKeyRead,
+		},
+
+		// Remove
+		{
+			name:          "remove_one",
+			existingPerms: rbac.CodeIssue,
+			changePerms:   rbac.CodeIssue,
+			action:        BulkPermissionActionRemove,
+			expPerms:      0,
+		},
+		{
+			name:          "remove_many",
+			existingPerms: rbac.CodeIssue | rbac.APIKeyRead,
+			changePerms:   rbac.CodeIssue | rbac.APIKeyRead,
+			action:        BulkPermissionActionRemove,
+			expPerms:      0,
+		},
+		{
+			name:          "remove_doesnt_have",
+			existingPerms: rbac.CodeIssue,
+			changePerms:   rbac.APIKeyRead,
+			action:        BulkPermissionActionRemove,
+			expPerms:      rbac.CodeIssue,
+		},
+		{
+			name:          "remove_doesnt_have_subset",
+			existingPerms: rbac.CodeIssue | rbac.APIKeyRead,
+			changePerms:   rbac.APIKeyRead,
+			action:        BulkPermissionActionRemove,
+			expPerms:      rbac.CodeIssue,
+		},
+		{
+			name:          "remove_implied_added",
+			existingPerms: rbac.APIKeyRead | rbac.APIKeyWrite,
+			changePerms:   rbac.APIKeyRead,
+			action:        BulkPermissionActionRemove,
+			expPerms:      rbac.APIKeyRead | rbac.APIKeyWrite,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+			realm, err := db.FindRealm(1)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			// Create users in the realm with the provided permissions
+			user1 := &User{
+				Email: "one@example.com",
+				Name:  "One",
+			}
+			if err := db.SaveUser(user1, SystemTest); err != nil {
+				t.Fatal(err)
+			}
+			if err := user1.AddToRealm(db, realm, tc.existingPerms, SystemTest); err != nil {
+				t.Fatal(err)
+			}
+			user2 := &User{
+				Email: "two@example.com",
+				Name:  "two",
+			}
+			if err := db.SaveUser(user2, SystemTest); err != nil {
+				t.Fatal(err)
+			}
+			if err := user2.AddToRealm(db, realm, tc.existingPerms, SystemTest); err != nil {
+				t.Fatal(err)
+			}
+
+			// Perform bulk operation
+			bulk := &BulkPermission{
+				RealmID:     realm.ID,
+				UserIDs:     []uint{user1.ID, user2.ID},
+				Permissions: tc.changePerms,
+				Action:      tc.action,
+			}
+			if err := bulk.Apply(db, user1); err != nil {
+				t.Fatal(err)
+			}
+
+			// Can't modify self, so these should be unchanged from given
+			membership1, err := user1.FindMembership(db, realm.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := membership1.Permissions, tc.existingPerms; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+
+			membership2, err := user2.FindMembership(db, realm.ID)
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := membership2.Permissions, tc.expPerms; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/database/scopes_test.go
+++ b/pkg/database/scopes_test.go
@@ -1,0 +1,131 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+)
+
+func TestScopes_parseUserSearch(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		q    string
+		exp  *userSearchQuery
+		err  bool
+	}{
+		{
+			name: "empty",
+			q:    "",
+			exp:  &userSearchQuery{},
+		},
+		{
+			name: "name",
+			q:    "name:seth",
+			exp: &userSearchQuery{
+				name: "seth",
+			},
+		},
+		{
+			name: "name_twice",
+			q:    "name:seth name:vargo",
+			err:  true,
+		},
+		{
+			name: "email",
+			q:    "email:foo@bar.com",
+			exp: &userSearchQuery{
+				email: "foo@bar.com",
+			},
+		},
+		{
+			name: "email_twice",
+			q:    "email:foo@bar.com email:bar@foo.com",
+			err:  true,
+		},
+		{
+			name: "name_email",
+			q:    "name:seth email:foo@bar.com",
+			exp: &userSearchQuery{
+				name:  "seth",
+				email: "foo@bar.com",
+			},
+		},
+		{
+			name: "naked",
+			q:    "foo bar",
+			exp: &userSearchQuery{
+				other: []string{"foo", "bar"},
+			},
+		},
+		{
+			name: "can",
+			q:    "can:APIKeyRead",
+			exp: &userSearchQuery{
+				withPerms: rbac.APIKeyRead,
+			},
+		},
+		{
+			name: "can_multi",
+			q:    "can:APIKeyRead can:APIKeyWrite",
+			exp: &userSearchQuery{
+				withPerms: rbac.APIKeyRead | rbac.APIKeyWrite,
+			},
+		},
+		{
+			name: "cannot",
+			q:    "cannot:APIKeyRead",
+			exp: &userSearchQuery{
+				withoutPerms: rbac.APIKeyRead,
+			},
+		},
+		{
+			name: "cannot_multi",
+			q:    "cannot:APIKeyRead cannot:APIKeyWrite",
+			exp: &userSearchQuery{
+				withoutPerms: rbac.APIKeyRead | rbac.APIKeyWrite,
+			},
+		},
+		{
+			name: "can_cannot",
+			q:    "can:APIKeyRead cannot:APIKeyWrite",
+			exp: &userSearchQuery{
+				withPerms:    rbac.APIKeyRead,
+				withoutPerms: rbac.APIKeyWrite,
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			resp, err := parseUserSearch(tc.q)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if !reflect.DeepEqual(resp, tc.exp) {
+				t.Errorf("expected %#v to be %#v", resp, tc.exp)
+			}
+		})
+	}
+}

--- a/pkg/rbac/rbac.go
+++ b/pkg/rbac/rbac.go
@@ -75,15 +75,21 @@ func CompileAndAuthorize(actorPermission Permission, toUpdate []Permission) (Per
 
 	// Ensure implied permissions. The actor must also have the implied
 	// permissions by definition.
+	permission = AddImplied(permission)
+	return permission, nil
+}
+
+// AddImplied adds any missing implied permissions.
+func AddImplied(target Permission) Permission {
 	for has, needs := range requiredPermission {
 		// If granted has, ensure that we have all needs.
-		if Can(permission, has) {
+		if Can(target, has) {
 			for _, required := range needs {
-				permission = permission | required
+				target = target | required
 			}
 		}
 	}
-	return permission, nil
+	return target
 }
 
 // ImpliedBy returns any permissions that cause this permission to be added


### PR DESCRIPTION
This change has two major parts: advanced searching and bulk permission management.

**Advanced searching**

Advanced searching is a new feature for user search that allows for more granular searching. It's backwards-compatible with the former search syntax, but now includes the ability to filter searches by fields. Specifically, you can now query like "name:foo" or "can:APIKeyWrite" to perform advanced queries. Advanced searching is useful for bulk permission management. For example, I can search for all users that have a particular permission, then click the checkboxes next to the names that should have said permission, then remove it in a single form.

**Bulk permission management**

Bulk permission management is a new feature that allows people with UserWrite permissions to modify other users' permissions in bulk from the users index page or a user search.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1388

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Advanced searching is a new feature for user search that allows for more granular searching. It's backwards-compatible with the former search syntax, but now includes the ability to filter searches by fields. Specifically, you can now query like "name:foo" or "can:APIKeyWrite" to perform advanced queries.

Bulk permission management is a new feature that allows people with `UserWrite` permissions to modify other users' permissions in bulk in their realm.
```

/assign @whaught 
/assign @mikehelmick 