### PR TITLE
Add Binary Authorization for Cloud Run

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -31,6 +31,8 @@ options:
     path: '/go/pkg'
 
 substitutions:
+  _BINAUTHZ_ATTESTOR:
+  _BINAUTHZ_KEY_VERSION:
   _REPO: 'github.com/google/exposure-notifications-verification-server'
   _TAG:
 
@@ -48,9 +50,8 @@ steps:
   name: 'golang:1.15.2'
   args:
   - 'go'
-  - 'mod'
-  - 'download'
-  - '-x'
+  - 'install'
+  - './...'
   waitFor:
   - 'restore-cache'
 
@@ -89,6 +90,29 @@ steps:
   waitFor:
   - 'build-adminapi'
 
+- id: 'push-adminapi'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/adminapi:${_TAG}'
+
+- id: 'attest-adminapi'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/adminapi:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-adminapi'
+
 #
 # apiserver
 #
@@ -114,6 +138,30 @@ steps:
   - '.'
   waitFor:
   - 'build-apiserver'
+
+- id: 'push-apiserver'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/apiserver:${_TAG}'
+
+- id: 'attest-apiserver'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/apiserver:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-apiserver'
+
 
 #
 # appsync
@@ -141,6 +189,30 @@ steps:
   waitFor:
   - 'build-appsync'
 
+- id: 'push-appsync'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/appsync:${_TAG}'
+
+- id: 'attest-appsync'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/appsync:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-appsync'
+
+
 #
 # cleanup
 #
@@ -166,6 +238,30 @@ steps:
   - '.'
   waitFor:
   - 'build-cleanup'
+
+- id: 'push-cleanup'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/cleanup:${_TAG}'
+
+- id: 'attest-cleanup'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/cleanup:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-cleanup'
+
 
 #
 # e2e-runner
@@ -193,6 +289,30 @@ steps:
   waitFor:
   - 'build-e2e-runner'
 
+- id: 'push-e2e-runner'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/e2e-runner:${_TAG}'
+
+- id: 'attest-e2e-runner'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/e2e-runner:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-e2e-runner'
+
+
 #
 # enx-redirect
 #
@@ -218,6 +338,30 @@ steps:
   waitFor:
   - 'build-enx-redirect'
 
+- id: 'push-enx-redirect'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/enx-redirect:${_TAG}'
+
+- id: 'attest-enx-redirect'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/enx-redirect:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-enx-redirect'
+
+
 #
 # migrate
 #
@@ -242,6 +386,30 @@ steps:
   - '.'
   waitFor:
   - 'build-migrate'
+
+- id: 'push-migrate'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/migrate:${_TAG}'
+
+- id: 'attest-migrate'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/migrate:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-migrate'
+
 
 #
 # modeler
@@ -269,6 +437,30 @@ steps:
   waitFor:
   - 'build-modeler'
 
+- id: 'push-modeler'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/modeler:${_TAG}'
+
+- id: 'attest-modeler'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/modeler:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-modeler'
+
+
 #
 # server
 #
@@ -294,13 +486,25 @@ steps:
   waitFor:
   - 'build-server'
 
-images:
-- 'gcr.io/${PROJECT_ID}/${_REPO}/adminapi:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/apiserver:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/appsync:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/cleanup:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/e2e-runner:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/enx-redirect:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/migrate:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/modeler:${_TAG}'
-- 'gcr.io/${PROJECT_ID}/${_REPO}/server:${_TAG}'
+- id: 'push-server'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/server:${_TAG}'
+
+- id: 'attest-server'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/server:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-server'

--- a/scripts/build
+++ b/scripts/build
@@ -35,6 +35,8 @@ fi
 echo "🎉 Building all services in ${PROJECT_ID}"
 
 SUBS="_TAG=${TAG}"
+SUBS="${SUBS},_BINAUTHZ_ATTESTOR=${BINAUTHZ_ATTESTOR:-""}"
+SUBS="${SUBS},_BINAUTHZ_KEY_VERSION=${BINAUTHZ_KEY_VERSION:-""}"
 
 gcloud builds submit "${ROOT}" \
   --project "${PROJECT_ID}" \

