### PR TITLE
add locking to appsync handler

### DIFF
--- a/pkg/config/appsync_server_config.go
+++ b/pkg/config/appsync_server_config.go
@@ -42,10 +42,10 @@ type AppSyncConfig struct {
 	RateLimit uint64 `env:"RATE_LIMIT,default=60"`
 
 	// AppSync config
-	AppSyncURL         string        `env:"APP_SYNC_URL"`
-	FileSizeLimitBytes int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
-	Timeout            time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
-	AppSyncPeriod      time.Duration `env:"APP_SYNC_PERIOD, default=5m"`
+	AppSyncURL           string        `env:"APP_SYNC_URL"`
+	FileSizeLimitBytes   int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
+	Timeout              time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
+	AppSyncMinimumPeriod time.Duration `env:"APP_SYNC_MINIMUM_PERIOD, default=5m"`
 }
 
 // NewAppSyncConfig returns the environment config for the appsync server.

--- a/pkg/config/appsync_server_config.go
+++ b/pkg/config/appsync_server_config.go
@@ -45,6 +45,7 @@ type AppSyncConfig struct {
 	AppSyncURL         string        `env:"APP_SYNC_URL"`
 	FileSizeLimitBytes int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
 	Timeout            time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
+	AppSyncPeriod      time.Duration `env:"APP_SYNC_PERIOD, default=5m"`
 }
 
 // NewAppSyncConfig returns the environment config for the appsync server.

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -47,13 +47,15 @@ func (c *Controller) HandleSync() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		if ok, err := c.shouldSync(ctx); err != nil {
+		ok, err := c.shouldSync(ctx)
+		if err != nil {
 			c.h.RenderJSON(w, http.StatusInternalServerError, &AppSyncResult{
 				OK:     false,
 				Errors: []string{err.Error()},
 			})
 			return
-		} else if !ok {
+		}
+		if !ok {
 			c.h.RenderJSON(w, http.StatusTooManyRequests, &AppSyncResult{
 				OK:     false,
 				Errors: []string{"too early"},

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -105,7 +105,7 @@ func (c *Controller) shouldSync(ctx context.Context) (bool, error) {
 	}
 
 	// Attempt to advance the generation.
-	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncPeriod); err != nil {
+	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncMinimumPeriod); err != nil {
 		return false, fmt.Errorf("failed to claim appsync lock: %w", err)
 	}
 	return true, nil

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
+	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -30,7 +31,11 @@ import (
 	"github.com/hashicorp/go-multierror"
 )
 
-const playStoreHost = `play.google.com/store/apps/details`
+const (
+	playStoreHost = `play.google.com/store/apps/details`
+
+	appSyncLock = "appsync"
+)
 
 // HandleSync performs the logic to sync mobile apps.
 func (c *Controller) HandleSync() http.Handler {
@@ -41,6 +46,20 @@ func (c *Controller) HandleSync() http.Handler {
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		if ok, err := c.shouldSync(ctx); err != nil {
+			c.h.RenderJSON(w, http.StatusInternalServerError, &AppSyncResult{
+				OK:     false,
+				Errors: []string{err.Error()},
+			})
+			return
+		} else if !ok {
+			c.h.RenderJSON(w, http.StatusTooManyRequests, &AppSyncResult{
+				OK:     false,
+				Errors: []string{"too early"},
+			})
+			return
+		}
 
 		apps, err := c.appSyncClient.AppSync(ctx)
 		if err != nil {
@@ -70,6 +89,24 @@ func (c *Controller) HandleSync() http.Handler {
 		}
 		c.h.RenderJSON(w, http.StatusOK, &AppSyncResult{OK: true})
 	})
+}
+
+// shouldSync is used to ensure that only one app sync process runs per AppSyncPeriod duration.
+func (c *Controller) shouldSync(ctx context.Context) (bool, error) {
+	cStat, err := c.db.CreateCleanup(appSyncLock)
+	if err != nil {
+		return false, fmt.Errorf("failed to create appsync lock: %w", err)
+	}
+
+	if cStat.NotBefore.After(time.Now().UTC()) {
+		return false, nil
+	}
+
+	// Attempt to advance the generation.
+	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncPeriod); err != nil {
+		return false, fmt.Errorf("failed to claim appsync lock: %w", err)
+	}
+	return true, nil
 }
 
 // syncApps looks up the realm and associated list of MobileApps for each entry

--- a/pkg/controller/appsync/appsync_test.go
+++ b/pkg/controller/appsync/appsync_test.go
@@ -40,7 +40,7 @@ func TestShouldSync(t *testing.T) {
 	ctx := project.TestContext(t)
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	config := &config.AppSyncConfig{
-		AppSyncPeriod: period,
+		AppSyncMinimumPeriod: period,
 	}
 	c, _ := New(config, db, nil)
 

--- a/pkg/controller/appsync/appsync_test.go
+++ b/pkg/controller/appsync/appsync_test.go
@@ -16,6 +16,7 @@ package appsync
 
 import (
 	"testing"
+	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
@@ -29,6 +30,39 @@ func TestMain(m *testing.M) {
 	testDatabaseInstance = database.MustTestInstance()
 	defer testDatabaseInstance.MustClose()
 	m.Run()
+}
+
+func TestShouldSync(t *testing.T) {
+	t.Parallel()
+
+	period := 1 * time.Second
+
+	ctx := project.TestContext(t)
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	config := &config.AppSyncConfig{
+		AppSyncPeriod: period,
+	}
+	c, _ := New(config, db, nil)
+
+	if ok, err := c.shouldSync(ctx); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatalf("failed to claim app sync lock when available")
+	}
+
+	if ok, err := c.shouldSync(ctx); err != nil {
+		t.Fatal(err)
+	} else if ok {
+		t.Fatalf("allowed to claim lock when it should not be available")
+	}
+
+	time.Sleep(period)
+
+	if ok, err := c.shouldSync(ctx); err != nil {
+		t.Fatal(err)
+	} else if !ok {
+		t.Fatalf("failed to claim app sync lock when available")
+	}
 }
 
 func TestAppSync(t *testing.T) {

--- a/pkg/database/cleanup.go
+++ b/pkg/database/cleanup.go
@@ -27,6 +27,9 @@ var (
 
 var CleanupName = "cleanup"
 
+// CleanupStatus represents a distributed lock that spaces operations out.
+// These are only self expring locks (NotBefore) and are not explicitly
+// released.
 type CleanupStatus struct {
 	gorm.Model
 	Type       string `gorm:"type:varchar(50);unique_index"`


### PR DESCRIPTION

## Proposed Changes

* ensure app sync doesn't run too frequently

**Release Note**

```release-note
App sync will run no more than once every 5 minutes, controlled via database.
```
