### PR TITLE
Stop issuing codes if the twilio SMS queue is full

### DIFF
--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -269,6 +269,7 @@ const stopUploadingCodes = [
 
 const stopUploadingEnum = [
   'maintenance_mode',
+  'sms_queue_full',
 ];
 
 async function uploadWithRetries(uploadFn) {
@@ -404,7 +405,6 @@ function loginScripts(hasCurrentUser, onLoginSuccess) {
   let $submitPin = $('#sms-code-submit');
   let $resendPin = $('#sms-code-resend');
   let $smsChange = $('#sms-change');
-  let $retype = $('#retype');
 
   let $registeredDiv = $('#registered-div');
   let $factors = $('#factors');

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -69,6 +69,8 @@ const (
 	ErrMaintenanceMode = "maintenance_mode"
 	// ErrQuotaExceeded indicates the realm has exceeded its daily allotment of codes.
 	ErrQuotaExceeded = "quota_exceeded"
+	// ErrSMSQueueFull indicates that Twilio's SMS queue is full and may not accept more SMS messages to send.
+	ErrSMSQueueFull = "sms_queue_full"
 
 	// Certificate API responses
 

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+	"github.com/google/exposure-notifications-verification-server/pkg/sms"
 )
 
 var (
@@ -100,6 +101,10 @@ func (c *Controller) SendSMS(ctx context.Context, request *api.IssueCodeRequest,
 	if err != nil {
 		result.HTTPCode = http.StatusBadRequest
 		result.ErrorReturn = api.Errorf("failed to send sms: %s", err)
+
+		if sms.IsSMSQueueFull(err) {
+			result.ErrorReturn = result.ErrorReturn.WithCode(api.ErrSMSQueueFull)
+		}
 		return err
 	}
 	return nil

--- a/pkg/sms/twilio.go
+++ b/pkg/sms/twilio.go
@@ -17,6 +17,7 @@ package sms
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -118,4 +119,18 @@ type TwilioError struct {
 
 func (e *TwilioError) Error() string {
 	return e.Message
+}
+
+// IsSMSQueueFull returns if the given error is Twilio's message queue full error.
+func IsSMSQueueFull(err error) bool {
+	return IsTwilioCode(err, 21611) // https://www.twilio.com/docs/api/errors/21611
+}
+
+// IsTwilioCode returns if the given error matches a Twilio error code.
+func IsTwilioCode(err error, code int) bool {
+	var tErr *TwilioError
+	if errors.As(err, &tErr) {
+		return tErr.Code == code
+	}
+	return false
 }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1568

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds a util method to sms to test if an error is a Twilio code
* Check for 21611 and give that a special response code
* Cancel bulk-uploader if we see `sms_queue_full`

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Stop bulk-issue client if the Twilio SMS queue is full
```
