### PR TITLE
Marshal errors with *ErrorReturn type

### DIFF
--- a/cmd/server/assets/codes/issue.html
+++ b/cmd/server/assets/codes/issue.html
@@ -394,7 +394,7 @@
           'X-CSRF-Token': '{{.csrfToken}}',
         },
         success: function(result) {
-          if(result.error != "") {
+          if(result.error && result.error != "") {
             showError(result.error);
           } else {
             // Hide the main form

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -71,6 +71,8 @@ const (
 	ErrQuotaExceeded = "quota_exceeded"
 	// ErrSMSQueueFull indicates that Twilio's SMS queue is full and may not accept more SMS messages to send.
 	ErrSMSQueueFull = "sms_queue_full"
+	// ErrSMSFailure indicates that Twilio's responded with a failure.
+	ErrSMSFailure = "sms_failure"
 
 	// Certificate API responses
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -249,7 +249,7 @@ type IssueCodeResponse struct {
 	LongExpiresAt          string `json:"longExpiresAt,omitempty"`
 	LongExpiresAtTimestamp int64  `json:"longExpiresAtTimestamp,omitempty"`
 
-	Error     string `json:"error"`
+	Error     string `json:"error,omitempty"`
 	ErrorCode string `json:"errorCode,omitempty"`
 }
 

--- a/pkg/controller/issueapi/handle_issue.go
+++ b/pkg/controller/issueapi/handle_issue.go
@@ -113,7 +113,7 @@ func (c *Controller) decodeAndIssue(ctx context.Context, w http.ResponseWriter, 
 		c.h.RenderJSON(w, http.StatusOK, res.IssueCodeResponse())
 		return
 	default:
-		c.h.RenderJSON(w, result.HTTPCode, res.ErrorReturn)
+		c.h.RenderJSON(w, res.HTTPCode, res.ErrorReturn)
 		return
 	}
 }

--- a/pkg/controller/issueapi/handle_issue.go
+++ b/pkg/controller/issueapi/handle_issue.go
@@ -104,16 +104,16 @@ func (c *Controller) decodeAndIssue(ctx context.Context, w http.ResponseWriter, 
 
 	res := c.IssueOne(ctx, &request)
 	result.HTTPCode = res.HTTPCode
-	resp := res.IssueCodeResponse()
-	if resp.Error != "" {
-		if result.HTTPCode == http.StatusInternalServerError {
-			controller.InternalError(w, r, c.h, errors.New(resp.Error))
-			return
-		}
-		c.h.RenderJSON(w, result.HTTPCode, resp)
+
+	switch res.HTTPCode {
+	case http.StatusInternalServerError:
+		controller.InternalError(w, r, c.h, errors.New(res.ErrorReturn.Error))
+		return
+	case http.StatusOK:
+		c.h.RenderJSON(w, http.StatusOK, res.IssueCodeResponse())
+		return
+	default:
+		c.h.RenderJSON(w, result.HTTPCode, res.ErrorReturn)
 		return
 	}
-
-	c.h.RenderJSON(w, http.StatusOK, resp)
-	return
 }

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -100,7 +100,7 @@ func (c *Controller) SendSMS(ctx context.Context, request *api.IssueCodeRequest,
 	observability.RecordLatency(ctx, smsStart, mSMSLatencyMs, &result.obsResult)
 	if err != nil {
 		result.HTTPCode = http.StatusBadRequest
-		result.ErrorReturn = api.Errorf("failed to send sms: %s", err)
+		result.ErrorReturn = api.Errorf("failed to send sms: %s", err).WithCode(api.ErrSMSFailure)
 
 		if sms.IsSMSQueueFull(err) {
 			result.ErrorReturn = result.ErrorReturn.WithCode(api.ErrSMSQueueFull)


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1581

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Marshal json with ErrorReturn struct rather than the IssueResponse struct, although identical they differ in that ErrorReturn does not include `OmitEmpty`
* Add an error code `sms_failure` for generic Twilio errors
