### PR TITLE
Fix padding

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -126,7 +126,7 @@ type Padding []byte
 // MarshalJSON is a custom JSON marshaler for padding. It generates and returns
 // 1-2kb (random) of base64-encoded bytes.
 func (p Padding) MarshalJSON() ([]byte, error) {
-	if p != nil {
+	if p == nil {
 		bi, err := rand.Int(rand.Reader, big.NewInt(1024))
 		if err != nil {
 			return nil, fmt.Errorf("padding: failed to generate random number: %w", err)
@@ -147,6 +147,13 @@ func (p Padding) MarshalJSON() ([]byte, error) {
 
 	s := fmt.Sprintf("%q", base64.StdEncoding.EncodeToString(p))
 	return []byte(s), nil
+}
+
+// UnmarshalJSON is a custom JSON unmarshaler for padding.
+// The field is meaningless bytes, so this is just a passthrough.
+func (p *Padding) UnmarshalJSON(b []byte) error {
+	*p = b[1 : len(b)-1] // remove outer quotes
+	return nil
 }
 
 // CSRFResponse is the return type when requesting an AJAX CSRF token.
@@ -184,7 +191,7 @@ type UserBatchResponse struct {
 // code. This is called by the Web frontend.
 // API is served at /api/issue
 type IssueCodeRequest struct {
-	Padding Padding `json:"padding,omitempty"`
+	Padding Padding `json:"padding"`
 
 	SymptomDate string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
 	TestDate    string `json:"testDate"`
@@ -215,7 +222,7 @@ type IssueCodeRequest struct {
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.
 type IssueCodeResponse struct {
-	Padding Padding `json:"padding,omitempty"`
+	Padding Padding `json:"padding"`
 
 	// UUID is a handle which allows the issuer to track status of the issued verification code.
 	UUID string `json:"uuid"`
@@ -242,13 +249,13 @@ type IssueCodeResponse struct {
 
 // BatchIssueCodeRequest defines the request for issuing many codes at once.
 type BatchIssueCodeRequest struct {
-	Padding Padding             `json:"padding,omitempty"`
+	Padding Padding             `json:"padding"`
 	Codes   []*IssueCodeRequest `json:"codes"`
 }
 
 // BatchIssueCodeResponse defines the response for BatchIssueCodeRequest.
 type BatchIssueCodeResponse struct {
-	Padding Padding              `json:"padding,omitempty"`
+	Padding Padding              `json:"padding"`
 	Codes   []*IssueCodeResponse `json:"codes,omitempty"`
 
 	Error     string `json:"error,omitempty"`

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -155,8 +155,6 @@ func (p *Padding) UnmarshalJSON(b []byte) error {
 	l := len(b)
 	if l >= 2 {
 		*p = b[1 : l-1] // remove outer quotes
-	} else {
-		*p = b
 	}
 	return nil
 }

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -152,7 +152,12 @@ func (p Padding) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON is a custom JSON unmarshaler for padding.
 // The field is meaningless bytes, so this is just a passthrough.
 func (p *Padding) UnmarshalJSON(b []byte) error {
-	*p = b[1 : len(b)-1] // remove outer quotes
+	l := len(b)
+	if l >= 2 {
+		*p = b[1 : l-1] // remove outer quotes
+	} else {
+		*p = b
+	}
 	return nil
 }
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -61,7 +61,7 @@ const (
 	// ErrMissingDate indicates the realm requires a date, but none was supplied.
 	ErrMissingDate = "missing_date"
 	// ErrInvalidDate indicates the realm requires a date, but the supplied date
-	// was older or newer than the allowed date ramge.
+	// was older or newer than the allowed date range.
 	ErrInvalidDate = "invalid_date"
 	// ErrUUIDAlreadyExists indicates that the UUID has already been used for an issued code.
 	ErrUUIDAlreadyExists = "uuid_already_exists"
@@ -152,9 +152,8 @@ func (p Padding) MarshalJSON() ([]byte, error) {
 // UnmarshalJSON is a custom JSON unmarshaler for padding.
 // The field is meaningless bytes, so this is just a passthrough.
 func (p *Padding) UnmarshalJSON(b []byte) error {
-	l := len(b)
-	if l >= 2 {
-		*p = b[1 : l-1] // remove outer quotes
+	if l := len(b); l > 2 {
+		*p = b[1 : l-2] // remove outer quotes
 	}
 	return nil
 }
@@ -194,7 +193,7 @@ type UserBatchResponse struct {
 // code. This is called by the Web frontend.
 // API is served at /api/issue
 type IssueCodeRequest struct {
-	Padding Padding `json:"padding,omitempty"`
+	Padding Padding `json:"padding"`
 
 	SymptomDate string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
 	TestDate    string `json:"testDate"`
@@ -225,7 +224,7 @@ type IssueCodeRequest struct {
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.
 type IssueCodeResponse struct {
-	Padding Padding `json:"padding,omitempty"`
+	Padding Padding `json:"padding"`
 
 	// UUID is a handle which allows the issuer to track status of the issued verification code.
 	UUID string `json:"uuid"`

--- a/pkg/controller/issueapi/handle_issue_batch.go
+++ b/pkg/controller/issueapi/handle_issue_batch.go
@@ -129,6 +129,7 @@ func (c *Controller) decodeAndBulkIssue(ctx context.Context, w http.ResponseWrit
 	for i, result := range results {
 		singleResponse := result.IssueCodeResponse()
 		batchResp.Codes[i] = singleResponse
+		singleResponse.Padding = []byte{} // prevent inner padding of each response
 		if singleResponse.Error == "" {
 			continue
 		}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* @mikehelmick was right and I should have tested this. **https://github.com/google/exposure-notifications-verification-server/pull/1539** added `omitempty` to the json response which causes MarshalJSON to never be called to begin with
* Corrected and added test
    * The downside is we do get inner `padding:""` for batch, but that's not the worst thing

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
correct padding
```
