### PR TITLE
Fire alerts when humans do secret things

### DIFF
--- a/docs/playbooks/alerts/HumanAccessedSecret.md
+++ b/docs/playbooks/alerts/HumanAccessedSecret.md
@@ -1,0 +1,18 @@
+# HumanAccessedSecret
+
+This alert fires when a non-service account accessed a secret. It only fires
+once in the period, even if multiple secrets are accessed.
+
+## Triage Steps
+
+Go to Logs Explorer, use the following filter:
+
+```
+resource.type="audited_resource"
+resource.labels.service="secretmanager.googleapis.com"
+resource.labels.method="google.cloud.secretmanager.v1.SecretManagerService.AccessSecretVersion"
+protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
+```
+
+Expand the JSON fields to identify which secret(s) were accessed and which
+human(s) performed the access.

--- a/docs/playbooks/alerts/HumanDecryptedValue.md
+++ b/docs/playbooks/alerts/HumanDecryptedValue.md
@@ -1,0 +1,17 @@
+# HumanDecryptedValue
+
+This alert fires when a non-service account decrypts a value using Cloud KMS. It
+only fires once in the period, even if multiple decryption events occur.
+
+## Triage Steps
+
+Go to Logs Explorer, use the following filter:
+
+```
+resource.type="audited_resource"
+resource.labels.service="cloudkms.googleapis.com"
+resource.labels.method:"Decrypt"
+protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
+```
+
+Expand the JSON fields to identify who performed a decryption operation.

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -253,3 +253,85 @@ resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
     null_resource.manual-step-to-enable-workspace,
   ]
 }
+
+resource "google_monitoring_alert_policy" "HumanAccessedSecret" {
+  count = var.alert_on_human_accessed_secret ? 1 : 0
+
+  project      = var.project
+  display_name = "HumanAccessedSecret"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "A non-service account accessed a secret."
+
+    condition_monitoring_query_language {
+      duration = "60s"
+
+      query = <<-EOT
+      fetch audited_resource
+      | metric 'logging.googleapis.com/user/human_accessed_secret'
+      | align rate(5m)
+      | every 1m
+      | group_by [resource.project_id],
+          [value_human_accessed_secret_aggregate: aggregate(value.human_accessed_secret)]
+      | condition value_human_accessed_secret_aggregate > 0
+      EOT
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${local.playbook_prefix}/HumanAccessedSecret.md"
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [for x in values(google_monitoring_notification_channel.channels) : x.id]
+
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace,
+  ]
+}
+
+resource "google_monitoring_alert_policy" "HumanDecryptedValue" {
+  count = var.alert_on_human_decrypted_value ? 1 : 0
+
+  project      = var.project
+  display_name = "HumanDecryptedValue"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "A non-service account decrypted something."
+
+    condition_monitoring_query_language {
+      duration = "60s"
+
+      query = <<-EOT
+      fetch audited_resource
+      | metric 'logging.googleapis.com/user/human_decrypted_value'
+      | align rate(5m)
+      | every 1m
+      | group_by [resource.project_id],
+          [value_human_decrypted_value_aggregate: aggregate(value.human_decrypted_value)]
+      | condition value_human_decrypted_value_aggregate > 0
+      EOT
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${local.playbook_prefix}/HumanDecryptedValue.md"
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [for x in values(google_monitoring_notification_channel.channels) : x.id]
+
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace,
+  ]
+}

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -269,12 +269,12 @@ resource "google_monitoring_alert_policy" "HumanAccessedSecret" {
 
       query = <<-EOT
       fetch audited_resource
-      | metric 'logging.googleapis.com/user/human_accessed_secret'
+      | metric 'logging.googleapis.com/user/${google_logging_metric.human_accessed_secret.name}'
       | align rate(5m)
       | every 1m
       | group_by [resource.project_id],
-          [value_human_accessed_secret_aggregate: aggregate(value.human_accessed_secret)]
-      | condition value_human_accessed_secret_aggregate > 0
+          [val: aggregate(value.human_accessed_secret)]
+      | condition val > 0
       EOT
 
       trigger {
@@ -310,12 +310,12 @@ resource "google_monitoring_alert_policy" "HumanDecryptedValue" {
 
       query = <<-EOT
       fetch audited_resource
-      | metric 'logging.googleapis.com/user/human_decrypted_value'
+      | metric 'logging.googleapis.com/user/${google_logging_metric.human_decrypted_value.name}'
       | align rate(5m)
       | every 1m
       | group_by [resource.project_id],
-          [value_human_decrypted_value_aggregate: aggregate(value.human_decrypted_value)]
-      | condition value_human_decrypted_value_aggregate > 0
+          [val: aggregate(value.human_decrypted_value)]
+      | condition val > 0
       EOT
 
       trigger {

--- a/terraform/alerting/monitoring.tf
+++ b/terraform/alerting/monitoring.tf
@@ -81,7 +81,7 @@ protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 EOT
 
   metric_descriptor {
-    metric_kind = "CUMULATIVE"
+    metric_kind = "DELTA"
     value_type  = "INT64"
 
     labels {
@@ -116,7 +116,7 @@ protoPayload.authenticationInfo.principalEmail!~"gserviceaccount.com$"
 EOT
 
   metric_descriptor {
-    metric_kind = "CUMULATIVE"
+    metric_kind = "DELTA"
     value_type  = "INT64"
 
     labels {

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -53,7 +53,19 @@ variable "slo_thresholds_overrides" {
   default = {}
 }
 
+variable "alert_on_human_accessed_secret" {
+  type    = bool
+  default = true
 
+  description = "Alert when a human accesses a secret. You must enable DATA_READ audit logs for Secret Manager."
+}
+
+variable "alert_on_human_decrypted_value" {
+  type    = bool
+  default = true
+
+  description = "Alert when a human accesses a secret. You must enable DATA_READ audit logs for Cloud KMS."
+}
 
 terraform {
   required_version = ">= 0.14.2"


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1389

We still need to figure out how to handle the situation where humans are running Terraform. 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fire alerts when humans do secret things
```
