### PR TITLE
DB model for storing key server stats

### DIFF
--- a/cmd/server/assets/realmadmin/_form_codes.html
+++ b/cmd/server/assets/realmadmin/_form_codes.html
@@ -39,6 +39,7 @@
     </div>
   </div>
 
+  <hr>
   <div class="form-group">
     <label>Allowed test types</label>
     {{if not $realm.EnableENExpress}}
@@ -86,6 +87,7 @@
     </div>
   </div>
 
+  <hr>
   <div class="form-group">
     <label>Date configuration</label>
     <div class="form-group">
@@ -117,6 +119,7 @@
     </div>
   </div>
 
+  <hr>
   <div class="form-group">
     <label for="code-length">Short code length</label>
     {{if $realm.EnableENExpress}}
@@ -197,6 +200,8 @@
       </small>
     {{end}}
   </div>
+
+  <hr>
   <div>
     <div class="btn-grou dropright pb-2">
       {{if $realm.ErrorsFor "smsTextTemplate"}}<span class="text-danger oi oi-warning"></span>{{end}}

--- a/cmd/server/assets/realmadmin/_form_general.html
+++ b/cmd/server/assets/realmadmin/_form_general.html
@@ -2,6 +2,7 @@
 
 {{$realm := .realm}}
 {{$testTypes := .testTypes}}
+{{$statsConfig := .statsConfig}}
 
 <p class="mb-4">
   These are common settings that apply to all of {{$realm.Name}}.
@@ -52,6 +53,41 @@
       This field supports the common <a
       href="https://daringfireball.net/projects/markdown/syntax">markdown</a>
       standard.
+    </small>
+  </div>
+
+  <hr>
+  <div class="form-group">
+    <div class="form-check">
+      <input type="checkbox" name="allow_key_server_stats" id="allow-key-server-stats" class="form-check-input"
+        value="true" {{checkedIf (ne $statsConfig.RealmID 0)}} />
+      <label for="allow-bulk-true" class="form-check-label">
+        Enable key-server statistics
+        <small class="form-text text-muted mb-3">
+          Checking this box will allow this realm to collect statistics from the key-server about codes
+          that this realm has issued.
+        </small>
+      </label>
+    </div>
+  </div>
+
+  <div class="form-label-group">
+    <input type="text" name="key_server_url" id="key-server-url" class="form-control{{if $statsConfig.ErrorsFor "keyServerURLOverride"}} is-invalid{{end}}"
+      value="{{$statsConfig.KeyServerURLOverride}}" placeholder="Key server"/>
+    <label for="name">Key-server URL override</label>
+    {{template "errorable" $statsConfig.ErrorsFor "keyServerURLOverride"}}
+    <small class="form-text text-muted">
+      A key-server url to gather statistics from. This overrides the default value of the server and should be left empty to use the default.
+    </small>
+  </div>
+
+  <div class="form-label-group">
+    <input type="text" name="key_server_audience" id="key-server-audience" class="form-control{{if $statsConfig.ErrorsFor "keyServerAudienceOverride"}} is-invalid{{end}}"
+      value="{{$statsConfig.KeyServerAudienceOverride}}" placeholder="Audience"/>
+    <label for="name">Audience override</label>
+    {{template "errorable" $statsConfig.ErrorsFor "keyServerAudienceOverride"}}
+    <small class="form-text text-muted">
+      The key-server audience. This overrides the default value of the server and should be left empty to use the default.
     </small>
   </div>
 

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -21,7 +21,7 @@ import (
 )
 
 // TokenSigningConfig represents the settings for system-wide certificate
