### PR TITLE
Display realm_id in system admin event logs

### DIFF
--- a/cmd/server/assets/admin/events/index.html
+++ b/cmd/server/assets/admin/events/index.html
@@ -77,7 +77,12 @@
 
                 <span>{{$event.Action}}</span>
 
-                <span class="text-primary text-nowrap text-truncate">{{$event.TargetDisplay}}</span>
+                <span class="text-primary text-nowrap text-truncate">
+                  {{$event.TargetDisplay}}
+                  {{if $event.RealmID}}
+                    on realm {{$event.RealmID}}
+                  {{end}}
+                </span>
 
                 {{if $event.Diff}}
                 <br>


### PR DESCRIPTION
This isn't relevant in realm logs since all records are tied to that realm, but for system event logs, it's important to know upon which realm the action took place.

We can't lookup the actual realm here safely because the realm_id is "0" for system events. Also realm names can change but IDs are stable.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Display realm_id in system admin event logs
```

/assign @whaught 