### PR TITLE
Unwind stats when we delete verification codes

### DIFF
--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -86,7 +86,7 @@ func (c *Controller) SendSMS(ctx context.Context, request *api.IssueCodeRequest,
 
 		if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
 			// Delete the token
-			if err := c.db.DeleteVerificationCode(result.VerCode.Code); err != nil {
+			if err := c.db.DeleteVerificationCode(result.VerCode); err != nil {
 				logger.Errorw("failed to delete verification code", "error", err)
 				// fallthrough to the error
 			}

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -332,7 +332,7 @@ func TestDeleteVerificationCode(t *testing.T) {
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	realm := NewRealmWithDefaults("Test Realm")
 
-	code := VerificationCode{
+	code := &VerificationCode{
 		Code:          "12345678",
 		LongCode:      "12345678",
 		TestType:      "confirmed",
@@ -340,11 +340,11 @@ func TestDeleteVerificationCode(t *testing.T) {
 		LongExpiresAt: time.Now().Add(time.Hour),
 	}
 
-	if err := db.SaveVerificationCode(&code, realm); err != nil {
+	if err := db.SaveVerificationCode(code, realm); err != nil {
 		t.Fatal(err)
 	}
 
-	if err := db.DeleteVerificationCode("12345678"); err != nil {
+	if err := db.DeleteVerificationCode(&VerificationCode{Code: "12345678"}); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* When we fail to SMS a code, we invalidate it by deleting the code. This change also decrements the stats

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Decrement stats for unsuccessful code-issuance
```
