### PR TITLE
Put migration name back

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -90,7 +90,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			},
 		},
 		{
-			ID: "00005-CreateLocks",
+			ID: "00005-CreateCleanups",
 			Migrate: func(tx *gorm.DB) error {
 				if err := tx.AutoMigrate(&CleanupStatus{}).Error; err != nil {
 					return err


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This was a find/replace mistake in https://github.com/google/exposure-notifications-verification-server/pull/1608. We don't want to change already-run migration IDs
