### PR TITLE
Switch the batch uploader client to outer padding

### DIFF
--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -915,15 +915,16 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
       }
     }
   }
-
-  // Request is padded with 5-15 random chars. These are ignored but vary the size of the request
-  // to prevent network traffic observation.
-  request["padding"] = btoa(genRandomString(5 + Math.floor(Math.random() * 15)));
-
   return request;
 }
 
 function uploadBatchIssue(data, lines) {
+  req = {
+    'codes': data,
+    // Request is padded with 5-15 random chars. These are ignored but vary the size of the request
+    // to prevent network traffic observation.
+    'padding': btoa(genRandomString(5 + Math.floor(Math.random() * 15)))
+  };
   return $.ajax({
     url: '/codes/batch-issue',
     type: 'POST',
@@ -931,7 +932,7 @@ function uploadBatchIssue(data, lines) {
     cache: false,
     contentType: 'application/json',
     headers: { 'X-CSRF-Token': csrfToken },
-    data: JSON.stringify({ 'codes': data }),
+    data: JSON.stringify(req),
     success: function(result) {
       if (!result.responseJSON || !result.responseJSON.codes) {
         return;

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -919,7 +919,7 @@ function buildBatchIssueRequest(thisRow, retryCode, template, line) {
 }
 
 function uploadBatchIssue(data, lines) {
-  req = {
+  let req = {
     'codes': data,
     // Request is padded with 5-15 random chars. These are ignored but vary the size of the request
     // to prevent network traffic observation.

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,11 @@
     - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)
   - [`/api/batch-issue`](#apibatch-issue)
     - [Handling batch partial success/failure](#handling-batch-partial-successfailure)
+  - [`/api/checkcodestatus`](#apicheckcodestatus)
+  - [`/api/expirecode`](#apiexpirecode)
+  - [`/api/stats/*` (preview)](#apistats-preview)
+- [Chaffing requests](#chaffing-requests)
+- [Response codes overview](#response-codes-overview)
 
 <!-- /TOC -->
 
@@ -344,14 +349,14 @@ eg.
       "testType": "<valid test type>",
       "tzOffset": 0,
       "phone": "+CC Phone number",
-      "padding": "<bytes>",
       "uuid": "optional string UUID",
       "externalIssuerID": "external-ID",
     },
     {
       ...
     },
-  ]
+  ],
+  "padding": "<bytes>"
 }
 ```
 
@@ -380,6 +385,7 @@ for each code response. The index of each responses will match the index of the 
       ...
     },
   ],
+  "padding": "<bytes>"
   "error": "descriptive error message",
   "errorCode": "well defined error code from api.go",
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Followup to https://github.com/google/exposure-notifications-verification-server/pull/1541
* Create the padding in the outer request for batch, not on each item
* Add field to docs

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use outer padding for bulk-uploader client
```
