### PR TITLE
Rename certificate signing keyring to database keyring

### DIFF
--- a/docs/development.md
+++ b/docs/development.md
@@ -119,11 +119,11 @@ represent best practices.
     export TOKEN_KEY_FILESYSTEM_ROOT="$(pwd)/local"
     export TOKEN_SIGNING_KEY="TODO" # (e.g. "/system/token-signing/1122334455")
 
-    # Configure the database key manager. The CERTIFICATE_SIGNING_KEYRING and
-    # DB_ENCRYPTION_KEY should be the values output in the previous step.
+    # Configure the database key manager. The DB_KEYRING and DB_ENCRYPTION_KEY
+    # should be the values output in the previous step.
     export DB_KEY_MANAGER="FILESYSTEM"
     export DB_KEY_FILESYSTEM_ROOT="$(pwd)/local"
-    export CERTIFICATE_SIGNING_KEYRING="TODO" # (e.g. "/realm")
+    export DB_KEYRING="TODO" # (e.g. "/realm")
     export DB_ENCRYPTION_KEY="TODO" # (e.g. "/system/database-encryption")
 
     # Use an in-memory key manager for encrypting values in the database. Create

--- a/pkg/controller/realmkeys/render.go
+++ b/pkg/controller/realmkeys/render.go
@@ -43,7 +43,7 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 
 		m["realmKeys"] = keys
 
-		maximumKeyVersions := c.db.MaxCertificateSigningKeyVersions()
+		maximumKeyVersions := c.db.MaxKeyVersions()
 		m["maximumKeyVersions"] = maximumKeyVersions
 
 		publicKeys := make(map[string]string)

