### PR TITLE
Add a CloudSchedulerJobFailed alert based on log metric.

### DIFF
--- a/docs/playbooks/alerts/CloudSchedulerJobFailed.md
+++ b/docs/playbooks/alerts/CloudSchedulerJobFailed.md
@@ -1,0 +1,16 @@
+# CloudSchedulerJobFailed
+
+Cloud Scheduler produced some ERROR level logs, indicating the job is
+failing for some reason.
+
+## Triage Steps
+
+Go to Logs Explorer, use the following filter:
+
+```
+resource.type="cloud_scheduler_job"
+severity=ERROR
+```
+
+See what the error message is. Depending on the error, you may also need
+to check the corresponding Cloud Run service's log.

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -219,3 +219,37 @@ resource "google_monitoring_alert_policy" "StackdriverExportFailed" {
     google_logging_metric.stackdriver_export_error_count
   ]
 }
+
+resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
+  project      = var.project
+  display_name = "CloudSchedulerJobFailed"
+  combiner     = "OR"
+  conditions {
+    display_name = "Cloud Scheduler Job Error Ratio"
+    condition_monitoring_query_language {
+      duration = "900s"
+      # Uses rate(5m). See the reasoning above.
+      query = <<-EOT
+      fetch cloud_scheduler_job::logging.googleapis.com/log_entry_count
+      | filter (metric.severity == 'ERROR')
+      | align rate(5m)
+      | group_by [resource.job_id], [val: aggregate(value.log_entry_count)]
+      | condition val > 0
+      EOT
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${local.playbook_prefix}/CloudSchedulerJobFailed.md"
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [for x in values(google_monitoring_notification_channel.channels) : x.id]
+
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace,
+  ]
+}


### PR DESCRIPTION
```release-note
Monitoring: Add ClouldSchedulerJobFailed alert.
```