### PR TITLE
Pagination starts at page 1

### DIFF
--- a/pkg/database/pagination.go
+++ b/pkg/database/pagination.go
@@ -59,6 +59,9 @@ func PaginateFn(query *gorm.DB, page, limit uint64, populateFn func(query *gorm.
 	}
 
 	// Calculate offset.
+	if page < 1 {
+		page = 1 // pages start at 1
+	}
 	offset := uint64((page - 1) * limit)
 
 	// Get the list of records, limiting and offsetting as needed.

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -51,7 +51,7 @@ type PageParams struct {
 // FromRequest builds the PageParams from an http.Request. If there are no
 // pagination parameters, the struct is returned with the default values.
 func FromRequest(r *http.Request) (*PageParams, error) {
-	page := uint64(0)
+	page := uint64(1)
 	if v := strings.TrimSpace(r.FormValue(QueryKeyPage)); v != "" {
 		var err error
 		page, err = strconv.ParseUint(v, 10, 64)


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1595

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Page 0 does funny things with a negative uint64 overflow
