### PR TITLE
Skip conflict and already succeeded lines of csv retries

### DIFF
--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -964,7 +964,10 @@ function readCodesBatch(data, lines, codes) {
 }
 
 function showErroredCode(request, code, line) {
-  totalErrs++;
+  // We show error for already-succeeded codes. Skip those for the count.
+  if (code.errorCode != "success") {
+    totalErrs++;
+  }
   $receiptFailure.text(totalErrs);
   if (totalErrs == 1) {
     $receiptDiv.removeClass('d-none');
@@ -985,7 +988,7 @@ function showErroredCode(request, code, line) {
   $row.append($('<td/>').text(request["phone"]));
   $row.append($('<td/>').text(request["testDate"]));
   $row.append($('<td/>').text(code.error));
-  $errorTableBody.append($row);
+  $errorTableBody.append($row); // TODO prepend if there's one there that < ?
 }
 
 function showSuccessfulCode(request, code, line) {

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -892,7 +892,14 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
   // Skip un-retryable errors
   if (cols.length >= 8) {
     let errCode = $("<div>").text(cols[7].trim()).html();
-    if (errCode == "uuid_already_exists") {
+    if (errCode == "success") {
+      let code = {
+        errorCode: errCode,
+        error: `code uuid ${uuid} already succeeded. skipping code.`,
+      };
+      showErroredCode(request, code, line);
+      return "";
+    } else if (errCode == "uuid_already_exists") {
       let existingUUID = $("<div>").text(cols[6].trim()).html();
       if (uuid == existingUUID) {
         let code = {
@@ -994,7 +1001,7 @@ function showSuccessfulCode(request, code, line) {
     $successTable.addClass('d-none');
     $successTooMany.removeClass('d-none');
   }
-  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid}\n`);
+  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid},success\n`);
   if (total > showMaxResults) {
     return;
   }

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -890,16 +890,18 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
 
   // CSV file has error codes in the file. Usually means a retry of the receipt file.
   // Skip un-retryable errors
-  if (cols.length > 8) {
-    let existingUUID = $("<div>").text(cols[7].trim()).html();
-    let code = $("<div>").text(cols[7].trim()).html();
-    if (uuid == existingUUID && code == "uuid_already_exists") {
-      let code = {
-        errorCode: code,
-        error: "code already exists on the server. skipping code.",
-      };
-      showErroredCode(request, code, line);
-      return "";
+  if (cols.length >= 8) {
+    let errCode = $("<div>").text(cols[7].trim()).html();
+    if (errCode == "uuid_already_exists") {
+      let existingUUID = $("<div>").text(cols[6].trim()).html();
+      if (uuid == existingUUID) {
+        let code = {
+          errorCode: errCode,
+          error: `code uuid ${existingUUID} already exists on the server. skipping code.`,
+        };
+        showErroredCode(request, code, line);
+        return "";
+      }
     }
   }
 

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -988,7 +988,7 @@ function showErroredCode(request, code, line) {
   $row.append($('<td/>').text(request["phone"]));
   $row.append($('<td/>').text(request["testDate"]));
   $row.append($('<td/>').text(code.error));
-  $errorTableBody.append($row); // TODO prepend if there's one there that < ?
+  $errorTableBody.append($row);
 }
 
 function showSuccessfulCode(request, code, line) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Show the error and line if we skip an entry with < 2 items or no phone number
* Skip reuploading conflicts (which will conflict again) and successes (which will now conflict). The user can still do so if they clear the error code, but if re-using the log CSV which keeps error columns we want to skip those. This will also make correcting errors and re-uploading faster.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The bulk-uploader will skip conflict or already-succeeded lines when re-using a log csv from a previous attempt
```
