### PR TITLE
Add other email templates to the realm settings UI

### DIFF
--- a/cmd/server/assets/realmadmin/_form_email.html
+++ b/cmd/server/assets/realmadmin/_form_email.html
@@ -73,10 +73,13 @@
       </small>
     </div>
 
+    <hr>
+    <h6 class="mb-3">New user invitation email</h6>
+
     <div class="form-label-group">
       <textarea name="email_invite_template" id="email-invite-template" class="form-control text-monospace{{if $realm.ErrorsFor "EmailInviteTemplate"}} is-invalid{{end}}"
-        rows="5" placeholder="Email invite template">{{$realm.EmailInviteTemplate}}</textarea>
-      <label for="email-invite-template">Email invitation template</label>
+        rows="5" placeholder="Template text">{{$realm.EmailInviteTemplate}}</textarea>
+      <label for="email-invite-template">Template text</label>
       {{if $realm.ErrorsFor "EmailInviteTemplate"}}
       <div class="invalid-feedback">
         {{joinStrings ($realm.ErrorsFor "EmailInviteTemplate") ", "}}
@@ -101,8 +104,85 @@
           <samp class="text-dark">
             Welcome,<br/>
             You have been invited to the State of Wonder Dept. of Health COVID-19 exposure notification
-            server. You may use the following link to set your password and sign-in:<br/>
-            [invitelink]
+            server. You may use the following link to set your password and sign-in: [invitelink]
+            <br/><br/>
+            If you did not request this, please ignore this email.
+          </samp>
+        </p>
+      </small>
+    </div>
+
+    <hr>
+    <h6 class="mb-3">Password reset email</h6>
+
+    <div class="form-label-group">
+      <textarea name="password_reset_template" id="password-reset-template" class="form-control text-monospace{{if $realm.ErrorsFor "EmailPasswordResetTemplate"}} is-invalid{{end}}"
+        rows="5" placeholder="Template text">{{$realm.EmailPasswordResetTemplate}}</textarea>
+      <label for="password-reset-template">Template text</label>
+      {{if $realm.ErrorsFor "EmailPasswordResetTemplate"}}
+      <div class="invalid-feedback">
+        {{joinStrings ($realm.ErrorsFor "EmailPasswordResetTemplate") ", "}}
+      </div>
+      {{end}}
+      <small class="form-text text-muted">
+        <p>
+        The password reset email message will be constructed based on the template you provide.
+        This can help users trust the email with a more specific message for this realm.
+        There are some special strings that you can use to substitute items.
+
+        Your password reset template <em>MUST</em> contain <code>[passwordresetlink]</code>.
+        </p>
+
+        <ul>
+          <li><code>[passwordresetlink]</code> The link given to the user to reset their password.</li>
+          <li><code>[realname]</code> The name of the current realm. Currently <em>{{$realm.Name}}</em>.</li>
+        </ul>
+
+        Here is an example invitation template.
+        <p>
+          <samp class="text-dark">
+            You have requested your password to the State of Wonder Dept. of Health COVID-19 exposure notification
+            server to be reset. You may use the following link to set a new password: [passwordresetlink]
+            <br/><br/>
+            If you did not request this, please ignore this email.
+          </samp>
+        </p>
+      </small>
+    </div>
+
+    <hr>
+    <h6 class="mb-3">Verify email address</h6>
+
+    <div class="form-label-group">
+      <textarea name="email_verify_template" id="email-verify-template" class="form-control text-monospace{{if $realm.ErrorsFor "EmailVerifyTemplate"}} is-invalid{{end}}"
+        rows="5" placeholder="Template text">{{$realm.EmailVerifyTemplate}}</textarea>
+      <label for="email-verify-template">Template text</label>
+      {{if $realm.ErrorsFor "EmailVerifyTemplate"}}
+      <div class="invalid-feedback">
+        {{joinStrings ($realm.ErrorsFor "EmailVerifyTemplate") ", "}}
+      </div>
+      {{end}}
+      <small class="form-text text-muted">
+        <p>
+        The email verification message will be constructed based on the template you provide.
+        This can help users trust the email with a more specific message for this realm.
+        There are some special strings that you can use to substitute items.
+
+        Your email verification template <em>MUST</em> contain <code>[verifylink]</code>.
+        </p>
+
+        <ul>
+          <li><code>[verifylink]</code> The link given to the user to verify their email address.</li>
+          <li><code>[realname]</code> The name of the current realm. Currently <em>{{$realm.Name}}</em>.</li>
+        </ul>
+
+        Here is an example invitation template.
+        <p>
+          <samp class="text-dark">
+            Use the following link toverify your email address for the State of Wonder Dept. of Health COVID-19 exposure notification
+            server: [verifylink]
+            <br/><br/>
+            If you did not request this, please ignore this email.
           </samp>
         </p>
       </small>

--- a/internal/project/context_test.go
+++ b/internal/project/context_test.go
@@ -1,0 +1,30 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+)
+
+func TestTestContext(t *testing.T) {
+	ctx := TestContext(t)
+	logger := logging.FromContext(ctx)
+
+	if logger == nil {
+		t.Error("expected a test logger")
+	}
+}

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -78,13 +78,15 @@ type formData struct {
 	TwilioAuthToken    string `form:"twilio_auth_token"`
 	TwilioFromNumber   string `form:"twilio_from_number"`
 
-	Email                bool   `form:"email"`
-	UseSystemEmailConfig bool   `form:"use_system_email_config"`
-	SMTPAccount          string `form:"smtp_account"`
-	SMTPPassword         string `form:"smtp_password"`
-	SMTPHost             string `form:"smtp_host"`
-	SMTPPort             string `form:"smtp_port"`
-	EmailInviteTemplate  string `form:"email_invite_template"`
+	Email                      bool   `form:"email"`
+	UseSystemEmailConfig       bool   `form:"use_system_email_config"`
+	SMTPAccount                string `form:"smtp_account"`
+	SMTPPassword               string `form:"smtp_password"`
+	SMTPHost                   string `form:"smtp_host"`
+	SMTPPort                   string `form:"smtp_port"`
+	EmailInviteTemplate        string `form:"email_invite_template"`
+	EmailPasswordResetTemplate string `form:"password_reset_template"`
+	EmailVerifyTemplate        string `form:"email_verify_template"`
 
 	Security                    bool   `form:"security"`
 	MFAMode                     int16  `form:"mfa_mode"`
@@ -196,6 +198,8 @@ func (c *Controller) HandleSettings() http.Handler {
 		if form.Email {
 			currentRealm.UseSystemEmailConfig = form.UseSystemEmailConfig
 			currentRealm.EmailInviteTemplate = form.EmailInviteTemplate
+			currentRealm.EmailPasswordResetTemplate = form.EmailPasswordResetTemplate
+			currentRealm.EmailVerifyTemplate = form.EmailVerifyTemplate
 		}
 
 		// Security


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds password-reset and email-verification email templates into the email realm settings
    * We've got all the db fields wired up
    * 
![templates](https://user-images.githubusercontent.com/36240966/104228962-71bee080-5400-11eb-965e-5f9be1d0f4b0.png)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add password-reset and email-verification email templates to realm settings
```
