### PR TITLE
Support testType field as input for bulk-upload

### DIFF
--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -38,7 +38,7 @@
               <label class="custom-file-label" for="csv" id="file-label">{{t $.locale "codes.bulk-issue.select-csv"}}</label>
             </div>
             <small class="form-text text-muted">
-              {{t $.locale "codes.bulk-issue.csv-format1" `<code>phone,testDate,[optional]symptomDate.[optional]testType</code>` | safeHTML}}
+              {{t $.locale "codes.bulk-issue.csv-format1" `<code>phone,testDate,[optional]symptomDate,[optional]testType</code>` | safeHTML}}
               {{t $.locale "codes.bulk-issue.csv-format2" `<a href="https://www.twilio.com/docs/glossary/what-e164" target="_blank">E.164</a>` `<a href="https://www.iso.org/iso-8601-date-and-time-format.html" target="_blank">ISO 8601</a>` | safeHTML}}
             </small>
           </div>

--- a/cmd/server/assets/codes/bulk-issue.html
+++ b/cmd/server/assets/codes/bulk-issue.html
@@ -38,7 +38,7 @@
               <label class="custom-file-label" for="csv" id="file-label">{{t $.locale "codes.bulk-issue.select-csv"}}</label>
             </div>
             <small class="form-text text-muted">
-              {{t $.locale "codes.bulk-issue.csv-format1" `<code>phone,testDate,[optional]symptomDate</code>` | safeHTML}}
+              {{t $.locale "codes.bulk-issue.csv-format1" `<code>phone,testDate,[optional]symptomDate.[optional]testType</code>` | safeHTML}}
               {{t $.locale "codes.bulk-issue.csv-format2" `<a href="https://www.twilio.com/docs/glossary/what-e164" target="_blank">E.164</a>` `<a href="https://www.iso.org/iso-8601-date-and-time-format.html" target="_blank">ISO 8601</a>` | safeHTML}}
             </small>
           </div>

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -862,6 +862,11 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
   request["phone"] = $("<div>").text(cols[0].trim()).html();
   request["testDate"] = (cols.length > 1) ? $("<div>").text(cols[1].trim()).html() : "";
   request["symptomDate"] = (cols.length > 2) ? $("<div>").text(cols[2].trim()).html() : "";
+  request["testType"] = (cols.length > 3) ? $("<div>").text(cols[3].trim()).html() : "confirmed";
+
+  if (request["testType"] == "") {
+    request["testType"] = "confirmed";
+  }
 
   // Skip missing phone number
   if (request["phone"] == "" || cols.Length < 2) {
@@ -885,7 +890,6 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
 
   request["uuid"] = uuid;
   request["smsTemplateLabel"] = template;
-  request["testType"] = "confirmed";
   request["tzOffset"] = tzOffset;
 
   // CSV file has error codes in the file. Usually means a retry of the receipt file.
@@ -978,7 +982,7 @@ function showErroredCode(request, code, line) {
     $errorTable.addClass('d-none');
     $errorTooMany.removeClass('d-none');
   }
-  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${request["uuid"]},${code.errorCode},${code.error}\n`);
+  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},${request["testType"]},,,${request["uuid"]},${code.errorCode},${code.error}\n`);
   if (totalErrs > showMaxResults) {
     return;
   }
@@ -1004,7 +1008,7 @@ function showSuccessfulCode(request, code, line) {
     $successTable.addClass('d-none');
     $successTooMany.removeClass('d-none');
   }
-  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},,,,${code.uuid},success\n`);
+  $save.attr("href", `${$save.attr("href")}${request["phone"]},${request["testDate"]},${request["symptomDate"]},${request["testType"]},,,${code.uuid},success\n`);
   if (total > showMaxResults) {
     return;
   }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Currently `TestType` is hard-coded to "confirmed"
* Allows an optional field to provide another value, remains "confirmed" if omitted

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Support testType field as input for bulk-upload
```
