### PR TITLE
Standardize response codes and add tests to SMS keys

### DIFF
--- a/cmd/server/assets/header.html
+++ b/cmd/server/assets/header.html
@@ -140,9 +140,9 @@ aria-expanded="false" aria-label="Toggle navigation">
             <a class="dropdown-item {{if .currentPath.IsDir "/realm/keys"}}active{{end}}" href="/realm/keys">
               {{t $.locale "nav.signing-keys"}}
             </a>
-            {{if .enableAuthenticatedSMS}}
+            {{if .features.EnableAuthenticatedSMS}}
               <a class="dropdown-item {{if .currentPath.IsDir "/realm/sms-keys"}}active{{end}}" href="/realm/sms-keys">
-                {{t $.locale "nav.sms-signing-keys"}}
+                {{t $.locale "nav.authenticated-sms"}}
               </a>
             {{end}}
           {{end}}

--- a/cmd/server/assets/realmadmin/smskeys.html
+++ b/cmd/server/assets/realmadmin/smskeys.html
@@ -19,167 +19,183 @@
   <main role="main" class="container">
     {{template "flash" .}}
 
-    <h1>Authenticated SMS key settings</h1>
+    <h1>Authenticated SMS</h1>
     <p>
-      View or edit the Authenticated SMS signing keys for <strong>{{$realm.Name}}</strong> below.
+      View or edit the Authenticated SMS settings and signing keys for
+      <strong>{{$realm.Name}}</strong> below.
     </p>
+
+    {{template "beta-notice" .}}
 
     {{template "errorSummary" $realm}}
 
-      <div class="card mb-3 shadow-sm">
-        <div class="card-header">
-          <span class="oi oi-key mr-2 ml-n1"></span>
-          Realm Authenticated SMS signing key configuration
-        </div>
-        <div class="card-body">
-            {{template "beta-notice" .}}
-            {{if .activeRealmKey}}
-              {{if $realm.UseAuthenticatedSMS}}
-                <div class="alert alert-success">
-                  <p>This realm is signing outgoing SMS containing verification codes.
-                    <a href="/realm/sms-keys/disable" data-method="POST"
-                    data-confirm="Are you sure you want disable Authenticated SMS?">Disable Authenticated SMS.</a>
-                  </p>
-                </div>
-              {{else}}
-                <div class="alert alert-warning">
-                  <p><strong>⚠️ Attention! ⚠️</strong> 
-                    Authenticated SMS is an experimental feature. This is only utilized by the iOS
-                    Exposure Notifications Express client. You should not enable this until you
-                    have confirmed with Apple that this feature is enabled in your jurisdiction. 
-                    If you enable this, your verification messages will be broken into multiple SMS segments,
-                    which could incur additional cost. <br/>
-                    This feature is not currently available on Android Exposure Notifications Express.
-                    <a href="/realm/sms-keys/enable" data-method="POST"
-                    data-confirm="Are you sure you want enable Authenticated SMS?">Enable Authenticated SMS.</a>
-                  </p>
-                </div>
-              {{end}}
-                
-
-              <div class="form-label-group">
-                <div class="input-group">
-                  <input type="text" id="certKeyID" class="form-control"
-                    placeholder="Key ID (kid)" value="{{.activeRealmKey}}" readonly />
-                  <label for="certKeyID" class="col-sm-3">Key ID (kid)</label>
-                  {{template "clippy" "certKeyID"}}
-                </div>
-                <small class="form-text text-muted">
-                  This is the Key ID (kid) of the currently active key.
-                </small>
-              </div>
-
-              <div class="form-label-group">
-                <div class="input-group">
-                  <textarea class="form-control form-control-sm" rows="4" id="activePublicKey" placeholder="Public key" readonly>{{if .activePublicKey}}{{.activePublicKey | trimSpace}}{{else}}Temporarily unable to show public key{{end}}</textarea>
-                  <label for="activePublicKey">Public key</label>
-                  {{template "clippy" "activePublicKey"}}
-                </div>
-                <small class="form-text text-muted">
-                  This is the currently active public key.
-                </small>
-              </div>
-            {{else}}
-              <div class="alert alert-warning" role="alert">
-                There are no SMS signing keys active for this realm.
-              </div>
-            {{end}}
-        </div>        
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">
+        {{if $realm.UseAuthenticatedSMS}}
+          <span class="oi oi-lock-locked mr-2 ml-n1"></span>
+        {{else}}
+          <span class="oi oi-lock-unlocked mr-2 ml-n1"></span>
+        {{end}}
+        Status
       </div>
