### PR TITLE
Make seed script also verify codes and claim tokens

### DIFF
--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -139,7 +139,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 
 		// Do the transactional update to the database last so that if it fails, the
 		// client can retry.
-		if err := c.db.ClaimToken(authApp, tokenID, subject); err != nil {
+		if err := c.db.ClaimToken(now, authApp, tokenID, subject); err != nil {
 			blame = observability.BlameClient
 			switch {
 			case errors.Is(err, database.ErrTokenExpired):

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -31,6 +31,8 @@ import (
 func TestHandleIssue_IssueCode(t *testing.T) {
 	t.Parallel()
 
+	now := time.Now().UTC()
+
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	realm, user, session, err := harness.ProvisionAndLogin()
@@ -98,7 +100,7 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 
 	// Exchange the code for a verification certificate.
 	allowedTypes := api.AcceptTypes{api.TestTypeConfirmed: struct{}{}}
-	token, err := harness.Database.VerifyCodeAndIssueToken(authApp, code, allowedTypes, 30*time.Minute)
+	token, err := harness.Database.VerifyCodeAndIssueToken(now, authApp, code, allowedTypes, 30*time.Minute)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -140,7 +140,7 @@ func (t *Token) Subject() *Subject {
 
 // ClaimToken looks up the token by ID, verifies that it is not expired and that
 // the specified subject matches the parameters that were configured when issued.
-func (db *Database) ClaimToken(authApp *AuthorizedApp, tokenID string, subject *Subject) error {
+func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID string, subject *Subject) error {
 	if err := db.db.Transaction(func(tx *gorm.DB) error {
 		var tok Token
 		if err := tx.
@@ -192,12 +192,12 @@ func (db *Database) ClaimToken(authApp *AuthorizedApp, tokenID string, subject *
 		return nil
 	}); err != nil {
 		if !errors.Is(err, ErrTokenUsed) {
-			go db.updateStatsTokenInvalid(authApp)
+			go db.updateStatsTokenInvalid(t, authApp)
 		}
 		return err
 	}
 
-	go db.updateStatsTokenClaimed(authApp)
+	go db.updateStatsTokenClaimed(t, authApp)
 	return nil
 }
 
@@ -208,7 +208,7 @@ func (db *Database) ClaimToken(authApp *AuthorizedApp, tokenID string, subject *
 // The verCode can be the "short code" or the "long code" which impacts expiry time.
 //
 // The long term token can be used later to sign keys when they are submitted.
-func (db *Database) VerifyCodeAndIssueToken(authApp *AuthorizedApp, verCode string, acceptTypes api.AcceptTypes, expireAfter time.Duration) (*Token, error) {
+func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp, verCode string, acceptTypes api.AcceptTypes, expireAfter time.Duration) (*Token, error) {
 	hmacedCodes, err := db.generateVerificationCodeHMACs(verCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create hmac: %w", err)
@@ -277,12 +277,12 @@ func (db *Database) VerifyCodeAndIssueToken(authApp *AuthorizedApp, verCode stri
 		return tx.Create(tok).Error
 	}); err != nil {
 		if !errors.Is(err, ErrVerificationCodeUsed) {
-			go db.updateStatsCodeInvalid(authApp)
+			go db.updateStatsCodeInvalid(t, authApp)
 		}
 		return nil, err
 	}
 
-	go db.updateStatsCodeClaimed(authApp)
+	go db.updateStatsCodeClaimed(t, authApp)
 	return tok, nil
 }
 
@@ -312,8 +312,8 @@ func (db *Database) PurgeTokens(maxAge time.Duration) (int64, error) {
 
 // updateStatsCodeInvalid updates the statistics, increasing the number of codes
 // that were invalid.
-func (db *Database) updateStatsCodeInvalid(authApp *AuthorizedApp) {
-	now := timeutils.UTCMidnight(time.Now().UTC())
+func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp) {
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_invalid)
@@ -321,7 +321,7 @@ func (db *Database) updateStatsCodeInvalid(authApp *AuthorizedApp) {
 			ON CONFLICT (date, realm_id) DO UPDATE
 				SET codes_invalid = realm_stats.codes_invalid + 1
 		`
-	if err := db.db.Exec(realmSQL, now, authApp.RealmID).Error; err != nil {
+	if err := db.db.Exec(realmSQL, t, authApp.RealmID).Error; err != nil {
 		db.logger.Errorw("failed to update realm stats", "error", err)
 	}
 
@@ -331,15 +331,15 @@ func (db *Database) updateStatsCodeInvalid(authApp *AuthorizedApp) {
 			ON CONFLICT (date, authorized_app_id) DO UPDATE
 				SET codes_invalid = authorized_app_stats.codes_invalid + 1
 		`
-	if err := db.db.Exec(authAppSQL, now, authApp.ID).Error; err != nil {
+	if err := db.db.Exec(authAppSQL, t, authApp.ID).Error; err != nil {
 		db.logger.Errorw("failed to update authorized app stats", "error", err)
 	}
 }
 
 // updateStatsCodeClaimed updates the statistics, increasing the number of codes
 // claimed.
-func (db *Database) updateStatsCodeClaimed(authApp *AuthorizedApp) {
-	now := timeutils.UTCMidnight(time.Now().UTC())
+func (db *Database) updateStatsCodeClaimed(t time.Time, authApp *AuthorizedApp) {
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_claimed)
@@ -347,7 +347,7 @@ func (db *Database) updateStatsCodeClaimed(authApp *AuthorizedApp) {
 			ON CONFLICT (date, realm_id) DO UPDATE
 				SET codes_claimed = realm_stats.codes_claimed + 1
 		`
-	if err := db.db.Exec(realmSQL, now, authApp.RealmID).Error; err != nil {
+	if err := db.db.Exec(realmSQL, t, authApp.RealmID).Error; err != nil {
 		db.logger.Errorw("failed to update realm stats", "error", err)
 	}
 
@@ -357,15 +357,15 @@ func (db *Database) updateStatsCodeClaimed(authApp *AuthorizedApp) {
 			ON CONFLICT (date, authorized_app_id) DO UPDATE
 				SET codes_claimed = authorized_app_stats.codes_claimed + 1
 		`
-	if err := db.db.Exec(authAppSQL, now, authApp.ID).Error; err != nil {
+	if err := db.db.Exec(authAppSQL, t, authApp.ID).Error; err != nil {
 		db.logger.Errorw("failed to update authorized app stats", "error", err)
 	}
 }
 
 // updateStatsTokenInvalid updates the statistics, increasing the number of
 // tokens that were invalid.
-func (db *Database) updateStatsTokenInvalid(authApp *AuthorizedApp) {
-	now := timeutils.UTCMidnight(time.Now().UTC())
+func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp) {
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_invalid)
@@ -373,7 +373,7 @@ func (db *Database) updateStatsTokenInvalid(authApp *AuthorizedApp) {
 			ON CONFLICT (date, realm_id) DO UPDATE
 				SET tokens_invalid = realm_stats.tokens_invalid + 1
 		`
-	if err := db.db.Exec(realmSQL, now, authApp.RealmID).Error; err != nil {
+	if err := db.db.Exec(realmSQL, t, authApp.RealmID).Error; err != nil {
 		db.logger.Errorw("failed to update realm stats", "error", err)
 	}
 
@@ -383,15 +383,15 @@ func (db *Database) updateStatsTokenInvalid(authApp *AuthorizedApp) {
 			ON CONFLICT (date, authorized_app_id) DO UPDATE
 				SET tokens_invalid = authorized_app_stats.tokens_invalid + 1
 		`
-	if err := db.db.Exec(authAppSQL, now, authApp.ID).Error; err != nil {
+	if err := db.db.Exec(authAppSQL, t, authApp.ID).Error; err != nil {
 		db.logger.Errorw("failed to update authorized app stats", "error", err)
 	}
 }
 
 // updateStatsTokenClaimed updates the statistics, increasing the number of
 // tokens claimed.
-func (db *Database) updateStatsTokenClaimed(authApp *AuthorizedApp) {
-	now := timeutils.UTCMidnight(time.Now().UTC())
+func (db *Database) updateStatsTokenClaimed(t time.Time, authApp *AuthorizedApp) {
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_claimed)
@@ -399,7 +399,7 @@ func (db *Database) updateStatsTokenClaimed(authApp *AuthorizedApp) {
 			ON CONFLICT (date, realm_id) DO UPDATE
 				SET tokens_claimed = realm_stats.tokens_claimed + 1
 		`
-	if err := db.db.Exec(realmSQL, now, authApp.RealmID).Error; err != nil {
+	if err := db.db.Exec(realmSQL, t, authApp.RealmID).Error; err != nil {
 		db.logger.Errorw("failed to update realm stats", "error", err)
 	}
 
@@ -409,7 +409,7 @@ func (db *Database) updateStatsTokenClaimed(authApp *AuthorizedApp) {
 			ON CONFLICT (date, authorized_app_id) DO UPDATE
 				SET tokens_claimed = authorized_app_stats.tokens_claimed + 1
 		`
-	if err := db.db.Exec(authAppSQL, now, authApp.ID).Error; err != nil {
+	if err := db.db.Exec(authAppSQL, t, authApp.ID).Error; err != nil {
 		db.logger.Errorw("failed to update authorized app stats", "error", err)
 	}
 }

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -141,6 +141,8 @@ func (t *Token) Subject() *Subject {
 // ClaimToken looks up the token by ID, verifies that it is not expired and that
 // the specified subject matches the parameters that were configured when issued.
 func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID string, subject *Subject) error {
+	t = t.UTC()
+
 	if err := db.db.Transaction(func(tx *gorm.DB) error {
 		var tok Token
 		if err := tx.
@@ -209,6 +211,8 @@ func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID stri
 //
 // The long term token can be used later to sign keys when they are submitted.
 func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp, verCode string, acceptTypes api.AcceptTypes, expireAfter time.Duration) (*Token, error) {
+	t = t.UTC()
+
 	hmacedCodes, err := db.generateVerificationCodeHMACs(verCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create hmac: %w", err)
@@ -313,7 +317,7 @@ func (db *Database) PurgeTokens(maxAge time.Duration) (int64, error) {
 // updateStatsCodeInvalid updates the statistics, increasing the number of codes
 // that were invalid.
 func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t)
+	t = timeutils.UTCMidnight(t.UTC())
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_invalid)
@@ -339,7 +343,7 @@ func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp) 
 // updateStatsCodeClaimed updates the statistics, increasing the number of codes
 // claimed.
 func (db *Database) updateStatsCodeClaimed(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t)
+	t = timeutils.UTCMidnight(t.UTC())
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_claimed)
@@ -365,7 +369,7 @@ func (db *Database) updateStatsCodeClaimed(t time.Time, authApp *AuthorizedApp) 
 // updateStatsTokenInvalid updates the statistics, increasing the number of
 // tokens that were invalid.
 func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t)
+	t = timeutils.UTCMidnight(t.UTC())
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_invalid)
@@ -391,7 +395,7 @@ func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp)
 // updateStatsTokenClaimed updates the statistics, increasing the number of
 // tokens claimed.
 func (db *Database) updateStatsTokenClaimed(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t)
+	t = timeutils.UTCMidnight(t.UTC())
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_claimed)

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -317,7 +317,7 @@ func (db *Database) PurgeTokens(maxAge time.Duration) (int64, error) {
 // updateStatsCodeInvalid updates the statistics, increasing the number of codes
 // that were invalid.
 func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t.UTC())
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_invalid)
@@ -343,7 +343,7 @@ func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp) 
 // updateStatsCodeClaimed updates the statistics, increasing the number of codes
 // claimed.
 func (db *Database) updateStatsCodeClaimed(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t.UTC())
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, codes_claimed)
@@ -369,7 +369,7 @@ func (db *Database) updateStatsCodeClaimed(t time.Time, authApp *AuthorizedApp) 
 // updateStatsTokenInvalid updates the statistics, increasing the number of
 // tokens that were invalid.
 func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t.UTC())
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_invalid)
@@ -395,7 +395,7 @@ func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp)
 // updateStatsTokenClaimed updates the statistics, increasing the number of
 // tokens claimed.
 func (db *Database) updateStatsTokenClaimed(t time.Time, authApp *AuthorizedApp) {
-	t = timeutils.UTCMidnight(t.UTC())
+	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
 			INSERT INTO realm_stats(date, realm_id, tokens_claimed)

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -297,6 +297,8 @@ func TestIssueToken(t *testing.T) {
 		t.Run(tc.Name, func(t *testing.T) {
 			t.Parallel()
 
+			now := time.Now().UTC()
+
 			// Create the verification. We do this here instead of inside the test
 			// struct to mitigate as much time drift as possible. It also ensures we
 			// get a new VerificationCode on each invocation.
@@ -318,7 +320,7 @@ func TestIssueToken(t *testing.T) {
 				time.Sleep(tc.Delay)
 			}
 
-			tok, err := db.VerifyCodeAndIssueToken(authApp, code, tc.Accept, tc.TokenAge)
+			tok, err := db.VerifyCodeAndIssueToken(now, authApp, code, tc.Accept, tc.TokenAge)
 			if err != nil {
 				if tc.Error == "" {
 					t.Fatalf("error issuing token: %v", err)
@@ -357,7 +359,7 @@ func TestIssueToken(t *testing.T) {
 				if err != nil {
 					t.Fatalf("unable to parse subject: %v", err)
 				}
-				if err := db.ClaimToken(authApp, got.TokenID, subject); err != nil && tc.ClaimError == "" {
+				if err := db.ClaimToken(now, authApp, got.TokenID, subject); err != nil && tc.ClaimError == "" {
 					t.Fatalf("unexpected error claiming token: %v", err)
 				} else if tc.ClaimError != "" {
 					if err == nil {


### PR DESCRIPTION
This updates the seed script to produce a more probabilistic distribution of codes claimed, codes failed, tokens claimed, and tokens failed based on a random distribution. This can be an expensive operation, which is why it's guarded by the newly-added `-stats` flag.

As part of this change, the function signatures for verifying codes and claiming tokens were updated to accepted a time parameter. This is only used for testing and seeding. In production codepaths, the value of time is always `time.Now().UTC()`, which was the previously-hardcoded value in the function body.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make seed script also optionally verify codes and claim tokens
```
