### PR TITLE
expect generic onboarding redirect

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -258,8 +258,13 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 			return
 		}
 		defer unknownHTTPResp.Body.Close()
-		if got, want := unknownHTTPResp.StatusCode, 404; got != want {
+		if got, want := unknownHTTPResp.StatusCode, 303; got != want {
 			renderJSONError(w, r, h, fmt.Errorf("expected unknown redirect code %d to be %d", got, want))
+			return
+		}
+		// expecting generic onboarding redirect
+		if got, want := iosHTTPResp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications"; !strings.Contains(got, want) {
+			renderJSONError(w, r, h, fmt.Errorf("expected unknown redirect location %q to contain %q", got, want))
 			return
 		}
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* We added onboarding redirect with https://github.com/google/exposure-notifications-verification-server/pull/1635
* Fixes the e2e test to expect this

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix e2e test to expect redirect onboarding for unknown user-agent header
```
