### PR TITLE
Pad batch requests and eliminate inner padding

### DIFF
--- a/pkg/controller/issueapi/handle_issue_batch.go
+++ b/pkg/controller/issueapi/handle_issue_batch.go
@@ -129,6 +129,7 @@ func (c *Controller) decodeAndBulkIssue(ctx context.Context, w http.ResponseWrit
 	for i, result := range results {
 		singleResponse := result.IssueCodeResponse()
 		batchResp.Codes[i] = singleResponse
+		singleResponse.Padding = []byte{} // prevent inner padding of each response
 		if singleResponse.Error == "" {
 			continue
 		}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds padding to the batch API request / repsonse
* Initializes padding of the inner IssueRequest
    * Change the custom marshaller to ignore already-initialized padding
* We add `omitempty` to the standard IssueResponse (so the batch doesn't get it), but in practice all single-issue calls will have the padding