### PR TITLE
csv link in the ui

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -254,7 +254,7 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 		// unknown redirect
 		unknownHTTPResp, err := client.CheckRedirect(ctx, "unknown")
 		if err != nil {
-			renderJSONError(w, r, h, fmt.Errorf("iphone redirect: %w", err))
+			renderJSONError(w, r, h, fmt.Errorf("unknown redirect: %w", err))
 			return
 		}
 		defer unknownHTTPResp.Body.Close()

--- a/cmd/server/assets/apikeys/show.html
+++ b/cmd/server/assets/apikeys/show.html
@@ -86,8 +86,8 @@
         </span>
         <span>
           <span class="mr-1">Export as:</span>
-          <a href="/stats/realm/api-keys/{{$authApp.ID}}.csv" class="mr-1">CSV</a>
-          <a href="/stats/realm/api-keys/{{$authApp.ID}}.json">JSON</a>
+          <a href="/stats/realm/api-keys/{{$authApp.ID}}.csv" target="_blank" class="mr-1">CSV</a>
+          <a href="/stats/realm/api-keys/{{$authApp.ID}}.json" target="_blank">JSON</a>
         </span>
       </small>
     </div>

--- a/cmd/server/assets/apikeys/show.html
+++ b/cmd/server/assets/apikeys/show.html
@@ -86,7 +86,7 @@
         </span>
         <span>
           <span class="mr-1">Export as:</span>
-          <a href="/stats/realm/api-keys/{{$authApp.ID}}.csv" target="_blank" class="mr-1">CSV</a>
+          <a href="/stats/realm/api-keys/{{$authApp.ID}}.csv" class="mr-1">CSV</a>
           <a href="/stats/realm/api-keys/{{$authApp.ID}}.json" target="_blank">JSON</a>
         </span>
       </small>

--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -15,8 +15,8 @@
     <a href="#" data-toggle="modal" data-target="#realm-codes-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm.json">JSON</a>
+      <a href="/stats/realm.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
     </span>
   </small>
 </div>

--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -15,7 +15,7 @@
     <a href="#" data-toggle="modal" data-target="#realm-codes-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
       <a href="/stats/realm.json" target="_blank">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/realmadmin/_stats_external_issuers.html
+++ b/cmd/server/assets/realmadmin/_stats_external_issuers.html
@@ -14,8 +14,8 @@
     <a href="#" data-toggle="modal" data-target="#per-external-issuer-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm/external-issuers.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm/external-issuers.json">JSON</a>
+      <a href="/stats/realm/external-issuers.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/external-issuers.json" target="_blank">JSON</a>
     </span>
   </small>
 </div>

--- a/cmd/server/assets/realmadmin/_stats_external_issuers.html
+++ b/cmd/server/assets/realmadmin/_stats_external_issuers.html
@@ -14,7 +14,7 @@
     <a href="#" data-toggle="modal" data-target="#per-external-issuer-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm/external-issuers.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/external-issuers.csv" class="mr-1">CSV</a>
       <a href="/stats/realm/external-issuers.json" target="_blank">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -37,8 +37,8 @@
     <a href="#" data-toggle="modal" data-target="#keyserver-stats-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.key-server.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm/key-server.json">JSON</a>
+      <a href="/stats/realm/key-server.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
     </span>
   </small>
 </div>

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -37,6 +37,7 @@
     <a href="#" data-toggle="modal" data-target="#keyserver-stats-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
+      <a href="/stats/realm.key-server.csv" class="mr-1">CSV</a>
       <a href="/stats/realm/key-server.json">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -37,7 +37,7 @@
     <a href="#" data-toggle="modal" data-target="#keyserver-stats-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm/key-server.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
       <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/realmadmin/_stats_tokens.html
+++ b/cmd/server/assets/realmadmin/_stats_tokens.html
@@ -12,8 +12,8 @@
     <a href="#" data-toggle="modal" data-target="#realm-tokens-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm.json">JSON</a>
+      <a href="/stats/realm.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
     </span>
   </small>
 </div>

--- a/cmd/server/assets/realmadmin/_stats_tokens.html
+++ b/cmd/server/assets/realmadmin/_stats_tokens.html
@@ -12,7 +12,7 @@
     <a href="#" data-toggle="modal" data-target="#realm-tokens-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
       <a href="/stats/realm.json" target="_blank">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/realmadmin/_stats_users.html
+++ b/cmd/server/assets/realmadmin/_stats_users.html
@@ -14,8 +14,8 @@
     <a href="#" data-toggle="modal" data-target="#per-user-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm/users.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm/users.json">JSON</a>
+      <a href="/stats/realm/users.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/users.json" target="_blank">JSON</a>
     </span>
   </small>
 </div>

--- a/cmd/server/assets/realmadmin/_stats_users.html
+++ b/cmd/server/assets/realmadmin/_stats_users.html
@@ -14,7 +14,7 @@
     <a href="#" data-toggle="modal" data-target="#per-user-table-modal">Learn more about this table</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm/users.csv" target="_blank" class="mr-1">CSV</a>
+      <a href="/stats/realm/users.csv" class="mr-1">CSV</a>
       <a href="/stats/realm/users.json" target="_blank">JSON</a>
     </span>
   </small>

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -95,8 +95,8 @@
         </span>
         <span>
           <span class="mr-1">Export as:</span>
-          <a href="/stats/realm/users/{{$user.ID}}.csv" class="mr-1">CSV</a>
-          <a href="/stats/realm/users/{{$user.ID}}.json">JSON</a>
+          <a href="/stats/realm/users/{{$user.ID}}.csv" target="_blank" class="mr-1">CSV</a>
+          <a href="/stats/realm/users/{{$user.ID}}.json" target="_blank">JSON</a>
         </span>
       </small>
     </div>

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -95,7 +95,7 @@
         </span>
         <span>
           <span class="mr-1">Export as:</span>
-          <a href="/stats/realm/users/{{$user.ID}}.csv" target="_blank" class="mr-1">CSV</a>
+          <a href="/stats/realm/users/{{$user.ID}}.csv" class="mr-1">CSV</a>
           <a href="/stats/realm/users/{{$user.ID}}.json" target="_blank">JSON</a>
         </span>
       </small>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* https://github.com/google/exposure-notifications-verification-server/pull/1691 created the routes to do CSV marshal and this sticks the link into the UI
    * (sorry for the absurdly small PRs - I missed a spot here)
* `target="_blank"` for new tab when downloading as a file