### PR TITLE
Implement first pass at SMS signature algorithm

### DIFF
--- a/pkg/jwthelper/jwthelper.go
+++ b/pkg/jwthelper/jwthelper.go
@@ -48,7 +48,7 @@ func SignJWT(token *jwt.Token, signer crypto.Signer) (string, error) {
 
 	// Unpack the ASN1 signature. ECDSA signers are supposed to return this format
 	// https://golang.org/pkg/crypto/#Signer
-	// All suporrted signers in thise codebase are verified to return ASN1.
+	// All supported signers in thise codebase are verified to return ASN1.
 	var parsedSig struct{ R, S *big.Int }
 	// ASN1 is not the expected format for an ES256 JWT signature.
 	// The output format is specified here, https://tools.ietf.org/html/rfc7518#section-3.4

--- a/pkg/signatures/signatures.go
+++ b/pkg/signatures/signatures.go
@@ -1,0 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package signatures implements common signing algorithms.
+package signatures

--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -26,6 +26,9 @@ import (
 )
 
 const (
+	// authPrefix is the beginning of the authorization bit.
+	authPrefix = " Authorization: "
+
 	// Dot represents a period, which is used as a separator in some signatures.
 	dot = "."
 )
@@ -49,7 +52,7 @@ func SMSSignature(signer crypto.Signer, keyID string, t time.Time, purpose SMSPu
 	}
 	sig := base64.RawStdEncoding.EncodeToString(b)
 
-	return keyID + dot + sig, nil
+	return authPrefix + keyID + dot + sig, nil
 }
 
 // smsSignatureString builds the string that is to be signed. The provided date