--- a/pkg/controller/smskeys/render.go
+++ b/pkg/controller/smskeys/render.go
@@ -41,7 +41,7 @@ func (c *Controller) renderShow(ctx context.Context, w http.ResponseWriter, r *h
 
 	m["realmKeys"] = keys
 
-	maximumKeyVersions := c.db.MaxCertificateSigningKeyVersions()
+	maximumKeyVersions := c.db.MaxKeyVersions()
 	m["maximumKeyVersions"] = maximumKeyVersions
 
 	publicKeys := make(map[string]string)

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -51,14 +51,12 @@ type Config struct {
 	// that are encrypted via a KMS.
 	Keys keys.Config `env:",prefix=DB_"`
 
-	// The KMS managed KeyRing that per-realm certificate signing keys are
-	// created on.
-	CertificateSigningKeyRing string `env:"CERTIFICATE_SIGNING_KEYRING"`
+	// KeyRing is the KMS keyring to use for managing KMS keys.
+	KeyRing string `env:"DB_KEYRING"`
 
-	// MaxCertificateSigningKeyVersions is the maximum number of certificate
-	// signing key versions per realm. This is enforced at the database layer, not
-	// the upstream KMS.
-	MaxCertificateSigningKeyVersions int64 `env:"MAX_CERTIFICATE_SIGNING_KEY_VERSIONS, default=5"`
+	// MaxKeyVersions is the maximum number of signing key versions for a type,
+	// per realm. This is enforced at the database layer, not the upstream KMS.
+	MaxKeyVersions int64 `env:"DB_MAX_KEY_VERSIONS, default=5"`
 
 	// EncryptionKey is the reference to an encryption/decryption key to use when
 	// for application-layer encryption before values are persisted to the

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -93,9 +93,9 @@ func (db *Database) SupportsPerRealmSigning() bool {
 	return db.signingKeyManager != nil
 }
 
-// MaxCertificateSigningKeyVersions returns the configured maximum.
-func (db *Database) MaxCertificateSigningKeyVersions() int64 {
-	return db.config.MaxCertificateSigningKeyVersions
+// MaxKeyVersions returns the configured maximum.
+func (db *Database) MaxKeyVersions() int64 {
+	return db.config.MaxKeyVersions
 }
 
 func (db *Database) KeyManager() keys.KeyManager {

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -192,8 +192,8 @@ func NewTestInstance() (*TestInstance, error) {
 			KeyManagerType: keys.KeyManagerTypeFilesystem,
 		},
 
-		CertificateSigningKeyRing:        filepath.Join(project.Root(), "local", "test", "certificates"),
-		MaxCertificateSigningKeyVersions: 5,
+		KeyRing:        filepath.Join(project.Root(), "local", "test", "certificates"),
+		MaxKeyVersions: 5,
 	}
 
 	// Parse configuration and override with test data.

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -693,8 +693,8 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 
-	db.config.CertificateSigningKeyRing = filepath.Join(project.Root(), "local", "test", "realm")
-	db.config.MaxCertificateSigningKeyVersions = 2
+	db.config.KeyRing = filepath.Join(project.Root(), "local", "test", "realm")
+	db.config.MaxKeyVersions = 2
 
 	realm1 := NewRealmWithDefaults("realm1")
 	if err := db.SaveRealm(realm1, SystemTest); err != nil {
@@ -766,8 +766,8 @@ func TestRealm_CreateSMSSigningKeyVersion(t *testing.T) {
 	ctx := context.Background()
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 
-	db.config.CertificateSigningKeyRing = filepath.Join(project.Root(), "local", "test", "realm")
-	db.config.MaxCertificateSigningKeyVersions = 2
+	db.config.KeyRing = filepath.Join(project.Root(), "local", "test", "realm")
+	db.config.MaxKeyVersions = 2
 
 	realm1 := NewRealmWithDefaults("realm1")
 	if err := db.SaveRealm(realm1, SystemTest); err != nil {

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -37,10 +37,12 @@ locals {
   }
 
   database_config = {
-    DB_KEY_MANAGER                    = "GOOGLE_CLOUD_KMS"
-    DB_APIKEY_DATABASE_KEY            = "secret://${google_secret_manager_secret_version.db-apikey-db-hmac.id}"
-    DB_APIKEY_SIGNATURE_KEY           = "secret://${google_secret_manager_secret_version.db-apikey-sig-hmac.id}"
-    DB_ENCRYPTION_KEY                 = google_kms_crypto_key.database-encrypter.self_link
+    DB_KEY_MANAGER          = "GOOGLE_CLOUD_KMS"
+    DB_APIKEY_DATABASE_KEY  = "secret://${google_secret_manager_secret_version.db-apikey-db-hmac.id}"
+    DB_APIKEY_SIGNATURE_KEY = "secret://${google_secret_manager_secret_version.db-apikey-sig-hmac.id}"
+    DB_ENCRYPTION_KEY       = google_kms_crypto_key.database-encrypter.self_link
+    DB_KEYRING              = google_kms_key_ring.verification.self_link
+
     DB_HOST                           = google_sql_database_instance.db-inst.private_ip_address
     DB_NAME                           = google_sql_database.db.name
     DB_PASSWORD                       = "secret://${google_secret_manager_secret_version.db-secret-version["password"].id}"
@@ -73,9 +75,8 @@ locals {
   }
 
   signing_config = {
-    CERTIFICATE_KEY_MANAGER     = "GOOGLE_CLOUD_KMS"
-    CERTIFICATE_SIGNING_KEY     = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")
-    CERTIFICATE_SIGNING_KEYRING = google_kms_key_ring.verification.self_link
+    CERTIFICATE_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
+    CERTIFICATE_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")
 
     SMS_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
 

--- a/tools/gen-keys/main.go
+++ b/tools/gen-keys/main.go
@@ -98,8 +98,8 @@ func realMain(ctx context.Context) error {
 
 	// Print realm-specific certificate signing ring
 	{
-		fmt.Printf("\nRealm signing key ring:\n\n")
-		fmt.Printf("    export CERTIFICATE_SIGNING_KEYRING=\"%s\"\n", "/realm")
+		fmt.Printf("\nDatabase key ring:\n\n")
+		fmt.Printf("    export DB_KEYRING=\"%s\"\n", "/realm")
 	}
 
 	// Create token keys


### PR DESCRIPTION
This keyring is no longer specific to certificate signing, and some of the documentation is now out of date and misleading. This changes the name of the field and envvars to make it explicit that this is the keyring where database-managed keys reside.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Rename certificate signing keyring to database keyring. **Upgrade note!** Rename the
environment variable `CERTIFICATE_SIGNING_KEYRING` to `DB_KEYRING` in your
configurations. If you are using the Terraform configurations bundled with the project, this
will happen automatically.
```