+      {{if .activeRealmKey}}
+        {{if not $realm.UseAuthenticatedSMS}}
+          <div class="card-body">
+            <p>
+              <strong>Warning!</strong> Authenticated SMS is an experimental
+              feature for iOS. Do not enable this unless Apple has instructed
+              you to do so. This feature is not currently available for
+              Android devices.
+            </p>
 
-      <div class="card mb-3 shadow-sm">
-        <div class="card-header">
-          <span class="oi oi-globe mr-2 ml-n1"></span>
-          Authenticated SMS public keys
-        </div>
-        <div class="card-body">      
-            <p>To manual rotate your Authenticated SMS signing key:</p>
-            <ol class="mb-3">
-              <li class="mb-1">Create a new key by clicking the button below.</li>
-              <li class="mb-1">Communicate that key version and public key to Google and Apple</li>
-              <li class="mb-1">Wait for confirmation from Google AND Apple that the new key is live</li>
-              <li class="mb-1">Activate the new key in this system.</li>
-              <li class="mb-1">Wait at least 48 hours post activation to delete old keys.</li>
-            </ol>
+            <p>
+              Enabling this feature will increase the length of your SMS
+              messages such that they are split across multiple messages,
+              <strong>which will increase costs</strong>.
+            </p>
 
-            {{if ge (len .realmKeys) .maximumKeyVersions }}
-              <div class="alert alert-warning">
-                There is a limit of {{.maximumKeyVersions}} key versions. Destroy an existing key version to create another.
+            <a href="/realm/sms-keys/enable"
+              data-method="PUT" data-confirm="Are you sure you want enable Authenticated SMS?"
+              class="btn btn-block btn-success">
+              Enable Authenticated SMS
+            </a>
+          </div>
+        {{else}}
+          <div class="card-body">
+            <div class="form-label-group">
+              <div class="input-group">
+                <input type="text" id="certKeyID" class="form-control"
+                  placeholder="Key ID (kid)" value="{{.activeRealmKey}}" readonly />
+                <label for="certKeyID" class="col-sm-3">Key ID (kid)</label>
+                {{template "clippy" "certKeyID"}}
               </div>
