### PR TITLE
Add optional enx-redirect tests to e2e-runner

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -225,6 +225,7 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 			renderJSONError(w, r, h, fmt.Errorf("android redirect: %w", err))
 			return
 		}
+		defer androidHTTPResp.Body.Close()
 		if got, want := androidHTTPResp.StatusCode, 303; got != want {
 			renderJSONError(w, r, h, fmt.Errorf("expected android redirect code %d to be %d", got, want))
 			return
@@ -240,6 +241,7 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 			renderJSONError(w, r, h, fmt.Errorf("iphone redirect: %w", err))
 			return
 		}
+		defer iosHTTPResp.Body.Close()
 		if got, want := iosHTTPResp.StatusCode, 303; got != want {
 			renderJSONError(w, r, h, fmt.Errorf("expected ios redirect code %d to be %d", got, want))
 			return

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -251,6 +251,18 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 			return
 		}
 
+		// unknown redirect
+		unknownHTTPResp, err := client.CheckRedirect(ctx, "unknown")
+		if err != nil {
+			renderJSONError(w, r, h, fmt.Errorf("iphone redirect: %w", err))
+			return
+		}
+		defer unknownHTTPResp.Body.Close()
+		if got, want := unknownHTTPResp.StatusCode, 404; got != want {
+			renderJSONError(w, r, h, fmt.Errorf("expected unknown redirect code %d to be %d", got, want))
+			return
+		}
+
 		renderOK(w, h)
 	})
 }

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -20,6 +20,8 @@ import (
 	"fmt"
 	"net/http"
 	"os"
+	"strings"
+	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/observability"
@@ -29,6 +31,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/pkg/buildinfo"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 
@@ -65,14 +68,14 @@ func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
 	// load configs
-	e2eConfig, err := config.NewE2ERunnerConfig(ctx)
+	cfg, err := config.NewE2ERunnerConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to process e2e-runner config: %w", err)
 	}
 
 	// Setup monitoring
 	logger.Info("configuring observability exporter")
-	oe, err := observability.NewFromEnv(e2eConfig.Observability)
+	oe, err := observability.NewFromEnv(cfg.Observability)
 	if err != nil {
 		return fmt.Errorf("unable to create ObservabilityExporter provider: %w", err)
 	}
@@ -81,9 +84,9 @@ func realMain(ctx context.Context) error {
 	}
 	defer oe.Close()
 	ctx, obs := middleware.WithObservability(ctx)
-	logger.Infow("observability exporter", "config", e2eConfig.Observability)
+	logger.Infow("observability exporter", "config", cfg.Observability)
 
-	db, err := e2eConfig.Database.Load(ctx)
+	db, err := cfg.Database.Load(ctx)
 	if err != nil {
 		return fmt.Errorf("failed to load database config: %w", err)
 	}
@@ -93,7 +96,7 @@ func realMain(ctx context.Context) error {
 	defer db.Close()
 
 	// Create the renderer
-	h, err := render.New(ctx, "", e2eConfig.DevMode)
+	h, err := render.New(ctx, "", cfg.DevMode)
 	if err != nil {
 		return fmt.Errorf("failed to create renderer: %w", err)
 	}
@@ -108,8 +111,19 @@ func realMain(ctx context.Context) error {
 		}
 	}()
 
-	e2eConfig.TestConfig.VerificationAdminAPIKey = resp.AdminAPIKey
-	e2eConfig.TestConfig.VerificationAPIServerKey = resp.DeviceAPIKey
+	// Create the enx-redirect client if the URL was specified.
+	var enxRedirectClient *clients.ENXRedirectClient
+	if u := cfg.ENXRedirectURL; u != "" {
+		var err error
+		enxRedirectClient, err = clients.NewENXRedirectClient(u,
+			clients.WithTimeout(30*time.Second))
+		if err != nil {
+			return fmt.Errorf("failed to create enx-redirect client: %s", err)
+		}
+	}
+
+	cfg.VerificationAdminAPIKey = resp.AdminAPIKey
+	cfg.VerificationAPIServerKey = resp.DeviceAPIKey
 
 	// Create the router
 	r := mux.NewRouter()
