### PR TITLE
Add db lock to stats-puller service. Share 'Should<servicename>' func

### DIFF
--- a/pkg/config/appsync_server_config.go
+++ b/pkg/config/appsync_server_config.go
@@ -42,10 +42,13 @@ type AppSyncConfig struct {
 	RateLimit uint64 `env:"RATE_LIMIT,default=60"`
 
 	// AppSync config
-	AppSyncURL           string        `env:"APP_SYNC_URL"`
-	FileSizeLimitBytes   int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
-	Timeout              time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
-	AppSyncMinimumPeriod time.Duration `env:"APP_SYNC_MINIMUM_PERIOD, default=5m"`
+	AppSyncURL         string        `env:"APP_SYNC_URL"`
+	FileSizeLimitBytes int64         `env:"APP_SYNC_SIZE_LIMIT, default=64000"`
+	Timeout            time.Duration `env:"APP_SYNC_TIMEOUT, default=1m"`
+
+	// AppSyncMinPeriod defines the period for which the app sync service will hold a lock
+	// which prevents other calls from entering.
+	AppSyncMinPeriod time.Duration `env:"APP_SYNC_MIN_PERIOD, default=5m"`
 }
 
 // NewAppSyncConfig returns the environment config for the appsync server.

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -45,7 +45,7 @@ type CleanupConfig struct {
 	// Cleanup config
 	AuditEntryMaxAge    time.Duration `env:"AUDIT_ENTRY_MAX_AGE, default=720h"`
 	AuthorizedAppMaxAge time.Duration `env:"AUTHORIZED_APP_MAX_AGE, default=336h"`
-	CleanupPeriod       time.Duration `env:"CLEANUP_PERIOD, default=15m"`
+	CleanupMinPeriod    time.Duration `env:"CLEANUP_MIN_PERIOD, default=15m"`
 	MobileAppMaxAge     time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
 
 	// SigningTokenKeyMaxAge is the maximum amount of time that a rotated signing
@@ -78,7 +78,7 @@ func (c *CleanupConfig) Validate() error {
 		Name string
 	}{
 		{c.VerificationCodeMaxAge, "VERIFICATION_TOKEN_DURATION"},
-		{c.CleanupPeriod, "CLEANUP_PERIOD"},
+		{c.CleanupMinPeriod, "CLEANUP_MIN_PERIOD"},
 		{c.VerificationCodeMaxAge, "VERIFICATION_CODE_MAX_AGE"},
 		{c.VerificationCodeStatusMaxAge, "VERIFICATION_CODE_STATUS_MAX_AGE"},
 		{c.VerificationTokenMaxAge, "VERIFICATION_TOKEN_MAX_AGE"},

--- a/pkg/config/stats_puller_config.go
+++ b/pkg/config/stats_puller_config.go
@@ -43,6 +43,10 @@ type StatsPullerConfig struct {
 	// attempted at the controller layer, independent of the data layer. In
 	// effect, it rate limits the number of rotation requests.
 	MinTTL time.Duration `env:"MIN_TTL, default=15m"`
+
+	// StatsPullerMinPeriod defines the period for which the stats puller will hold a lock
+	// which prevents other calls from entering.
+	StatsPullerMinPeriod time.Duration `env:"STATS_PULLER_MIN_PERIOD, default=5m"`
 }
 
 // NewStatsPullerConfig returns the config for the stats-puller service.

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -105,7 +105,7 @@ func (c *Controller) shouldSync(ctx context.Context) (bool, error) {
 	}
 
 	// Attempt to advance the generation.
-	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncMinimumPeriod); err != nil {
+	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncMinPeriod); err != nil {
 		return false, fmt.Errorf("failed to claim appsync lock: %w", err)
 	}
 	return true, nil

--- a/pkg/controller/appsync/appsync.go
+++ b/pkg/controller/appsync/appsync.go
@@ -19,7 +19,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -29,12 +28,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/hashicorp/go-multierror"
-)
-
-const (
-	playStoreHost = `play.google.com/store/apps/details`
-
-	appSyncLock = "appsync"
 )
 
 // HandleSync performs the logic to sync mobile apps.
