### PR TITLE
Nits: never rollback code sql type, check content-type header

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -24,6 +24,7 @@ import (
 	"io/ioutil"
 	"net/http"
 	"net/url"
+	"strings"
 	"time"
 )
 
@@ -128,7 +129,7 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 	r := io.LimitReader(resp.Body, c.maxBodySize)
 
 	ct := resp.Header.Get("Content-Type")
-	if ct != "application/json" {
+	if !strings.HasPrefix(ct, "application/json") {
 		bodyBytes, rawErr := ioutil.ReadAll(r)
 		if rawErr != nil {
 			return nil, fmt.Errorf("failed to read %s response body %w", ct, rawErr)

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -126,10 +126,20 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 	defer resp.Body.Close()
 
 	r := io.LimitReader(resp.Body, c.maxBodySize)
+
+	ct := resp.Header.Get("Content-Type")
+	if ct != "application/json" {
+		bodyBytes, rawErr := ioutil.ReadAll(r)
+		if rawErr != nil {
+			return nil, fmt.Errorf("failed to read %s response body %w", ct, rawErr)
+		}
+		return nil, fmt.Errorf("response content type: %s. Raw response: %s", ct, string(bodyBytes))
+	}
+
 	if err := json.NewDecoder(r).Decode(out); err != nil {
 		bodyBytes, rawErr := ioutil.ReadAll(r)
 		if rawErr != nil {
-			return nil, fmt.Errorf("failed to read response body %w", rawErr)
+			return nil, fmt.Errorf("failed to read JSON response body %w", rawErr)
 		}
 		return nil, fmt.Errorf("failed to decode JSON response: %w. Raw response: %s", err, string(bodyBytes))
 	}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -650,16 +650,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return nil
 			},
 			Rollback: func(tx *gorm.DB) error {
-				sqls := []string{
-					"ALTER TABLE verification_codes ALTER COLUMN code TYPE varchar(20)",
-					"ALTER TABLE verification_codes ALTER COLUMN long_code TYPE varchar(20)",
-				}
-
-				for _, sql := range sqls {
-					if err := tx.Exec(sql).Error; err != nil {
-						return err
-					}
-				}
+				// No rollback for this, which would destroy data.
 				return nil
 			},
 		},


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Never rollback the code and long_code fields to be shorter - this would lose data
* Check the content-type header when decoding JSON and give a more detailed response if unexpected type