--- a/terraform/binary_authorization.tf
+++ b/terraform/binary_authorization.tf
@@ -1,0 +1,144 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_binary_authorization_policy" "policy" {
+  project = var.project
+
+  global_policy_evaluation_mode = "ENABLE"
+
+  default_admission_rule {
+    evaluation_mode  = "REQUIRE_ATTESTATION"
+    enforcement_mode = var.binary_authorization_enforcement_mode
+    require_attestations_by = [
+      google_binary_authorization_attestor.built-by-ci.name,
+    ]
+  }
+
+  dynamic "admission_whitelist_patterns" {
+    for_each = var.binary_authorization_allowlist_patterns
+    content {
+      name_pattern = admission_whitelist_patterns.value
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["binaryauthorization.googleapis.com"],
+  ]
+}
+
+resource "google_container_analysis_note" "built-by-ci" {
+  project = var.project
+  name    = "built-by-ci"
+
+  attestation_authority {
+    hint {
+      human_readable_name = "Built by continuous integration"
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["containeranalysis.googleapis.com"],
+  ]
+}
+
+resource "google_binary_authorization_attestor" "built-by-ci" {
+  project = var.project
+  name    = "built-by-ci"
+
+  attestation_authority_note {
+    note_reference = google_container_analysis_note.built-by-ci.name
+
+    public_keys {
+      id = data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.id
+      pkix_public_key {
+        public_key_pem      = data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.public_key[0].pem
+        signature_algorithm = data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.public_key[0].algorithm
+      }
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["binaryauthorization.googleapis.com"],
+  ]
+}
+
+# Unfortunately Terraform does not have the ability to attach IAM permissions to
+# the note. Granting this at the project level isn't ideal, but it is acceptable
+# given the few notes in this project.
+resource "google_project_iam_member" "ci-notes" {
+  project = var.project
+  role    = "roles/containeranalysis.notes.attacher"
+  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
+}
+
+resource "google_binary_authorization_attestor_iam_member" "ci-attestor" {
+  project  = var.project
+  attestor = google_binary_authorization_attestor.built-by-ci.id
+  role     = "roles/binaryauthorization.attestorsViewer"
+  member   = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
+}
+
+resource "google_kms_key_ring" "binauthz-keyring" {
+  project  = var.project
+  name     = "${var.kms_key_ring_name}-binary-authorization"
+  location = var.kms_location
+
+  depends_on = [
+    google_project_service.services["cloudkms.googleapis.com"],
+  ]
+}
+
+resource "google_kms_crypto_key" "binauthz-built-by-ci-signer" {
+  key_ring = google_kms_key_ring.binauthz-keyring.self_link
+  name     = "binauthz-built-by-ci-signer"
+  purpose  = "ASYMMETRIC_SIGN"
+
+  version_template {
+    algorithm        = "RSA_SIGN_PKCS1_4096_SHA512"
+    protection_level = "HSM"
+  }
+}
+
+data "google_kms_crypto_key_version" "binauthz-built-by-ci-signer-version" {
+  crypto_key = google_kms_crypto_key.binauthz-built-by-ci-signer.self_link
+}
+
+resource "google_kms_crypto_key_iam_binding" "ci-attest" {
+  crypto_key_id = google_kms_crypto_key.binauthz-built-by-ci-signer.id
+  role          = "roles/cloudkms.signerVerifier"
+
+  members = [
+    "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com",
+  ]
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
+}
+
+output "binary_authorization_key_id" {
+  value = trimprefix(data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.id, "//cloudkms.googleapis.com/v1/")
+}
+
+output "binary_authorization_attestor_id" {
+  value = google_binary_authorization_attestor.built-by-ci.id
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -196,6 +196,9 @@ export RATE_LIMIT_REDIS_PORT="${google_redis_instance.cache.port}"
 
 export CERTIFICATE_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
 export TOKEN_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
+
+export BINAUTHZ_ATTESTOR="${google_binary_authorization_attestor.built-by-ci.id}"
+export BINAUTHZ_KEY_VERSION="${trimprefix(data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
 EOF
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -303,6 +303,19 @@ variable "default_revision_annotations_overrides" {
   EOT
 }
 
+variable "binary_authorization_enforcement_mode" {
+  type    = string
+  default = "ENFORCED_BLOCK_AND_AUDIT_LOG"
+
+  description = "Binary authorization enforcement mechanism, must be one of ENFORCED_BLOCK_AND_AUDIT_LOG or DRYRUN_AUDIT_LOG_ONLY"
+}
+
+variable "binary_authorization_allowlist_patterns" {
+  type    = set(string)
+  default = []
+
+  description = "List of container references to always allow, even without attestations."
+}
 
 terraform {
   required_version = ">= 0.14.2"


### PR DESCRIPTION
This adds Binary Authorization enforcement for Cloud Run services. It requires services to be built and deployed by Cloud Build, reducing insider risk. This change will be inapplicable to projects that are not enrolled in the Cloud Run Binary Authorization preview (noop). You can request access at https://docs.google.com/forms/d/e/1FAIpQLSehF8FfPFtf6xlzIhPiN8jggZ2hn3SgOV8CGYWejSRAJYiBpA/viewform.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add Binary Authorization enforcement for Cloud Run
```

/assign @mikehelmick 