### PR TITLE
Increment stats at the end of successfully issuing codes

### DIFF
--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -98,5 +98,5 @@ func (c *Controller) recordStats(ctx context.Context, results []*IssueResult) {
 			codes = append(codes, result.VerCode)
 		}
 	}
-	c.db.UpdateStats(ctx, codes)
+	c.db.UpdateStats(ctx, codes...)
 }

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -304,7 +304,7 @@ func (db *Database) UpdateStats(v *VerificationCode, issued int) error {
 			INSERT INTO external_issuer_stats (date, realm_id, issuer_id, codes_issued)
 				VALUES ($1, $2, $3, 1)
 			ON CONFLICT (date, realm_id, issuer_id) DO UPDATE
-				, issued)SET codes_issued = external_issuer_stats.codes_issued + %d
+				SET codes_issued = external_issuer_stats.codes_issued + %d
 		`, issued)
 
 		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingExternalID).Error; err != nil {

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/hashicorp/go-multierror"
 	"github.com/jinzhu/gorm"
 )
 
@@ -100,69 +101,6 @@ func (v *VerificationCode) BeforeSave(tx *gorm.DB) error {
 		return fmt.Errorf("validation failed: %s", strings.Join(msgs, ", "))
 	}
 	return nil
-}
-
-// AfterCreate runs after the verification code has been saved, primarily used
-// to update statistics about usage. If the executions fail, an error is logged
-// but the transaction continues. This is called automatically by gorm.
-func (v *VerificationCode) AfterCreate(scope *gorm.Scope) {
-	date := timeutils.Midnight(v.CreatedAt)
-
-	// If the issuer was a user, update the user stats for the day.
-	if v.IssuingUserID != 0 {
-		sql := `
-			INSERT INTO user_stats (date, realm_id, user_id, codes_issued)
-				VALUES ($1, $2, $3, 1)
-			ON CONFLICT (date, realm_id, user_id) DO UPDATE
-				SET codes_issued = user_stats.codes_issued + 1
-		`
-
-		if err := scope.DB().Exec(sql, date, v.RealmID, v.IssuingUserID).Error; err != nil {
-			scope.Log(fmt.Sprintf("failed to update stats: %v", err))
-		}
-	}
-
-	// If the request was an API request, we might have an external issuer ID.
-	if len(v.IssuingExternalID) != 0 {
-		sql := `
-			INSERT INTO external_issuer_stats (date, realm_id, issuer_id, codes_issued)
-				VALUES ($1, $2, $3, 1)
-			ON CONFLICT (date, realm_id, issuer_id) DO UPDATE
-				SET codes_issued = external_issuer_stats.codes_issued + 1
-		`
-
-		if err := scope.DB().Exec(sql, date, v.RealmID, v.IssuingExternalID).Error; err != nil {
-			scope.Log(fmt.Sprintf("failed to update audit stats: %v", err))
-		}
-	}
-
-	// If the issuer was a app, update the app stats for the day.
-	if v.IssuingAppID != 0 {
-		sql := `
-			INSERT INTO authorized_app_stats (date, authorized_app_id, codes_issued)
-				VALUES ($1, $2, 1)
-			ON CONFLICT (date, authorized_app_id) DO UPDATE
-				SET codes_issued = authorized_app_stats.codes_issued + 1
-		`
-
-		if err := scope.DB().Exec(sql, date, v.IssuingAppID).Error; err != nil {
-			scope.Log(fmt.Sprintf("failed to update stats: %v", err))
-		}
-	}
-
-	// Update the per-realm stats.
-	if v.RealmID != 0 {
-		sql := `
-			INSERT INTO realm_stats(date, realm_id, codes_issued)
-				VALUES ($1, $2, 1)
-			ON CONFLICT (date, realm_id) DO UPDATE
-				SET codes_issued = realm_stats.codes_issued + 1
-		`
-
-		if err := scope.DB().Exec(sql, date, v.RealmID).Error; err != nil {
-			scope.Log(fmt.Sprintf("failed to update stats: %v", err))
-		}
-	}
 }
 
 // FormatSymptomDate returns YYYY-MM-DD formatted test date, or "" if nil.
@@ -339,6 +277,70 @@ func (db *Database) DeleteVerificationCode(code string) error {
 		Where("code IN (?) OR long_code IN (?)", hmacedCodes, hmacedCodes).
 		Delete(&VerificationCode{}).
 		Error
+}
+
+// UpdateStats increments VerificationCode statistics incrementing stats but the number issued.
+func (db *Database) UpdateStats(v *VerificationCode, issued int) error {
+	date := timeutils.Midnight(v.CreatedAt)
+	var merr *multierror.Error
+
+	// If the issuer was a user, update the user stats for the day.
+	if v.IssuingUserID != 0 {
+		sql := fmt.Sprintf(`
+			INSERT INTO user_stats (date, realm_id, user_id, codes_issued)
+				VALUES ($1, $2, $3, 1)
+			ON CONFLICT (date, realm_id, user_id) DO UPDATE
+				SET codes_issued = user_stats.codes_issued + %d
+		`, issued)
+
+		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingUserID).Error; err != nil {
+			multierror.Append(merr, fmt.Errorf("failed to update stats: %v", err))
+		}
+	}
+
+	// If the request was an API request, we might have an external issuer ID.
+	if len(v.IssuingExternalID) != 0 {
+		sql := fmt.Sprintf(`
+			INSERT INTO external_issuer_stats (date, realm_id, issuer_id, codes_issued)
+				VALUES ($1, $2, $3, 1)
+			ON CONFLICT (date, realm_id, issuer_id) DO UPDATE
+				, issued)SET codes_issued = external_issuer_stats.codes_issued + %d
+		`, issued)
+
+		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingExternalID).Error; err != nil {
+			multierror.Append(merr, fmt.Errorf("failed to update audit stats: %v", err))
+		}
+	}
+
+	// If the issuer was a app, update the app stats for the day.
+	if v.IssuingAppID != 0 {
+		sql := fmt.Sprintf(`
+			INSERT INTO authorized_app_stats (date, authorized_app_id, codes_issued)
+				VALUES ($1, $2, 1)
+			ON CONFLICT (date, authorized_app_id) DO UPDATE
+				SET codes_issued = authorized_app_stats.codes_issued + %d
+		`, issued)
+
+		if err := db.db.Exec(sql, date, v.IssuingAppID).Error; err != nil {
+			multierror.Append(merr, fmt.Errorf("failed to update stats: %v", err))
+		}
+	}
+
+	// Update the per-realm stats.
+	if v.RealmID != 0 {
+		sql := fmt.Sprintf(`
+			INSERT INTO realm_stats(date, realm_id, codes_issued)
+				VALUES ($1, $2, 1)
+			ON CONFLICT (date, realm_id) DO UPDATE
+				SET codes_issued = realm_stats.codes_issued + %d
+		`, issued)
+
+		if err := db.db.Exec(sql, date, v.RealmID).Error; err != nil {
+			multierror.Append(merr, fmt.Errorf("failed to update stats: %v", err))
+		}
+	}
+
+	return merr.ErrorOrNil()
 }
 
 // RecycleVerificationCodes sets to null code and long_code values

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -282,7 +282,7 @@ func (db *Database) DeleteVerificationCode(code string) error {
 }
 
 // UpdateStats increments VerificationCode statistics incrementing stats but the number issued.
-func (db *Database) UpdateStats(ctx context.Context, codes []*VerificationCode) {
+func (db *Database) UpdateStats(ctx context.Context, codes ...*VerificationCode) {
 	issued := len(codes)
 	if issued == 0 {
 		return

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -443,6 +443,7 @@ func TestStatDates(t *testing.T) {
 	// smokescreen.
 	t.Parallel()
 
+	ctx := project.TestContext(t)
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	realm := NewRealmWithDefaults("Test Realm")
 
@@ -475,9 +476,7 @@ func TestStatDates(t *testing.T) {
 		}
 
 		test.code.Code = "111111"
-		if err := db.UpdateStats(test.code, 1); err != nil {
-			t.Fatal(err)
-		}
+		db.UpdateStats(ctx, test.code)
 
 		{
 			var stats []*RealmUserStat

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -437,7 +437,7 @@ func TestVerificationCodesCleanup(t *testing.T) {
 	}
 }
 
-func TestStatDatesOnCreate(t *testing.T) {
+func TestStatDates(t *testing.T) {
 	// Please note, this test is NOT exhaustive. A better engineer would try
 	// all dates, and a bunch of corner cases. This is intended as a
 	// smokescreen.
@@ -472,6 +472,11 @@ func TestStatDatesOnCreate(t *testing.T) {
 	for i, test := range tests {
 		if err := db.SaveVerificationCode(test.code, realm); err != nil {
 			t.Fatalf("[%d] error saving code: %v", i, err)
+		}
+
+		test.code.Code = "111111"
+		if err := db.UpdateStats(test.code, 1); err != nil {
+			t.Fatal(err)
 		}
 
 		{


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This is an alternative to https://github.com/google/exposure-notifications-verification-server/pull/1633
* Wait until the end of code issuance to increment stats - only increment for codes that are successful.
    * Batch issuance can increment stats by N, so fewer queries

/hold 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Increment code-issue stats at the end of issuance logic. This avoids recording [known] failures.
```
