### PR TITLE
Cleanup old key-server stats

### DIFF
--- a/cmd/server/assets/realmadmin/_form_general.html
+++ b/cmd/server/assets/realmadmin/_form_general.html
@@ -56,6 +56,8 @@
     </small>
   </div>
 
+  {{/*TODO(whaught): knock this out at v0.21.0*/}}
+  {{if .devMode}}
   <hr>
   <div class="form-group">
     <div class="form-check">
@@ -65,7 +67,7 @@
         Enable key-server statistics
         <small class="form-text text-muted mb-3">
           Checking this box will allow this realm to collect statistics from the key-server about codes
-          that this realm has issued.
+          that this realm has issued. This may need to be disclosed your applications privacy policy.
         </small>
       </label>
     </div>
@@ -90,6 +92,8 @@
       The key-server audience. This overrides the default value of the server and should be left empty to use the default.
     </small>
   </div>
+  {{end}}
+
 
   <div class="mt-4">
     <input type="submit" class="btn btn-primary btn-block" value="Update general settings" />

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -46,14 +46,13 @@ type CleanupConfig struct {
 	AuditEntryMaxAge    time.Duration `env:"AUDIT_ENTRY_MAX_AGE, default=720h"`
 	AuthorizedAppMaxAge time.Duration `env:"AUTHORIZED_APP_MAX_AGE, default=336h"`
 	CleanupMinPeriod    time.Duration `env:"CLEANUP_MIN_PERIOD, default=15m"`
-	MobileAppMaxAge     time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
+	// KeyServerStatsMaxAge is the maximum amount of time to retain key-server stats.
+	KeyServerStatsMaxAge time.Duration `env:"KEY_SERVER_STATS_MAX_AGE, default=720h"`
+	MobileAppMaxAge      time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
 
 	// SigningTokenKeyMaxAge is the maximum amount of time that a rotated signing
 	// token key should remain unpurged.
 	SigningTokenKeyMaxAge time.Duration `env:"SIGNING_TOKEN_KEY_MAX_AGE, default=36h"`
-
-	// KeyServerStatsMaxAge is the maximum amount of time to retain key-server stats.
-	KeyServerStatsMaxAge time.Duration `env:"SIGNING_TOKEN_KEY_MAX_AGE, default=720h"`
 
 	UserPurgeMaxAge time.Duration `env:"USER_PURGE_MAX_AGE, default=720h"`
 	// VerificationCodeMaxAge is the period in which the full code should be available.

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -52,6 +52,9 @@ type CleanupConfig struct {
 	// token key should remain unpurged.
 	SigningTokenKeyMaxAge time.Duration `env:"SIGNING_TOKEN_KEY_MAX_AGE, default=36h"`
 
+	// KeyServerStatsMaxAge is the maximum amount of time to retain key-server stats.
+	KeyServerStatsMaxAge time.Duration `env:"SIGNING_TOKEN_KEY_MAX_AGE, default=720h"`
+
 	UserPurgeMaxAge time.Duration `env:"USER_PURGE_MAX_AGE, default=720h"`
 	// VerificationCodeMaxAge is the period in which the full code should be available.
 	// After this time it will be recycled. The code will be zeroed out, but its status persist.

--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -168,6 +168,19 @@ func (c *Controller) HandleCleanup() http.Handler {
 			}
 		}()
 
+		// Key server stats
+		func() {
+			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "KEY_SERVER_STATS")
+			if count, err := c.db.DeleteOldKeyServerStatsDays(c.config.KeyServerStatsMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge key-server stats: %w", err))
+				result = observability.ResultError("FAILED")
+			} else {
+				logger.Infow("purged key-server stats", "count", count)
+				result = observability.ResultOK()
+			}
+		}()
+
 		// If there are any errors, return them
 		if merr != nil {
 			if errs := merr.WrappedErrors(); len(errs) > 0 {

--- a/pkg/controller/middleware/template.go
+++ b/pkg/controller/middleware/template.go
@@ -38,6 +38,7 @@ func PopulateTemplateVariables(config *config.ServerConfig) mux.MiddlewareFunc {
 			m["buildID"] = buildinfo.BuildID
 			m["buildTag"] = buildinfo.BuildTag
 			m["maintenanceMode"] = config.MaintenanceMode
+			m["devMode"] = config.DevMode
 
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -21,8 +21,6 @@ import (
 	"github.com/lib/pq"
 )
 
-const thirtyDays = 30 * 24 * time.Hour
-
 // KeyServerStats represents statistics for a key-server for this realm
 type KeyServerStats struct {
 	Errorable

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -21,6 +21,8 @@ import (
 	"github.com/lib/pq"
 )
 
+const thirtyDays = 30 * 24 * time.Hour
+
 // KeyServerStats represents statistics for a key-server for this realm
 type KeyServerStats struct {
 	Errorable
@@ -114,11 +116,10 @@ func (db *Database) DeleteKeyServerStats(realmID uint) error {
 
 // ListKeyServerStatsDays retrieves the last 30 days of key-server statistics
 func (db *Database) ListKeyServerStatsDays(realmID uint, day time.Time) ([]*KeyServerStatsDay, error) {
-	thirtyDaysAgo := time.Now().Add(-30 * 24 * time.Hour)
 	var stats []*KeyServerStatsDay
 	if err := db.db.
 		Model(&KeyServerStatsDay{}).
-		Where("realm_id = ? AND day >= ?", realmID, thirtyDaysAgo).
+		Where("realm_id = ?", realmID).
 		Order("day DESC").
 		Limit(30).
 		Find(&stats).
@@ -131,4 +132,12 @@ func (db *Database) ListKeyServerStatsDays(realmID uint, day time.Time) ([]*KeyS
 // SaveKeyServerStatsDay stores a single day of key-server statistics
 func (db *Database) SaveKeyServerStatsDay(day *KeyServerStatsDay) error {
 	return db.db.Debug().Save(day).Error
+}
+
+// DeleteOldKeyServerStatsDays deletes rows from KeyServerStatsDays that are older than 30 days
+func (db *Database) DeleteOldKeyServerStatsDays(maxAge time.Duration) (int64, error) {
+	rtn := db.db.Unscoped().
+		Where("day < ?", maxAge).
+		Delete(&KeyServerStatsDay{})
+	return rtn.RowsAffected, rtn.Error
 }

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -134,8 +134,9 @@ func (db *Database) SaveKeyServerStatsDay(day *KeyServerStatsDay) error {
 
 // DeleteOldKeyServerStatsDays deletes rows from KeyServerStatsDays that are older than 30 days
 func (db *Database) DeleteOldKeyServerStatsDays(maxAge time.Duration) (int64, error) {
+	a := time.Now().Add(-maxAge)
 	rtn := db.db.Unscoped().
-		Where("day < ?", maxAge).
+		Where("day < ?", a).
 		Delete(&KeyServerStatsDay{})
 	return rtn.RowsAffected, rtn.Error
 }

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -134,7 +134,7 @@ func (db *Database) SaveKeyServerStatsDay(day *KeyServerStatsDay) error {
 
 // DeleteOldKeyServerStatsDays deletes rows from KeyServerStatsDays that are older than 30 days
 func (db *Database) DeleteOldKeyServerStatsDays(maxAge time.Duration) (int64, error) {
-	a := time.Now().Add(-maxAge)
+	a := time.Now().UTC().Add(-maxAge)
 	rtn := db.db.Unscoped().
 		Where("day < ?", a).
 		Delete(&KeyServerStatsDay{})

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -87,4 +87,30 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 	if got, want := stats[0].TEKAgeDistribution[4], int64(5); got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
 	}
+
+	err = db.SaveKeyServerStatsDay(&KeyServerStatsDay{
+		RealmID:            realm.ID,
+		Day:                now.Add(-50 * 24 * time.Hour),
+		TotalTEKsPublished: 50,
+		TEKAgeDistribution: []int64{1, 2, 3, 4, 5},
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	stats, err = db.ListKeyServerStatsDays(realm.ID, now)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(stats) > 1 {
+		t.Error("stats older than 30 days should not be retrieved")
+	}
+
+	rows, err := db.DeleteOldKeyServerStatsDays()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if rows != 1 {
+		t.Errorf("expected purged row, got %d", rows)
+	}
 }

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -19,6 +19,8 @@ import (
 	"time"
 )
 
+const thirtyDays = 30 * 24 * time.Hour
+
 func TestSaveKeyServerStats(t *testing.T) {
 	t.Parallel()
 
@@ -106,7 +108,7 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 		t.Error("stats older than 30 days should not be retrieved")
 	}
 
-	rows, err := db.DeleteOldKeyServerStatsDays()
+	rows, err := db.DeleteOldKeyServerStatsDays(thirtyDays)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -104,8 +104,8 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(stats) > 1 {
-		t.Error("stats older than 30 days should not be retrieved")
+	if got, want := len(stats), 2; got != want {
+		t.Errorf("incorrect number of stats. got %d, want %d", got, want)
 	}
 
 	rows, err := db.DeleteOldKeyServerStatsDays(thirtyDays)


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1512

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Deletes old stats if > 30 days old
* Hide UI unless dev-mode. We can remove that later once finished.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Cleanup for key-server stats
```
