### PR TITLE
Add intelligence for redirecting post-login

### DIFF
--- a/cmd/server/assets/login/register-phone.html
+++ b/cmd/server/assets/login/register-phone.html
@@ -66,7 +66,7 @@
               {{if ne $mfaMode.String "required"}}
                 <div class="card-footer text-right">
                   <small>
-                    <a id="skip" href="/codes/issue" class="text-secondary">
+                    <a id="skip" href="/login/post-authenticate" class="text-secondary">
                       Skip for now &rarr;
                     </a>
                   </small>

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -46,7 +46,7 @@
 
               {{if .currentRealm}}
               {{if ne .currentRealm.EmailVerifiedMode.String "required"}}
-              <a id="skip" class="card-link float-right mt-3" href="/codes/issue">Skip for now</a>
+              <a id="skip" class="card-link float-right mt-3" href="/login/post-authenticate">Skip for now</a>
               {{end}}
               {{end}}
             </div>
@@ -73,7 +73,7 @@
       if (user.emailVerified) {
         flash.clear();
         flash.alert("Your email address is already verified.");
-        window.location.assign("/codes/issue");
+        window.location.assign("/login/post-authenticate");
         return;
       }
 

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -182,6 +182,7 @@ func Server(
 			sub.Use(loadCurrentMembership)
 			sub.Handle("/login", loginController.HandleReauth()).Methods("GET")
 			sub.Handle("/login", loginController.HandleReauth()).Queries("redir", "").Methods("GET")
+			sub.Handle("/login/post-authenticate", loginController.HandlePostAuthenticate()).Methods("GET", "POST", "PUT", "PATCH")
 			sub.Handle("/login/select-realm", loginController.HandleSelectRealm()).Methods("GET", "POST")
 			sub.Handle("/login/change-password", loginController.HandleShowChangePassword()).Methods("GET")
 			sub.Handle("/login/change-password", loginController.HandleSubmitChangePassword()).Methods("POST")

--- a/pkg/controller/login/change_password.go
+++ b/pkg/controller/login/change_password.go
@@ -61,6 +61,6 @@ func (c *Controller) HandleSubmitChangePassword() http.Handler {
 		}
 
 		flash.Alert("Successfully changed password.")
-		http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+		http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 	})
 }

--- a/pkg/controller/login/controller.go
+++ b/pkg/controller/login/controller.go
@@ -33,7 +33,6 @@ type Controller struct {
 
 // New creates a new login controller.
 func New(authProvider auth.Provider, cacher cache.Cacher, config *config.ServerConfig, db *database.Database, h render.Renderer) *Controller {
-
 	return &Controller{
 		authProvider: authProvider,
 		cacher:       cacher,

--- a/pkg/controller/login/login.go
+++ b/pkg/controller/login/login.go
@@ -64,7 +64,7 @@ func (c *Controller) HandleLogin() http.Handler {
 
 		// If we got this far, the session is probably valid. Redirect to issue
 		// page. However, the auth middleware will still run after the redirect.
-		http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+		http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 		return
 	})
 }

--- a/pkg/controller/login/login_test.go
+++ b/pkg/controller/login/login_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/login/login_test.go
+++ b/pkg/controller/login/login_test.go
@@ -1,0 +1,29 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login_test
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var testDatabaseInstance *database.TestInstance
+
+func TestMain(m *testing.M) {
+	testDatabaseInstance = database.MustTestInstance()
+	defer testDatabaseInstance.MustClose()
+	m.Run()
+}

--- a/pkg/controller/login/post_authenticate.go
+++ b/pkg/controller/login/post_authenticate.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/login/post_authenticate.go
+++ b/pkg/controller/login/post_authenticate.go
@@ -1,0 +1,64 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package login defines the controller for the login page.
+package login
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+)
+
+func (c *Controller) HandlePostAuthenticate() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		session := controller.SessionFromContext(ctx)
+		if session == nil {
+			controller.MissingSession(w, r, c.h)
+			return
+		}
+
+		currentMembership := controller.MembershipFromContext(ctx)
+		if currentMembership == nil {
+			controller.MissingMembership(w, r, c.h)
+			return
+		}
+
+		switch {
+		case currentMembership.Can(rbac.CodeIssue):
+			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+		case currentMembership.Can(rbac.CodeBulkIssue):
+			http.Redirect(w, r, "/codes/bulk-issue", http.StatusSeeOther)
+		case currentMembership.Can(rbac.StatsRead):
+			http.Redirect(w, r, "/realm/stats", http.StatusSeeOther)
+		case currentMembership.Can(rbac.SettingsRead):
+			http.Redirect(w, r, "/realm/settings", http.StatusSeeOther)
+		case currentMembership.Can(rbac.AuditRead):
+			http.Redirect(w, r, "/realm/events", http.StatusSeeOther)
+		case currentMembership.Can(rbac.UserRead):
+			http.Redirect(w, r, "/realm/users", http.StatusSeeOther)
+		case currentMembership.Can(rbac.APIKeyRead):
+			http.Redirect(w, r, "/realm/apikeys", http.StatusSeeOther)
+		case currentMembership.Can(rbac.MobileAppRead):
+			http.Redirect(w, r, "/realm/mobile-apps", http.StatusSeeOther)
+		default:
+			// The user probably has no RBAC permissions. Redirect to code issue
+			// (which will fail), but preserves existing behavior.
+			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+		}
+	})
+}