-            {{else}}
-              <a href="/realm/sms-keys/create" data-method="POST" class="btn btn-primary btn-block">
-                Create new signing key version
-              </a>
-            {{end}}
-
-          {{if .realmKeys}}
-            <hr />
-
-            <div class="table-responsive">
-              <table class="table table-bordered table-striped table-fixed mb-0">
-                <thead>
-                  <tr>
-                    <th scope="col" width="75">Key ID</th>
-                    <th scope="col">Public key</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {{$csrfField := .csrfField}}
-                  {{$publicKeys := .publicKeys}}
-                  {{range $rk := .realmKeys}}
-                  <tr>
-                    <td>
-                      {{$rk.GetKID}}
-                      {{if $rk.Active}}<span class="badge badge-success">Active</span>{{end}}
-                    </td>
-                    <td>
-                      <div class="input-group">
-                        <textarea class="form-control form-control-sm text-monospace" rows="4" id="{{$rk.GetKID}}" readonly>{{index $publicKeys $rk.GetKID | trimSpace}}</textarea>
-                        {{template "clippy" $rk.GetKID}}
-                      </div>
-
-                      <p class="mt-3">Backed by:</p>
-                      <div class="input-group">
-                        <input type="text" id="key-{{$rk.ID}}" class="form-control text-monospace" value="{{$rk.KeyID}}" readonly/>
-                        {{template "clippy" (printf "key-%d" $rk.ID)}}
-                      </div>
-                      <small class="form-text text-muted">
-                        Your server operator may ask for this.
-                      </small>
-
-                      {{if not $rk.Active}}
-                      <div class="row mt-3 align-items-end h-100">
-                        <div class="col">
-                          <a href="/realm/sms-keys/{{$rk.ID}}"
-                            class="text-danger"
-                            data-method="DELETE"
-                            data-confirm="Are you sure you want to destroy this key? This action is irreversible!"
-                            data-toggle="tooltip"
-                            title="Destroy this key version">
-                            <span class="oi oi-trash" aria-hidden="true"></span>
-                          </a>
-                        </div>
-
-                        <div class="col">
-                          <form method="POST" action="/realm/sms-keys/activate">
-                            {{ $csrfField }}
-                            <input type="hidden" name="id" value="{{$rk.ID}}" />
-                            <a href="#" class="btn btn-primary float-right" data-confirm="Have you already shared this new version and public key with Apple and Google?" data-submit-form>
-                              Activate
-                            </a>
-                          </form>
-                        </div>
-                      </div>
-                      {{end}}
-                    </td>
-                  </tr>
-                {{end}}
-                </tbody>
-              </table>
+              <small class="form-text text-muted">
+                This is the Key ID (kid) of the currently active key.
+              </small>
             </div>
-          {{end}}
+
+            <div class="form-label-group mb-0">
+              <div class="input-group">
+                <textarea class="form-control form-control-sm" rows="4" id="activePublicKey" placeholder="Public key" readonly>{{if .activePublicKey}}{{.activePublicKey | trimSpace}}{{else}}Temporarily unable to show public key{{end}}</textarea>
+                <label for="activePublicKey">Public key</label>
+                {{template "clippy" "activePublicKey"}}
+              </div>
+              <small class="form-text text-muted">
+                This is the currently active public key.
+              </small>
+            </div>
+          </div>
+
+          <small class="card-footer d-flex justify-content-end text-muted">
+            <a href="/realm/sms-keys/disable"
+              data-method="PUT" data-confirm="Are you sure you want disable Authenticated SMS?"
+              class="text-muted">
+              Disable Authenticated SMS
+            </a>
+          </small>
+        {{end}}
+      {{else}}
+        <div class="card-body">
+          <div class="alert alert-warning" role="alert">
+            There are no SMS signing keys active for this realm.
+          </div>
         </div>
+      {{end}}
+    </div>
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">
+        <span class="oi oi-key mr-2 ml-n1"></span>
+        Signing keys
       </div>
