### PR TITLE
Add stats-puller harness

### DIFF
--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -558,3 +558,54 @@ steps:
       --keyversion "${_BINAUTHZ_KEY_VERSION}"
   waitFor:
   - 'push-server'
+
+
+
+#
+# stats-puller
+#
+- id: 'build-stats-puller'
+  name: 'golang:1.15.2'
+  args:
+  - 'go'
+  - 'build'
+  - '-trimpath'
+  - '-ldflags=-s -w -X=${_REPO}/pkg/buildinfo.BuildID=${BUILD_ID} -X=${_REPO}/pkg/buildinfo.BuildTag=${_TAG} -extldflags=-static'
+  - '-o=./bin/stats-puller'
+  - './cmd/stats-puller'
+  waitFor:
+  - 'download-modules'
+
+- id: 'dockerize-stats-puller'
+  name: 'docker:19'
+  args:
+  - 'build'
+  - '--file=builders/service.dockerfile'
+  - '--tag=gcr.io/${PROJECT_ID}/${_REPO}/stats-puller:${_TAG}'
+  - '--build-arg=SERVICE=stats-puller'
+  - '.'
+  waitFor:
+  - 'build-stats-puller'
+
+- id: 'push-stats-puller'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/stats-puller:${_TAG}'
+
+- id: 'attest-stats-puller'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/stats-puller:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-stats-puller'

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -212,3 +212,25 @@ steps:
       --no-traffic
   waitFor:
   - '-'
+
+
+#
+# stats-puller
+#
+- id: 'deploy-stats-puller'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0-alpine'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    gcloud run deploy "stats-puller" \
+      --quiet \
+      --project "${PROJECT_ID}" \
+      --platform "managed" \
+      --region "${_REGION}" \
+      --image "gcr.io/${PROJECT_ID}/${_REPO}/stats-puller:${_TAG}" \
+      --no-traffic
+  waitFor:
+  - '-'

--- a/builders/promote.yaml
+++ b/builders/promote.yaml
@@ -201,3 +201,24 @@ steps:
       --to-revisions "${_REVISION}=${_PERCENTAGE}"
   waitFor:
   - '-'
+
+
+#
+# stats-puller
+#
+- id: 'promote-stats-puller'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:307.0.0-alpine'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    gcloud run services update-traffic "stats-puller" \
+      --quiet \
+      --project "${PROJECT_ID}" \
+      --platform "managed" \
+      --region "${_REGION}" \
+      --to-revisions "${_REVISION}=${_PERCENTAGE}"
+  waitFor:
+  - '-'

