### PR TITLE
Remove leading slash in clients

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -81,6 +81,7 @@ func newClient(base, apiKey string, opts ...Option) (*client, error) {
 // newRequest creates a new request with the given method, path (relative to the
 // baseURL), and optional body. If the body is given, it's encoded as json.
 func (c *client) newRequest(ctx context.Context, method, pth string, body interface{}) (*http.Request, error) {
+	pth = strings.TrimPrefix(pth, "/")
 	u := c.baseURL.ResolveReference(&url.URL{Path: pth})
 
 	var b bytes.Buffer


### PR DESCRIPTION
This is required so that ResolveReference resolves relative to the provided path.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove leading slash in clients
```