+      <div class="card-body">
+          <p>To manual rotate your Authenticated SMS signing key:</p>
+          <ol class="mb-3">
+            <li class="mb-1">Create a new key by clicking the button below</li>
+            <li class="mb-1">Communicate that key version and public key to Google and Apple</li>
+            <li class="mb-1">Wait for confirmation from Google AND Apple that the new key is live</li>
+            <li class="mb-1">Activate the new key in this system</li>
+            <li class="mb-1">Wait at least 48 hours post activation to delete old keys</li>
+          </ol>
+
+          {{if ge (len .realmKeys) .maximumKeyVersions }}
+            <div class="alert alert-warning">
+              There is a limit of {{.maximumKeyVersions}} key versions. Destroy an existing key version to create another.
+            </div>
+          {{else}}
+            <a href="/realm/sms-keys" data-method="POST" class="btn btn-primary btn-block">
+              Create new signing key version
+            </a>
+          {{end}}
+
+        {{if .realmKeys}}
+          <hr />
+
+          <div class="table-responsive">
+            <table class="table table-bordered table-striped table-fixed mb-0">
+              <thead>
+                <tr>
+                  <th scope="col" width="75">Key ID</th>
+                  <th scope="col">Public key</th>
+                </tr>
+              </thead>
+              <tbody>
+                {{$csrfField := .csrfField}}
+                {{$publicKeys := .publicKeys}}
+                {{range $rk := .realmKeys}}
+                <tr>
+                  <td>
+                    {{$rk.GetKID}}
+                    {{if $rk.Active}}<span class="badge badge-success">Active</span>{{end}}
+                  </td>
+                  <td>
+                    <div class="input-group">
+                      <textarea class="form-control form-control-sm text-monospace" rows="4" id="{{$rk.GetKID}}" readonly>{{index $publicKeys $rk.GetKID | trimSpace}}</textarea>
+                      {{template "clippy" $rk.GetKID}}
+                    </div>
+
+                    <p class="mt-3">Backed by:</p>
+                    <div class="input-group">
+                      <input type="text" id="key-{{$rk.ID}}" class="form-control text-monospace" value="{{$rk.KeyID}}" readonly/>
+                      {{template "clippy" (printf "key-%d" $rk.ID)}}
+                    </div>
+                    <small class="form-text text-muted">
+                      Your server operator may ask for this.
+                    </small>
+
+                    {{if not $rk.Active}}
+                    <div class="row mt-3 align-items-end h-100">
+                      <div class="col">
+                        <a href="/realm/sms-keys/{{$rk.ID}}"
+                          class="text-danger"
+                          data-method="DELETE"
+                          data-confirm="Are you sure you want to destroy this key? This action is irreversible!"
+                          data-toggle="tooltip"
+                          title="Destroy this key version">
+                          <span class="oi oi-trash" aria-hidden="true"></span>
+                        </a>
+                      </div>
+
+                      <div class="col">
+                        <form method="POST" action="/realm/sms-keys/activate">
+                          {{ $csrfField }}
+                          <input type="hidden" name="id" value="{{$rk.ID}}" />
+                          <a href="#" class="btn btn-primary float-right" data-confirm="Have you already shared this new version and public key with Apple and Google?" data-submit-form>
+                            Activate
+                          </a>
+                        </form>
+                      </div>
+                    </div>
+                    {{end}}
+                  </td>
+                </tr>
+              {{end}}
+              </tbody>
+            </table>
+          </div>
+        {{end}}
+      </div>
+    </div>
   </main>
 
   <script type="text/javascript">
@@ -201,4 +217,3 @@
 </body>
 </html>
 {{end}}
- 

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -31,8 +31,8 @@ msgstr "Event Protokoll"
 msgid "nav.signing-keys"
 msgstr "Signaturschlüssel"
 
-msgid "nav.sms-signing-keys"
-msgstr "SMS Signaturschlüssel"
+msgid "nav.authenticated-sms"
+msgstr "SMS autenticados"
 
 msgid "nav.statistics"
 msgstr "Statistiken"

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -31,8 +31,8 @@ msgstr "Event log"
 msgid "nav.signing-keys"
 msgstr "Signing keys"
 
-msgid "nav.sms-signing-keys"
-msgstr "SMS Signing keys"
+msgid "nav.authenticated-sms"
+msgstr "Authenticated SMS"
 
 msgid "nav.statistics"
 msgstr "Statistics"

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -31,8 +31,8 @@ msgstr "Bitácora de eventos"
 msgid "nav.signing-keys"
 msgstr "Llaves firmantes"
 
-msgid "nav.sms-signing-keys"
-msgstr "Llaves firmantes de SMS"
+msgid "nav.authenticated-sms"
+msgstr "SMS autenticados"
 
 msgid "nav.statistics"
 msgstr "Estadísticas"

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -31,8 +31,8 @@ msgstr "Journal d'événements"
 msgid "nav.signing-keys"
 msgstr "Clés de signature"
 
