### PR TITLE
add UI for managing SMS signing keys

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -141,6 +141,12 @@ aria-expanded="false" aria-label="Toggle navigation">
               {{t $.locale "nav.signing-keys"}}
             </a>
           {{end}}
+          {{if $currentMembership.Can rbac.SettingsRead}}
+            {{$showRealmMenu = true}}
+            <a class="dropdown-item {{if .currentPath.IsDir "/realm/smskeys"}}active{{end}}" href="/realm/smskeys">
+              {{t $.locale "nav.sms-signing-keys"}}
+            </a>
+          {{end}}
           {{if $currentMembership.Can rbac.StatsRead}}
             {{$showRealmMenu = true}}
             <a class="dropdown-item {{if .currentPath.IsDir "/realm/stats"}}active{{end}}" href="/realm/stats">

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -140,10 +140,7 @@ aria-expanded="false" aria-label="Toggle navigation">
             <a class="dropdown-item {{if .currentPath.IsDir "/realm/keys"}}active{{end}}" href="/realm/keys">
               {{t $.locale "nav.signing-keys"}}
             </a>
-          {{end}}
-          {{if .enableAuthenticatedSMS}}
-            {{if $currentMembership.Can rbac.SettingsRead}}
-              {{$showRealmMenu = true}}
+            {{if .enableAuthenticatedSMS}}
               <a class="dropdown-item {{if .currentPath.IsDir "/realm/smskeys"}}active{{end}}" href="/realm/smskeys">
                 {{t $.locale "nav.sms-signing-keys"}}
               </a>

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -141,11 +141,13 @@ aria-expanded="false" aria-label="Toggle navigation">
               {{t $.locale "nav.signing-keys"}}
             </a>
           {{end}}
-          {{if $currentMembership.Can rbac.SettingsRead}}
-            {{$showRealmMenu = true}}
-            <a class="dropdown-item {{if .currentPath.IsDir "/realm/smskeys"}}active{{end}}" href="/realm/smskeys">
-              {{t $.locale "nav.sms-signing-keys"}}
-            </a>
+          {{if .enableAuthenticatedSMS}}
+            {{if $currentMembership.Can rbac.SettingsRead}}
+              {{$showRealmMenu = true}}
+              <a class="dropdown-item {{if .currentPath.IsDir "/realm/smskeys"}}active{{end}}" href="/realm/smskeys">
+                {{t $.locale "nav.sms-signing-keys"}}
+              </a>
+            {{end}}
           {{end}}
           {{if $currentMembership.Can rbac.StatsRead}}
             {{$showRealmMenu = true}}

--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -141,7 +141,7 @@ aria-expanded="false" aria-label="Toggle navigation">
               {{t $.locale "nav.signing-keys"}}
             </a>
             {{if .enableAuthenticatedSMS}}
-              <a class="dropdown-item {{if .currentPath.IsDir "/realm/smskeys"}}active{{end}}" href="/realm/smskeys">
+              <a class="dropdown-item {{if .currentPath.IsDir "/realm/sms-keys"}}active{{end}}" href="/realm/sms-keys">
                 {{t $.locale "nav.sms-signing-keys"}}
               </a>
             {{end}}

--- a/cmd/server/assets/realmadmin/smskeys.html
+++ b/cmd/server/assets/realmadmin/smskeys.html
@@ -37,7 +37,7 @@
               {{if $realm.UseAuthenticatedSMS}}
                 <div class="alert alert-success">
                   <p>This realm is signing outgoing SMS containing verification codes.
-                    <a href="/realm/smskeys/disable" data-method="POST"
+                    <a href="/realm/sms-keys/disable" data-method="POST"
                     data-confirm="Are you sure you want disable Authenticated SMS?">Disable Authenticated SMS.</a>
                   </p>
                 </div>
@@ -50,7 +50,7 @@
                     If you enable this, your verification messages will be broken into multiple SMS segments,
                     which could incur additional cost. <br/>
                     This feature is not currently available on Android Exposure Notifications Express.
-                    <a href="/realm/smskeys/enable" data-method="POST"
+                    <a href="/realm/sms-keys/enable" data-method="POST"
                     data-confirm="Are you sure you want enable Authenticated SMS?">Enable Authenticated SMS.</a>
                   </p>
                 </div>
@@ -107,7 +107,7 @@
                 There is a limit of {{.maximumKeyVersions}} key versions. Destroy an existing key version to create another.
               </div>
             {{else}}
-              <a href="/realm/smskeys/create" data-method="POST" class="btn btn-primary btn-block">
+              <a href="/realm/sms-keys/create" data-method="POST" class="btn btn-primary btn-block">
                 Create new signing key version
               </a>
             {{end}}
@@ -150,7 +150,7 @@
                       {{if not $rk.Active}}
                       <div class="row mt-3 align-items-end h-100">
                         <div class="col">
