### PR TITLE
Don't return http.Response when unneeded

### DIFF
--- a/internal/clients/adminapi.go
+++ b/internal/clients/adminapi.go
@@ -46,7 +46,7 @@ func (c *AdminAPIServerClient) BatchIssueCode(ctx context.Context, in *api.Batch
 	}
 
 	var out api.BatchIssueCodeResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
 	return &out, nil
@@ -60,7 +60,7 @@ func (c *AdminAPIServerClient) CheckCodeStatus(ctx context.Context, in *api.Chec
 	}
 
 	var out api.CheckCodeStatusResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
 	return &out, nil
@@ -75,7 +75,7 @@ func (c *AdminAPIServerClient) IssueCode(ctx context.Context, in *api.IssueCodeR
 	}
 
 	var out api.IssueCodeResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
 	return &out, nil

--- a/internal/clients/apiserver.go
+++ b/internal/clients/apiserver.go
@@ -45,7 +45,7 @@ func (c *APIServerClient) Verify(ctx context.Context, in *api.VerifyCodeRequest)
 	}
 
 	var out api.VerifyCodeResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
 	return &out, nil
@@ -59,7 +59,7 @@ func (c *APIServerClient) Certificate(ctx context.Context, in *api.VerificationC
 	}
 
 	var out api.VerificationCertificateResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
 	return &out, nil

--- a/internal/clients/appsync.go
+++ b/internal/clients/appsync.go
@@ -43,7 +43,7 @@ func (c *AppSyncClient) AppSync(ctx context.Context) (*AppsResponse, error) {
 	}
 
 	var out AppsResponse
-	if _, err := c.doOK(req, &out); err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return nil, err
 	}
 	return &out, nil

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -106,16 +106,17 @@ func (c *client) newRequest(ctx context.Context, method, pth string, body interf
 }
 
 // doOK is like do, but expects a 200 response.
-func (c *client) doOK(req *http.Request, out interface{}) (*http.Response, error) {
+func (c *client) doOK(req *http.Request, out interface{}) error {
 	resp, err := c.do(req, out)
 	if err != nil {
-		return nil, err
+		return err
 	}
+	defer resp.Body.Close()
 
 	if resp.StatusCode > 299 {
-		return nil, fmt.Errorf("expected 200 response, got %d", resp.StatusCode)
+		return fmt.Errorf("expected 200 response, got %d", resp.StatusCode)
 	}
-	return resp, nil
+	return nil
 }
 
 // do executes the request and decodes the result into out. It returns the http

--- a/internal/clients/enx_redirect.go
+++ b/internal/clients/enx_redirect.go
@@ -46,12 +46,9 @@ func (c *ENXRedirectClient) AppleSiteAssociation(ctx context.Context) (*api.IOSD
 	}
 
 	var out api.IOSDataResponse
-	resp, err := c.doOK(req, &out)
-	if err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return &out, err
 	}
-	defer resp.Body.Close()
-
 	return &out, nil
 }
 
@@ -63,12 +60,9 @@ func (c *ENXRedirectClient) AndroidAssetLinks(ctx context.Context) ([]*api.Andro
 	}
 
 	var out []*api.AndroidDataResponse
-	resp, err := c.doOK(req, &out)
-	if err != nil {
+	if err := c.doOK(req, &out); err != nil {
 		return out, err
 	}
-	defer resp.Body.Close()
-
 	return out, nil
 }
 

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -119,7 +119,7 @@ resource "null_resource" "build" {
       TAG        = "initial"
 
       BINAUTHZ_ATTESTOR    = google_binary_authorization_attestor.built-by-ci.id
-      BINAUTHZ_KEY_VERSION = "${trimprefix(data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
+      BINAUTHZ_KEY_VERSION = trimprefix(data.google_kms_crypto_key_version.binauthz-built-by-ci-signer-version.id, "//cloudkms.googleapis.com/v1/")
     }
 
     command = "${path.module}/../scripts/build"


### PR DESCRIPTION
Also a small Terraform issue

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Don't return http.Response when unneeded
```
