### PR TITLE
Clean up nits from verification certification rotation

### DIFF
--- a/cmd/server/assets/realmadmin/keys.html
+++ b/cmd/server/assets/realmadmin/keys.html
@@ -91,6 +91,8 @@
       View or edit the verification certificate signing keys for <strong>{{$realm.Name}}</strong> below.
     </p>
 
+    {{template "errorSummary" $realm}}
+
     {{if not $realm.UseRealmCertificateKey}}
       {{template "systemkeys" .}}
     {{end}}
@@ -216,24 +218,24 @@
         <div class="card-body">
           {{if $realm.AutoRotateCertificateKey}}
             <div class="alert alert-warning">
-              <p>This realm is automatically rotating verification certificate signing keys. If 
+              <p>This realm is automatically rotating verification certificate signing keys. If
                 desired, you can
                 <a href="/realm/keys/manual" data-method="POST"
                   data-confirm="Are you sure you want revert to manual key rotation?">revert to manual key rotation.</a>
               </p>
-            </div>  
+            </div>
 
           {{else}}
             <div class="alert alert-info">
               <p><strong>Enable automatic key rotation</strong>.
               It is possible to have the system automatically rotate your verification certificate signing key.
               This is highly recommended, but requires that your key server is configured using the JWKS public key
-              discover doc. 
+              discover doc.
               <a href="/realm/keys/automatic" data-method="POST"
                 data-confirm="Are you sure you want to enable automatic key rotation?
 
 Have you had your key server operator configure public key import through the JWKS public key discovery document?
-                
+
 Failure to do so in advance will prevent your application users from sharing temporary exposure keys.">
                 Enable automatic verification certificate key rotation.</a>
               </p>

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -1,0 +1,230 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realmkeys_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandleAutomaticRotate(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ServerConfig{}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleAutomaticRotate()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+		envstest.ExercisePermissionMissing(t, handler)
+	})
+
+	t.Run("not_realm_specific_keys", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleAutomaticRotate()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm: &database.Realm{
+				CertificateIssuer:      "iss",
+				CertificateAudience:    "aud",
+				UseRealmCertificateKey: false,
+			},
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 422; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "must upgrade to realm-specific signing keys"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	})
+
+	t.Run("already_enabled", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleAutomaticRotate()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm: &database.Realm{
+				CertificateIssuer:        "iss",
+				CertificateAudience:      "aud",
+				UseRealmCertificateKey:   true,
+				AutoRotateCertificateKey: true,
+			},
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 422; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "is already enabled"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	})
+
+	t.Run("internal_error", func(t *testing.T) {
+		t.Parallel()
+
+		harness := envstest.NewServerConfig(t, testDatabaseInstance)
+		harness.Database.SetRawDB(envstest.NewFailingDatabase())
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleAutomaticRotate()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm: &database.Realm{
+				CertificateIssuer:        "iss",
+				CertificateAudience:      "aud",
+				UseRealmCertificateKey:   true,
+				AutoRotateCertificateKey: false,
+			},
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 500; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	})
+
+	t.Run("enables", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleAutomaticRotate()
+
+		realm := database.NewRealmWithDefaults("test")
+		realm.CertificateIssuer = "iss"
+		realm.CertificateAudience = "aud"
+		realm.UseRealmCertificateKey = true
+		realm.AutoRotateCertificateKey = false
+		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 303; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+
+		updatedRealm, err := harness.Database.FindRealm(realm.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := updatedRealm.AutoRotateCertificateKey, true; got != want {
+			t.Errorf("expected %t to be %t", got, want)
+		}
+	})
+}

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -1,0 +1,183 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realmkeys_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandleManualRotate(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ServerConfig{}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleManualRotate()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+		envstest.ExercisePermissionMissing(t, handler)
+	})
+
+	t.Run("not_enabled", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleManualRotate()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm: &database.Realm{
+				AutoRotateCertificateKey: false,
+			},
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 422; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "Already in manual key rotation mode"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	})
+
+	t.Run("internal_error", func(t *testing.T) {
+		t.Parallel()
+
+		harness := envstest.NewServerConfig(t, testDatabaseInstance)
+		harness.Database.SetRawDB(envstest.NewFailingDatabase())
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleManualRotate()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm: &database.Realm{
+				AutoRotateCertificateKey: true,
+			},
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 500; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
+			t.Errorf("expected %q to contain %q", got, want)
+		}
+	})
+
+	t.Run("enables", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleManualRotate()
+
+		realm := database.NewRealmWithDefaults("test")
+		realm.AutoRotateCertificateKey = true
+		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 303; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+
+		updatedRealm, err := harness.Database.FindRealm(realm.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := updatedRealm.AutoRotateCertificateKey, false; got != want {
+			t.Errorf("expected %t to be %t", got, want)
+		}
+	})
+}

--- a/pkg/controller/realmkeys/realmkeys_test.go
+++ b/pkg/controller/realmkeys/realmkeys_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realmkeys_test
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var testDatabaseInstance *database.TestInstance
+
+func TestMain(m *testing.M) {
+	testDatabaseInstance = database.MustTestInstance()
+	defer testDatabaseInstance.MustClose()
+	m.Run()
+}

--- a/pkg/controller/rotation/handle_verification_rotate.go
+++ b/pkg/controller/rotation/handle_verification_rotate.go
@@ -23,6 +23,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -65,7 +66,7 @@ func (c *Controller) HandleVerificationRotate() http.Handler {
 
 		var merr *multierror.Error
 
-		realms, err := c.db.ListRealmsWithAutoKeyRotation()
+		realms, _, err := c.db.ListRealms(pagination.UnlimitedResults, database.WithRealmAutoKeyRotationEnabled(true))
 		if err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("unable to list realms to rotate signing keys: %w", err))
 		}