-                          <a href="/realm/smskeys/{{$rk.ID}}"
+                          <a href="/realm/sms-keys/{{$rk.ID}}"
                             class="text-danger"
                             data-method="DELETE"
                             data-confirm="Are you sure you want to destroy this key? This action is irreversible!"
@@ -161,7 +161,7 @@
                         </div>
 
                         <div class="col">
-                          <form method="POST" action="/realm/smskeys/activate">
+                          <form method="POST" action="/realm/sms-keys/activate">
                             {{ $csrfField }}
                             <input type="hidden" name="id" value="{{$rk.ID}}" />
                             <a href="#" class="btn btn-primary float-right" data-confirm="Have you already shared this new version and public key with Apple and Google?" data-submit-form>

--- a/cmd/server/assets/realmadmin/smskeys.html
+++ b/cmd/server/assets/realmadmin/smskeys.html
@@ -1,0 +1,204 @@
+{{define "realmadmin/smskeys"}}
+
+{{$realm := .realm}}
+{{$publicKeys := .publicKeys}}
+{{$csrfField := .csrfField}}
+
+{{$currentMembership := .currentMembership}}
+{{$canWrite := $currentMembership.Can rbac.SettingsWrite}}
+
+<!doctype html>
+<html lang="en">
+<head>
+  {{template "head" .}}
+</head>
+
+<body class="tab-content">
+  {{template "navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <h1>Authenticated SMS key settings</h1>
+    <p>
+      View or edit the Authenticated SMS signing keys for <strong>{{$realm.Name}}</strong> below.
+    </p>
+
+    {{template "errorSummary" $realm}}
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          <span class="oi oi-key mr-2 ml-n1"></span>
+          Realm Authenticated SMS signing key configuration
+        </div>
+        <div class="card-body">
+            {{template "beta-notice" .}}
+            {{if .activeRealmKey}}
+              {{if $realm.UseAuthenticatedSMS}}
+                <div class="alert alert-success">
+                  <p>This realm is signing outgoing SMS containing verification codes.
+                    <a href="/realm/smskeys/disable" data-method="POST"
+                    data-confirm="Are you sure you want disable Authenticated SMS?">Disable Authenticated SMS.</a>
+                  </p>
+                </div>
+              {{else}}
+                <div class="alert alert-warning">
+                  <p><strong>⚠️ Attention! ⚠️</strong> 
+                    Authenticated SMS is an experimental feature. This is only utilized by the iOS
+                    Exposure Notifications Express client. You should not enable this until you
+                    have confirmed with Apple that this feature is enabled in your jurisdiction. 
+                    If you enable this, your verification messages will be broken into multiple SMS segments,
+                    which could incur additional cost. <br/>
+                    This feature is not currently available on Android Exposure Notifications Express.
+                    <a href="/realm/smskeys/enable" data-method="POST"
+                    data-confirm="Are you sure you want enable Authenticated SMS?">Enable Authenticated SMS.</a>
+                  </p>
+                </div>
+              {{end}}
+                
+
+              <div class="form-label-group">
+                <div class="input-group">
+                  <input type="text" id="certKeyID" class="form-control"
+                    placeholder="Key ID (kid)" value="{{.activeRealmKey}}" readonly />
+                  <label for="certKeyID" class="col-sm-3">Key ID (kid)</label>
+                  {{template "clippy" "certKeyID"}}
+                </div>
+                <small class="form-text text-muted">
+                  This is the Key ID (kid) of the currently active key.
+                </small>
+              </div>
+
+              <div class="form-label-group">
+                <div class="input-group">
+                  <textarea class="form-control form-control-sm" rows="4" id="activePublicKey" placeholder="Public key" readonly>{{if .activePublicKey}}{{.activePublicKey | trimSpace}}{{else}}Temporarily unable to show public key{{end}}</textarea>
+                  <label for="activePublicKey">Public key</label>
+                  {{template "clippy" "activePublicKey"}}
+                </div>
+                <small class="form-text text-muted">
+                  This is the currently active public key.
+                </small>
+              </div>
+            {{else}}
+              <div class="alert alert-warning" role="alert">
+                There are no SMS signing keys active for this realm.
+              </div>
+            {{end}}
+        </div>        
+      </div>
+
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          <span class="oi oi-globe mr-2 ml-n1"></span>
+          Authenticated SMS public keys
+        </div>
+        <div class="card-body">      
+            <p>To manual rotate your Authenticated SMS signing key:</p>
+            <ol class="mb-3">
+              <li class="mb-1">Create a new key by clicking the button below.</li>
+              <li class="mb-1">Communicate that key version and public key to Google and Apple</li>
+              <li class="mb-1">Wait for confirmation from Google AND Apple that the new key is live</li>
+              <li class="mb-1">Activate the new key in this system.</li>
+              <li class="mb-1">Wait at least 48 hours post activation to delete old keys.</li>
+            </ol>
+
+            {{if ge (len .realmKeys) .maximumKeyVersions }}
+              <div class="alert alert-warning">
+                There is a limit of {{.maximumKeyVersions}} key versions. Destroy an existing key version to create another.
+              </div>
+            {{else}}
+              <a href="/realm/smskeys/create" data-method="POST" class="btn btn-primary btn-block">
+                Create new signing key version
+              </a>
+            {{end}}
+
+          {{if .realmKeys}}
+            <hr />
+
+            <div class="table-responsive">
+              <table class="table table-bordered table-striped table-fixed mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col" width="75">Key ID</th>
+                    <th scope="col">Public key</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {{$csrfField := .csrfField}}
+                  {{$publicKeys := .publicKeys}}
+                  {{range $rk := .realmKeys}}
+                  <tr>
+                    <td>
+                      {{$rk.GetKID}}
+                      {{if $rk.Active}}<span class="badge badge-success">Active</span>{{end}}
+                    </td>
+                    <td>
+                      <div class="input-group">
+                        <textarea class="form-control form-control-sm text-monospace" rows="4" id="{{$rk.GetKID}}" readonly>{{index $publicKeys $rk.GetKID | trimSpace}}</textarea>
+                        {{template "clippy" $rk.GetKID}}
+                      </div>
+
+                      <p class="mt-3">Backed by:</p>
+                      <div class="input-group">
+                        <input type="text" id="key-{{$rk.ID}}" class="form-control text-monospace" value="{{$rk.KeyID}}" readonly/>
+                        {{template "clippy" (printf "key-%d" $rk.ID)}}
+                      </div>
+                      <small class="form-text text-muted">
+                        Your server operator may ask for this.
+                      </small>
+
+                      {{if not $rk.Active}}
+                      <div class="row mt-3 align-items-end h-100">
+                        <div class="col">
+                          <a href="/realm/smskeys/{{$rk.ID}}"
+                            class="text-danger"
+                            data-method="DELETE"
+                            data-confirm="Are you sure you want to destroy this key? This action is irreversible!"
+                            data-toggle="tooltip"
+                            title="Destroy this key version">
+                            <span class="oi oi-trash" aria-hidden="true"></span>
+                          </a>
+                        </div>
+
+                        <div class="col">
+                          <form method="POST" action="/realm/smskeys/activate">
+                            {{ $csrfField }}
+                            <input type="hidden" name="id" value="{{$rk.ID}}" />
+                            <a href="#" class="btn btn-primary float-right" data-confirm="Have you already shared this new version and public key with Apple and Google?" data-submit-form>
+                              Activate
+                            </a>
+                          </form>
+                        </div>
+                      </div>
+                      {{end}}
+                    </td>
+                  </tr>
+                {{end}}
+                </tbody>
+              </table>
+            </div>
+          {{end}}
+        </div>
+      </div>
+  </main>
+
+  <script type="text/javascript">
+    {{if not $canWrite}}
+      {{/*
+
+        This is a little bit hacky, since technically the user could disable
+        javascript, but we do server-side validation to prevent actual data
+        mutation without permission.
+
+      */}}
+      $('body').find('input, button, select, textarea, a.btn')
+        .addClass('disabled')
+        .addClass('readonly')
+        .prop('disabled', true)
+        .prop('readonly', true);
+    {{end}}
+  </script>
+</body>
+</html>
+{{end}}
+ 

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -35,6 +35,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/mobileapps"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/stats"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/user"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -297,6 +298,12 @@ func Server(
 			return nil, fmt.Errorf("failed to create realmkeys controller: %w", err)
 		}
 		realmkeysRoutes(sub, realmkeysController)
+
+		realmSMSKeysController, err := smskeys.New(ctx, cfg, db, cacher, h)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create smskeys controller: %w", err)
+		}
+		realmSMSkeysRoutes(sub, realmSMSKeysController)
 	}
 
 	// JWKs