@@ -125,52 +139,126 @@ func realMain(ctx context.Context) error {
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)
 
-	r.HandleFunc("/default", defaultHandler(ctx, e2eConfig.TestConfig))
-	r.HandleFunc("/revise", reviseHandler(ctx, e2eConfig.TestConfig))
+	r.Handle("/default", handleDefault(cfg, h))
+	r.Handle("/revise", handleRevise(cfg, h))
+	r.Handle("/enx-redirect", handleENXRedirect(enxRedirectClient, h))
 
 	mux := http.Handler(r)
-	if e2eConfig.DevMode {
+	if cfg.DevMode {
 		// Also log requests in local dev.
 		mux = handlers.LoggingHandler(os.Stdout, r)
 	}
 
-	srv, err := server.New(e2eConfig.Port)
+	srv, err := server.New(cfg.Port)
 	if err != nil {
 		return fmt.Errorf("failed to create server: %w", err)
 	}
-	logger.Infow("server listening", "port", e2eConfig.Port)
+	logger.Infow("server listening", "port", cfg.Port)
 	return srv.ServeHTTPHandler(ctx, mux)
 }
 
-// Config is passed by value so that each http handler has a separate copy (since they are changing one of the)
-// config elements. Previous versions of those code had a race condition where the "DoRevise" status
-// could be changed while a handler was executing.
-func defaultHandler(ctx context.Context, config config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {
-	logger := logging.FromContext(ctx)
-	c := &config
+// handleDefault handles the default end-to-end scenario.
+func handleDefault(cfg *config.E2ERunnerConfig, h render.Renderer) http.Handler {
+	c := *cfg
 	c.DoRevise = false
-	return func(w http.ResponseWriter, r *http.Request) {
-		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			logger.Errorw("could not run default end to end", "error", err)
-			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
-			return
-		}
-
-		fmt.Fprint(w, "ok")
-	}
+	return handleEndToEnd(&c, h)
 }
 
-func reviseHandler(ctx context.Context, config config.E2ETestConfig) func(http.ResponseWriter, *http.Request) {
-	logger := logging.FromContext(ctx)
-	c := &config
+// handleRevise runs the end-to-end runner with revision tokens.
+func handleRevise(cfg *config.E2ERunnerConfig, h render.Renderer) http.Handler {
+	c := *cfg
 	c.DoRevise = true
-	return func(w http.ResponseWriter, r *http.Request) {
-		if err := clients.RunEndToEnd(ctx, c); err != nil {
-			logger.Errorw("could not run revise end to end", "error", err)
-			http.Error(w, "failed (check server logs for more details): "+err.Error(), http.StatusInternalServerError)
+	return handleEndToEnd(&c, h)
+}
+
+// handleEndToEnd handles the common end-to-end scenario.
+func handleEndToEnd(cfg *config.E2ERunnerConfig, h render.Renderer) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		if err := clients.RunEndToEnd(ctx, cfg); err != nil {
+			renderJSONError(w, r, h, err)
 			return
 		}
 
-		fmt.Fprint(w, "ok")
+		renderOK(w, h)
+	})
+}
+
+// handleENXRedirect handles tests for the redirector service.
+func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) http.Handler {
+	// If the client doesn't exist, it means the host was not provided.
+	if client == nil {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			renderOK(w, h)
+		})
 	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		// Android
