### PR TITLE
Make sure return results are []string

### DIFF
--- a/internal/project/errors.go
+++ b/internal/project/errors.go
@@ -1,0 +1,27 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+// ErrorsToStrings converts a list of errors to a list of strings of those
+// error's Error() value, excluding any nil errors.
+func ErrorsToStrings(errs []error) []string {
+	out := make([]string, 0, len(errs))
+	for _, err := range errs {
+		if err != nil {
+			out = append(out, err.Error())
+		}
+	}
+	return out
+}

--- a/pkg/controller/rotation/handle_rotate.go
+++ b/pkg/controller/rotation/handle_rotate.go
@@ -20,6 +20,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"github.com/hashicorp/go-multierror"
 	"go.opencensus.io/stats"
@@ -29,8 +30,8 @@ import (
 // HandleRotate handles key rotation.
 func (c *Controller) HandleRotate() http.Handler {
 	type Result struct {
-		OK     bool    `json:"ok"`
-		Errors []error `json:"errors,omitempty"`
+		OK     bool     `json:"ok"`
+		Errors []string `json:"errors,omitempty"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -45,7 +46,7 @@ func (c *Controller) HandleRotate() http.Handler {
 			logger.Errorw("failed to run shouldRotate", "error", err)
 			c.h.RenderJSON(w, http.StatusInternalServerError, &Result{
 				OK:     false,
-				Errors: []error{err},
+				Errors: []string{err.Error()},
 			})
 			return
 		}
@@ -53,7 +54,7 @@ func (c *Controller) HandleRotate() http.Handler {
 			stats.RecordWithTags(ctx, []tag.Mutator{observability.ResultNotOK()}, mClaimRequests.M(1))
 			c.h.RenderJSON(w, http.StatusOK, &Result{
 				OK:     false,
-				Errors: []error{fmt.Errorf("too early")},
+				Errors: []string{"too early"},
 			})
 			return
 		}
@@ -94,7 +95,7 @@ func (c *Controller) HandleRotate() http.Handler {
 				logger.Errorw("failed to rotate", "errors", errs)
 				c.h.RenderJSON(w, http.StatusInternalServerError, &Result{
 					OK:     false,
-					Errors: errs,
+					Errors: project.ErrorsToStrings(errs),
 				})
 				return
 			}


### PR DESCRIPTION
[]error does not actually marshal and you end up with an empty array
with no errors

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

/assign @whaught 