### PR TITLE
Add new stats for codes_invalid and tokens to responses

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -12,6 +12,11 @@
     - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)
   - [`/api/batch-issue`](#apibatch-issue)
     - [Handling batch partial success/failure](#handling-batch-partial-successfailure)
+  - [`/api/checkcodestatus`](#apicheckcodestatus)
+  - [`/api/expirecode`](#apiexpirecode)
+  - [`/api/stats/*` (preview)](#apistats-preview)
+- [Chaffing requests](#chaffing-requests)
+- [Response codes overview](#response-codes-overview)
 
 <!-- /TOC -->
 
@@ -331,7 +336,7 @@ eg.
   error: "the first code failed",
   errorCode: "missing_date",
 }
-``
+```
 
 **BatchIssueCodeRequest**
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -12,11 +12,6 @@
     - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)
   - [`/api/batch-issue`](#apibatch-issue)
     - [Handling batch partial success/failure](#handling-batch-partial-successfailure)
-  - [`/api/checkcodestatus`](#apicheckcodestatus)
-  - [`/api/expirecode`](#apiexpirecode)
-  - [`/api/stats/*` (preview)](#apistats-preview)
-- [Chaffing requests](#chaffing-requests)
-- [Response codes overview](#response-codes-overview)
 
 <!-- /TOC -->
 
@@ -468,7 +463,7 @@ notice!**
 This path includes realm-level statistics for the past 30 days.
 
 -   `/api/stats/realm.{csv,json}` - Daily statistics for the realm, including
-    codes issued, codes claimed, and daily active users (if enabled).
+    codes issued, codes claimed, tokens claimed, and invalid attempts.
 
 -   `/api/stats/realm/users.{csv,json}` - Daily statistics for codes issued by
     realm user. These statistics only include codes issued by humans logged into

--- a/pkg/database/authorized_app_stats.go
+++ b/pkg/database/authorized_app_stats.go
@@ -66,7 +66,11 @@ func (s AuthorizedAppStats) MarshalCSV() ([]byte, error) {
 	var b bytes.Buffer
 	w := csv.NewWriter(&b)
 
-	if err := w.Write([]string{"date", "authorized_app_id", "authorized_app_name", "codes_issued"}); err != nil {
+	if err := w.Write([]string{
+		"date", "authorized_app_id", "authorized_app_name",
+		"codes_issued", "codes_claimed", "codes_invalid",
+		"tokens_claimed", "tokens_invalid",
+	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
@@ -76,6 +80,10 @@ func (s AuthorizedAppStats) MarshalCSV() ([]byte, error) {
 			strconv.FormatUint(uint64(stat.AuthorizedAppID), 10),
 			stat.AuthorizedAppName,
 			strconv.FormatUint(uint64(stat.CodesIssued), 10),
+			strconv.FormatUint(uint64(stat.CodesClaimed), 10),
+			strconv.FormatUint(uint64(stat.CodesInvalid), 10),
+			strconv.FormatUint(uint64(stat.TokensClaimed), 10),
+			strconv.FormatUint(uint64(stat.TokensInvalid), 10),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
 		}
@@ -101,7 +109,11 @@ type jsonAuthorizedAppStatstats struct {
 }
 
 type jsonAuthorizedAppStatstatsData struct {
-	CodesIssued uint `json:"codes_issued"`
+	CodesIssued   uint `json:"codes_issued"`
+	CodesClaimed  uint `json:"codes_claimed"`
+	CodesInvalid  uint `json:"codes_invalid"`
+	TokensClaimed uint `json:"tokens_claimed"`
+	TokensInvalid uint `json:"tokens_invalid"`
 }
 
 // MarshalJSON is a custom JSON marshaller.
@@ -116,7 +128,11 @@ func (s AuthorizedAppStats) MarshalJSON() ([]byte, error) {
 		stats = append(stats, &jsonAuthorizedAppStatstats{
 			Date: stat.Date,
 			Data: &jsonAuthorizedAppStatstatsData{
-				CodesIssued: stat.CodesIssued,
+				CodesIssued:   stat.CodesIssued,
+				CodesClaimed:  stat.CodesClaimed,
+				CodesInvalid:  stat.CodesInvalid,
+				TokensClaimed: stat.TokensClaimed,
+				TokensInvalid: stat.TokensInvalid,
 			},
 		})
 	}
@@ -154,6 +170,10 @@ func (s *AuthorizedAppStats) UnmarshalJSON(b []byte) error {
 			AuthorizedAppID:   result.AuthorizedAppID,
 			AuthorizedAppName: result.AuthorizedAppName,
 			CodesIssued:       stat.Data.CodesIssued,
+			CodesClaimed:      stat.Data.CodesClaimed,
+			CodesInvalid:      stat.Data.CodesInvalid,
+			TokensClaimed:     stat.Data.TokensClaimed,
+			TokensInvalid:     stat.Data.TokensInvalid,
 		})
 	}
 

--- a/pkg/database/authorized_app_stats_test.go
+++ b/pkg/database/authorized_app_stats_test.go
@@ -41,11 +41,15 @@ func TestAuthorizedAppStats_MarshalCSV(t *testing.T) {
 					Date:              time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
 					AuthorizedAppID:   1,
 					CodesIssued:       10,
+					CodesClaimed:      4,
+					CodesInvalid:      2,
+					TokensClaimed:     3,
+					TokensInvalid:     1,
 					AuthorizedAppName: "Appy",
 				},
 			},
-			exp: `date,authorized_app_id,authorized_app_name,codes_issued
-2020-02-03,1,Appy,10
+			exp: `date,authorized_app_id,authorized_app_name,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid
+2020-02-03,1,Appy,10,4,2,3,1
 `,
 		},
 		{
@@ -55,25 +59,37 @@ func TestAuthorizedAppStats_MarshalCSV(t *testing.T) {
 					Date:              time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
 					AuthorizedAppID:   1,
 					CodesIssued:       10,
+					CodesClaimed:      10,
+					CodesInvalid:      2,
+					TokensClaimed:     4,
+					TokensInvalid:     2,
 					AuthorizedAppName: "Appy",
 				},
 				{
 					Date:              time.Date(2020, 2, 4, 0, 0, 0, 0, time.UTC),
 					AuthorizedAppID:   1,
 					CodesIssued:       45,
+					CodesClaimed:      44,
+					CodesInvalid:      5,
+					TokensClaimed:     3,
+					TokensInvalid:     2,
 					AuthorizedAppName: "Mc",
 				},
 				{
 					Date:              time.Date(2020, 2, 5, 0, 0, 0, 0, time.UTC),
 					AuthorizedAppID:   1,
 					CodesIssued:       15,
+					CodesClaimed:      13,
+					CodesInvalid:      4,
+					TokensClaimed:     6,
+					TokensInvalid:     2,
 					AuthorizedAppName: "Apperson",
 				},
 			},
-			exp: `date,authorized_app_id,authorized_app_name,codes_issued
-2020-02-03,1,Appy,10
-2020-02-04,1,Mc,45
-2020-02-05,1,Apperson,15
+			exp: `date,authorized_app_id,authorized_app_name,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid
+2020-02-03,1,Appy,10,10,2,4,2
+2020-02-04,1,Mc,45,44,5,3,2
+2020-02-05,1,Apperson,15,13,4,6,2
 `,
 		},
 	}

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -21,7 +21,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
 	"github.com/jinzhu/gorm"
 )
@@ -164,13 +163,11 @@ func TestAuthorizedApp_Stats(t *testing.T) {
 
 	// Ensure graph is contiguous.
 	{
-		stop := timeutils.Midnight(time.Now().UTC())
-		start := stop.Add(6 * -24 * time.Hour)
-		stats, err := authorizedApp.Stats(db, start, stop)
+		stats, err := authorizedApp.Stats(db)
 		if err != nil {
 			t.Fatal(err)
 		}
-		if got, want := len(stats), 7; got != want {
+		if got, want := len(stats), 30; got < want {
 			t.Errorf("expected stats for %d days, got %d", want, got)
 		}
 	}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1443,7 +1443,10 @@ func (r *Realm) Stats(db *Database) (RealmStats, error) {
 			d.date AS date,
 			$1 AS realm_id,
 			COALESCE(s.codes_issued, 0) AS codes_issued,
-			COALESCE(s.codes_claimed, 0) AS codes_claimed
+			COALESCE(s.codes_claimed, 0) AS codes_claimed,
+			COALESCE(s.codes_invalid, 0) AS codes_invalid,
+			COALESCE(s.tokens_claimed, 0) AS tokens_claimed,
+			COALESCE(s.tokens_invalid, 0) AS tokens_invalid
 		FROM (
 			SELECT date::date FROM generate_series($2, $3, '1 day'::interval) date
 		) d

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -61,7 +61,11 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 	var b bytes.Buffer
 	w := csv.NewWriter(&b)
 
-	if err := w.Write([]string{"date", "codes_issued", "codes_claimed"}); err != nil {
+	if err := w.Write([]string{
+		"date",
+		"codes_issued", "codes_claimed", "codes_invalid",
+		"tokens_claimed", "tokens_invalid",
+	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
 
@@ -70,6 +74,9 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 			stat.Date.Format(project.RFC3339Date),
 			strconv.FormatUint(uint64(stat.CodesIssued), 10),
 			strconv.FormatUint(uint64(stat.CodesClaimed), 10),
+			strconv.FormatUint(uint64(stat.CodesInvalid), 10),
+			strconv.FormatUint(uint64(stat.TokensClaimed), 10),
+			strconv.FormatUint(uint64(stat.TokensInvalid), 10),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
 		}
@@ -94,8 +101,11 @@ type jsonRealmStatStats struct {
 }
 
 type jsonRealmStatStatsData struct {
-	CodesIssued  uint `json:"codes_issued"`
-	CodesClaimed uint `json:"codes_claimed"`
+	CodesIssued   uint `json:"codes_issued"`
+	CodesClaimed  uint `json:"codes_claimed"`
+	CodesInvalid  uint `json:"codes_invalid"`
+	TokensClaimed uint `json:"tokens_claimed"`
+	TokensInvalid uint `json:"tokens_invalid"`
 }
 
 // MarshalJSON is a custom JSON marshaller.
@@ -110,8 +120,11 @@ func (s RealmStats) MarshalJSON() ([]byte, error) {
 		stats = append(stats, &jsonRealmStatStats{
 			Date: stat.Date,
 			Data: &jsonRealmStatStatsData{
-				CodesIssued:  stat.CodesIssued,
-				CodesClaimed: stat.CodesClaimed,
+				CodesIssued:   stat.CodesIssued,
+				CodesClaimed:  stat.CodesClaimed,
+				CodesInvalid:  stat.CodesInvalid,
+				TokensClaimed: stat.TokensClaimed,
+				TokensInvalid: stat.TokensInvalid,
 			},
 		})
 	}
@@ -144,10 +157,13 @@ func (s *RealmStats) UnmarshalJSON(b []byte) error {
 
 	for _, stat := range result.Stats {
 		*s = append(*s, &RealmStat{
-			Date:         stat.Date,
-			RealmID:      result.RealmID,
-			CodesIssued:  stat.Data.CodesIssued,
-			CodesClaimed: stat.Data.CodesClaimed,
+			Date:          stat.Date,
+			RealmID:       result.RealmID,
+			CodesIssued:   stat.Data.CodesIssued,
+			CodesClaimed:  stat.Data.CodesClaimed,
+			CodesInvalid:  stat.Data.CodesInvalid,
+			TokensClaimed: stat.Data.TokensClaimed,
+			TokensInvalid: stat.Data.TokensInvalid,
 		})
 	}
 

--- a/pkg/database/realm_stats_test.go
+++ b/pkg/database/realm_stats_test.go
@@ -38,42 +38,54 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 			name: "single",
 			stats: []*RealmStat{
 				{
-					Date:         time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
-					RealmID:      1,
-					CodesIssued:  10,
-					CodesClaimed: 9,
+					Date:          time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
+					RealmID:       1,
+					CodesIssued:   10,
+					CodesClaimed:  9,
+					CodesInvalid:  1,
+					TokensClaimed: 7,
+					TokensInvalid: 2,
 				},
 			},
-			exp: `date,codes_issued,codes_claimed
-2020-02-03,10,9
+			exp: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid
+2020-02-03,10,9,1,7,2
 `,
 		},
 		{
 			name: "multi",
 			stats: []*RealmStat{
 				{
-					Date:         time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
-					RealmID:      1,
-					CodesIssued:  10,
-					CodesClaimed: 9,
+					Date:          time.Date(2020, 2, 3, 0, 0, 0, 0, time.UTC),
+					RealmID:       1,
+					CodesIssued:   10,
+					CodesClaimed:  9,
+					CodesInvalid:  1,
+					TokensClaimed: 7,
+					TokensInvalid: 2,
 				},
 				{
-					Date:         time.Date(2020, 2, 4, 0, 0, 0, 0, time.UTC),
-					RealmID:      1,
-					CodesIssued:  45,
-					CodesClaimed: 30,
+					Date:          time.Date(2020, 2, 4, 0, 0, 0, 0, time.UTC),
+					RealmID:       1,
+					CodesIssued:   45,
+					CodesClaimed:  30,
+					CodesInvalid:  29,
+					TokensClaimed: 27,
+					TokensInvalid: 2,
 				},
 				{
-					Date:         time.Date(2020, 2, 5, 0, 0, 0, 0, time.UTC),
-					RealmID:      1,
-					CodesIssued:  15,
-					CodesClaimed: 2,
+					Date:          time.Date(2020, 2, 5, 0, 0, 0, 0, time.UTC),
+					RealmID:       1,
+					CodesIssued:   15,
+					CodesClaimed:  2,
+					CodesInvalid:  0,
+					TokensClaimed: 2,
+					TokensInvalid: 0,
 				},
 			},
-			exp: `date,codes_issued,codes_claimed
-2020-02-03,10,9
-2020-02-04,45,30
-2020-02-05,15,2
+			exp: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid
+2020-02-03,10,9,1,7,2
+2020-02-04,45,30,29,27,2
+2020-02-05,15,2,0,2,0
 `,
 		},
 	}


### PR DESCRIPTION
These statistics already exist and are collected in 0.20. This adds them to the response payload.

Part of #1231 and #1232

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add new stats for codes_invalid and tokens to responses
```

/assign @mikehelmick 