-msgid "nav.sms-signing-keys"
-msgstr "Clés de signature SMS"
+msgid "nav.authenticated-sms"
+msgstr "SMS authentifié"
 
 msgid "nav.statistics"
 msgstr "Statistiques"

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -31,8 +31,8 @@ msgstr "Registro eventi"
 msgid "nav.signing-keys"
 msgstr "Chiavi di firma"
 
-msgid "nav.sms-signing-keys"
-msgstr "Chiavi di firma SMS"
+msgid "nav.authenticated-sms"
+msgstr "SMS autenticato"
 
 msgid "nav.statistics"
 msgstr "Statistiche"

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -31,8 +31,8 @@ msgstr "イベントログ"
 msgid "nav.signing-keys"
 msgstr "署名鍵"
 
-msgid "nav.sms-signing-keys"
-msgstr "SMS 署名鍵"
+msgid "nav.authenticated-sms"
+msgstr "認証されたSMS"
 
 msgid "nav.statistics"
 msgstr "統計"

--- a/internal/i18n/locales/ph/default.po
+++ b/internal/i18n/locales/ph/default.po
@@ -31,8 +31,8 @@ msgstr "Event log"
 msgid "nav.signing-keys"
 msgstr "Signing keys"
 
-msgid "nav.sms-signing-keys"
-msgstr "SMS Signing keys"
+msgid "nav.authenticated-sms"
+msgstr "Pinatunayan ang SMS"
 
 msgid "nav.statistics"
 msgstr "Statistics"

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -31,8 +31,8 @@ msgstr "Registro de eventos"
 msgid "nav.signing-keys"
 msgstr "Chaves de assinatura"
 
-msgid "nav.sms-signing-keys"
-msgstr "Chaves de assinatura de SMS"
+msgid "nav.authenticated-sms"
+msgstr "Pinatunayan ang SMS"
 
 msgid "nav.statistics"
 msgstr "Estatísticas"

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -31,8 +31,8 @@ msgstr "Etkinlik kaydı"
 msgid "nav.signing-keys"
 msgstr "Kriptografik imzalama anahtarları"
 
-msgid "nav.sms-signing-keys"
-msgstr "SMS Kriptografik imzalama anahtarları"
+msgid "nav.authenticated-sms"
+msgstr "Kimliği doğrulanmış SMS"
 
 msgid "nav.statistics"
 msgstr "İstatistikler"

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -299,12 +299,13 @@ func Server(
 			return nil, err
 		}
 
-		realmkeysController := realmkeys.New(ctx, cfg, db, certificateSigner, publicKeyCache, h)
+		realmkeysController := realmkeys.New(cfg, db, certificateSigner, publicKeyCache, h)
 		realmkeysRoutes(sub, realmkeysController)
 
-		realmSMSKeysController := smskeys.New(ctx, cfg, db, publicKeyCache, h)
-		authenticatedSMSEnabled := middleware.OnlyIfEnabled(cfg.Features.EnableAuthenticatedSMS, h)
-		realmSMSkeysRoutes(sub, realmSMSKeysController, authenticatedSMSEnabled)
+		realmSMSKeysController := smskeys.New(cfg, db, publicKeyCache, h)
+		if cfg.Features.EnableAuthenticatedSMS {
+			realmSMSkeysRoutes(sub, realmSMSKeysController)
+		}
 	}
 
 	// JWKs
@@ -402,13 +403,13 @@ func realmkeysRoutes(r *mux.Router, c *realmkeys.Controller) {
 }
 
 // realmSMSkeysRoutes are the realm key routes.