--- a/pkg/controller/login/post_authenticate_test.go
+++ b/pkg/controller/login/post_authenticate_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/controller/login/post_authenticate_test.go
+++ b/pkg/controller/login/post_authenticate_test.go
@@ -1,0 +1,143 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package login_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandlePostAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServerConfig(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, h)
+		handler := c.HandlePostAuthenticate()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+	})
+
+	cases := []struct {
+		name  string
+		perms rbac.Permission
+		exp   string
+	}{
+		{
+			name:  "code_issue",
+			perms: rbac.CodeIssue,
+			exp:   "/codes/issue",
+		},
+		{
+			name:  "code_issue_priority",
+			perms: rbac.CodeIssue | rbac.SettingsRead,
+			exp:   "/codes/issue",
+		},
+		{
+			name:  "code_issue_fallback",
+			perms: 0,
+			exp:   "/codes/issue",
+		},
+		{
+			name:  "bulk_issue",
+			perms: rbac.CodeBulkIssue,
+			exp:   "/codes/bulk-issue",
+		},
+		{
+			name:  "stats_read",
+			perms: rbac.StatsRead,
+			exp:   "/realm/stats",
+		},
+		{
+			name:  "settings_read",
+			perms: rbac.SettingsRead,
+			exp:   "/realm/settings",
+		},
+		{
+			name:  "audit_read",
+			perms: rbac.AuditRead,
+			exp:   "/realm/events",
+		},
+		{
+			name:  "user_read",
+			perms: rbac.UserRead,
+			exp:   "/realm/users",
+		},
+		{
+			name:  "apikey_read",
+			perms: rbac.APIKeyRead,
+			exp:   "/realm/apikeys",
+		},
+		{
+			name:  "mobile_apps_read",
+			perms: rbac.MobileAppRead,
+			exp:   "/realm/mobile-apps",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, h)
+			handler := c.HandlePostAuthenticate()
+
+			ctx := ctx
+			ctx = controller.WithSession(ctx, &sessions.Session{})
+			ctx = controller.WithMembership(ctx, &database.Membership{
+				Realm:       &database.Realm{},
+				User:        &database.User{},
+				Permissions: tc.perms,
+			})
+
+			r := httptest.NewRequest("GET", "/", nil)
+			r = r.Clone(ctx)
+
+			w := httptest.NewRecorder()
+
+			handler.ServeHTTP(w, r)
+			w.Flush()
+
+			if got, want := w.Code, 303; got != want {
+				t.Errorf("expected %d to be %d", got, want)
+			}
+			if got, want := w.Header().Get("Location"), tc.exp; !strings.Contains(got, want) {
+				t.Errorf("expected %q to contain %q", got, want)
+			}
+		})
+	}
+}

--- a/pkg/controller/login/select_realm.go
+++ b/pkg/controller/login/select_realm.go
@@ -59,7 +59,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 			// The user is already logged in and the current realm matches the
 			// expected realm - just redirect.
 			if controller.RealmIDFromSession(session) == realm.ID {
-				http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+				http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 				return
 			}
 
@@ -74,7 +74,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 			flash.Clear()
 
 			controller.StoreSessionRealm(session, realm)
-			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+			http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 			return
 		default:
 			// Continue below
@@ -106,7 +106,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 		}
 
 		controller.StoreSessionRealm(session, membership.Realm)
-		http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+		http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 	})
 }
 

--- a/pkg/controller/user/delete.go
+++ b/pkg/controller/user/delete.go
@@ -77,7 +77,7 @@ func (c *Controller) HandleDelete() http.Handler {
 		if user.ID == currentUser.ID {
 			flash.Alert("Successfully removed you from the realm")
 			controller.ClearSessionRealm(session)
-			http.Redirect(w, r, "/codes/issue", http.StatusSeeOther)
+			http.Redirect(w, r, "/login/post-authenticate", http.StatusSeeOther)
 			return
 		}
 


### PR DESCRIPTION
This removes the assumption that users have permission to issue codes.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1548

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add intelligence for redirecting post-login
```
