### PR TITLE
fix lints. Add presubmit overall test coverage output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,8 +75,13 @@ test-acc:
 		-race \
 		-timeout=10m \
 		-vet="${VETTERS}" \
-		./...
+		./... \
+		-coverprofile=coverage.out
 .PHONY: test-acc
+
+test-coverage:
+	@go tool cover -func ./coverage.out | grep total
+.PHONY: test-coverage
 
 e2e-test:
 	@go test \

--- a/scripts/presubmit.sh
+++ b/scripts/presubmit.sh
@@ -107,3 +107,5 @@ fi
 
 echo "🧪 Test"
 make test-acc
+echo "🔬 Test Coverage"
+make test-coverage


### PR DESCRIPTION

## Proposed Changes

* fix lint / static check errors on test mains
* add test coverage output to presubmit script

**Release Note**

```release-note
DEV: Overall test coverage displayed on presubmit.
```