@@ -391,6 +398,16 @@ func realmkeysRoutes(r *mux.Router, c *realmkeys.Controller) {
 	r.Handle("/keys/manual", c.HandleManualRotate()).Methods("POST")
 	r.Handle("/keys/save", c.HandleSave()).Methods("POST")
 	r.Handle("/keys/activate", c.HandleActivate()).Methods("POST")
+}
+
+// realmSMSkeysRoutes are the realm key routes.
+func realmSMSkeysRoutes(r *mux.Router, c *smskeys.Controller) {
+	r.Handle("/smskeys", c.HandleIndex()).Methods("GET")
+	r.Handle("/smskeys/enable", c.HandleEnable()).Methods("POST")
+	r.Handle("/smskeys/disable", c.HandleDisable()).Methods("POST")
+	r.Handle("/smskeys/create", c.HandleCreateKey()).Methods("POST")
+	r.Handle("/smskeys/{id:[0-9]+}", c.HandleDestroy()).Methods("DELETE")
+	r.Handle("/smskeys/activate", c.HandleActivate()).Methods("POST")
 }
 
 // statsRoutes are the statistics routes, rooted at /stats.

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -403,12 +403,12 @@ func realmkeysRoutes(r *mux.Router, c *realmkeys.Controller) {
 
 // realmSMSkeysRoutes are the realm key routes.
 func realmSMSkeysRoutes(r *mux.Router, c *smskeys.Controller, enabledCheck mux.MiddlewareFunc) {
-	r.Handle("/smskeys", enabledCheck(c.HandleIndex())).Methods("GET")
-	r.Handle("/smskeys/enable", enabledCheck(c.HandleEnable())).Methods("POST")
-	r.Handle("/smskeys/disable", enabledCheck(c.HandleDisable())).Methods("POST")
-	r.Handle("/smskeys/create", enabledCheck(c.HandleCreateKey())).Methods("POST")
-	r.Handle("/smskeys/{id:[0-9]+}", enabledCheck(c.HandleDestroy())).Methods("DELETE")
-	r.Handle("/smskeys/activate", enabledCheck(c.HandleActivate())).Methods("POST")
+	r.Handle("/sms-keys", enabledCheck(c.HandleIndex())).Methods("GET")
+	r.Handle("/sms-keys/enable", enabledCheck(c.HandleEnable())).Methods("POST")
+	r.Handle("/sms-keys/disable", enabledCheck(c.HandleDisable())).Methods("POST")
+	r.Handle("/sms-keys/create", enabledCheck(c.HandleCreateKey())).Methods("POST")
+	r.Handle("/sms-keys/{id:[0-9]+}", enabledCheck(c.HandleDestroy())).Methods("DELETE")
+	r.Handle("/sms-keys/activate", enabledCheck(c.HandleActivate())).Methods("POST")
 }
 
 // statsRoutes are the statistics routes, rooted at /stats.

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -1,0 +1,33 @@
+// Copyright 2020 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import "github.com/google/exposure-notifications-verification-server/pkg/controller"
+
+// FeatureConfig represents features that are introduced as off by default allowing
+// for server operators to control their release.
+type FeatureConfig struct {
+	// EnableAuthenticatedSMS allows for realms to managed SMS specific signing keys,
+	// and enable/disable this feature. There is no launch timeline for GA.
+	// This should not be used without prior coordination with Apple/Google.
+	EnableAuthenticatedSMS bool `env:"ENABLE_AUTHENTICATED_SMS, default=false"`
+}
+
+// AddToTemplate takes TemplateMap and writes the status of all known
+// feature flags for use in HTML templates.
+func (f *FeatureConfig) AddToTemplate(m controller.TemplateMap) controller.TemplateMap {
+	m["enableAuthenticatedSMS"] = f.EnableAuthenticatedSMS
+	return m
+}

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -51,6 +51,7 @@ type ServerConfig struct {
 	Database      database.Config
 	Observability observability.Config
 	Cache         cache.Config
+	Features      FeatureConfig
 
 	Port string `env:"PORT,default=8080"`
 

--- a/pkg/controller/middleware/enabled.go
+++ b/pkg/controller/middleware/enabled.go
@@ -1,0 +1,39 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/gorilla/mux"
+)
+
+// OnlyIfEnabled can be used to hide legitimate routes behind a 404
+// if the feature has been disabled.
+func OnlyIfEnabled(enabled bool, h render.Renderer) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if !enabled {
+				controller.NotFound(w, r, h)
+				return
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/template.go
+++ b/pkg/controller/middleware/template.go
@@ -40,6 +40,9 @@ func PopulateTemplateVariables(config *config.ServerConfig) mux.MiddlewareFunc {
 			m["maintenanceMode"] = config.MaintenanceMode
 			m["devMode"] = config.DevMode
 
+			// Add in any feature flags.
+			m = config.Features.AddToTemplate(m)
+
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)
 			r = r.Clone(ctx)

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/sessions"
@@ -46,10 +47,11 @@ func TestHandleAutomaticRotate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -60,10 +62,11 @@ func TestHandleAutomaticRotate(t *testing.T) {
 	t.Run("not_realm_specific_keys", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -98,10 +101,11 @@ func TestHandleAutomaticRotate(t *testing.T) {
 	t.Run("already_enabled", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -140,10 +144,11 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -179,10 +184,11 @@ func TestHandleAutomaticRotate(t *testing.T) {
 	t.Run("enables", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		realm := database.NewRealmWithDefaults("test")

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/sessions"
@@ -46,10 +47,11 @@ func TestHandleManualRotate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleManualRotate()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -60,10 +62,11 @@ func TestHandleManualRotate(t *testing.T) {
 	t.Run("not_enabled", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleManualRotate()
 
 		ctx := ctx
@@ -99,10 +102,11 @@ func TestHandleManualRotate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleManualRotate()
 
 		ctx := ctx
@@ -135,10 +139,11 @@ func TestHandleManualRotate(t *testing.T) {
 	t.Run("enables", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleManualRotate()
 
 		realm := database.NewRealmWithDefaults("test")

--- a/pkg/controller/realmkeys/realmkeys.go
+++ b/pkg/controller/realmkeys/realmkeys.go
@@ -19,7 +19,6 @@ import (
 	"context"
 
 	"github.com/google/exposure-notifications-server/pkg/keys"
-	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
@@ -37,12 +36,7 @@ type Controller struct {
 	systemCertificateKeyManager keys.KeyManager
 }
 
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, cacher cache.Cacher, h render.Renderer) (*Controller, error) {
-	publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, config.CertificateSigning.PublicKeyCacheDuration)
-	if err != nil {
-		return nil, err
-	}
-
+func New(ctx context.Context, config *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
 	return &Controller{
 		config:         config,
 		db:             db,
@@ -50,5 +44,5 @@ func New(ctx context.Context, config *config.ServerConfig, db *database.Database
 		publicKeyCache: publicKeyCache,
 
 		systemCertificateKeyManager: systemCertificationKeyManager,
-	}, nil
+	}
 }

--- a/pkg/controller/smskeys/activate.go
+++ b/pkg/controller/smskeys/activate.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmkeys
+package smskeys
 
 import (
 	"net/http"
@@ -21,7 +21,11 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
-func (c *Controller) HandleIndex() http.Handler {
+func (c *Controller) HandleActivate() http.Handler {
+	type FormData struct {
+		SigningKeyID uint `form:"id"`
+	}
+
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -30,18 +34,35 @@ func (c *Controller) HandleIndex() http.Handler {
 			controller.MissingSession(w, r, c.h)
 			return
 		}
+		flash := controller.Flash(session)
 
 		membership := controller.MembershipFromContext(ctx)
 		if membership == nil {
 			controller.MissingMembership(w, r, c.h)
 			return
 		}
-		if !membership.Can(rbac.SettingsRead) {
+		if !membership.Can(rbac.SettingsWrite) {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+
 		currentRealm := membership.Realm
 
-		c.renderShow(ctx, w, r, currentRealm)
+		var form FormData
+		if err := controller.BindForm(w, r, &form); err != nil {
+			flash.Error("Failed to process form: %v", err)
+			c.renderShow(ctx, w, r, currentRealm)
+			return
+		}
+
+		kid, err := currentRealm.SetActiveSMSSigningKey(c.db, form.SigningKeyID)
+		if err != nil {
+			flash.Error("Unable to set active SMS signing key: %v", err)
+			c.renderShow(ctx, w, r, currentRealm)
+			return
+		}
+		flash.Alert("Updated active SMS signing key to %q", kid)
+
+		c.redirectShow(ctx, w, r)
 	})
 }

--- a/pkg/controller/smskeys/activate.go
+++ b/pkg/controller/smskeys/activate.go
@@ -15,8 +15,10 @@
 package smskeys
 
 import (
+	"fmt"
 	"net/http"
 
+	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
@@ -57,7 +59,9 @@ func (c *Controller) HandleActivate() http.Handler {
 
 		kid, err := currentRealm.SetActiveSMSSigningKey(c.db, form.SigningKeyID)
 		if err != nil {
-			flash.Error("Unable to set active SMS signing key: %v", err)
+			logging.FromContext(ctx).Errorw("realm.SetActiveSMSSigningKey", "error", err)
+			currentRealm.AddError("", fmt.Sprintf("Unable to set active SMS signing key: %v", err))
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShow(ctx, w, r, currentRealm)
 			return
 		}

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -1,0 +1,110 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smskeys_test
+
+import (
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandleCreate(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ServerConfig{}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleCreateKey()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+		envstest.ExercisePermissionMissing(t, handler)
+	})
+
+	t.Run("create_first", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleCreateKey()
+
+		realm := database.NewRealmWithDefaults("test")
+		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 303; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Header().Get("Location"), "/realm/smskeys"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+
+		updatedRealm, err := harness.Database.FindRealm(realm.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, err := updatedRealm.ListSMSSigningKeys(harness.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("no SMS key present after create")
+		}
+	})
+}

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -65,8 +65,8 @@ func TestHandleCreate(t *testing.T) {
 		}
 		handler := c.HandleCreateKey()
 
-		realm := database.NewRealmWithDefaults("test")
-		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+		realm, err := harness.Database.FindRealm(1)
+		if err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/sessions"
@@ -45,10 +46,11 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleCreateKey()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -59,10 +61,11 @@ func TestHandleCreate(t *testing.T) {
 	t.Run("create_first", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleCreateKey()
 
 		realm, err := harness.Database.FindRealm(1)

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -90,7 +90,7 @@ func TestHandleCreate(t *testing.T) {
 		if got, want := w.Code, 303; got != want {
 			t.Errorf("expected %d to be %d", got, want)
 		}
-		if got, want := w.Header().Get("Location"), "/realm/smskeys"; got != want {
+		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
 

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smskeys_test
+
+import (
+	"fmt"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandleDestroy(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ServerConfig{}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleDestroy()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+		envstest.ExercisePermissionMissing(t, handler)
+	})
+
+	t.Run("destroy", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleDestroy()
+
+		realm := database.NewRealmWithDefaults("test")
+		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+		// Create 2 signing keys - we need to destroy the non-active one.
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database); err != nil {
+			t.Fatal(err)
+		}
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database); err != nil {
+			t.Fatal(err)
+		}
+
+		keys, err := realm.ListSMSSigningKeys(harness.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		toDestroy := uint(0)
+		for _, k := range keys {
+			if !k.Active {
+				toDestroy = k.ID
+			}
+		}
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        &database.User{},
+			Permissions: rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("PUT", "/", nil)
+		r = r.Clone(ctx)
+		r = mux.SetURLVars(r, map[string]string{"id": fmt.Sprintf("%d", toDestroy)})
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 303; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+		if got, want := w.Header().Get("Location"), "/realm/smskeys"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+
+		updatedRealm, err := harness.Database.FindRealm(realm.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		keys, err = updatedRealm.ListSMSSigningKeys(harness.Database)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if len(keys) != 1 {
+			t.Fatalf("no SMS key present after create")
+		}
+		if keys[0].ID == toDestroy {
+			t.Fatalf("didn't destroy specified key")
+		}
+	})
+}

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -67,8 +67,8 @@ func TestHandleDestroy(t *testing.T) {
 		}
 		handler := c.HandleDestroy()
 
-		realm := database.NewRealmWithDefaults("test")
-		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+		realm, err := harness.Database.FindRealm(1)
+		if err != nil {
 			t.Fatal(err)
 		}
 		// Create 2 signing keys - we need to destroy the non-active one.

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -111,7 +111,7 @@ func TestHandleDestroy(t *testing.T) {
 		if got, want := w.Code, 303; got != want {
 			t.Errorf("expected %d to be %d", got, want)
 		}
-		if got, want := w.Header().Get("Location"), "/realm/smskeys"; got != want {
+		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
 

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/mux"
@@ -47,10 +48,11 @@ func TestHandleDestroy(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleDestroy()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -61,10 +63,11 @@ func TestHandleDestroy(t *testing.T) {
 	t.Run("destroy", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleDestroy()
 
 		realm, err := harness.Database.FindRealm(1)

--- a/pkg/controller/smskeys/disable.go
+++ b/pkg/controller/smskeys/disable.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmkeys
+package smskeys
 
 import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
-func (c *Controller) HandleIndex() http.Handler {
+func (c *Controller) HandleDisable() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -30,18 +31,41 @@ func (c *Controller) HandleIndex() http.Handler {
 			controller.MissingSession(w, r, c.h)
 			return
 		}
+		flash := controller.Flash(session)
 
 		membership := controller.MembershipFromContext(ctx)
 		if membership == nil {
 			controller.MissingMembership(w, r, c.h)
 			return
 		}
-		if !membership.Can(rbac.SettingsRead) {
+		if !membership.Can(rbac.SettingsWrite) {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
 		currentRealm := membership.Realm
+		currentUser := membership.User
 
-		c.renderShow(ctx, w, r, currentRealm)
+		if !currentRealm.UseAuthenticatedSMS {
+			currentRealm.AddError("", "Authenticated SMS is not currently enabled")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			c.renderShow(ctx, w, r, currentRealm)
+			return
+		}
+
+		currentRealm.UseAuthenticatedSMS = false
+		if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
+			if database.IsNotFound(err) || database.IsValidationError(err) {
+				currentRealm.AddError("", err.Error())
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				c.renderShow(ctx, w, r, currentRealm)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		flash.Alert("Successfully disabled Authenticated SMS.")
+		c.redirectShow(ctx, w, r)
 	})
 }

--- a/pkg/controller/smskeys/enable.go
+++ b/pkg/controller/smskeys/enable.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmkeys
+package smskeys
 
 import (
 	"net/http"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
-func (c *Controller) HandleIndex() http.Handler {
+func (c *Controller) HandleEnable() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -30,18 +31,41 @@ func (c *Controller) HandleIndex() http.Handler {
 			controller.MissingSession(w, r, c.h)
 			return
 		}
+		flash := controller.Flash(session)
 
 		membership := controller.MembershipFromContext(ctx)
 		if membership == nil {
 			controller.MissingMembership(w, r, c.h)
 			return
 		}
-		if !membership.Can(rbac.SettingsRead) {
+		if !membership.Can(rbac.SettingsWrite) {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
 		currentRealm := membership.Realm
+		currentUser := membership.User
 
-		c.renderShow(ctx, w, r, currentRealm)
+		if currentRealm.UseAuthenticatedSMS {
+			currentRealm.AddError("", "Authenticated SMS is already enabled")
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			c.renderShow(ctx, w, r, currentRealm)
+			return
+		}
+
+		currentRealm.UseAuthenticatedSMS = true
+		if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
+			if database.IsNotFound(err) || database.IsValidationError(err) {
+				currentRealm.AddError("", err.Error())
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				c.renderShow(ctx, w, r, currentRealm)
+				return
+			}
+
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		flash.Alert("Successfully enabled authenticated SMS.")
+		c.redirectShow(ctx, w, r)
 	})
 }

--- a/pkg/controller/smskeys/index.go
+++ b/pkg/controller/smskeys/index.go
@@ -1,4 +1,4 @@
-// Copyright 2020 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmkeys
+package smskeys
 
 import (
 	"net/http"

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -25,6 +25,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/sessions"
@@ -46,10 +47,11 @@ func TestHandleIndex(t *testing.T) {
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleIndex()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -60,10 +62,11 @@ func TestHandleIndex(t *testing.T) {
 	t.Run("no_keys", func(t *testing.T) {
 		t.Parallel()
 
-		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
 		if err != nil {
 			t.Fatal(err)
 		}
+		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleIndex()
 
 		realm, err := harness.Database.FindRealm(1)

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -66,8 +66,8 @@ func TestHandleIndex(t *testing.T) {
 		}
 		handler := c.HandleIndex()
 
-		realm := database.NewRealmWithDefaults("test")
-		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+		realm, err := harness.Database.FindRealm(1)
+		if err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -1,0 +1,99 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smskeys_test
+
+import (
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
+)
+
+func TestHandleIndex(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.ServerConfig{}
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleIndex()
+
+		envstest.ExerciseSessionMissing(t, handler)
+		envstest.ExerciseMembershipMissing(t, handler)
+		envstest.ExercisePermissionMissing(t, handler)
+	})
+
+	t.Run("no_keys", func(t *testing.T) {
+		t.Parallel()
+
+		c, err := smskeys.New(ctx, cfg, harness.Database, harness.Cacher, h)
+		if err != nil {
+			t.Fatal(err)
+		}
+		handler := c.HandleIndex()
+
+		realm := database.NewRealmWithDefaults("test")
+		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        &database.User{},
+			Permissions: rbac.SettingsRead | rbac.SettingsWrite,
+		})
+
+		r := httptest.NewRequest("GET", "/", nil)
+		r = r.Clone(ctx)
+		r.Header.Set("Content-Type", "text/html")
+
+		w := httptest.NewRecorder()
+
+		handler.ServeHTTP(w, r)
+		w.Flush()
+
+		if got, want := w.Code, 200; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+
+		if !strings.Contains(w.Body.String(), "There are no SMS signing keys active for this realm.") {
+			t.Fatalf("missing required text")
+		}
+	})
+}

--- a/pkg/controller/smskeys/render.go
+++ b/pkg/controller/smskeys/render.go
@@ -1,0 +1,72 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smskeys
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
+)
+
+func (c *Controller) redirectShow(ctx context.Context, w http.ResponseWriter, r *http.Request) {
+	http.Redirect(w, r, "/realm/smskeys", http.StatusSeeOther)
+}
+
+func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *http.Request, realm *database.Realm) {
+	m := controller.TemplateMapFromContext(ctx)
+	m.Title("Authenticated SMS Signing keys")
+	m["realm"] = realm
+
+	keys, err := realm.ListSMSSigningKeys(c.db)
+	if err != nil {
+		controller.InternalError(w, r, c.h, err)
+		return
+	}
+
+	m["realmKeys"] = keys
+
+	maximumKeyVersions := c.db.MaxCertificateSigningKeyVersions()
+	m["maximumKeyVersions"] = maximumKeyVersions
+
+	publicKeys := make(map[string]string)
+	// Go through and load / parse all of the public keys for the realm.
+	for _, k := range keys {
+		if k.Active {
+			m["activeRealmKey"] = k.GetKID()
+			m["activePublicKey"] = ""
+		}
+		pk, err := c.publicKeyCache.GetPublicKey(ctx, k.KeyID, c.db.KeyManager())
+		if err != nil {
+			publicKeys[k.GetKID()] = fmt.Errorf("error loading public key: %v", err).Error()
+		} else {
+			pem, err := keyutils.EncodePublicKey(pk)
+			if err != nil {
+				publicKeys[k.GetKID()] = fmt.Errorf("error decoding public key: %v", err).Error()
+			} else {
+				publicKeys[k.GetKID()] = pem
+				if k.Active {
+					m["activePublicKey"] = pem
+				}
+			}
+		}
+	}
+	m["publicKeys"] = publicKeys
+
+	c.h.RenderHTML(w, "realmadmin/smskeys", m)
+}

--- a/pkg/controller/smskeys/render.go
+++ b/pkg/controller/smskeys/render.go
@@ -25,7 +25,7 @@ import (
 )
 
 func (c *Controller) redirectShow(ctx context.Context, w http.ResponseWriter, r *http.Request) {
-	http.Redirect(w, r, "/realm/smskeys", http.StatusSeeOther)
+	http.Redirect(w, r, "/realm/sms-keys", http.StatusSeeOther)
 }
 
 func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *http.Request, realm *database.Realm) {

--- a/pkg/controller/smskeys/smskeys.go
+++ b/pkg/controller/smskeys/smskeys.go
@@ -18,7 +18,6 @@ package smskeys
 import (
 	"context"
 
-	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
@@ -34,16 +33,11 @@ type Controller struct {
 }
 
 // New creates a new Controller
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, cacher cache.Cacher, h render.Renderer) (*Controller, error) {
-	publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, config.CertificateSigning.PublicKeyCacheDuration)
-	if err != nil {
-		return nil, err
-	}
-
+func New(ctx context.Context, config *config.ServerConfig, db *database.Database, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
 	return &Controller{
 		config:         config,
 		db:             db,
 		h:              h,
 		publicKeyCache: publicKeyCache,
-	}, nil
+	}
 }

--- a/pkg/controller/smskeys/smskeys.go
+++ b/pkg/controller/smskeys/smskeys.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package smskeys contains web controllers for realm certificate key management.
+package smskeys
+
+import (
+	"context"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+// Controller has handlers HTTP actions realted to SMS signing key management.
+type Controller struct {
+	config         *config.ServerConfig
+	db             *database.Database
+	h              render.Renderer
+	publicKeyCache *keyutils.PublicKeyCache
+}
+
+// New creates a new Controller
+func New(ctx context.Context, config *config.ServerConfig, db *database.Database, cacher cache.Cacher, h render.Renderer) (*Controller, error) {
+	publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, config.CertificateSigning.PublicKeyCacheDuration)
+	if err != nil {
+		return nil, err
+	}
+
+	return &Controller{
+		config:         config,
+		db:             db,
+		h:              h,
+		publicKeyCache: publicKeyCache,
+	}, nil
+}

--- a/pkg/controller/smskeys/smskeys_test.go
+++ b/pkg/controller/smskeys/smskeys_test.go
@@ -1,0 +1,29 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package smskeys_test
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var testDatabaseInstance *database.TestInstance
+
+func TestMain(m *testing.M) {
+	testDatabaseInstance = database.MustTestInstance()
+	defer testDatabaseInstance.MustClose()
+	m.Run()
+}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2060,6 +2060,18 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`DROP TABLE IF EXISTS sms_signing_keys`)
 			},
 		},
+		{
+			ID: "00091-AddRealmAAuthenticatedSMSSetting",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS use_authenticated_sms BOOLEAN DEFAULT false`,
+					`ALTER TABLE realms ALTER COLUMN use_authenticated_sms SET NOT NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS use_authenticated_sms`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -186,6 +186,10 @@ type Realm struct {
 	SMSFromNumberID    uint  `gorm:"-"`
 	SMSFromNumberIDPtr *uint `gorm:"column:sms_from_number_id; type:integer;"`
 
+	// UseAuthenticatedSMS indicates if this realm wants to sign text messages that are sent
+	// containing verification codes.
+	UseAuthenticatedSMS bool `gorm:"column:use_authenticated_sms; type:bool; not null; default:false;"`
+
 	// EmailInviteTemplate is the template for inviting new users.
 	EmailInviteTemplate string `gorm:"type:text;"`
 

--- a/pkg/database/sms_signing_key.go
+++ b/pkg/database/sms_signing_key.go
@@ -39,7 +39,7 @@ type SMSSigningKey struct {
 
 // GetKID returns the 'kid' field value to use in signing JWTs.
 func (s *SMSSigningKey) GetKID() string {
-	return fmt.Sprintf("r%dv%ds", s.RealmID, s.ID)
+	return fmt.Sprintf("r%dv%dsms", s.RealmID, s.ID)
 }
 
 func (s *SMSSigningKey) ManagedKeyID() string {

--- a/pkg/database/sms_signing_key.go
+++ b/pkg/database/sms_signing_key.go
@@ -39,7 +39,7 @@ type SMSSigningKey struct {
 
 // GetKID returns the 'kid' field value to use in signing JWTs.
 func (s *SMSSigningKey) GetKID() string {
-	return fmt.Sprintf("r%dmv%d", s.RealmID, s.ID)
+	return fmt.Sprintf("r%dv%ds", s.RealmID, s.ID)
 }
 
 func (s *SMSSigningKey) ManagedKeyID() string {


### PR DESCRIPTION
towards #1640 

## Proposed Changes

* Add realm setting for enabling Authenticated SMS
* Add key management

![image](https://user-images.githubusercontent.com/92319/105562214-32c93e80-5cce-11eb-80b5-3aff7e381634.png)


**Release Note**

```release-note
Realm admins can create/rotate SMS signing keys and enable authenticated SMS.
```