--- a/pkg/controller/rotation/handle_verification_rotate_test.go
+++ b/pkg/controller/rotation/handle_verification_rotate_test.go
@@ -28,16 +28,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-type testUser struct{}
-
-func (t *testUser) AuditID() string {
-	return "1"
-}
-
-func (t *testUser) AuditDisplay() string {
-	return "system"
-}
-
 func TestHandleVerificationRotation(t *testing.T) {
 	t.Parallel()
 
@@ -51,7 +41,7 @@ func TestHandleVerificationRotation(t *testing.T) {
 	realm.CertificateIssuer = "iss"
 	realm.CertificateAudience = "aud"
 	realm.CertificateDuration = database.FromDuration(time.Second)
-	if err := db.SaveRealm(realm, &testUser{}); err != nil {
+	if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -23,6 +23,7 @@ import (
 	"io/ioutil"
 	"log"
 	"os"
+	"path/filepath"
 	"strconv"
 	"strings"
 	"sync"
@@ -31,6 +32,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-server/pkg/secrets"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
@@ -189,6 +191,9 @@ func NewTestInstance() (*TestInstance, error) {
 		Keys: keys.Config{
 			KeyManagerType: keys.KeyManagerTypeFilesystem,
 		},
+
+		CertificateSigningKeyRing:        filepath.Join(project.Root(), "local", "test", "certificates"),
+		MaxCertificateSigningKeyVersions: 5,
 	}
 
 	// Parse configuration and override with test data.
@@ -277,8 +282,6 @@ func (i *TestInstance) NewDatabase(tb testing.TB, cacher cache.Cacher) (*Databas
 		tb.Fatalf("failed to load database configuration: %s", err)
 	}
 	db.keyManager = keys.TestKeyManager(tb)
-	db.config.CertificateSigningKeyRing = "certificates"
-	db.config.MaxCertificateSigningKeyVersions = 5
 	db.config.EncryptionKey = keys.TestEncryptionKey(tb, db.keyManager)
 
 	// Try to establish a connection to the database.

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -970,18 +970,6 @@ func (db *Database) FindRealmByRegionOrID(val string) (*Realm, error) {
 	return db.FindRealmByRegion(val)
 }
 
-// ListRealmsWithAutoKeyRotation returns all realms that have automatic key rotation enabled.
-func (db *Database) ListRealmsWithAutoKeyRotation() ([]*Realm, error) {
-	var realms []*Realm
-	if err := db.db.
-		Model(&Realm{}).
-		Where("auto_rotate_certificate_key = ?", true).
-		Find(&realms).Error; err != nil {
-		return nil, fmt.Errorf("list auto rotate realms: %w", err)
-	}
-	return realms, nil
-}
-
 // ListRealms lists all available realms in the system.
 func (db *Database) ListRealms(p *pagination.PageParams, scopes ...Scope) ([]*Realm, *pagination.Paginator, error) {
 	var realms []*Realm

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -178,6 +178,14 @@ func WithRealmSearch(q string) Scope {
 	}
 }
 
+// WithRealmAutoKeyRotationEnabled filters by realms which have the auto key
+// rotation enabled/disabled depending on the boolean.
+func WithRealmAutoKeyRotationEnabled(b bool) Scope {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Where("auto_rotate_certificate_key = ?", b)
+	}
+}
+
 // WithoutAuditTest excludes audit entries related to test entries created from
 // SystemTest.
 func WithoutAuditTest() Scope {

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -50,10 +50,10 @@ type PageParams struct {
 }
 
 // UnlimitedResults is a paginator that doesn't do pagination and returns all
-// results (up to (1<<64)-1).
+// results (up to (1<<63)-1).
 var UnlimitedResults = &PageParams{
 	Page:  1,
-	Limit: math.MaxUint64,
+	Limit: math.MaxInt64,
 }
 
 // FromRequest builds the PageParams from an http.Request. If there are no

--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -17,6 +17,7 @@ package pagination
 
 import (
 	"fmt"
+	"math"
 	"net/http"
 	"net/url"
 	"strconv"
@@ -46,6 +47,13 @@ type PageParams struct {
 
 	// Limit is the per-page limit.
 	Limit uint64
+}
+
+// UnlimitedResults is a paginator that doesn't do pagination and returns all
+// results (up to (1<<64)-1).
+var UnlimitedResults = &PageParams{
+	Page:  1,
+	Limit: math.MaxUint64,
 }
 
 // FromRequest builds the PageParams from an http.Request. If there are no

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -237,8 +237,10 @@ resource "google_cloud_scheduler_job" "rotation-worker" {
 }
 
 resource "google_cloud_scheduler_job" "realm-key-rotation-worker" {
-  name             = "realm-key-rotation-worker"
-  region           = var.cloudscheduler_location
+  name   = "realm-key-rotation-worker"
+  region = var.cloudscheduler_location
+
+  // This schedule is offset from the token rotation schedule.
   schedule         = "2,32 * * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"


### PR DESCRIPTION
A few cleanup items from https://github.com/google/exposure-notifications-verification-server/pull/1614:

- Return proper response codes when enabling/disabling fails
- Add tests for manual/automatic rotation
- Move ListRealmsWithAutoKeyRotation() into a scope on ListRealms
- Add `pagination.UnlimitedResults`
- Remove testUser for auditing (use SystemTest instead)
- Add comment on why Cloud Scheduler schedule is weird

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Clean up nits from verification certification rotation
```