@@ -47,7 +40,7 @@ func (c *Controller) HandleSync() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		ok, err := c.shouldSync(ctx)
+		ok, err := c.db.TryLock(ctx, appSyncLock, c.config.AppSyncMinPeriod)
 		if err != nil {
 			c.h.RenderJSON(w, http.StatusInternalServerError, &AppSyncResult{
 				OK:     false,
@@ -91,24 +84,6 @@ func (c *Controller) HandleSync() http.Handler {
 		}
 		c.h.RenderJSON(w, http.StatusOK, &AppSyncResult{OK: true})
 	})
-}
-
-// shouldSync is used to ensure that only one app sync process runs per AppSyncPeriod duration.
-func (c *Controller) shouldSync(ctx context.Context) (bool, error) {
-	cStat, err := c.db.CreateCleanup(appSyncLock)
-	if err != nil {
-		return false, fmt.Errorf("failed to create appsync lock: %w", err)
-	}
-
-	if cStat.NotBefore.After(time.Now().UTC()) {
-		return false, nil
-	}
-
-	// Attempt to advance the generation.
-	if _, err = c.db.ClaimCleanup(cStat, c.config.AppSyncMinPeriod); err != nil {
-		return false, fmt.Errorf("failed to claim appsync lock: %w", err)
-	}
-	return true, nil
 }
 
 // syncApps looks up the realm and associated list of MobileApps for each entry

