### PR TITLE
Set maxScale to 2.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -260,7 +260,7 @@ variable "enable_lb_logging" {
 
 locals {
   default_revision_annotations = {
-    "autoscaling.knative.dev/maxScale" : "1",
+    "autoscaling.knative.dev/maxScale" : "2",
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
     "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
   }


### PR DESCRIPTION
The limit was set to low so it doesn't cause too much spending when
running as a dev env. Set it to 1 will cause brief downtime in some edge
cases.