### PR TITLE
Log URLs and response codes in appsync errors, increase max size to 64kb

### DIFF
--- a/pkg/config/appsync_server_config.go
+++ b/pkg/config/appsync_server_config.go
@@ -43,7 +43,7 @@ type AppSyncConfig struct {
 
 	// AppSync config
 	AppSyncURL         string        `env:"APP_SYNC_URL"`
-	FileSizeLimitBytes int64         `env:"APP_SYNC_SIZE_LIMIT, default=10240"`
+	FileSizeLimitBytes int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
 	Timeout            time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
 }
 


### PR DESCRIPTION
/assign @whaught 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Log URLs and response codes in appsync errors, increase max size to 64kb
```