--- a/pkg/controller/appsync/appsync_test.go
+++ b/pkg/controller/appsync/appsync_test.go
@@ -40,7 +40,7 @@ func TestShouldSync(t *testing.T) {
 	ctx := project.TestContext(t)
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	config := &config.AppSyncConfig{
-		AppSyncMinimumPeriod: period,
+		AppSyncMinPeriod: period,
 	}
 	c, _ := New(config, db, nil)
 

--- a/pkg/controller/appsync/appsync_test.go
+++ b/pkg/controller/appsync/appsync_test.go
@@ -16,7 +16,6 @@ package appsync
 
 import (
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
@@ -30,39 +29,6 @@ func TestMain(m *testing.M) {
 	testDatabaseInstance = database.MustTestInstance()
 	defer testDatabaseInstance.MustClose()
 	m.Run()
-}
-
-func TestShouldSync(t *testing.T) {
-	t.Parallel()
-
-	period := 1 * time.Second
-
-	ctx := project.TestContext(t)
-	db, _ := testDatabaseInstance.NewDatabase(t, nil)
-	config := &config.AppSyncConfig{
-		AppSyncMinPeriod: period,
-	}
-	c, _ := New(config, db, nil)
-
-	if ok, err := c.shouldSync(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim app sync lock when available")
-	}
-
-	if ok, err := c.shouldSync(ctx); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatalf("allowed to claim lock when it should not be available")
-	}
-
-	time.Sleep(period)
-
-	if ok, err := c.shouldSync(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim app sync lock when available")
-	}
 }
 
 func TestAppSync(t *testing.T) {

--- a/pkg/controller/appsync/controller.go
+++ b/pkg/controller/appsync/controller.go
@@ -25,7 +25,7 @@ import (
 const (
 	playStoreHost = `play.google.com/store/apps/details`
 
-	appSyncLock = "appsync"
+	appSyncLock = "appSyncLock"
 )
 
 // Controller is a controller for the appsync service.

--- a/pkg/controller/appsync/controller.go
+++ b/pkg/controller/appsync/controller.go
@@ -22,6 +22,12 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
+const (
+	playStoreHost = `play.google.com/store/apps/details`
+
+	appSyncLock = "appsync"
+)
+
 // Controller is a controller for the appsync service.
 type Controller struct {
 	config *config.AppSyncConfig

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -22,6 +22,8 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
+const cleanupName = "cleanup"
+
 // Controller is a controller for the cleanup service.
 type Controller struct {
 	config                 *config.CleanupConfig

--- a/pkg/controller/cleanup/cleanup.go
+++ b/pkg/controller/cleanup/cleanup.go
@@ -22,7 +22,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-const cleanupName = "cleanup"
+const cleanupName = "cleanupLock"
 
 // Controller is a controller for the cleanup service.
 type Controller struct {

--- a/pkg/controller/cleanup/handle_cleanup_test.go
+++ b/pkg/controller/cleanup/handle_cleanup_test.go
@@ -28,40 +28,6 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-func Test_shouldCleanup(t *testing.T) {
-	t.Parallel()
-
-	period := 1 * time.Second
-
-	ctx := project.TestContext(t)
-	db, _ := testDatabaseInstance.NewDatabase(t, nil)
-
-	config := &config.CleanupConfig{
-		CleanupMinPeriod: period,
-	}
-	c := New(config, db, nil, nil)
-
-	if ok, err := c.shouldCleanup(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim lock when available")
-	}
-
-	if ok, err := c.shouldCleanup(ctx); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatalf("allowed to claim lock when it should not be available")
-	}
-
-	time.Sleep(period)
-
-	if ok, err := c.shouldCleanup(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim lock when available")
-	}
-}
-
 func TestHandleCleanup(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controller/cleanup/handle_cleanup_test.go
+++ b/pkg/controller/cleanup/handle_cleanup_test.go
@@ -37,7 +37,7 @@ func Test_shouldCleanup(t *testing.T) {
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 
 	config := &config.CleanupConfig{
-		CleanupPeriod: period,
+		CleanupMinPeriod: period,
 	}
 	c := New(config, db, nil, nil)
 

--- a/pkg/controller/rotation/handle_rotate_test.go
+++ b/pkg/controller/rotation/handle_rotate_test.go
@@ -27,39 +27,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-func Test_shouldRotate(t *testing.T) {
-	t.Parallel()
-
-	ttl := 1 * time.Second
-
-	ctx := project.TestContext(t)
-	db, _ := testDatabaseInstance.NewDatabase(t, nil)
-	config := &config.RotationConfig{
-		MinTTL: ttl,
-	}
-	c := New(config, db, nil, nil)
-
-	if ok, err := c.shouldRotate(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim lock when available")
-	}
-
-	if ok, err := c.shouldRotate(ctx); err != nil {
-		t.Fatal(err)
-	} else if ok {
-		t.Fatalf("allowed to claim lock when it should not be available")
-	}
-
-	time.Sleep(ttl)
-
-	if ok, err := c.shouldRotate(ctx); err != nil {
-		t.Fatal(err)
-	} else if !ok {
-		t.Fatalf("failed to claim lock when available")
-	}
-}
-
 func TestHandleRotate(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/controller/statspuller/handle_pull.go
+++ b/pkg/controller/statspuller/handle_pull.go
@@ -34,7 +34,7 @@ func (c *Controller) HandlePullStats() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		ok, err := c.db.ShouldSync(ctx, statsPullerLock, c.config.StatsPullerMinPeriod)
+		ok, err := c.db.TryLock(ctx, statsPullerLock, c.config.StatsPullerMinPeriod)
 		if err != nil {
 			c.h.RenderJSON(w, http.StatusInternalServerError, &Result{
 				OK:     false,

--- a/pkg/controller/statspuller/handle_pull.go
+++ b/pkg/controller/statspuller/handle_pull.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	statsPullerLock = "stats-puller" 
+	statsPullerLock = "statsPullerLock"
 )
 
 // HandlePullStats pulls key-server statistics.
@@ -43,7 +43,7 @@ func (c *Controller) HandlePullStats() http.Handler {
 			return
 		}
 		if !ok {
-			c.h.RenderJSON(w, http.StatusTooManyRequests, &Result{
+			c.h.RenderJSON(w, http.StatusOK, &Result{
 				OK:     false,
 				Errors: []string{"too early"},
 			})

--- a/pkg/controller/statspuller/handle_pull.go
+++ b/pkg/controller/statspuller/handle_pull.go
@@ -20,15 +20,35 @@ import (
 	"github.com/google/exposure-notifications-server/pkg/logging"
 )
 
+const (
+	statsPullerLock = "statspuller"
+)
+
 // HandlePullStats pulls key-server statistics.
 func (c *Controller) HandlePullStats() http.Handler {
 	type Result struct {
-		OK     bool    `json:"ok"`
-		Errors []error `json:"errors,omitempty"`
+		OK     bool     `json:"ok"`
+		Errors []string `json:"errors,omitempty"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
+
+		ok, err := c.db.ShouldSync(ctx, statsPullerLock, c.config.StatsPullerMinPeriod)
+		if err != nil {
+			c.h.RenderJSON(w, http.StatusInternalServerError, &Result{
+				OK:     false,
+				Errors: []string{err.Error()},
+			})
+			return
+		}
+		if !ok {
+			c.h.RenderJSON(w, http.StatusTooManyRequests, &Result{
+				OK:     false,
+				Errors: []string{"too early"},
+			})
+			return
+		}
 
 		logger := logging.FromContext(ctx).Named("rotation.HandlePullStats")
 		logger.Debug("no-op stats pull") // TODO(whaught): remove this and put in logic

--- a/pkg/controller/statspuller/handle_pull.go
+++ b/pkg/controller/statspuller/handle_pull.go
@@ -21,7 +21,7 @@ import (
 )
 
 const (
-	statsPullerLock = "statspuller"
+	statsPullerLock = "stats-puller" 
 )
 
 // HandlePullStats pulls key-server statistics.

--- a/pkg/database/lock.go
+++ b/pkg/database/lock.go
@@ -37,9 +37,9 @@ type CleanupStatus struct {
 	NotBefore  time.Time
 }
 
-// ShouldSync is used to ensure that only one app sync process runs per AppSyncPeriod duration.
-func (db *Database) ShouldSync(ctx context.Context, lockName string, lockDuration time.Duration) (bool, error) {
-	cStat, err := db.CreateCleanup(lockName)
+// TryLock is used to ensure that only one app sync process runs per AppSyncPeriod duration.
+func (db *Database) TryLock(ctx context.Context, lockName string, lockDuration time.Duration) (bool, error) {
+	cStat, err := db.CreateLock(lockName)
 	if err != nil {
 		return false, fmt.Errorf("failed to create %s lock: %w", lockName, err)
 	}
@@ -49,14 +49,14 @@ func (db *Database) ShouldSync(ctx context.Context, lockName string, lockDuratio
 	}
 
 	// Attempt to advance the generation.
-	if _, err = db.ClaimCleanup(cStat, lockDuration); err != nil {
+	if _, err = db.ClaimLock(cStat, lockDuration); err != nil {
 		return false, fmt.Errorf("failed to claim %s lock: %w", lockName, err)
 	}
 	return true, nil
 }
 
-// CreateCleanup is used to create a new 'cleanup' type/row in the database.
-func (db *Database) CreateCleanup(cType string) (*CleanupStatus, error) {
+// CreateLock is used to create a new 'cleanup' type/row in the database.
+func (db *Database) CreateLock(cType string) (*CleanupStatus, error) {
 	var cstat CleanupStatus
 
 	sql := `INSERT INTO cleanup_statuses (type, generation, not_before)
@@ -73,8 +73,8 @@ func (db *Database) CreateCleanup(cType string) (*CleanupStatus, error) {
 	return &cstat, nil
 }
 
-// FindCleanupStatus looks up the current cleanup state in the database by cleanup type.
-func (db *Database) FindCleanupStatus(cType string) (*CleanupStatus, error) {
+// FindLockStatus looks up the current cleanup state in the database by cleanup type.
+func (db *Database) FindLockStatus(cType string) (*CleanupStatus, error) {
 	var cstat CleanupStatus
 	if err := db.db.Where("type = ?", cType).First(&cstat).Error; err != nil {
 		return nil, err
@@ -82,9 +82,9 @@ func (db *Database) FindCleanupStatus(cType string) (*CleanupStatus, error) {
 	return &cstat, nil
 }
 
-// ClaimCleanup attempts to obtain a lock for the specified `lockTime` so that
+// ClaimLock attempts to obtain a lock for the specified `lockTime` so that
 // that type of cleanup can be performed exclusively by the owner.
-func (db *Database) ClaimCleanup(current *CleanupStatus, lockTime time.Duration) (*CleanupStatus, error) {
+func (db *Database) ClaimLock(current *CleanupStatus, lockTime time.Duration) (*CleanupStatus, error) {
 	var cstat CleanupStatus
 	if err := db.db.Transaction(func(tx *gorm.DB) error {
 		if err := tx.

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -90,7 +90,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			},
 		},
 		{
-			ID: "00005-CreateCleanups",
+			ID: "00005-CreateLocks",
 			Migrate: func(tx *gorm.DB) error {
 				if err := tx.AutoMigrate(&CleanupStatus{}).Error; err != nil {
 					return err


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1512

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds the db lock to the stats-puller service
* Shares the `SyncFoo` function each of these has defined
* Renames `Cleanup` to `Lock` except for CleanupStatus - that's in the db schema

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add locking to stats-puller service. Refactor cleanup -> lock
```
