### PR TITLE
Fix nits from signing key cleanup

### DIFF
--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -174,10 +174,10 @@ func (c *Controller) HandleCleanup() http.Handler {
 			defer observability.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_SIGNING_KEY")
 			if count, err := c.db.PurgeSigningKeys(c.config.VerificationSigningKeyMaxAge); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("failed to purge token signing keys: %w", err))
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge verification signing keys: %w", err))
 				result = observability.ResultError("FAILED")
 			} else {
-				logger.Infow("purged token signing keys", "count", count)
+				logger.Infow("purged verification signing keys", "count", count)
 				result = observability.ResultOK()
 			}
 		}()

--- a/pkg/database/signing_key.go
+++ b/pkg/database/signing_key.go
@@ -46,9 +46,9 @@ func (db *Database) PurgeSigningKeys(maxAge time.Duration) (int64, error) {
 		maxAge = -1 * maxAge
 	}
 	deleteBefore := time.Now().UTC().Add(maxAge)
-	// Delete users who were created/updated before the expiry time.
-	rtn := db.db.Unscoped().
-		Where("deleted_at < ?", deleteBefore).
+
+	result := db.db.Unscoped().
+		Where("deleted_at IS NOT NULL AND deleted_at < ?", deleteBefore).
 		Delete(&SigningKey{})
-	return rtn.RowsAffected, rtn.Error
+	return result.RowsAffected, result.Error
 }


### PR DESCRIPTION
Cleanup nits from https://github.com/google/exposure-notifications-verification-server/pull/1616

- Fix error and log output
- Exclude NULL from deleted_at search

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix nits from signing key cleanup
```