-func realmSMSkeysRoutes(r *mux.Router, c *smskeys.Controller, enabledCheck mux.MiddlewareFunc) {
-	r.Handle("/sms-keys", enabledCheck(c.HandleIndex())).Methods("GET")
-	r.Handle("/sms-keys/enable", enabledCheck(c.HandleEnable())).Methods("POST")
-	r.Handle("/sms-keys/disable", enabledCheck(c.HandleDisable())).Methods("POST")
-	r.Handle("/sms-keys/create", enabledCheck(c.HandleCreateKey())).Methods("POST")
-	r.Handle("/sms-keys/{id:[0-9]+}", enabledCheck(c.HandleDestroy())).Methods("DELETE")
-	r.Handle("/sms-keys/activate", enabledCheck(c.HandleActivate())).Methods("POST")
+func realmSMSkeysRoutes(r *mux.Router, c *smskeys.Controller) {
+	r.Handle("/sms-keys", c.HandleIndex()).Methods("GET")
+	r.Handle("/sms-keys", c.HandleCreateKey()).Methods("POST")
+	r.Handle("/sms-keys/enable", c.HandleEnable()).Methods("PUT")
+	r.Handle("/sms-keys/disable", c.HandleDisable()).Methods("PUT")
+	r.Handle("/sms-keys/{id:[0-9]+}", c.HandleDestroy()).Methods("DELETE")
+	r.Handle("/sms-keys/activate", c.HandleActivate()).Methods("POST")
 }
 
 // statsRoutes are the statistics routes, rooted at /stats.

--- a/internal/routes/server_test.go
+++ b/internal/routes/server_test.go
@@ -246,6 +246,42 @@ func TestRoutes_realmkeysRoutes(t *testing.T) {
 	}
 }
 
