### PR TITLE
Source token signing keys from the database

### DIFF
--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -104,7 +104,7 @@ func realMain(ctx context.Context) error {
 	}
 	tokenSignerTyp, ok := tokenSigner.(keys.SigningKeyManager)
 	if !ok {
-		return fmt.Errorf("token signing key manage is not a signing key manager (is %T)", tokenSigner)
+		return fmt.Errorf("token signing key manager is not a signing key manager (is %T)", tokenSigner)
 	}
 
 	// Create the router

--- a/cmd/rotation/main.go
+++ b/cmd/rotation/main.go
@@ -104,7 +104,7 @@ func realMain(ctx context.Context) error {
 	}
 	tokenSignerTyp, ok := tokenSigner.(keys.SigningKeyManager)
 	if !ok {
-		return fmt.Errorf("token signing key manage is not a signing key manager (is %T)", tokenSigner)
+		return fmt.Errorf("token signing key manager is not a signing key manager (is %T)", tokenSigner)
 	}
 
 	// Create the router

--- a/cmd/server/assets/admin/info.html
+++ b/cmd/server/assets/admin/info.html
@@ -19,8 +19,23 @@
           <dt>Build ID</dt>
           <dd>{{.buildID}}</dd>
 
-          <dt>Build Tag</dt>
+          <dt>Build tag</dt>
           <dd>{{.buildTag}}</dd>
+
+          <dt>Token signing key</dt>
+          {{if $key := .activeTokenSigningKey}}
+            <dd class="mb-0">
+              kid: <span class="text-monospace user-select-all">{{$key.UUID}}</span>
+            </dd>
+            <dd class="mb-0">
+              key: <span class="text-monospace user-select-all">{{$key.KeyVersionID}}</span>
+            </dd>
+            <dd>
+              created: <span class="text-monospace user-select-all" data-timestamp="{{$key.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$key.CreatedAt.Format "2006-02-01 15:04"}}</span>
+            </dd>
+          {{else}}
+            <dd>not configured</dd>
+          {{end}}
         </dl>
       </div>
     </div>

--- a/cmd/server/assets/admin/info.html
+++ b/cmd/server/assets/admin/info.html
@@ -22,16 +22,39 @@
           <dt>Build tag</dt>
           <dd>{{.buildTag}}</dd>
 
-          <dt>Token signing key</dt>
-          {{if $key := .activeTokenSigningKey}}
-            <dd class="mb-0">
-              kid: <span class="text-monospace user-select-all">{{$key.UUID}}</span>
-            </dd>
-            <dd class="mb-0">
-              key: <span class="text-monospace user-select-all">{{$key.KeyVersionID}}</span>
-            </dd>
+          <dt>Token signing keys</dt>
+          {{if $keys := .tokenSigningKeys}}
             <dd>
-              created: <span class="text-monospace user-select-all" data-timestamp="{{$key.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$key.CreatedAt.Format "2006-02-01 15:04"}}</span>
+              <table class="small table table-bordered table-striped table-fixed mt-2">
+                <thead>
+                  <tr>
+                    <th width="40"></th>
+                    <th width="305">Key ID (kid)</th>
+                    <th>Key version</th>
+                    <th width="165">Created at</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{range $key := $keys}}
+                    <tr>
+                      <td class="text-center">
+                        {{if $key.IsActive}}
+                          <span class="oi oi-check" aria-hidden="true" data-toggle="tooltip" title="Active key"></span>
+                        {{end}}
+                      </td>
+                      <td class="text-monospace user-select-all">
+                        {{$key.UUID}}
+                      </td>
+                      <td class="text-monospace user-select-all">
+                        {{$key.KeyVersionID}}
+                      </td>
+                      <td>
+                        <span data-timestamp="{{$key.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$key.CreatedAt.Format "2006-02-01 15:04"}}</span>
+                      </td>
+                    </tr>
+                  {{end}}
+                </tbody>
+              </table>
             </dd>
           {{else}}
             <dd>not configured</dd>

--- a/docs/production.md
+++ b/docs/production.md
@@ -117,7 +117,7 @@ There are two types of "users" for the system:
     permissions in the realm determine their level of access. Most users will
     only have permission to issue codes. However, some users will have control
     over administering the realm, viewing statistics, inviting other realm