@@ -58,5 +61,5 @@ func SMSSignature(signer crypto.Signer, keyID string, t time.Time, purpose SMSPu
 // including any codes and links.
 func smsSignatureString(t time.Time, purpose SMSPurpose, phone, body string) string {
 	t = t.UTC()
-	return string(purpose) + dot + phone + dot + t.Format(project.RFC3339Date) + dot + body
+	return string(purpose) + dot + phone + dot + t.Format(project.RFC3339Date) + dot + body + authPrefix
 }

--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -1,0 +1,67 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signatures
+
+import (
+	"crypto"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"fmt"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+)
+
+const (
+	// authPrefix is the string to prepend to the authentication
+	// signature.
+	authPrefix = "Authentication: "
+
+	// Dot represents a period, which is used as a separator in some signatures.
+	dot = "."
+)
+
+// SMSPurpose is an SMS purpose, used in signature calculation.
+type SMSPurpose string
+
+const (
+	// SMSPurposeENReport is an SMS purpose for EN reporting.
+	SMSPurposeENReport SMSPurpose = "EN Report"
+)
+
+// SMSSignature returns the signature of the message uses the provided signer.
+func SMSSignature(signer crypto.Signer, keyID string, t time.Time, purpose SMSPurpose, phone, body string) (string, error) {
+	t = t.UTC()
+	signingString := smsSignatureString(t, purpose, phone, body)
+
+	digest := sha256.Sum256([]byte(signingString))
+	b, err := signer.Sign(rand.Reader, digest[:], nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to sign sms: %w", err)
+	}
+	sig := base64.RawStdEncoding.EncodeToString(b)
+
+	return authPrefix + t.Format(project.RFC3339Date) + dot + keyID + dot + sig, nil
+}
+
+// smsSignatureString builds the string that is to be signed. The provided date
+// will be converted to UTC and then appended in ISO 8601 format. The phone
+// number must be in E.164 format. The body must be the complete message body
+// including any codes and links.
+func smsSignatureString(t time.Time, purpose SMSPurpose, phone, body string) string {
+	t = t.UTC()
+	return string(purpose) + dot + phone + dot + t.Format(project.RFC3339Date) + dot + body
+}

--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -26,10 +26,6 @@ import (
 )
 
 const (
-	// authPrefix is the string to prepend to the authentication
-	// signature.
-	authPrefix = "Authentication: "
-
 	// Dot represents a period, which is used as a separator in some signatures.
 	dot = "."
 )
@@ -44,7 +40,6 @@ const (
 
 // SMSSignature returns the signature of the message uses the provided signer.
 func SMSSignature(signer crypto.Signer, keyID string, t time.Time, purpose SMSPurpose, phone, body string) (string, error) {
-	t = t.UTC()
 	signingString := smsSignatureString(t, purpose, phone, body)
 
 	digest := sha256.Sum256([]byte(signingString))
@@ -54,7 +49,7 @@ func SMSSignature(signer crypto.Signer, keyID string, t time.Time, purpose SMSPu
 	}
 	sig := base64.RawStdEncoding.EncodeToString(b)
 
-	return authPrefix + t.Format(project.RFC3339Date) + dot + keyID + dot + sig, nil
+	return keyID + dot + sig, nil
 }
 
 // smsSignatureString builds the string that is to be signed. The provided date

--- a/pkg/signatures/sms_test.go
+++ b/pkg/signatures/sms_test.go
@@ -89,12 +89,12 @@ func Test_smsSignatureString(t *testing.T) {
 		{
 			name: "default",
 			in:   smsSignatureString(time.Unix(0, 0), SMSPurposeENReport, "+11111111111", "Hello world"),
-			exp:  "EN Report.+11111111111.1970-01-01.Hello world",
+			exp:  "EN Report.+11111111111.1970-01-01.Hello world Authorization: ",
 		},
 		{
 			name: "default",
 			in:   smsSignatureString(time.Unix(0, 0).In(time.FixedZone("Test/Test", -10000000)), SMSPurposeENReport, "+11111111111", "Hello world"),
-			exp:  "EN Report.+11111111111.1970-01-01.Hello world",
+			exp:  "EN Report.+11111111111.1970-01-01.Hello world Authorization: ",
 		},
 	}
 

--- a/pkg/signatures/sms_test.go
+++ b/pkg/signatures/sms_test.go
@@ -1,0 +1,112 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package signatures
+
+import (
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+	"testing"
+	"time"
+)
+
+func Test_SMSSignature(t *testing.T) {
+	t.Parallel()
+
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name  string
+		keyID string
+		time  time.Time
+		phone string
+		body  string
+	}{
+		{
+			name:  "default",
+			keyID: "v1",
+			time:  time.Unix(0, 0),
+			phone: "+11111111111",
+			body:  "This is a message",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			result, err := SMSSignature(key, tc.keyID, tc.time, SMSPurposeENReport, tc.phone, tc.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			parts := strings.Split(result, ".")
+			last := parts[len(parts)-1]
+
+			b, err := base64.RawStdEncoding.DecodeString(last)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			signingString := smsSignatureString(tc.time, SMSPurposeENReport, tc.phone, tc.body)
+			digest := sha256.Sum256([]byte(signingString))
+
+			if !ecdsa.VerifyASN1(&key.PublicKey, digest[:], b) {
+				t.Error("did not verify")
+			}
+		})
+	}
+}
+
+func Test_smsSignatureString(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   string
+		exp  string
+	}{
+		{
+			name: "default",
+			in:   smsSignatureString(time.Unix(0, 0), SMSPurposeENReport, "+11111111111", "Hello world"),
+			exp:  "EN Report.+11111111111.1970-01-01.Hello world",
+		},
+		{
+			name: "default",
+			in:   smsSignatureString(time.Unix(0, 0).In(time.FixedZone("Test/Test", -10000000)), SMSPurposeENReport, "+11111111111", "Hello world"),
+			exp:  "EN Report.+11111111111.1970-01-01.Hello world",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			if got, want := tc.in, tc.exp; got != want {
+				t.Errorf("expected %v to be %v", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I expect this to change over time as we reach consensus with Apple, but this is good to review and merge for now.

Part of https://github.com/google/exposure-notifications-verification-server/issues/1640

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Implement first pass at SMS signature algorithm package
```