+func TestRoutes_realmSMSkeysRoutes(t *testing.T) {
+	t.Parallel()
+
+	m := mux.NewRouter()
+	realmSMSkeysRoutes(m, nil)
+
+	cases := []struct {
+		req  *http.Request
+		vars map[string]string
+	}{
+		{
+			req: httptest.NewRequest("GET", "/sms-keys", nil),
+		},
+		{
+			req: httptest.NewRequest("POST", "/sms-keys", nil),
+		},
+		{
+			req: httptest.NewRequest("PUT", "/sms-keys/enable", nil),
+		},
+		{
+			req: httptest.NewRequest("PUT", "/sms-keys/disable", nil),
+		},
+		{
+			req: httptest.NewRequest("POST", "/sms-keys/activate", nil),
+		},
+		{
+			req:  httptest.NewRequest("DELETE", "/sms-keys/12345", nil),
+			vars: map[string]string{"id": "12345"},
+		},
+	}
+
+	for _, tc := range cases {
+		testRoute(t, m, tc.req, tc.vars)
+	}
+}
+
 func TestRoutes_statsRoutes(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -28,6 +28,6 @@ type FeatureConfig struct {
 // AddToTemplate takes TemplateMap and writes the status of all known
 // feature flags for use in HTML templates.
 func (f *FeatureConfig) AddToTemplate(m controller.TemplateMap) controller.TemplateMap {
-	m["enableAuthenticatedSMS"] = f.EnableAuthenticatedSMS
+	m["features"] = f
 	return m
 }

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -51,7 +51,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
+		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -66,7 +66,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
+		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -105,7 +105,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
+		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -148,7 +148,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
+		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		ctx := ctx
@@ -188,7 +188,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(ctx, cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
+		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
 		handler := c.HandleAutomaticRotate()
 
 		realm := database.NewRealmWithDefaults("test")

--- a/pkg/controller/realmkeys/realmkeys.go
+++ b/pkg/controller/realmkeys/realmkeys.go
@@ -16,8 +16,6 @@
 package realmkeys
 
 import (
-	"context"
-
 	"github.com/google/exposure-notifications-server/pkg/keys"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -36,9 +34,9 @@ type Controller struct {
 	systemCertificateKeyManager keys.KeyManager
 }
 
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
+func New(cfg *config.ServerConfig, db *database.Database, systemCertificationKeyManager keys.KeyManager, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
 	return &Controller{
-		config:         config,
+		config:         cfg,
 		db:             db,
 		h:              h,
 		publicKeyCache: publicKeyCache,

--- a/pkg/controller/smskeys/enable_test.go
+++ b/pkg/controller/smskeys/enable_test.go
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package realmkeys_test
+package smskeys_test
 
 import (
 	"net/http/httptest"
@@ -23,7 +23,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmkeys"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/smskeys"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
@@ -31,69 +31,33 @@ import (
 	"github.com/gorilla/sessions"
 )
 
-func TestHandleManualRotate(t *testing.T) {
+func TestHandleEnable(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	cfg := &config.ServerConfig{}
+
+	publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatal(err)
 	}
 
-	cfg := &config.ServerConfig{}
-
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
 
-		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-		handler := c.HandleManualRotate()
+		c := smskeys.New(cfg, harness.Database, publicKeyCache, h)
+		handler := c.HandleEnable()
 
 		envstest.ExerciseSessionMissing(t, handler)
 		envstest.ExerciseMembershipMissing(t, handler)
 		envstest.ExercisePermissionMissing(t, handler)
-	})
-
-	t.Run("not_enabled", func(t *testing.T) {
-		t.Parallel()
-
-		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-		handler := c.HandleManualRotate()
-
-		ctx := ctx
-		ctx = controller.WithSession(ctx, &sessions.Session{})
-		ctx = controller.WithMembership(ctx, &database.Membership{
-			Realm: &database.Realm{
-				AutoRotateCertificateKey: false,
-			},
-			User:        &database.User{},
-			Permissions: rbac.SettingsWrite,
-		})
-
-		r := httptest.NewRequest("PUT", "/", nil)
-		r = r.Clone(ctx)
-		r.Header.Set("Content-Type", "text/html")
-
-		w := httptest.NewRecorder()
-
-		handler.ServeHTTP(w, r)
-		w.Flush()
-
-		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
-		}
-		if got, want := w.Body.String(), "Already in manual key rotation mode"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
-		}
 	})
 
 	t.Run("internal_error", func(t *testing.T) {
@@ -102,18 +66,14 @@ func TestHandleManualRotate(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 		harness.Database.SetRawDB(envstest.NewFailingDatabase())
 
-		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-		handler := c.HandleManualRotate()
+		c := smskeys.New(cfg, harness.Database, publicKeyCache, h)
+		handler := c.HandleEnable()
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
-				AutoRotateCertificateKey: true,
+				UseAuthenticatedSMS: false,
 			},
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,
@@ -121,7 +81,8 @@ func TestHandleManualRotate(t *testing.T) {
 
 		r := httptest.NewRequest("PUT", "/", nil)
 		r = r.Clone(ctx)
-		r.Header.Set("Content-Type", "text/html")
+		r.Header.Set("Accept", "text/html")
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		w := httptest.NewRecorder()
 
@@ -139,18 +100,14 @@ func TestHandleManualRotate(t *testing.T) {
 	t.Run("enables", func(t *testing.T) {
 		t.Parallel()
 
-		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, harness.Cacher, cfg.CertificateSigning.PublicKeyCacheDuration)
+		realm, err := harness.Database.FindRealm(1)
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-		handler := c.HandleManualRotate()
+		realm.UseAuthenticatedSMS = false
 
-		realm := database.NewRealmWithDefaults("test")
-		realm.AutoRotateCertificateKey = true
-		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
-			t.Fatal(err)
-		}
+		c := smskeys.New(cfg, harness.Database, publicKeyCache, h)
+		handler := c.HandleEnable()
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -162,26 +119,20 @@ func TestHandleManualRotate(t *testing.T) {
 
 		r := httptest.NewRequest("PUT", "/", nil)
 		r = r.Clone(ctx)
-		r.Header.Set("Content-Type", "text/html")
+		r.Header.Set("Accept", "text/html")
+		r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 
 		w := httptest.NewRecorder()
 
 		handler.ServeHTTP(w, r)
 		w.Flush()
 
-		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
-		}
-		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
-		}
-
-		updatedRealm, err := harness.Database.FindRealm(realm.ID)
+		updatedRealm, err := harness.Database.FindRealm(1)
 		if err != nil {
 			t.Fatal(err)
 		}
 
-		if got, want := updatedRealm.AutoRotateCertificateKey, false; got != want {
+		if got, want := updatedRealm.UseAuthenticatedSMS, true; got != want {
 			t.Errorf("expected %t to be %t", got, want)
 		}
 	})

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -51,7 +51,7 @@ func TestHandleIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
+		c := smskeys.New(cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleIndex()
 
 		envstest.ExerciseSessionMissing(t, handler)
@@ -66,7 +66,7 @@ func TestHandleIndex(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		c := smskeys.New(ctx, cfg, harness.Database, publicKeyCache, h)
+		c := smskeys.New(cfg, harness.Database, publicKeyCache, h)
 		handler := c.HandleIndex()
 
 		realm, err := harness.Database.FindRealm(1)

--- a/pkg/controller/smskeys/smskeys.go
+++ b/pkg/controller/smskeys/smskeys.go
@@ -16,8 +16,6 @@
 package smskeys
 
 import (
-	"context"
-
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/keyutils"
@@ -33,7 +31,7 @@ type Controller struct {
 }
 
 // New creates a new Controller
-func New(ctx context.Context, config *config.ServerConfig, db *database.Database, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
+func New(config *config.ServerConfig, db *database.Database, publicKeyCache *keyutils.PublicKeyCache, h render.Renderer) *Controller {
 	return &Controller{
 		config:         config,
 		db:             db,

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -752,7 +752,7 @@ func (r *Realm) setActiveManagedSigningKey(db *Database, id uint, signingKey Rea
 			First(signingKey).
 			Error; err != nil {
 			if IsNotFound(err) {
-				return fmt.Errorf("%s key to activate does not exist", signingKey.Purpose())
+				return fmt.Errorf("%s key to activate does not exist: %w", signingKey.Purpose(), err)
 			}
 			return fmt.Errorf("failed to find newly active key: %w", err)
 		}

--- a/pkg/database/sms_signing_key.go
+++ b/pkg/database/sms_signing_key.go
@@ -37,6 +37,19 @@ type SMSSigningKey struct {
 	Active bool
 }
 
+// FindSMSSigningKey finds an SMS signing key by the provided database id.
+func (db *Database) FindSMSSigningKey(id interface{}) (*SMSSigningKey, error) {
+	var key SMSSigningKey
+	if err := db.db.
+		Model(&SMSSigningKey{}).
+		Where("id = ?", id).
+		First(&key).
+		Error; err != nil {
+		return nil, err
+	}
+	return &key, nil
+}
+
 // GetKID returns the 'kid' field value to use in signing JWTs.
 func (s *SMSSigningKey) GetKID() string {
 	return fmt.Sprintf("r%dv%dsms", s.RealmID, s.ID)

--- a/pkg/database/sms_signing_key_test.go
+++ b/pkg/database/sms_signing_key_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+)
+
+func TestDatabase_FindSMSSigningKey(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	t.Run("not_found", func(t *testing.T) {
+		if _, err := db.FindSMSSigningKey(123456); !IsNotFound(err) {
+			t.Errorf("expected %v to be NotFound", err)
+		}
+	})
+
+	t.Run("finds", func(t *testing.T) {
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, db); err != nil {
+			t.Fatal(err)
+		}
+
+		result, err := db.FindSMSSigningKey(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := result.RealmID, realm.ID; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+	})
+}


### PR DESCRIPTION
This cleans up a few nits from the introduction of sms signing keys.

- Make "features" a top-level struct available in all templates instead of passing in specific features
- Update some language and HTML on actual sms keys page
- Rename page and nav to "Authenticated SMS"
- Check user-error vs server-error and return appropriate response codes
- Add more tests, including tests for database failures

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Standardize response codes and add tests to SMS keys
```

/assign @mikehelmick 
/assign @whaught 
