### PR TITLE
Make sure attestor is provisioned before building

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -128,6 +128,7 @@ resource "null_resource" "build" {
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
     google_storage_bucket_iam_member.cloudbuild-cache,
+    google_binary_authorization_attestor_iam_member.ci-attestor,
   ]
 }
 


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make sure attestor is provisioned before building
```