+		androidResp, err := client.AndroidAssetLinks(ctx)
+		if err != nil {
+			renderJSONError(w, r, h, fmt.Errorf("android asset links: %w", err))
+			return
+		}
+		if len(androidResp) == 0 || androidResp[0].Target.PackageName == "" {
+			renderJSONError(w, r, h, fmt.Errorf("expected android assetlinks, got %#v", androidResp))
+			return
+		}
+
+		// iOS
+		iosResp, err := client.AppleSiteAssociation(ctx)
+		if err != nil {
+			renderJSONError(w, r, h, fmt.Errorf("apple site association: %w", err))
+			return
+		}
+		if iosResp == nil || len(iosResp.Applinks.Details) == 0 {
+			renderJSONError(w, r, h, fmt.Errorf("expected ios site association apps, got %#v", iosResp))
+			return
+		}
+
+		// Android redirect
+		androidHTTPResp, err := client.CheckRedirect(ctx, "android")
+		if err != nil {
+			renderJSONError(w, r, h, fmt.Errorf("android redirect: %w", err))
+			return
+		}
+		if got, want := androidHTTPResp.StatusCode, 303; got != want {
+			renderJSONError(w, r, h, fmt.Errorf("expected android redirect code %d to be %d", got, want))
+			return
+		}
+		if got, want := androidHTTPResp.Header.Get("Location"), "android.test.app"; !strings.Contains(got, want) {
+			controller.InternalError(w, r, h, fmt.Errorf("expected android redirect location %q to contain %q", got, want))
+			return
+		}
+
+		// iOS redirect
+		iosHTTPResp, err := client.CheckRedirect(ctx, "iphone")
+		if err != nil {
+			renderJSONError(w, r, h, fmt.Errorf("iphone redirect: %w", err))
+			return
+		}
+		if got, want := iosHTTPResp.StatusCode, 303; got != want {
+			renderJSONError(w, r, h, fmt.Errorf("expected ios redirect code %d to be %d", got, want))
+			return
+		}
+		if got, want := iosHTTPResp.Header.Get("Location"), "ios.test.app"; !strings.Contains(got, want) {
+			renderJSONError(w, r, h, fmt.Errorf("expected ios redirect location %q to contain %q", got, want))
+			return
+		}
+
+		renderOK(w, h)
+	})
+}
+
+func renderOK(w http.ResponseWriter, h render.Renderer) {
+	h.RenderJSON(w, http.StatusOK, map[string]interface{}{"success": true})
+}
+
+func renderJSONError(w http.ResponseWriter, r *http.Request, h render.Renderer, err error) {
+	logger := logging.FromContext(r.Context())
+	logger.Errorw("failure", "error", err)
+	h.RenderJSON(w, http.StatusInternalServerError, err)
 }

--- a/docs/production.md
+++ b/docs/production.md
@@ -407,7 +407,9 @@ The verification server uses the Google Identity Platform for authorization.
 
 ## End-to-end test runner
 
-Log in as a system admin and view realms, select the `e2e-test-realm`.
+Log in as a system admin and view realms, select the `e2e-test-realm`. If this
+realm has not yet been created, wait a few minutes. The e2e runner executes
+every 15 minutes.
 
 ![system admin realms](images/e2e/image01.png)
 

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -139,7 +139,7 @@ func (c *client) do(req *http.Request, out interface{}) (*http.Response, error) 
 	}
 
 	if err := json.NewDecoder(r).Decode(out); err != nil {
-		b, _ := ioutil.ReadAll(r)
+		b, err := ioutil.ReadAll(r)
 		return nil, fmt.Errorf("%s: failed to decode JSON response: %w: body: %s",
 			errPrefix, err, string(b))
 	}

