### PR TITLE
Actually delete e2e API keys and mobile apps

### DIFF
--- a/internal/envstest/bootstrap.go
+++ b/internal/envstest/bootstrap.go
@@ -17,7 +17,6 @@ package envstest
 import (
 	"fmt"
 	"strings"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -175,10 +174,19 @@ func deleteAuthorizedApp(db *database.Database, key string) error {
 		}
 		return fmt.Errorf("failed to lookup api key: %w", err)
 	}
-	now := time.Now().UTC()
-	app.DeletedAt = &now
-	if err := db.SaveAuthorizedApp(app, database.SystemTest); err != nil {
-		return fmt.Errorf("failed to delete api key: %w", err)
-	}
-	return nil
+
+	return db.RawDB().
+		Unscoped().
+		Where("id = ?", app.ID).
+		Delete(&database.AuthorizedApp{}).
+		Error
+}
+
+// deleteMobileApp is a helper for ensuring an mobile app is deleted.
+func deleteMobileApp(db *database.Database, app *database.MobileApp) error {
+	return db.RawDB().
+		Unscoped().
+		Where("id = ?", app.ID).
+		Delete(&database.MobileApp{}).
+		Error
 }

--- a/internal/envstest/integration.go
+++ b/internal/envstest/integration.go
@@ -15,23 +15,11 @@
 package envstest
 
 import (
-	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
-
-// deleteMobileApp is a helper for ensuring an mobile app is deleted.
-func deleteMobileApp(db *database.Database, app *database.MobileApp) error {
-	now := time.Now().UTC()
-	app.DeletedAt = &now
-	if err := db.SaveMobileApp(app, database.SystemTest); err != nil {
-		return fmt.Errorf("failed to delete mobile app: %w", err)
-	}
-	return nil
-}
 
 // IntegrationSuite encompasses a local API server and Admin API server for
 // testing. Both servers run in-memory on the local machine.


### PR DESCRIPTION
If you look at any e2e realm, there's hundreds of API keys (and soon mobile apps). Even though we do mark them for deletion, it takes 14 days to cleanup. The e2e-runner executes every 15min.

To mitigate this, I propose actually deleting the API keys in the e2e runners. Since this is really specific to the e2e-runner, I intentionally did NOT add this to the core database package. I don't want anyone or anything else using it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Actually delete e2e API keys and mobile apps
```

/assign @mikehelmick 