-// signing. These should be used if you are managing certifiate keys externally.
+// signing. These should be used if you are managing certificate keys externally.
 type TokenSigningConfig struct {
 	// Keys determines the key manager configuration for this token signing
 	// configuration.

--- a/pkg/controller/realmadmin/express_disable.go
+++ b/pkg/controller/realmadmin/express_disable.go
@@ -49,7 +49,7 @@ func (c *Controller) HandleDisableExpress() http.Handler {
 		if !currentRealm.EnableENExpress {
 			currentRealm.AddError("", fmt.Sprintf("%s is not current enrolled in EN Express", currentRealm.Name))
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			c.renderSettings(ctx, w, r, currentRealm, nil, nil, 0, 0)
+			c.renderSettings(ctx, w, r, currentRealm, nil, nil, nil, 0, 0)
 			return
 		}
 
@@ -58,7 +58,7 @@ func (c *Controller) HandleDisableExpress() http.Handler {
 		if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
 			if database.IsValidationError(err) {
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				c.renderSettings(ctx, w, r, currentRealm, nil, nil, 0, 0)
+				c.renderSettings(ctx, w, r, currentRealm, nil, nil, nil, 0, 0)
 				return
 			}
 

--- a/pkg/controller/realmadmin/express_enable.go
+++ b/pkg/controller/realmadmin/express_enable.go
@@ -49,7 +49,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		if currentRealm.EnableENExpress {
 			currentRealm.AddError("", fmt.Sprintf("%s is already enrolled in EN Express", currentRealm.Name))
 			w.WriteHeader(http.StatusUnprocessableEntity)
-			c.renderSettings(ctx, w, r, currentRealm, nil, nil, 0, 0)
+			c.renderSettings(ctx, w, r, currentRealm, nil, nil, nil, 0, 0)
 			return
 		}
 
@@ -71,7 +71,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 				currentRealm.EnableENExpress = false
 
 				w.WriteHeader(http.StatusUnprocessableEntity)
-				c.renderSettings(ctx, w, r, currentRealm, nil, nil, 0, 0)
+				c.renderSettings(ctx, w, r, currentRealm, nil, nil, nil, 0, 0)
 				return
 			}
 

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -217,6 +217,7 @@ func (c *Controller) HandleSettings() http.Handler {
 			} else if statsConfig != nil {
 				if err := c.db.DeleteKeyServerStats(currentRealm.ID); err != nil {
 					controller.InternalError(w, r, c.h, err)
+					return
 				}
 			}
 		}

--- a/pkg/controller/realmadmin/settings_show.go
+++ b/pkg/controller/realmadmin/settings_show.go
@@ -32,7 +32,8 @@ type TemplateData struct {
 
 func (c *Controller) renderSettings(
 	ctx context.Context, w http.ResponseWriter, r *http.Request, realm *database.Realm,
-	smsConfig *database.SMSConfig, emailConfig *database.EmailConfig, quotaLimit, quotaRemaining uint64) {
+	smsConfig *database.SMSConfig, emailConfig *database.EmailConfig, keyServerStats *database.KeyServerStats,
+	quotaLimit, quotaRemaining uint64) {
 	if smsConfig == nil {
 		var err error
 		smsConfig, err = realm.SMSConfig(c.db)
@@ -55,6 +56,10 @@ func (c *Controller) renderSettings(
 			}
 			emailConfig = &database.EmailConfig{SMTPPort: "587"}
 		}
+	}
+
+	if keyServerStats == nil {
+		keyServerStats = &database.KeyServerStats{}
 	}
 
 	// Look up the sms from numbers.
@@ -124,6 +129,7 @@ func (c *Controller) renderSettings(
 	m["smsFromNumbers"] = smsFromNumbers
 	m["smsTemplates"] = templates
 	m["emailConfig"] = emailConfig
+	m["statsConfig"] = keyServerStats
 	m["countries"] = database.Countries
 	m["testTypes"] = map[string]database.TestType{
 		"confirmed": database.TestTypeConfirmed,

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -1,0 +1,106 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"time"
+
+	"github.com/jinzhu/gorm/dialects/postgres"
+	"github.com/lib/pq"
+)
+
+// KeyServerStats represents statistics for a key-server for this realm
+type KeyServerStats struct {
+	Errorable
+
+	// RealmId that these stats belong to.
+	RealmID uint `gorm:"column:realm_id; primary_key; type:integer; not null;"`
+
+	// IsSystem determines if this is a system-level stats configuration. There can
+	// only be one system-level stats configuration.
+	IsSystem bool `gorm:"column:is_system; type:bool; not null; default:false;"`
+
+	// KeyServerURL allows a realm to override the system's URL with its own
+	KeyServerURL string `gorm:"column:key_server_url; type:varchar(150); default: '';"`
+	// KeyServerAudience allows a realm to override the system's audience
+	KeyServerAudience string `gorm:"column:key_server_audience; type:varchar(150); default: '';"`
+
+	Stats []*KeyServerStatsDay `gorm:"PRELOAD:false; SAVE_ASSOCIATIONS:false; ASSOCIATION_AUTOUPDATE:false, ASSOCIATION_SAVE_REFERENCE:false;"`
+}
+
+// KeyServerStatsDay represents statistics for each day
+type KeyServerStatsDay struct {
+	Errorable
+
+	// RealmId that these stats belong to.
+	RealmID uint `gorm:"column:realm_id; primary_key; type:integer; not null;"`
+
+	// Day will be set to midnight UTC of the day represented. An individual day
+	// isn't released until there is a minimum threshold for updates has been met.
+	Day time.Time `gorm:"column:day; primary_key;"`
+
+	// PublishRequests is a count of requests per OS
+	PublishRequests postgres.Hstore `gorm:"column:publish_requests; type:hstore;"`
+
+	TotalTEKsPublished int64 `gorm:"column:total_teks_published; type:bigint; not null; default: 0;"`
+
+	// RevisionRequests is the number of publish requests that contained at least one TEK revision.
+	RevisionRequests int64 `gorm:"column:revision_requests; type:bigint; not null; default: 0;"`
+
+	// TEKAgeDistribution shows a distribution of the oldest tek in an upload.
+	// The count at index 0-15 represent the number of uploads there the oldest TEK is that value.
+	// Index 16 represents > 15 days.
+	TEKAgeDistribution pq.Int64Array `gorm:"column:tek_age_distribution; type:bigint[];"`
+
+	// OnsetToUploadDistribution shows a distribution of onset to upload, the index is in days.
+	// The count at index 0-29 represents the number of uploads with that symptom onset age.
+	// Index 30 represents > 29 days.
+	OnsetToUploadDistribution pq.Int64Array `gorm:"column:onset_to_upload_distribution; type:bigint[];"`
+
+	// RequestsMissingOnsetDate is the number of publish requests where no onset date
+	// was provided. These request are not included in the onset to upload distribution.
+	RequestsMissingOnsetDate int64 `gorm:"column:request_missing_onset_date; type:bigint; not null; default: 0;"`
+}
+
+func (db *Database) GetKeyServerStats(realmID uint) (*KeyServerStats, error) {
+	var stats KeyServerStats
+	if err := db.db.
+		Where("realm_id = ?", realmID).
+		First(&stats).
+		Error; err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+func (db *Database) SaveKeyServerStats(stats *KeyServerStats) error {
+	return db.db.Save(stats).Error
+}
+
+func (db *Database) GetKeyServerStatsDay(realmID uint, day time.Time) (*KeyServerStatsDay, error) {
+	var stats KeyServerStatsDay
+	if err := db.db.
+		Where("realm_id = ?", realmID).
+		Where("day = ?", day).
+		First(&stats).
+		Error; err != nil {
+		return nil, err
+	}
+	return &stats, nil
+}
+
+func (db *Database) SaveKeyServerStatsDay(day *KeyServerStatsDay) error {
+	return db.db.Save(day).Error
+}

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -104,6 +104,14 @@ func (db *Database) SaveKeyServerStats(stats *KeyServerStats) error {
 	return db.db.Save(stats).Error
 }
 
+// DeleteKeyServerStats disables gathering key-server statistics and removes the entry
+func (db *Database) DeleteKeyServerStats(realmID uint) error {
+	return db.db.Unscoped().
+		Where("realm_id = ?", realmID).
+		Delete(&KeyServerStats{}).
+		Error
+}
+
 // ListKeyServerStatsDays retrieves the last 30 days of key-server statistics
 func (db *Database) ListKeyServerStatsDays(realmID uint, day time.Time) ([]*KeyServerStatsDay, error) {
 	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -89,17 +89,20 @@ func (db *Database) SaveKeyServerStats(stats *KeyServerStats) error {
 	return db.db.Save(stats).Error
 }
 
-// GetKeyServerStatsDay retrieves a single day of key-server statistics
-func (db *Database) GetKeyServerStatsDay(realmID uint, day time.Time) (*KeyServerStatsDay, error) {
-	var stats KeyServerStatsDay
+// ListKeyServerStatsDays retrieves the last 30 days of key-server statistics
+func (db *Database) ListKeyServerStatsDays(realmID uint, day time.Time) ([]*KeyServerStatsDay, error) {
+	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)
+	var stats []*KeyServerStatsDay
 	if err := db.db.
-		Where("realm_id = ?", realmID).
-		Where("day = ?", day).
-		First(&stats).
+		Model(&KeyServerStatsDay{}).
+		Where("realm_id = ? AND day >= ?", realmID, thirtyDaysAgo).
+		Order("day DESC").
+		Limit(30).
+		Find(&stats).
 		Error; err != nil {
 		return nil, err
 	}
-	return &stats, nil
+	return stats, nil
 }
 
 // SaveKeyServerStatsDay stores a single day of key-server statistics

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -28,10 +28,10 @@ type KeyServerStats struct {
 	// RealmId that these stats belong to.
 	RealmID uint `gorm:"column:realm_id; primary_key; type:integer; not null;"`
 
-	// KeyServerURL allows a realm to override the system's URL with its own
-	KeyServerURL string `gorm:"column:key_server_url; type:text;"`
+	// KeyServerURLOverride allows a realm to override the system's URL with its own
+	KeyServerURLOverride string `gorm:"column:key_server_url_override; type:text;"`
 	// KeyServerAudience allows a realm to override the system's audience
-	KeyServerAudience string `gorm:"column:key_server_audience; type:text;"`
+	KeyServerAudienceOverride string `gorm:"column:key_server_audience_override; type:text;"`
 }
 
 // KeyServerStatsDay represents statistics for each day
@@ -71,7 +71,7 @@ type KeyServerStatsDay struct {
 
 // BeforeSave runs validations. If there are errors, the save fails.
 func (kss *KeyServerStats) BeforeSave(tx *gorm.DB) error {
-	if kss.RealmID == 0 && (kss.KeyServerURL == "" || kss.KeyServerAudience == "") {
+	if kss.RealmID == 0 && (kss.KeyServerURLOverride == "" || kss.KeyServerAudienceOverride == "") {
 		kss.AddError("realm_id", "the system realm must have a key server and audience")
 	}
 

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -32,9 +32,9 @@ type KeyServerStats struct {
 	IsSystem bool `gorm:"column:is_system; type:bool; not null; default:false;"`
 
 	// KeyServerURL allows a realm to override the system's URL with its own
-	KeyServerURL string `gorm:"column:key_server_url; type:text; default: '';"`
+	KeyServerURL string `gorm:"column:key_server_url; type:text;"`
 	// KeyServerAudience allows a realm to override the system's audience
-	KeyServerAudience string `gorm:"column:key_server_audience; type:text; default: '';"`
+	KeyServerAudience string `gorm:"column:key_server_audience; type:text;"`
 }
 
 // KeyServerStatsDay represents statistics for each day
@@ -104,5 +104,5 @@ func (db *Database) GetKeyServerStatsDay(realmID uint, day time.Time) (*KeyServe
 
 // SaveKeyServerStatsDay stores a single day of key-server statistics
 func (db *Database) SaveKeyServerStatsDay(day *KeyServerStatsDay) error {
-	return db.db.Save(day).Error
+	return db.db.Debug().Save(day).Error
 }

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -67,14 +67,14 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	stats, err := db.GetKeyServerStatsDay(realm.ID, now)
+	stats, err := db.ListKeyServerStatsDays(realm.ID, now)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := stats.TotalTEKsPublished, int64(50); got != want {
+	if got, want := stats[0].TotalTEKsPublished, int64(50); got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
 	}
-	if got, want := stats.TEKAgeDistribution[4], int64(5); got != want {
+	if got, want := stats[0].TEKAgeDistribution[4], int64(5); got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
 	}
 }

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -29,9 +29,9 @@ func TestSaveKeyServerStats(t *testing.T) {
 	}
 
 	err = db.SaveKeyServerStats(&KeyServerStats{
-		RealmID:           realm.ID,
-		KeyServerURL:      "TestKeyServerURL",
-		KeyServerAudience: "TestAud",
+		RealmID:                   realm.ID,
+		KeyServerURLOverride:      "TestKeyServerURL",
+		KeyServerAudienceOverride: "TestAud",
 	})
 	if err != nil {
 		t.Fatal(err)
@@ -41,7 +41,7 @@ func TestSaveKeyServerStats(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := stats.KeyServerURL, "TestKeyServerURL"; got != want {
+	if got, want := stats.KeyServerURLOverride, "TestKeyServerURL"; got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %s, wanted %s", got, want)
 	}
 }

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -44,6 +44,16 @@ func TestSaveKeyServerStats(t *testing.T) {
 	if got, want := stats.KeyServerURLOverride, "TestKeyServerURL"; got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %s, wanted %s", got, want)
 	}
+
+	err = db.DeleteKeyServerStats(realm.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = db.GetKeyServerStats(realm.ID)
+	if err != nil && !IsNotFound(err) {
+		t.Fatal(err)
+	}
 }
 
 func TestSaveKeyServerStatsDay(t *testing.T) {

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -1,0 +1,80 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+	"time"
+)
+
+func TestSaveKeyServerStats(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	realm, err := db.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = db.SaveKeyServerStats(&KeyServerStats{
+		RealmID:           realm.ID,
+		KeyServerURL:      "TestKeyServerURL",
+		KeyServerAudience: "TestAud",
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := db.GetKeyServerStats(realm.ID)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stats.KeyServerURL, "TestKeyServerURL"; got != want {
+		t.Errorf("failed retrieving KeyServerStats. got %s, wanted %s", got, want)
+	}
+}
+
+func TestSaveKeyServerStatsDay(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	realm, err := db.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	now := time.Now()
+
+	err = db.SaveKeyServerStatsDay(&KeyServerStatsDay{
+		RealmID:            realm.ID,
+		Day:                now,
+		TotalTEKsPublished: 50,
+		TEKAgeDistribution: []int64{1, 2, 3, 4, 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err := db.GetKeyServerStatsDay(realm.ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got, want := stats.TotalTEKsPublished, int64(50); got != want {
+		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
+	}
+	if got, want := stats.TEKAgeDistribution[4], int64(5); got != want {
+		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
+	}
+}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2002,8 +2002,24 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 		{
 			ID: "00088-KeyServerStats",
 			Migrate: func(tx *gorm.DB) error {
-				err := tx.AutoMigrate(&KeyServerStats{}, &KeyServerStatsDay{}).Error
-				return err
+				return multiExec(tx,
+					`CREATE TABLE key_server_stats (
+						realm_id INTEGER,
+						is_system BOOL NOT NULL DEFAULT FALSE,
+						key_server_url TEXT,
+						key_server_audience TEXT,
+						PRIMARY KEY (realm_id))`,
+					`CREATE TABLE key_server_stats_days (
+						realm_id INTEGER,
+						day TIMESTAMP WITH TIME ZONE,
+						publish_requests BIGINT[],
+						total_teks_published BIGINT NOT NULL DEFAULT 0,
+						revision_requests BIGINT NOT NULL DEFAULT 0,
+						tek_age_distribution BIGINT[],
+						onset_to_upload_distribution BIGINT[],
+						request_missing_onset_date BIGINT NOT NULL DEFAULT 0,
+						PRIMARY KEY (realm_id, day))`,
+				)
 			},
 			Rollback: func(tx *gorm.DB) error {
 				if err := tx.DropTableIfExists(&KeyServerStats{}, &KeyServerStatsDay{}).Error; err != nil {

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2005,8 +2005,8 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return multiExec(tx,
 					`CREATE TABLE key_server_stats (
 						realm_id INTEGER,
-						key_server_url TEXT,
-						key_server_audience TEXT,
+						key_server_url_override TEXT,
+						key_server_audience_override TEXT,
 						PRIMARY KEY (realm_id))`,
 					`CREATE TABLE key_server_stats_days (
 						realm_id INTEGER,

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2005,7 +2005,6 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return multiExec(tx,
 					`CREATE TABLE key_server_stats (
 						realm_id INTEGER,
-						is_system BOOL NOT NULL DEFAULT FALSE,
 						key_server_url TEXT,
 						key_server_audience TEXT,
 						PRIMARY KEY (realm_id))`,

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1980,6 +1980,19 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realms DROP COLUMN IF EXISTS auto_rotate_certificate_key`)
 			},
 		},
+		{
+			ID: "00087-KeyServerStats",
+			Migrate: func(tx *gorm.DB) error {
+				err := tx.AutoMigrate(&KeyServerStats{}, &KeyServerStatsDay{}).Error
+				return err
+			},
+			Rollback: func(tx *gorm.DB) error {
+				if err := tx.DropTableIfExists(&KeyServerStats{}, &KeyServerStatsDay{}).Error; err != nil {
+					return err
+				}
+				return nil
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1512

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*  Key Server Stats database model
* Realm settings UI to set or delete the value

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
New tables for storing key-server statistics
```
