### PR TITLE
Add top-level onboarding domain to redirect service

### DIFF
--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -43,6 +43,10 @@ type RedirectConfig struct {
 	// auto-reload is enabled.
 	DevMode bool `env:"DEV_MODE"`
 
+	// OnboardingDomain is the top-level ENX redirect domain (e.g. example.com).
+	// Requests routed to this domain trigger the generic onboarding flow.
+	OnboardingDomain string `env:"ONBOARDING_DOMAIN"`
+
 	// A map of hostnames to redirect to ens:// and a mapping to the region.
 	// For example to redirect
 	//   region.example.com to region US-AA

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -275,12 +275,11 @@ func TestDecideRedirect(t *testing.T) {
 		Path: "/v",
 	}
 	q := relativePinURL.Query()
-	q.Set("c", "1234567890abcdef")
+	q.Set("c", "123456")
 	relativePinURL.RawQuery = q.Encode()
 
 	cases := []struct {
 		name         string
-		host         string
 		url          string
 		altURL       *url.URL
 		enxEnabled   bool
@@ -291,29 +290,29 @@ func TestDecideRedirect(t *testing.T) {
 		// Android
 		{
 			name:         "android_both",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkBoth,
-			expected:     "intent://v?c=1234567890abcdef&r=US-MOO" + expectedSuffix,
+			expected:     "intent://v?c=123456&r=US-MOO" + expectedSuffix,
 		},
 		{
 			name:         "android_both_relative",
 			altURL:       &relativePinURL,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkBoth,
-			expected:     "intent://v?c=1234567890abcdef&r=US-MOO" + expectedSuffix,
+			expected:     "intent://v?c=123456&r=US-MOO" + expectedSuffix,
 		},
 		{
 			name:         "android_no_applink_enx",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			enxEnabled:   true,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
-			expected:     "ens://v?c=1234567890abcdef&r=US-MOO",
+			expected:     "ens://v?c=123456&r=US-MOO",
 		},
 		{
 			name:         "android_no_applink",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			enxEnabled:   false,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
@@ -331,14 +330,14 @@ func TestDecideRedirect(t *testing.T) {
 		// iOS
 		{
 			name:         "ios_both",
-			url:          "https://ios.example.com/store/moosylvania?c=123456",
+			url:          "https://moosylvania.gov/v?c=123456",
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkBoth,
 			expected:     "https://ios.example.com/store/moosylvania",
 		},
 		{
 			name:         "ios_both_relative",
-			url:          "https://ios.example.com/store/moosylvania?c=123456",
+			url:          "https://moosylvania.gov/v?c=123456",
 			altURL:       &relativePinURL,
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkBoth,
@@ -346,15 +345,15 @@ func TestDecideRedirect(t *testing.T) {
 		},
 		{
 			name:         "ios_no_applink_enx",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			enxEnabled:   true,
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkNeither,
-			expected:     "ens://v?c=1234567890abcdef&r=US-MOO",
+			expected:     "ens://v?c=123456&r=US-MOO",
 		},
 		{
 			name:         "ios_no_applink",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			enxEnabled:   false,
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkNeither,
@@ -372,7 +371,7 @@ func TestDecideRedirect(t *testing.T) {
 		// Other
 		{
 			name:         "other",
-			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
+			url:          "https://moosylvania.gov/v?c=123456",
 			userAgent:    userAgentNeither,
 			appStoreData: &appLinkBoth,
 			expected:     "",

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -319,18 +319,26 @@ func TestDecideRedirect(t *testing.T) {
 			appStoreData: &appLinkNeither,
 			expected:     "",
 		},
+		{
+			name:         "android_onboarding",
+			url:          "https://moosylvania.gov/",
+			enxEnabled:   false,
+			userAgent:    userAgentAndroid,
+			appStoreData: &appLinkNeither,
+			expected:     "market://search?q=exposure%20notifications",
+		},
 
 		// iOS
 		{
 			name:         "ios_both",
-			url:          "https://ios.example.com/store/moosylvania",
+			url:          "https://ios.example.com/store/moosylvania?c=123456",
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkBoth,
 			expected:     "https://ios.example.com/store/moosylvania",
 		},
 		{
 			name:         "ios_both_relative",
-			url:          "https://ios.example.com/store/moosylvania",
+			url:          "https://ios.example.com/store/moosylvania?c=123456",
 			altURL:       &relativePinURL,
 			userAgent:    userAgentIOS,
 			appStoreData: &appLinkBoth,
@@ -352,14 +360,30 @@ func TestDecideRedirect(t *testing.T) {
 			appStoreData: &appLinkNeither,
 			expected:     "",
 		},
+		{
+			name:         "ios_onboarding",
+			url:          "https://moosylvania.gov/",
+			enxEnabled:   false,
+			userAgent:    userAgentIOS,
+			appStoreData: &appLinkNeither,
+			expected:     "ens://onboarding",
+		},
 
 		// Other
 		{
-			name:         "windows",
+			name:         "other",
 			url:          "https://moosylvania.gov/v?c=1234567890abcdef",
 			userAgent:    userAgentNeither,
 			appStoreData: &appLinkBoth,
 			expected:     "",
+		},
+		// Other
+		{
+			name:         "other_onboarding",
+			url:          "https://moosylvania.gov/",
+			userAgent:    userAgentNeither,
+			appStoreData: &appLinkBoth,
+			expected:     "https://www.google.com/covid19/exposurenotifications/",
 		},
 	}
 

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -37,6 +37,22 @@ func (c *Controller) HandleIndex() http.Handler {
 			baseHost = host
 		}
 
+		// Check if this is the naked domain.
+		if baseHost == c.config.OnboardingDomain {
+			if isAndroid(r.UserAgent()) {
+				http.Redirect(w, r, androidOnboardingRedirect, http.StatusSeeOther)
+				return
+			}
+
+			if isIOS(r.UserAgent()) {
+				http.Redirect(w, r, iosOnboardingRedirect, http.StatusSeeOther)
+				return
+			}
+
+			http.Redirect(w, r, genericOnboardingRedirect, http.StatusSeeOther)
+			return
+		}
+
 		var hostRegion string = ""
 		for hostname, region := range c.hostnameToRegion {
 			if hostname == baseHost {

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -217,7 +217,7 @@ func TestIndex(t *testing.T) {
 	t.Run("bad_path", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL+"/css/view/main/gift.css", nil)
+		req, err := http.NewRequest("GET", srv.URL+"/css/appiew/main/gift.css", nil)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -288,7 +288,7 @@ func TestIndex(t *testing.T) {
 	t.Run("matching_region_no_apps", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL, nil)
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm1"
 		if err != nil {
 			t.Fatal(err)
@@ -308,11 +308,41 @@ func TestIndex(t *testing.T) {
 		}
 	})
 
-	// Not a mobile user agent returns a 404
+	// Not a mobile user agent with no query redirects to marketing
 	t.Run("not_mobile_user_agent", func(t *testing.T) {
 		t.Parallel()
 
 		req, err := http.NewRequest("GET", srv.URL, nil)
+		req.Host = "realm2"
+		req.Header.Set("User-Agent", "bananarama")
+		if err != nil {
+			t.Fatal(err)
+		}
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if got, want := resp.StatusCode, 303; got != want {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Errorf("expected %d to be %d: %s", got, want, body)
+		}
+
+		exp := "https://www.google.com/covid19/exposurenotifications/"
+		if got, want := resp.Header.Get("Location"), exp; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})
+
+	// Not a mobile user agent with a code returns a 404
+	t.Run("not_mobile_user_agent", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm2"
 		req.Header.Set("User-Agent", "bananarama")
 		if err != nil {
@@ -337,7 +367,7 @@ func TestIndex(t *testing.T) {
 	t.Run("android_redirect", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL, nil)
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm2"
 		req.Header.Set("User-Agent", "android")
 		if err != nil {
@@ -357,7 +387,7 @@ func TestIndex(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", got, want, body)
 		}
 
-		exp := "intent:?r=BB#Intent;scheme=ens;package=com.example.app2;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;S.browser_fallback_url=https%3A%2F%2Fapp2.example.com%2F;end"
+		exp := "intent://app?c=123456&r=BB#Intent;scheme=ens;package=com.example.app2;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;S.browser_fallback_url=https%3A%2F%2Fapp2.example.com%2F;end"
 		if got, want := resp.Header.Get("Location"), exp; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
@@ -367,7 +397,7 @@ func TestIndex(t *testing.T) {
 	t.Run("android_redirect_enx", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL+"/app", nil)
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm3"
 		req.Header.Set("User-Agent", "android")
 		if err != nil {
@@ -387,7 +417,7 @@ func TestIndex(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", got, want, body)
 		}
 
-		if got, want := resp.Header.Get("Location"), "ens://app?r=CC"; got != want {
+		if got, want := resp.Header.Get("Location"), "ens://app?c=123456&r=CC"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
 	})
@@ -396,7 +426,7 @@ func TestIndex(t *testing.T) {
 	t.Run("ios_redirect", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL, nil)
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm2"
 		req.Header.Set("User-Agent", "iphone")
 		if err != nil {
@@ -425,7 +455,7 @@ func TestIndex(t *testing.T) {
 	t.Run("ios_redirect_enx", func(t *testing.T) {
 		t.Parallel()
 
-		req, err := http.NewRequest("GET", srv.URL+"/app", nil)
+		req, err := http.NewRequest("GET", srv.URL+"/app?c=123456", nil)
 		req.Host = "realm3"
 		req.Header.Set("User-Agent", "iphone")
 		if err != nil {
@@ -445,7 +475,7 @@ func TestIndex(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", got, want, body)
 		}
 
-		if got, want := resp.Header.Get("Location"), "ens://app?r=CC"; got != want {
+		if got, want := resp.Header.Get("Location"), "ens://app?c=123456&r=CC"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
 	})

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -36,8 +36,9 @@ func TestIndex(t *testing.T) {
 
 	// Create config.
 	cfg := &config.RedirectConfig{
-		AssetsPath: filepath.Join(project.Root(), "cmd", "enx-redirect", "assets"),
-		DevMode:    true,
+		AssetsPath:       filepath.Join(project.Root(), "cmd", "enx-redirect", "assets"),
+		DevMode:          true,
+		OnboardingDomain: "onboard.me",
 		HostnameConfig: map[string]string{
 			"bad":    "nope",
 			"realm1": "aa",
@@ -121,6 +122,96 @@ func TestIndex(t *testing.T) {
 	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
+
+	// Onboarding, android
+	t.Run("onboarding/android", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Host = "onboard.me"
+		req.Header.Set("User-Agent", "android")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if got, want := resp.StatusCode, 303; got != want {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Errorf("expected %d to be %d: %s", got, want, body)
+		}
+
+		if got, want := resp.Header.Get("Location"), "market://search?q=exposure%20notifications"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})
+
+	// Onboarding, ios
+	t.Run("onboarding/ios", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Host = "onboard.me"
+		req.Header.Set("User-Agent", "iphone")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if got, want := resp.StatusCode, 303; got != want {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Errorf("expected %d to be %d: %s", got, want, body)
+		}
+
+		if got, want := resp.Header.Get("Location"), "ens://onboarding"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})
+
+	// Onboarding, unknown
+	t.Run("onboarding/unknown", func(t *testing.T) {
+		t.Parallel()
+
+		req, err := http.NewRequest("GET", srv.URL, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Host = "onboard.me"
+		req.Header.Set("User-Agent", "bananarama")
+
+		resp, err := client.Do(req)
+		if err != nil {
+			t.Fatal(err)
+		}
+		defer resp.Body.Close()
+
+		if got, want := resp.StatusCode, 303; got != want {
+			body, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				t.Fatal(err)
+			}
+			t.Errorf("expected %d to be %d: %s", got, want, body)
+		}
+
+		if got, want := resp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications/"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})
 
 	// Bad path
 	t.Run("bad_path", func(t *testing.T) {

--- a/pkg/controller/redirect/redirect.go
+++ b/pkg/controller/redirect/redirect.go
@@ -25,6 +25,14 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
+const (
+	// androidOnboardingRedirect and iosOnboardingRedirect are the URLs to
+	// redirect to for onboarding.
+	androidOnboardingRedirect = "market://search?q=exposure%20notifications"
+	iosOnboardingRedirect     = "ens://onboarding"
+	genericOnboardingRedirect = "https://www.google.com/covid19/exposurenotifications/"
+)
+
 type Controller struct {
 	config           *config.RedirectConfig
 	cacher           cache.Cacher

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -116,7 +116,10 @@ resource "google_compute_managed_ssl_certificate" "enx-redirect-root" {
   description = "Controlled by Terraform"
 
   managed {
-    domains = ["www.${var.enx_redirect_domain}"]
+    domains = compact([
+      var.enx_redirect_domain,
+      var.enx_onboarding_domain,
+    ])
   }
 
   # This is to prevent destroying the cert while it's still attached to the load
@@ -175,4 +178,3 @@ resource "google_compute_managed_ssl_certificate" "enx-redirect-next" {
     google_project_service.services["compute.googleapis.com"],
   ]
 }
-

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -97,6 +97,7 @@ locals {
   enx_redirect_config = {
     ASSETS_PATH        = "/assets"
     HOSTNAME_TO_REGION = join(",", [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : format("%s:%s", o.host, o.region)])
+    ONBOARDING_DOMAIN  = var.enx_onboarding_domain
   }
 
   observability_config = {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -190,6 +190,12 @@ variable "adminapi_hosts" {
   description = "List of domains upon which the adminapi is served."
 }
 
+variable "enx_onboarding_domain" {
+  type        = string
+  default     = ""
+  description = "Domain on which to serve onboarding redirects."
+}
+
 variable "enx_redirect_domain" {
   type        = string
   default     = ""


### PR DESCRIPTION
This adds the necessary configuration to support the ens://onboarding specification at the provided domain.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1634

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add optional onboarding support to redirect service. If `ONBOARDING_DOMAIN` is configured, the redirector service will redirect to the device-specific appropriate location to trigger onboarding when the host matches the value. This value can be configured via Terraform, but care should be taken to avoid an outage due to SSL certificate provisioning for the new domain.
```

/assign @mikehelmick 