--- a/internal/clients/e2e.go
+++ b/internal/clients/e2e.go
@@ -81,7 +81,7 @@ func init() {
 
 // RunEndToEnd - code that exercises the verification and key server, simulating a
 // mobile device uploading TEKs.
-func RunEndToEnd(ctx context.Context, cfg *config.E2ETestConfig) error {
+func RunEndToEnd(ctx context.Context, cfg *config.E2ERunnerConfig) error {
 	logger := logging.FromContext(ctx)
 
 	adminAPIClient, err := NewAdminAPIServerClient(cfg.VerificationAdminAPIServer, cfg.VerificationAdminAPIKey,

--- a/internal/clients/enx_redirect.go
+++ b/internal/clients/enx_redirect.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package clients
+
+import (
+	"context"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+)
+
+// ENXRedirectClient is a client that talks to the enx-redirect service.
+type ENXRedirectClient struct {
+	*client
+}
+
+// NewENXRedirectClient creates a new enx-redirect service http client.
+func NewENXRedirectClient(base string, opts ...Option) (*ENXRedirectClient, error) {
+	client, err := newClient(base, "", opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	return &ENXRedirectClient{
+		client: client,
+	}, nil
+}
+
+// AppleSiteAssociation calls and parses the Apple site association file.
+func (c *ENXRedirectClient) AppleSiteAssociation(ctx context.Context) (*api.IOSDataResponse, error) {
+	req, err := c.newRequest(ctx, "GET", "/.well-known/apple-app-site-association", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out api.IOSDataResponse
+	if _, err := c.doOK(req, &out); err != nil {
+		return nil, err
+	}
+	return &out, nil
+}
+
+// AndroidAssetLinks calls and parses the Android assetlinks file.
+func (c *ENXRedirectClient) AndroidAssetLinks(ctx context.Context) ([]*api.AndroidDataResponse, error) {
+	req, err := c.newRequest(ctx, "GET", "/.well-known/assetlinks.json", nil)
+	if err != nil {
+		return nil, err
+	}
+
+	var out []*api.AndroidDataResponse
+	if _, err := c.doOK(req, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}
+
+// CheckRedirect processes the redirect. It returns the http response. It does
+// not follow any redirects or check the response status.
+func (c *ENXRedirectClient) CheckRedirect(ctx context.Context, userAgent string) (*http.Response, error) {
+	// Copy the http client - we need one that doesn't follow redirects.
+	httpClient := &http.Client{
+		Transport: c.client.httpClient.Transport,
+		CheckRedirect: func(req *http.Request, via []*http.Request) error {
+			return http.ErrUseLastResponse
+		},
+		Jar:     c.client.httpClient.Jar,
+		Timeout: c.client.httpClient.Timeout,
+	}
+
+	req, err := c.newRequest(ctx, "GET", "/", nil)
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("User-Agent", userAgent)
+
+	resp, err := httpClient.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	return resp, nil
+}

--- a/internal/clients/enx_redirect.go
+++ b/internal/clients/enx_redirect.go
@@ -46,9 +46,12 @@ func (c *ENXRedirectClient) AppleSiteAssociation(ctx context.Context) (*api.IOSD
 	}
 
 	var out api.IOSDataResponse
-	if _, err := c.doOK(req, &out); err != nil {
-		return nil, err
+	resp, err := c.doOK(req, &out)
+	if err != nil {
+		return &out, err
 	}
+	defer resp.Body.Close()
+
 	return &out, nil
 }
 
@@ -60,9 +63,12 @@ func (c *ENXRedirectClient) AndroidAssetLinks(ctx context.Context) ([]*api.Andro
 	}
 
 	var out []*api.AndroidDataResponse
-	if _, err := c.doOK(req, &out); err != nil {
-		return nil, err
+	resp, err := c.doOK(req, &out)
+	if err != nil {
+		return out, err
 	}
+	defer resp.Body.Close()
+
 	return out, nil
 }
 
@@ -89,5 +95,6 @@ func (c *ENXRedirectClient) CheckRedirect(ctx context.Context, userAgent string)
 	if err != nil {
 		return nil, err
 	}
+
 	return resp, nil
 }

--- a/internal/envstest/bootstrap.go
+++ b/internal/envstest/bootstrap.go
@@ -120,7 +120,7 @@ func Bootstrap(db *database.Database) (*BootstrapResponse, error) {
 	iosApp := &database.MobileApp{
 		Name:    iosName,
 		RealmID: realm.ID,
-		URL:     fmt.Sprintf("https://%s.test.app", iosName),
+		URL:     "https://android.test.app",
 		OS:      database.OSTypeIOS,
 		AppID:   fmt.Sprintf("%s.com.test.app", iosName),
 	}
@@ -136,7 +136,7 @@ func Bootstrap(db *database.Database) (*BootstrapResponse, error) {
 	androidApp := &database.MobileApp{
 		Name:    androidName,
 		RealmID: realm.ID,
-		URL:     fmt.Sprintf("https://%s.test.app", androidName),
+		URL:     "https://ios.test.app",
 		OS:      database.OSTypeAndroid,
 		AppID:   fmt.Sprintf("%s.com.test.app", androidName),
 		SHA:     entropy + strings.Repeat("A", 89),

--- a/pkg/config/e2e_runner_server_config.go
+++ b/pkg/config/e2e_runner_server_config.go
@@ -33,11 +33,6 @@ type E2ERunnerConfig struct {
 
 	Port string `env:"PORT,default=8080"`
 
-	// Share config between server and command line versions.
-	TestConfig E2ETestConfig
-}
-
-type E2ETestConfig struct {
 	VerificationAdminAPIServer string `env:"VERIFICATION_ADMIN_API, default=http://localhost:8081"`
 	VerificationAdminAPIKey    string `env:"VERIFICATION_ADMIN_API_KEY"`
 	VerificationAPIServer      string `env:"VERIFICATION_SERVER_API, default=http://localhost:8082"`
@@ -45,6 +40,13 @@ type E2ETestConfig struct {
 	KeyServer                  string `env:"KEY_SERVER, default=http://localhost:8080"`
 	HealthAuthorityCode        string `env:"HEALTH_AUTHORITY_CODE,required"`
 	DoRevise                   bool   `env:"DO_REVISIONS"`
+
+	// ENXRedirectURL is the host to use for testing the ENX redirector service.
+	// This should be the value of the e2e realm's host, like
+	// "https://e2e-realm.redirect-domain.com", where "redirect-domain.com" is
+	// your enx redirect domain. The protocol is required. If this value is blank,
+	// the enx redirect tests are not executed on the e2e-runner.
+	ENXRedirectURL string `env:"ENX_REDIRECT_URL"`
 }
 
 // NewE2ERunnerConfig returns the environment config for the e2e-runner server.
@@ -55,17 +57,4 @@ func NewE2ERunnerConfig(ctx context.Context) (*E2ERunnerConfig, error) {
 		return nil, err
 	}
 	return &config, nil
-}
-
-// NewE2ETestConfig contains just the necessary elements for command line execution.
-func NewE2ETestConfig(ctx context.Context) (*E2ETestConfig, error) {
-	var config E2ETestConfig
-	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
-		return nil, err
-	}
-	return &config, nil
-}
-
-func (c *E2ERunnerConfig) Validate() error {
-	return nil
 }

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -254,3 +254,30 @@ resource "google_cloud_scheduler_job" "e2e-revise-workflow" {
     google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }
+
+resource "google_cloud_scheduler_job" "e2e-enx-redirect-workflow" {
+  name             = "e2e-enx-redirect-workflow"
+  region           = var.cloudscheduler_location
+  schedule         = "0,5,15,25,35,45,55 * * * *"
+  time_zone        = "America/Los_Angeles"
+  attempt_deadline = "30s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.e2e-runner.status.0.url}/enx-redirect"
+    oidc_token {
+      audience              = "${google_cloud_run_service.e2e-runner.status.0.url}/enx-redirect"
+      service_account_email = google_service_account.e2e-runner-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.e2e-runner-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}

--- a/tools/e2e-test/main.go
+++ b/tools/e2e-test/main.go
@@ -41,7 +41,7 @@ func main() {
 
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
-	config, err := config.NewE2ETestConfig(ctx)
+	config, err := config.NewE2ERunnerConfig(ctx)
 	if err != nil {
 		return fmt.Errorf("unable to process environment: %w", err)
 	}


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1574

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add optional enx-redirect tests to e2e-runner
```
