### PR TITLE
Add audits for saving a Token Signing Key

### DIFF
--- a/pkg/database/token_signing_keys_test.go
+++ b/pkg/database/token_signing_keys_test.go
@@ -159,6 +159,31 @@ func TestDatabase_RotateTokenSigningKey(t *testing.T) {
 	}
 }
 
+func TestDatabase_SaveTokenSigningKey(t *testing.T) {
+	t.Parallel()
+
+	t.Run("audits", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		key := &TokenSigningKey{
+			KeyVersionID: "foo/bar/baz",
+		}
+		if err := db.SaveTokenSigningKey(key, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		audits, _, err := db.ListAudits(nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(audits), 1; got != want {
+			t.Errorf("expected %d audits, got %d: %#v", want, got, audits)
+		}
+	})
+}
+
 func TestDatabase_PurgeTokenSigningKeys(t *testing.T) {
 	t.Parallel()
 
@@ -274,7 +299,7 @@ func TestDatabase_ActivateTokenSigningKey(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got, want := len(audits), 1; got != want {
+		if got, want := len(audits), 2; got != want {
 			t.Errorf("expected %d audits, got %d: %#v", want, got, audits)
 		}
 	})


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add audits for saving a Token Signing Key
```

/assign @whaught 