### PR TITLE
Keep Schedules in PST

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -387,7 +387,7 @@ resource "google_cloud_scheduler_job" "backup-database-worker" {
   name             = "backup-database-worker"
   region           = var.cloudscheduler_location
   schedule         = var.database_backup_schedule
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "1800s"
 
   retry_config {

--- a/terraform/mirror/service.tf
+++ b/terraform/mirror/service.tf
@@ -75,8 +75,8 @@ resource "google_cloud_run_service_iam_member" "docker-mirror-invoker" {
 resource "google_cloud_scheduler_job" "docker-mirror-worker" {
   name             = "docker-mirror-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 18 * * *"
-  time_zone        = "UTC"
+  schedule         = "0 11 * * *"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "900s"
 
   http_target {

--- a/terraform/service-stats-puller.tf
+++ b/terraform/service-stats-puller.tf
@@ -201,7 +201,7 @@ resource "google_cloud_scheduler_job" "stats-puller-worker" {
   name             = "stats-puller-worker"
   region           = var.cloudscheduler_location
   schedule         = "30 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -204,8 +204,8 @@ resource "google_cloud_run_service_iam_member" "appsync-invoker" {
 resource "google_cloud_scheduler_job" "appsync-worker" {
   name             = "appsync-worker"
   region           = var.cloudscheduler_location
-  schedule         = "20 18 * * *"
-  time_zone        = "UTC"
+  schedule         = "20 11 * * *"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -204,7 +204,7 @@ resource "google_cloud_scheduler_job" "cleanup-worker" {
   name             = "cleanup-worker"
   region           = var.cloudscheduler_location
   schedule         = "0 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -205,7 +205,7 @@ resource "google_cloud_scheduler_job" "e2e-default-workflow" {
   name             = "e2e-default-workflow"
   region           = var.cloudscheduler_location
   schedule         = "0,10,20,30,40,50,55 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "30s"
 
   retry_config {
@@ -232,7 +232,7 @@ resource "google_cloud_scheduler_job" "e2e-revise-workflow" {
   name             = "e2e-revise-workflow"
   region           = var.cloudscheduler_location
   schedule         = "0,5,15,25,35,45,55 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "30s"
 
   retry_config {
@@ -259,7 +259,7 @@ resource "google_cloud_scheduler_job" "e2e-enx-redirect-workflow" {
   name             = "e2e-enx-redirect-workflow"
   region           = var.cloudscheduler_location
   schedule         = "0,5,15,25,35,45,55 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "30s"
 
   retry_config {

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -230,8 +230,8 @@ resource "google_cloud_run_service_iam_member" "modeler-invoker" {
 resource "google_cloud_scheduler_job" "modeler-worker" {
   name             = "modeler-worker"
   region           = var.cloudscheduler_location
-  schedule         = "10 18 * * *"
-  time_zone        = "UTC"
+  schedule         = "10 11 * * *"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -213,7 +213,7 @@ resource "google_cloud_scheduler_job" "rotation-worker" {
   name             = "rotation-worker"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {
@@ -240,7 +240,7 @@ resource "google_cloud_scheduler_job" "realm-key-rotation-worker" {
   name             = "realm-key-rotation-worker"
   region           = var.cloudscheduler_location
   schedule         = "2,32 * * * *"
-  time_zone        = "UTC"
+  time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 
   retry_config {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* https://github.com/google/exposure-notifications-verification-server/pull/1622 is not what we want, despite UTC guidances for daylight savings time reasons
* Terraform apparently diffs with UTC badly
