### PR TITLE
Cover random number gen

### DIFF
--- a/internal/project/random.go
+++ b/internal/project/random.go
@@ -16,27 +16,27 @@ package project
 
 import (
 	"crypto/rand"
-	"crypto/sha256"
 	"encoding/base64"
+	"encoding/hex"
 	"fmt"
 )
 
 // RandomHexString generates a random string of the provided length.
 func RandomHexString(len int) (string, error) {
-	b := make([]byte, len)
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("failed to generate random: %w", err)
+	b, err := RandomBytes((len + 1) / 2)
+	if err != nil {
+		return "", err
 	}
-	return fmt.Sprintf("%x", sha256.Sum256(b[:])), nil
+	return hex.EncodeToString(b)[:len], nil
 }
 
 // RandomBase64String encodes a random base64 string of a given length.
 func RandomBase64String(len int) (string, error) {
-	b := make([]byte, len)
-	if _, err := rand.Read(b[:]); err != nil {
-		return "", fmt.Errorf("failed to generate random: %w", err)
+	b, err := RandomBytes(len)
+	if err != nil {
+		return "", err
 	}
-	return base64.URLEncoding.EncodeToString(b), nil
+	return base64.URLEncoding.EncodeToString(b)[:len], nil
 }
 
 // RandomBytes returns a byte slice of random values of the given length.

--- a/internal/project/random_test.go
+++ b/internal/project/random_test.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/internal/project/random_test.go
+++ b/internal/project/random_test.go
@@ -1,0 +1,55 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"testing"
+)
+
+func TestRandomHexString(t *testing.T) {
+	length := 255
+	s, err := RandomHexString(length)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(s), length; got != want {
+		t.Errorf("random hex string incorrect length. got %d want %d", got, want)
+	}
+}
+
+func TestRandomBase64String(t *testing.T) {
+	length := 255
+	s, err := RandomBase64String(length)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(s), length; got != want {
+		t.Errorf("random base64 string incorrect length. got %d want %d", got, want)
+	}
+}
+
+func TestRandomBytes(t *testing.T) {
+	length := 255
+	b, err := RandomBytes(length)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(b), length; got != want {
+		t.Errorf("random bytes incorrect length. got %d want %d", got, want)
+	}
+}


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Use hex encoding instead of crypto hash - this isn't really hashing anything meaningfully
    * sha.sum256 meant this function doesn't really return a `len int` length string 
* Bring coverage numbers up