### PR TITLE
Move associated site data responses into api package

### DIFF
--- a/pkg/api/android.go
+++ b/pkg/api/android.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// AndroidDataResponse is the structure returned from Android assetlinks.
+type AndroidDataResponse struct {
+	Relation []string      `json:"relation,omitempty"`
+	Target   AndroidTarget `json:"target,omitempty"`
+}
+
+type AndroidTarget struct {
+	Namespace    string   `json:"namespace,omitempty"`
+	PackageName  string   `json:"package_name,omitempty"`
+	Fingerprints []string `json:"sha256_cert_fingerprints,omitempty"`
+}

--- a/pkg/api/ios.go
+++ b/pkg/api/ios.go
@@ -1,0 +1,41 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package api
+
+// IOSDataResponse is the iOS format is specified by:
+//   https://developer.apple.com/documentation/safariservices/supporting_associated_domains
+//
+type IOSDataResponse struct {
+	Applinks IOSAppLinks `json:"applinks"`
+
+	// The following two fields are included for completeness' sake, but are not
+	// currently populated/used by the system.
+	Webcredentials *IOSAppstrings `json:"webcredentials,omitempty"`
+	Appclips       *IOSAppstrings `json:"appclips,omitempty"`
+}
+
+type IOSAppLinks struct {
+	Apps    []string    `json:"apps"`
+	Details []IOSDetail `json:"details,omitempty"`
+}
+
+type IOSDetail struct {
+	AppID string   `json:"appID,omitempty"`
+	Paths []string `json:"paths,omitempty"`
+}
+
+type IOSAppstrings struct {
+	Apps []string `json:"apps,omitempty"`
+}

--- a/pkg/controller/associated/android.go
+++ b/pkg/controller/associated/android.go
@@ -18,32 +18,22 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-type AndroidData struct {
-	Relation []string `json:"relation,omitempty"`
-	Target   Target   `json:"target,omitempty"`
-}
-
-type Target struct {
-	Namespace    string   `json:"namespace,omitempty"`
-	PackageName  string   `json:"package_name,omitempty"`
-	Fingerprints []string `json:"sha256_cert_fingerprints,omitempty"`
-}
-
 // AndroidData finds all the android data apps.
-func (c *Controller) AndroidData(realmID uint) ([]AndroidData, error) {
+func (c *Controller) AndroidData(realmID uint) ([]api.AndroidDataResponse, error) {
 	apps, err := c.db.ListActiveApps(realmID, database.WithAppOS(database.OSTypeAndroid))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get android data: %w", err)
 	}
 
-	ret := make([]AndroidData, 0, len(apps))
+	ret := make([]api.AndroidDataResponse, 0, len(apps))
 	for i := range apps {
-		ret = append(ret, AndroidData{
+		ret = append(ret, api.AndroidDataResponse{
 			Relation: []string{"delegate_permission/common.handle_all_urls"},
-			Target: Target{
+			Target: api.AndroidTarget{
 				Namespace:    "android_app",
 				PackageName:  apps[i].AppID,
 				Fingerprints: strings.Split(apps[i].SHA, "\n"),

--- a/pkg/controller/associated/index.go
+++ b/pkg/controller/associated/index.go
@@ -26,6 +26,7 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -55,7 +56,7 @@ func (c *Controller) HandleIos() http.Handler {
 			return
 		}
 
-		var data *IOSData
+		var data *api.IOSDataResponse
 		cacheKey := &cache.Key{
 			Namespace: "apps:ios:by_region",
 			Key:       region,
@@ -101,7 +102,7 @@ func (c *Controller) HandleAndroid() http.Handler {
 			return
 		}
 
-		var data []AndroidData
+		var data []api.AndroidDataResponse
 		cacheKey := &cache.Key{
 			Namespace: "apps:android:by_region",
 			Key:       region,

--- a/pkg/controller/associated/ios.go
+++ b/pkg/controller/associated/ios.go
@@ -14,35 +14,10 @@
 
 package associated
 
-// The iOS format is specified by:
-//   https://developer.apple.com/documentation/safariservices/supporting_associated_domains
-
 import (
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
-
-type IOSData struct {
-	Applinks Applinks `json:"applinks"`
-
-	// The following two fields are included for completeness' sake, but are not
-	// currently populated/used by the system.
-	Webcredentials *Appstrings `json:"webcredentials,omitempty"`
-	Appclips       *Appstrings `json:"appclips,omitempty"`
-}
-
-type Applinks struct {
-	Apps    []string `json:"apps"`
-	Details []Detail `json:"details,omitempty"`
-}
-
-type Detail struct {
-	AppID string   `json:"appID,omitempty"`
-	Paths []string `json:"paths,omitempty"`
-}
-
-type Appstrings struct {
-	Apps []string `json:"apps,omitempty"`
-}
 
 // iosAppIDs finds all the iOS app ids we know about.
 func (c *Controller) iosAppIDs(realmID uint) ([]string, error) {
@@ -58,7 +33,7 @@ func (c *Controller) iosAppIDs(realmID uint) ([]string, error) {
 }
 
 // IOSData gets the iOS app data.
-func (c *Controller) IOSData(realmID uint) (*IOSData, error) {
+func (c *Controller) IOSData(realmID uint) (*api.IOSDataResponse, error) {
 	ids, err := c.iosAppIDs(realmID)
 	if err != nil {
 		return nil, err
@@ -68,16 +43,16 @@ func (c *Controller) IOSData(realmID uint) (*IOSData, error) {
 		return nil, nil
 	}
 
-	details := make([]Detail, len(ids))
+	details := make([]api.IOSDetail, len(ids))
 	for i, id := range ids {
-		details[i] = Detail{
+		details[i] = api.IOSDetail{
 			AppID: id,
 			Paths: []string{"*"},
 		}
 	}
 
-	return &IOSData{
-		Applinks: Applinks{
+	return &api.IOSDataResponse{
+		Applinks: api.IOSAppLinks{
 			Apps:    []string{}, // expected always empty.
 			Details: details,
 		},


### PR DESCRIPTION
This resolves a future circular dependency, but it's also probably the better place for this anyway. There's a slight renaming to prevent ambiguity.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Move associated site data responses into api package
```