### PR TITLE
Revert "Set maxScale to 2. (#1591)"

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -260,7 +260,7 @@ variable "enable_lb_logging" {
 
 locals {
   default_revision_annotations = {
-    "autoscaling.knative.dev/maxScale" : "2",
+    "autoscaling.knative.dev/maxScale" : "1",
     "run.googleapis.com/vpc-access-egress" : "private-ranges-only"
     "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.id
   }


### PR DESCRIPTION
This reverts commit d9a46845e9cbc37549380f7147776c5bd28d45c1.

There are services that's not safe to run with more than 1 instances
concurrently. Will revert first and only set maxScale on services that's
safe to do.