-    users, or updating realm settings. See the [realm admininistration
+    users, or updating realm settings. See the [realm administration
     guide](realm-admin-guide.md) for more information.
 
 When bootstrapping a new system, a default system administrator with the email
@@ -305,7 +305,23 @@ lifetime is short, it is probably safe to remove the key beyond 30 days.
 If you are using Terraform, increment the `db_verification_code_hmac_count` by 1.
 
 
-### Certificate and token signing keys
+### Token signing keys
+
+**Recommended frequency:** automatic
+
+The system automatically rotates token signing keys every 30 days.
+
+When bootstrapping a new system from scratch, it can take up to 5 minutes for
+the initial token signing key to become available. To expedite this process, you
+can manually invoke the `rotation` scheduler job:
+
+```sh
+gcloud scheduler jobs run "rotation" \
+  --project "${PROJECT_ID}"
+```
+
+
+### Certificate signing keys
 
 **Recommended frequency:** on demand
 

--- a/internal/envstest/apiserver.go
+++ b/internal/envstest/apiserver.go
@@ -77,6 +77,9 @@ func NewAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstan
 	// Create the token key manager. We need both the signing key and the IDs, so
 	// we cannot use the helper here.
 	tokenSigningKey := keys.TestSigningKey(tb, harness.KeyManager)
+	if _, err := harness.Database.RotateTokenSigningKey(ctx, certTyp, tokenSigningKey, database.SystemTest); err != nil {
+		tb.Fatal(err)
+	}
 
 	// Create the config.
 	cfg := &config.APIServerConfig{

--- a/internal/envstest/integration.go
+++ b/internal/envstest/integration.go
@@ -46,9 +46,9 @@ func NewIntegrationSuite(tb testing.TB) *IntegrationSuite {
 	apiServerConfig := NewAPIServerConfig(tb, testDatabaseInstance)
 
 	// Point everything at the same database, cacher, and key manager.
-	apiServerConfig.Database = adminAPIServerConfig.Database
-	apiServerConfig.Cacher = adminAPIServerConfig.Cacher
-	apiServerConfig.RateLimiter = adminAPIServerConfig.RateLimiter
+	adminAPIServerConfig.Database = apiServerConfig.Database
+	adminAPIServerConfig.Cacher = apiServerConfig.Cacher
+	adminAPIServerConfig.RateLimiter = apiServerConfig.RateLimiter
 
 	db := adminAPIServerConfig.Database
 

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -49,6 +49,23 @@ func APIServer(
 ) (http.Handler, func(), error) {
 	closer := func() {}
 
+	// Configure system token signing keys. This is done here to ensure the
+	// bootstrapping is shared with the test harnesses, even though it's not
+	// strictly "route" setup.
+	if _, err := db.ActiveTokenSigningKey(); err != nil {
+		if !database.IsNotFound(err) {
+			return nil, closer, fmt.Errorf("failed to lookup active token signing key: %w", err)
+		}
+
+		tokenSignerTyp, ok := tokenSigner.(keys.SigningKeyManager)
+		if !ok {
+			return nil, closer, fmt.Errorf("token signing key manager is not a signing key manager (is %T)", tokenSigner)
+		}
+		if _, err := db.RotateTokenSigningKey(ctx, tokenSignerTyp, cfg.TokenSigning.ParentKeyName(), database.System); err != nil {
+			return nil, closer, fmt.Errorf("failed to create token signing key: %w", err)
+		}
+	}
+
 	// Create the router
 	r := mux.NewRouter()
 
@@ -123,10 +140,7 @@ func APIServer(
 		sub.Use(rateLimit)
 
 		// POST /api/verify
-		verifyapiController, err := verifyapi.New(ctx, cfg, db, h, tokenSigner)
-		if err != nil {
-			return nil, closer, fmt.Errorf("failed to create verify api controller: %w", err)
-		}
+		verifyapiController := verifyapi.New(cfg, db, cacher, tokenSigner, h)
 		sub.Handle("", verifyapiController.HandleVerify()).Methods("POST")
 	}
 

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -49,23 +49,6 @@ func APIServer(
 ) (http.Handler, func(), error) {
 	closer := func() {}
 
-	// Configure system token signing keys. This is done here to ensure the
-	// bootstrapping is shared with the test harnesses, even though it's not
-	// strictly "route" setup.
-	if _, err := db.ActiveTokenSigningKey(); err != nil {
-		if !database.IsNotFound(err) {
-			return nil, closer, fmt.Errorf("failed to lookup active token signing key: %w", err)
-		}
-
-		tokenSignerTyp, ok := tokenSigner.(keys.SigningKeyManager)
-		if !ok {
-			return nil, closer, fmt.Errorf("token signing key manager is not a signing key manager (is %T)", tokenSigner)
-		}
-		if _, err := db.RotateTokenSigningKey(ctx, tokenSignerTyp, cfg.TokenSigning.ParentKeyName(), database.System); err != nil {
-			return nil, closer, fmt.Errorf("failed to create token signing key: %w", err)
-		}
-	}
-
 	// Create the router
 	r := mux.NewRouter()
 

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -16,6 +16,7 @@ package config
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
 )
@@ -25,27 +26,72 @@ import (
 type TokenSigningConfig struct {
 	// Keys determines the key manager configuration for this token signing
 	// configuration.
-	Keys keys.Config `env:",prefix=TOKEN_"`
+	Keys keys.Config `env:", prefix=TOKEN_"`
 
-	TokenSigningKeys   []string `env:"TOKEN_SIGNING_KEY, required"`
+	// TokenSigningKeys is the parent token signing key (not the actual signing
+	// version). It is an array for backwards-compatibility, but in practice it
+	// should only have one element.
+	//
+	// Previously it was a list of all possible signing key versions, but those
+	// have moved into the database.
+	//
+	// TODO(sethvargo): Convert to string in 0.22+.
+	TokenSigningKeys []string `env:"TOKEN_SIGNING_KEY, required"`
+
+	// TokenSigningKeyIDs specifies the list of kids, corresponding to the
+	// TokenSigningKey
+	//
+	// TODO(sethvargo): Remove in 0.22+.
+	//
+	// Deprecated: moved into the database.
 	TokenSigningKeyIDs []string `env:"TOKEN_SIGNING_KEY_ID, default=v1"`
-	TokenIssuer        string   `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
+
+	// TokenIssuer is the `iss` field on the JWT.
+	TokenIssuer string `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
 }
 
-func (t *TokenSigningConfig) ActiveKey() string {
+// ParentKeyName returns the name of the parent key.
+func (t *TokenSigningConfig) ParentKeyName() string {
 	// Validation prevents this slice from being empty.
-	return t.TokenSigningKeys[0]
+	value := t.TokenSigningKeys[0]
+
+	// This is Google-specific, but that's the only platform where we can
+	// meaningfully detect this.
+	if idx := strings.Index(t.TokenSigningKeys[0], "/cryptoKeyVersions"); idx != -1 {
+		value = value[0:idx]
+	}
+
+	return value
 }
 
-func (t *TokenSigningConfig) ActiveKeyID() string {
-	// Validation prevents this slice from being empty.
-	return t.TokenSigningKeyIDs[0]
+// FindKeyByKid attempts to find the matching signing key for the given kid. The
+// boolean indicates whether the search was successful.
+//
+// TODO(sethvargo): remove in 0.22+.
+func (t *TokenSigningConfig) FindKeyByKid(kid string) (string, bool) {
+	idx := -1
+	for i, v := range t.TokenSigningKeyIDs {
+		if v == kid {
+			idx = i
+			break
+		}
+	}
+
+	if idx == -1 {
+		return "", false
+	}
+
+	// This is safe to index because the validation check ensures the lengths are
+	// equal.
+	return t.TokenSigningKeys[idx], true
 }
 
+// Validate validates the configuration.
 func (t *TokenSigningConfig) Validate() error {
 	if len(t.TokenSigningKeys) == 0 {
-		return fmt.Errorf("TOKEN_SIGNING_KEY must have at least one entry")
+		return fmt.Errorf("TOKEN_SIGNING_KEY must have at least one element")
 	}
+
 	if len(t.TokenSigningKeyIDs) == 0 {
 		return fmt.Errorf("TOKEN_SIGNING_KEY_ID must have at least one entry")
 	}
@@ -53,5 +99,6 @@ func (t *TokenSigningConfig) Validate() error {
 	if len(t.TokenSigningKeys) != len(t.TokenSigningKeyIDs) {
 		return fmt.Errorf("TOKEN_SIGNING_KEY and TOKEN_SIGNING_KEY_ID must be lists of the same length")
 	}
+
 	return nil
 }

--- a/pkg/controller/admin/caches.go
+++ b/pkg/controller/admin/caches.go
@@ -28,14 +28,15 @@ type cacheItem struct {
 }
 
 var caches = map[string]*cacheItem{
-	"apps:":            {"Mobile apps", "Registered mobile apps for the redirector service"},
-	"authorized_apps:": {"API keys", "Authentication for API keys"},
-	"jwks:":            {"JWKs", "JSON web key sets"},
-	"memberships:":     {"Memberships", "All membership information"},
-	"public_keys:":     {"Public keys", "PEM data from upstream key provider"},
-	"realms:":          {"Realms", "All realm data"},
-	"stats:":           {"Statistics", "API key, user, and realm statistics"},
-	"users:":           {"Users", "All user data"},
+	"apps:":               {"Mobile apps", "Registered mobile apps for the redirector service"},
+	"authorized_apps:":    {"API keys", "Authentication for API keys"},
+	"jwks:":               {"JWKs", "JSON web key sets"},
+	"memberships:":        {"Memberships", "All membership information"},
+	"public_keys:":        {"Public keys", "PEM data from upstream key provider"},
+	"realms:":             {"Realms", "All realm data"},
+	"stats:":              {"Statistics", "API key, user, and realm statistics"},
+	"token_signing_keys:": {"Token signing keys", "All token signing keys, including currently active"},
+	"users:":              {"Users", "All user data"},
 }
 
 // HandleCachesIndex shows the caches page.

--- a/pkg/controller/admin/info.go
+++ b/pkg/controller/admin/info.go
@@ -18,7 +18,6 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 // HandleInfoShow renders the list of system admins.
@@ -28,14 +27,12 @@ func (c *Controller) HandleInfoShow() http.Handler {
 
 		m := controller.TemplateMapFromContext(ctx)
 
-		activeTokenSigningKey, err := c.db.ActiveTokenSigningKey()
-		if err != nil && !database.IsNotFound(err) {
+		tokenSigningKeys, err := c.db.ListTokenSigningKeys()
+		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return
 		}
-		if activeTokenSigningKey != nil {
-			m["activeTokenSigningKey"] = activeTokenSigningKey
-		}
+		m["tokenSigningKeys"] = tokenSigningKeys
 
 		m.Title("Info - System Admin")
 		c.h.RenderHTML(w, "admin/info", m)

--- a/pkg/controller/admin/info.go
+++ b/pkg/controller/admin/info.go
@@ -18,13 +18,25 @@ import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 // HandleInfoShow renders the list of system admins.
 func (c *Controller) HandleInfoShow() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
 		m := controller.TemplateMapFromContext(ctx)
+
+		activeTokenSigningKey, err := c.db.ActiveTokenSigningKey()
+		if err != nil && !database.IsNotFound(err) {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+		if activeTokenSigningKey != nil {
+			m["activeTokenSigningKey"] = activeTokenSigningKey
+		}
+
 		m.Title("Info - System Admin")
 		c.h.RenderHTML(w, "admin/info", m)
 	})

--- a/pkg/controller/rotation/handle_rotate.go
+++ b/pkg/controller/rotation/handle_rotate.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
@@ -66,19 +67,19 @@ func (c *Controller) HandleRotate() http.Handler {
 			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 
 			existing, err := c.db.ActiveTokenSigningKey()
-			if err != nil {
+			if err != nil && !database.IsNotFound(err) {
 				merr = multierror.Append(merr, fmt.Errorf("failed to lookup existing signing key: %w", err))
 				result = observability.ResultError("FAILED")
 				return
 			}
-			if age, max := time.Now().UTC().Sub(existing.CreatedAt), c.config.TokenSigningKeyMaxAge; age < max {
-				logger.Debugw("token signing key does not require rotation", "age", age, "max", max)
-				return
+			if existing != nil {
+				if age, max := time.Now().UTC().Sub(existing.CreatedAt), c.config.TokenSigningKeyMaxAge; age < max {
+					logger.Debugw("token signing key does not require rotation", "age", age, "max", max)
+					return
+				}
 			}
 
-			// TODO(sethvargo): figure out what to do with .TokenSigningKeys since it
-			// can be an array.
-			key, err := c.db.RotateTokenSigningKey(ctx, c.keyManager, c.config.TokenSigning.ActiveKey(), RotationActor)
+			key, err := c.db.RotateTokenSigningKey(ctx, c.keyManager, c.config.TokenSigning.ParentKeyName(), RotationActor)
 			if err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to rotate token signing key: %w", err))
 				result = observability.ResultError("FAILED")

--- a/pkg/controller/verifyapi/verifyapi.go
+++ b/pkg/controller/verifyapi/verifyapi.go
@@ -15,9 +15,8 @@
 package verifyapi
 
 import (
-	"context"
-
 	"github.com/google/exposure-notifications-server/pkg/keys"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -27,15 +26,17 @@ import (
 type Controller struct {
 	config *config.APIServerConfig
 	db     *database.Database
-	h      render.Renderer
+	cacher cache.Cacher
 	kms    keys.KeyManager
+	h      render.Renderer
 }
 
-func New(ctx context.Context, config *config.APIServerConfig, db *database.Database, h render.Renderer, kms keys.KeyManager) (*Controller, error) {
+func New(cfg *config.APIServerConfig, db *database.Database, cacher cache.Cacher, kms keys.KeyManager, h render.Renderer) *Controller {
 	return &Controller{
-		config: config,
+		config: cfg,
 		db:     db,
-		h:      h,
+		cacher: cacher,
 		kms:    kms,
-	}, nil
+		h:      h,
+	}
 }

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -1999,6 +1999,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`DROP TABLE IF EXISTS token_signing_keys`)
 			},
 		},
+		{
+			ID: "00088-AddUUIDToTokenSigningKeys",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE token_signing_keys ADD COLUMN uuid UUID NOT NULL DEFAULT uuid_generate_v4()`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`DROP TABLE IF EXISTS token_signing_keys`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2003,7 +2003,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			ID: "00088-AddUUIDToTokenSigningKeys",
 			Migrate: func(tx *gorm.DB) error {
 				return multiExec(tx,
-					`ALTER TABLE token_signing_keys ADD COLUMN uuid UUID NOT NULL DEFAULT uuid_generate_v4()`)
+					`ALTER TABLE token_signing_keys ADD COLUMN uuid UUID NOT NULL UNIQUE DEFAULT uuid_generate_v4()`)
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,

--- a/pkg/database/token_signing_keys.go
+++ b/pkg/database/token_signing_keys.go
@@ -161,6 +161,7 @@ func (db *Database) ListTokenSigningKeys() ([]*TokenSigningKey, error) {
 	var keys []*TokenSigningKey
 	if err := db.db.
 		Model(&TokenSigningKey{}).
+		Order("token_signing_keys.is_active DESC, id DESC").
 		Find(&keys).
 		Error; err != nil {
 		if IsNotFound(err) {

--- a/pkg/database/token_signing_keys.go
+++ b/pkg/database/token_signing_keys.go
@@ -20,6 +20,8 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/uuid"
 	"github.com/jinzhu/gorm"
 )
 
@@ -34,6 +36,10 @@ type TokenSigningKey struct {
 
 	// KeyVersionID is the full name of the signing key version.
 	KeyVersionID string
+
+	// UUID is the uuid of the key. This is used as the `kid` header value in
+	// JWTs.
+	UUID string `gorm:"column:uuid; default:null;"`
 
 	// IsActive returns true if this signing key is the active one, false
 	// otherwise. There's a database-level constraint that only one row can have
@@ -52,12 +58,12 @@ var _ Auditable = (*TokenSigningKey)(nil)
 
 // AuditID is how the token signing key is stored in the audit entry.
 func (k *TokenSigningKey) AuditID() string {
-	return fmt.Sprintf("token_signing_key:%d", k.ID)
+	return fmt.Sprintf("token_signing_key:%s", k.UUID)
 }
 
 // AuditDisplay is how the token signing key will be displayed in audit entries.
 func (k *TokenSigningKey) AuditDisplay() string {
-	return fmt.Sprintf("%d (%s)", k.ID, k.KeyVersionID)
+	return fmt.Sprintf("%s (%s)", k.UUID, k.KeyVersionID)
 }
 
 // FindTokenSigningKey finds the given key by database ID. It returns an error
@@ -74,6 +80,46 @@ func (db *Database) FindTokenSigningKey(id interface{}) (*TokenSigningKey, error
 	return &key, nil
 }
 
+// FindTokenSigningKeyByUUID finds the given key by database ID. It returns an error
+// if the record is not found.
+func (db *Database) FindTokenSigningKeyByUUID(uuidStr string) (*TokenSigningKey, error) {
+	// Postgres returns an error if the provided input is not a valid UUID.
+	parsed, err := uuid.Parse(uuidStr)
+	if err != nil {
+		return nil, gorm.ErrRecordNotFound
+	}
+
+	var key TokenSigningKey
+	if err := db.db.
+		Model(&TokenSigningKey{}).
+		Where("uuid = ?", parsed.String()).
+		First(&key).
+		Error; err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
+// FindTokenSigningKeyByUUIDCached is like FindTokenSigningKeyByUUID, but the
+// results are cached for a short period to alleviate load on the database.
+func (db *Database) FindTokenSigningKeyByUUIDCached(ctx context.Context, cacher cache.Cacher, uuidStr string) (*TokenSigningKey, error) {
+	if cacher == nil {
+		return nil, fmt.Errorf("cacher cannot be nil")
+	}
+
+	var key *TokenSigningKey
+	cacheKey := &cache.Key{
+		Namespace: "token_signing_keys:by_id",
+		Key:       uuidStr,
+	}
+	if err := cacher.Fetch(ctx, cacheKey, &key, 30*time.Minute, func() (interface{}, error) {
+		return db.FindTokenSigningKeyByUUID(uuidStr)
+	}); err != nil {
+		return nil, err
+	}
+	return key, nil
+}
+
 // ActiveTokenSigningKey returns the currently-active token signing key. If no
 // key is currently marked as active, it returns NotFound.
 func (db *Database) ActiveTokenSigningKey() (*TokenSigningKey, error) {
@@ -86,6 +132,26 @@ func (db *Database) ActiveTokenSigningKey() (*TokenSigningKey, error) {
 		return nil, err
 	}
 	return &key, nil
+}
+
+// ActiveTokenSigningKeyCached is like ActiveTokenSigningKey, but the results
+// are cached for a short period to alleviate load on the database.
+func (db *Database) ActiveTokenSigningKeyCached(ctx context.Context, cacher cache.Cacher) (*TokenSigningKey, error) {
+	if cacher == nil {
+		return nil, fmt.Errorf("cacher cannot be nil")
+	}
+
+	var key *TokenSigningKey
+	cacheKey := &cache.Key{
+		Namespace: "token_signing_keys:active",
+		Key:       "value",
+	}
+	if err := cacher.Fetch(ctx, cacheKey, &key, 5*time.Minute, func() (interface{}, error) {
+		return db.ActiveTokenSigningKey()
+	}); err != nil {
+		return nil, err
+	}
+	return key, nil
 }
 
 // ListTokenSigningKeys lists all keys sorted by their active state, then

--- a/pkg/database/token_signing_keys_test.go
+++ b/pkg/database/token_signing_keys_test.go
@@ -56,6 +56,48 @@ func TestDatabase_FindTokenSigningKey(t *testing.T) {
 	})
 }
 
+func TestDatabase_FindTokenSigningKeyByUUID(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	t.Run("invalid", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := db.FindTokenSigningKeyByUUID("invalid"); !IsNotFound(err) {
+			t.Errorf("expected err to be NotFound, got %v", err)
+		}
+	})
+
+	t.Run("not_exist", func(t *testing.T) {
+		t.Parallel()
+
+		if _, err := db.FindTokenSigningKeyByUUID("00000000-0000-0000-0000-000000000000"); !IsNotFound(err) {
+			t.Errorf("expected err to be NotFound, got %v", err)
+		}
+	})
+
+	t.Run("finds", func(t *testing.T) {
+		t.Parallel()
+
+		key := &TokenSigningKey{
+			KeyVersionID: "foo/bar/baz",
+		}
+		if err := db.SaveTokenSigningKey(key, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := db.FindTokenSigningKeyByUUID(key.UUID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := result.UUID, result.UUID; got != want {
+			t.Errorf("expected %s to be %s", got, want)
+		}
+	})
+}
+
 func TestDatabase_ActiveTokenSigningKey(t *testing.T) {
 	t.Parallel()
 

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -37,6 +37,7 @@ locals {
     e2e-runner   = local.default_per_service_slo
     enx-redirect = local.default_per_service_slo
     modeler      = local.default_per_service_slo
+    rotation     = local.default_per_service_slo
     server = merge(local.default_per_service_slo,
       { enable_latency_alert = true,
     latency_threshold = 2000 })

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -200,7 +200,7 @@ resource "google_cloud_run_service_iam_member" "rotation-invoker" {
 resource "google_cloud_scheduler_job" "rotation-worker" {
   name             = "rotation-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 */6 * * *"
+  schedule         = "*/5 * * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -77,6 +77,8 @@ locals {
     CERTIFICATE_SIGNING_KEY     = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")
     CERTIFICATE_SIGNING_KEYRING = google_kms_key_ring.verification.self_link
 
+    # TODO(sethvargo): in 0.22+, this should be the parent crypto key (not the
+    # cryptp key version).
     TOKEN_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
     TOKEN_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")
   }


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1569

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
**Potentially breaking!** Source token signing keys from the database. This completes the move of system token signing keys from environment variables to the database. This change attempts to be backward compatible, but server are encouraged to test changes in an isolated environment before upgrading production systems.
```

/assign @mikehelmick 