### PR TITLE
allow for redirect cert changes without outages

### DIFF
--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -74,9 +74,9 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
     // unused cert in the first slot.
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id
-  ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
-    google_compute_managed_ssl_certificate.enx-redirect-next[0].id
-  ] : [])
+    ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
+      google_compute_managed_ssl_certificate.enx-redirect-next[0].id
+    ] : [])
 
   # Defined in verification-lb.tf
   ssl_policy = google_compute_ssl_policy.one-two-ssl-policy.id

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -75,7 +75,7 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id
     ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
-      google_compute_managed_ssl_certificate.enx-redirect-next[0].id
+     google_compute_managed_ssl_certificate.enx-redirect-next[0].id
   ] : [])
 
   # Defined in verification-lb.tf

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -69,12 +69,14 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
   project = var.project
 
   url_map = google_compute_url_map.enx-redirect-urlmap-https[0].id
-  ssl_certificates = [
+  ssl_certificates = concat([
     // First certificate is harder to change in UI, so let's keep a separate
     // unused cert in the first slot.
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id
-  ]
+  ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
+    google_compute_managed_ssl_certificate.enx-redirect-next[0].id
+  ] : [])
 
   # Defined in verification-lb.tf
   ssl_policy = google_compute_ssl_policy.one-two-ssl-policy.id
@@ -132,7 +134,7 @@ resource "google_compute_managed_ssl_certificate" "enx-redirect" {
   count    = local.enable_enx_redirect ? 1 : 0
   provider = google-beta
 
-  name        = "verification-enx-redirect-cert"
+  name        = format("verification-enx-redirect-cert%s", var.redirect_cert_generation)
   description = "Controlled by Terraform"
 
   managed {
@@ -150,3 +152,27 @@ resource "google_compute_managed_ssl_certificate" "enx-redirect" {
     google_project_service.services["compute.googleapis.com"],
   ]
 }
+
+resource "google_compute_managed_ssl_certificate" "enx-redirect-next" {
+  count    = var.redirect_cert_generation != var.redirect_cert_generation_next ? 1 : 0
+  provider = google-beta
+
+  name        = format("verification-enx-redirect-cert%s", var.redirect_cert_generation_next)
+  description = "Controlled by Terraform"
+
+  managed {
+    // we can only have 100 domains in this list.
+    domains = [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : o.host]
+  }
+
+  # This is to prevent destroying the cert while it's still attached to the load
+  # balancer.
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"],
+  ]
+}
+

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -76,7 +76,7 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
     google_compute_managed_ssl_certificate.enx-redirect[0].id
     ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
       google_compute_managed_ssl_certificate.enx-redirect-next[0].id
-    ] : [])
+  ] : [])
 
   # Defined in verification-lb.tf
   ssl_policy = google_compute_ssl_policy.one-two-ssl-policy.id

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -75,7 +75,7 @@ resource "google_compute_target_https_proxy" "enx-redirect-https" {
     google_compute_managed_ssl_certificate.enx-redirect-root[0].id,
     google_compute_managed_ssl_certificate.enx-redirect[0].id
     ], var.redirect_cert_generation != var.redirect_cert_generation_next ? [
-     google_compute_managed_ssl_certificate.enx-redirect-next[0].id
+    google_compute_managed_ssl_certificate.enx-redirect-next[0].id
   ] : [])
 
   # Defined in verification-lb.tf

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -94,7 +94,7 @@ locals {
 
   enx_redirect_config = {
     ASSETS_PATH        = "/assets"
-    HOSTNAME_TO_REGION = join(",", [for o in var.enx_redirect_domain_map : format("%s:%s", o.host, o.region)])
+    HOSTNAME_TO_REGION = join(",", [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : format("%s:%s", o.host, o.region)])
   }
 
   // TODO: remove once

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -23,6 +23,20 @@ variable "project" {
   type = string
 }
 
+variable "redirect_cert_generation" {
+  type    = string
+  default = ""
+
+  description = "generation of the ENX redirect certificate. Needs to be incremented when new subdomains are added."
+}
+
+variable "redirect_cert_generation_next" {
+  type    = string
+  default = ""
+
+  description = "generation of the ENX redirect certificate. Needs to be incremented when new subdomains are added."
+}
+
 variable "region" {
   type    = string
   default = "us-central1"
@@ -189,6 +203,15 @@ variable "enx_redirect_domain_map" {
   }))
   default     = []
   description = "Redirect domains and environments."
+}
+
+variable "enx_redirect_domain_map_add" {
+  type = list(object({
+    region = string
+    host   = string
+  }))
+  default     = []
+  description = "Redirect domains and environments to be added to the next cert."
 }
 
 variable "db_apikey_db_hmac_count" {


### PR DESCRIPTION
## Proposed Changes

* Allow for adding new enx-redirect domains through additive SSL certs rather than causing an outage

**Release Note**

```release-note
ENX redirect, add new sub-domains without outage.
```

/hold