### PR TITLE
legacy signing fixes

### DIFF
--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -28,11 +28,6 @@ type TokenSigningConfig struct {
 	// configuration.
 	Keys keys.Config `env:", prefix=TOKEN_"`
 
-	// AllowLegacyTokenSigning allows for temporarily allowing the legacy configuration to
-	// work as it did pre v 0.20.
-	// TODO(mikehelmick|sethvargo): Remove in v0.21
-	AllowLegacyTokenSigning bool `env:"ALLOW_LEGACY_TOKEN_SIGNING, default=true"`
-
 	// TokenSigningKeys is the parent token signing key (not the actual signing
 	// version). It is an array for backwards-compatibility, but in practice it
 	// should only have one element.

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -28,6 +28,11 @@ type TokenSigningConfig struct {
 	// configuration.
 	Keys keys.Config `env:", prefix=TOKEN_"`
 
+	// AllowLegacyTokenSigning allows for temporarily allowing the legacy configuration to
+	// work as it did pre v 0.20.
+	// TODO(mikehelmick|sethvargo): Remove in v0.21
+	AllowLegacyTokenSigning bool `env:"ALLOW_LEGACY_TOKEN_SIGNING, default=true"`
+
 	// TokenSigningKeys is the parent token signing key (not the actual signing
 	// version). It is an array for backwards-compatibility, but in practice it
 	// should only have one element.

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -95,8 +95,9 @@ func (c *Controller) validateToken(ctx context.Context, verToken string) (string
 					return nil, fmt.Errorf("no key corresponds to kid %q", kid)
 				}
 				tokenSigningKey = &database.TokenSigningKey{KeyVersionID: keyID}
+			} else {
+				return nil, fmt.Errorf("failed to lookup token signing key: %w", err)
 			}
-			return nil, fmt.Errorf("failed to lookup token signing key: %w", err)
 		}
 
 		publicKey, err := c.pubKeyCache.GetPublicKey(ctx, tokenSigningKey.KeyVersionID, c.kms)

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -73,6 +73,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		// TODO(mikehelmick|sethvargo) - remove the fallback code after
 		legacySigningOK := c.config.TokenSigning.AllowLegacyTokenSigning
 		legacyKey := c.config.TokenSigning.TokenSigningKeys[0]
+		// lint:ignore SA1019 - will removed in next release.
 		legacyKID := c.config.TokenSigning.TokenSigningKeyIDs[0]
 
 		// Get the currently active key.

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -73,7 +73,7 @@ func (c *Controller) HandleVerify() http.Handler {
 		// TODO(mikehelmick|sethvargo) - remove the fallback code after
 		legacySigningOK := c.config.TokenSigning.AllowLegacyTokenSigning
 		legacyKey := c.config.TokenSigning.TokenSigningKeys[0]
-		// lint:ignore SA1019 - will removed in next release.
+		//lint:ignore SA1019 will removed in next release.
 		legacyKID := c.config.TokenSigning.TokenSigningKeyIDs[0]
 
 		// Get the currently active key.

--- a/tools/get-certificate/main.go
+++ b/tools/get-certificate/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
@@ -41,6 +42,9 @@ func main() {
 
 	ctx, done := signalcontext.OnInterrupt()
 
+	if os.Getenv("LOG_LEVEL") == "" {
+		os.Setenv("LOG_LEVEL", "DEBUG")
+	}
 	logger := logging.NewLoggerFromEnv().Named("get-certificate")
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/tools/get-code/main.go
+++ b/tools/get-code/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
@@ -43,6 +44,9 @@ func main() {
 
 	ctx, done := signalcontext.OnInterrupt()
 
+	if os.Getenv("LOG_LEVEL") == "" {
+		os.Setenv("LOG_LEVEL", "DEBUG")
+	}
 	logger := logging.NewLoggerFromEnv().Named("get-code")
 	ctx = logging.WithLogger(ctx, logger)
 

--- a/tools/get-token/main.go
+++ b/tools/get-token/main.go
@@ -18,6 +18,7 @@ package main
 import (
 	"context"
 	"flag"
+	"os"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/clients"
@@ -40,6 +41,9 @@ func main() {
 
 	ctx, done := signalcontext.OnInterrupt()
 
+	if os.Getenv("LOG_LEVEL") == "" {
+		os.Setenv("LOG_LEVEL", "DEBUG")
+	}
 	logger := logging.NewLoggerFromEnv().Named("get-token")
 	ctx = logging.WithLogger(ctx, logger)
 


### PR DESCRIPTION
Fixes #1623

## Proposed Changes

* allow for tokens to be signed w/ legacy keys until DB one is present
   * can be disabled by flag
   * to be removed in v0.21
* fix bug where a not found on DB backed key lookup returned error instead of validating w/ legacy key
* debug logging by default in some tools - makes life easier

**Release Note**

```release-note
Allow for legacy signing key config for tokens to be used during the upgrade to DB backed tokens.
```
