### PR TITLE
Defensively check deleted_at fields in realm/user join tables for memberships

### DIFF
--- a/pkg/database/pagination.go
+++ b/pkg/database/pagination.go
@@ -34,6 +34,13 @@ const (
 // If page is 0, it defaults to 1. If limit is 0, it defaults to the global
 // pagination default limit.
 func Paginate(query *gorm.DB, result interface{}, page, limit uint64) (*pagination.Paginator, error) {
+	if page < 1 {
+		page = 1
+	}
+	if limit < 1 {
+		limit = pagination.DefaultLimit
+	}
+
 	return PaginateFn(query, page, limit, func(query *gorm.DB, offset uint64) error {
 		return query.
 			Limit(limit).
@@ -44,13 +51,6 @@ func Paginate(query *gorm.DB, result interface{}, page, limit uint64) (*paginati
 
 // PaginateFn paginates with a custom function for returning results.
 func PaginateFn(query *gorm.DB, page, limit uint64, populateFn func(query *gorm.DB, offset uint64) error) (*pagination.Paginator, error) {
-	if page < 1 {
-		page = 1
-	}
-	if limit < 1 {
-		limit = pagination.DefaultLimit
-	}
-
 	var total uint64
 	if err := query.
 		Count(&total).

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -860,6 +860,9 @@ func (r *Realm) ListMemberships(db *Database, p *pagination.PageParams, scopes .
 		Model(&Membership{}).
 		Scopes(scopes...).
 		Where("realm_id = ?", r.ID).
+		Where("realms.deleted_at IS NULL").
+		Where("users.deleted_at IS NULL").
+		Joins("JOIN realms ON realms.id = memberships.realm_id").
 		Joins("JOIN users ON users.id = memberships.user_id").
 		Order("LOWER(users.name)")
 

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -46,18 +46,18 @@ func WithUserSearch(q string) Scope {
 		}
 
 		if search.name != "" {
-			db = db.Where("name ~* ?", fmt.Sprintf("(%s)", search.name))
+			db = db.Where("users.name ~* ?", fmt.Sprintf("(%s)", search.name))
 		}
 
 		if search.email != "" {
-			db = db.Where("email ~* ?", fmt.Sprintf("(%s)", search.email))
+			db = db.Where("users.email ~* ?", fmt.Sprintf("(%s)", search.email))
 		}
 
 		// For backwards-compatibility with previous versions of search, other could
 		// have been a name or email.
 		if search.other != nil {
 			s := strings.Join(search.other, "|")
-			db = db.Where("name ~* ? OR email ~* ?", fmt.Sprintf("(%s)", s), fmt.Sprintf("(%s)", s))
+			db = db.Where("users.name ~* ? OR users.email ~* ?", fmt.Sprintf("(%s)", s), fmt.Sprintf("(%s)", s))
 		}
 
 		if p := search.withPerms; p != 0 {


### PR DESCRIPTION
- Fixes https://github.com/google/exposure-notifications-verification-server/issues/1564
- Fixes https://github.com/google/exposure-notifications-verification-server/issues/1562

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Defensively check `deleted_at fields in realm/user join tables for memberships
```

/assign @whaught 