--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -116,7 +116,7 @@ func AdminAPI(
 		sub.Use(requireStatsAPIKey)
 		sub.Use(processFirewall)
 
-		statsController := stats.New(ctx, cacher, db, h)
+		statsController := stats.New(cacher, db, h)
 		sub.Handle("/realm.csv", statsController.HandleRealmStats(stats.StatsTypeCSV)).Methods("GET")
 		sub.Handle("/realm.json", statsController.HandleRealmStats(stats.StatsTypeJSON)).Methods("GET")
 

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -274,7 +274,7 @@ func Server(
 		sub.Use(requireMFA)
 		sub.Use(rateLimit)
 
-		statsController := stats.New(ctx, cacher, db, h)
+		statsController := stats.New(cacher, db, h)
 		statsRoutes(sub, statsController)
 	}
 

--- a/pkg/config/stats_puller_config.go
+++ b/pkg/config/stats_puller_config.go
@@ -1,0 +1,59 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+
+	"github.com/google/exposure-notifications-server/pkg/observability"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+// StatsPullerConfig represents the environment-based configuration for the
+// stats-puller service.
+type StatsPullerConfig struct {
+	Database      database.Config
+	Observability observability.Config
+
+	// Port is the port upon which to bind.
+	Port string `env:"PORT, default=8080"`
+
+	// DevMode produces additional debugging information. Do not enable in
+	// production environments.
+	DevMode bool `env:"DEV_MODE"`
+
+	// MinTTL is the minimum amount of time that must elapse between attempting
+	// stats-pull events. This is used to control whether the pull is actually
+	// attempted at the controller layer, independent of the data layer. In
+	// effect, it rate limits the number of rotation requests.
+	MinTTL time.Duration `env:"MIN_TTL, default=15m"`
+}
+
+// NewStatsPullerConfig returns the config for the stats-puller service.
+func NewStatsPullerConfig(ctx context.Context) (*StatsPullerConfig, error) {
+	var config StatsPullerConfig
+	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (c *StatsPullerConfig) ObservabilityExporterConfig() *observability.Config {
+	return &c.Observability
+}

--- a/pkg/controller/stats/stats.go
+++ b/pkg/controller/stats/stats.go
@@ -45,7 +45,7 @@ type Controller struct {
 }
 
 // New creates a new stats controller.
-func New(ctx context.Context, cacher cache.Cacher, db *database.Database, h render.Renderer) *Controller {
+func New(cacher cache.Cacher, db *database.Database, h render.Renderer) *Controller {
 	return &Controller{
 		cacher: cacher,
 		db:     db,

--- a/pkg/controller/statspuller/handle_pull.go
+++ b/pkg/controller/statspuller/handle_pull.go
@@ -1,0 +1,40 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package statspuller
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+)
+
+// HandlePullStats pulls key-server statistics.
+func (c *Controller) HandlePullStats() http.Handler {
+	type Result struct {
+		OK     bool    `json:"ok"`
+		Errors []error `json:"errors,omitempty"`
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("rotation.HandlePullStats")
+		logger.Debug("no-op stats pull") // TODO(whaught): remove this and put in logic
+
+		c.h.RenderJSON(w, http.StatusOK, &Result{
+			OK: true,
+		})
+	})
+}

--- a/pkg/controller/statspuller/statspull.go
+++ b/pkg/controller/statspuller/statspull.go
@@ -1,0 +1,38 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package statspuller pulls statistics from the key server.
+package statspuller
+
+import (
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+// Controller is a stats controller.
+type Controller struct {
+	config *config.StatsPullerConfig
+	db     *database.Database
+	h      render.Renderer
+}
+
+// New creates a new stats-pull controller.
+func New(cfg *config.StatsPullerConfig, db *database.Database, h render.Renderer) *Controller {
+	return &Controller{
+		config: cfg,
+		db:     db,
+		h:      h,
+	}
+}

--- a/terraform/alerting/slos.tf
+++ b/terraform/alerting/slos.tf
@@ -40,6 +40,7 @@ locals {
     server = merge(local.default_per_service_slo,
       { enable_latency_alert = true,
     latency_threshold = 2000 })
+    stats-puller = local.default_per_service_slo
   }
 }
 

--- a/terraform/service-stats-puller.tf
+++ b/terraform/service-stats-puller.tf
@@ -1,0 +1,225 @@
+# Copyright 2021 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "stats-puller" {
+  project      = var.project
+  account_id   = "en-verification-stats-puller-sa"
+  display_name = "Verification stats-puller"
+}
+
+resource "google_service_account_iam_member" "cloudbuild-deploy-stats-puller" {
+  service_account_id = google_service_account.stats-puller.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+    google_project_service.services["iam.googleapis.com"],
+  ]
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-db" {
+  for_each = toset([
+    "sslcert",
+    "sslkey",
+    "sslrootcert",
+    "password",
+  ])
+
+  secret_id = google_secret_manager_secret.db-secret[each.key].id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_project_iam_member" "stats-puller-observability" {
+  for_each = toset([
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/stackdriver.resourceMetadata.writer",
+  ])
+
+  project = var.project
+  role    = each.key
+  member  = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_kms_crypto_key_iam_member" "stats-puller-database-encrypter" {
+  crypto_key_id = google_kms_crypto_key.database-encrypter.self_link
+  role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
+  member        = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-db-apikey-db-hmac" {
+  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-db-apikey-sig-hmac" {
+  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-db-verification-code-hmac" {
+  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-cache-hmac-key" {
+  secret_id = google_secret_manager_secret.cache-hmac-key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_secret_manager_secret_iam_member" "stats-puller-ratelimit-hmac-key" {
+  secret_id = google_secret_manager_secret.ratelimit-hmac-key.id
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.stats-puller.email}"
+}
+
+resource "google_cloud_run_service" "stats-puller" {
+  name     = "stats-puller"
+  location = var.region
+
+  autogenerate_revision_name = true
+
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "stats-puller", {})
+    )
+  }
+  template {
+    spec {
+      service_account_name = google_service_account.stats-puller.email
+
+      containers {
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/stats-puller:initial"
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+
+
+        dynamic "env" {
+          for_each = merge(
+            local.database_config,
+            local.gcp_config,
+            local.signing_config,
+            local.observability_config,
+
+            // This MUST come last to allow overrides!
+            lookup(var.service_environment, "stats-puller", {}),
+          )
+
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+
+    metadata {
+      annotations = merge(
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        lookup(var.revision_annotations, "stats-puller", {})
+      )
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["run.googleapis.com"],
+
+    google_secret_manager_secret_iam_member.stats-puller-db,
+    google_project_iam_member.stats-puller-observability,
+    google_kms_crypto_key_iam_member.stats-puller-database-encrypter,
+    google_secret_manager_secret_iam_member.stats-puller-db-apikey-db-hmac,
+    google_secret_manager_secret_iam_member.stats-puller-db-apikey-sig-hmac,
+    google_secret_manager_secret_iam_member.stats-puller-db-verification-code-hmac,
+    google_secret_manager_secret_iam_member.stats-puller-cache-hmac-key,
+    google_secret_manager_secret_iam_member.stats-puller-ratelimit-hmac-key,
+
+    null_resource.build,
+    null_resource.migrate,
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
+      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].labels["cloud.googleapis.com/location"],
+    ]
+  }
+}
+
+output "stats-puller_url" {
+  value = google_cloud_run_service.stats-puller.status.0.url
+}
+
+#
+# Create scheduler job to invoke the service on a fixed interval.
+#
+
+resource "google_service_account" "stats-puller-invoker" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-stats-puller-invoker-sa"
+  display_name = "Verification stats-puller invoker"
+}
+
+resource "google_cloud_run_service_iam_member" "stats-puller-invoker" {
+  project  = google_cloud_run_service.stats-puller.project
+  location = google_cloud_run_service.stats-puller.location
+  service  = google_cloud_run_service.stats-puller.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.stats-puller-invoker.email}"
+}
+
+resource "google_cloud_scheduler_job" "stats-puller-worker" {
+  name             = "stats-puller-worker"
+  region           = var.cloudscheduler_location
+  schedule         = "30 * * * *"
+  time_zone        = "America/Los_Angeles"
+  attempt_deadline = "600s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.stats-puller.status.0.url}/"
+    oidc_token {
+      audience              = google_cloud_run_service.stats-puller.status.0.url
+      service_account_email = google_service_account.stats-puller-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.stats-puller-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}

--- a/terraform/service-stats-puller.tf
+++ b/terraform/service-stats-puller.tf
@@ -14,7 +14,7 @@
 
 resource "google_service_account" "stats-puller" {
   project      = var.project
-  account_id   = "en-verification-stats-puller-sa"
+  account_id   = "en-ver-stats-puller-sa"
   display_name = "Verification stats-puller"
 }
 


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1512

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds all the boilerplate for a new service
    * build, deploy, promo scripts
    * main entry point
    * config file
    * controller which is currently a no-op
    *  terraform script for accounts, service, and cloud-scheduler (hourly)

[see Seth's similar PR for rotation](https://github.com/google/exposure-notifications-verification-server/pull/1597)

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Adds the stats-puller service to run every hour.
```
