### PR TITLE
Seven day totals

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -263,7 +263,7 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h render.Renderer) htt
 			return
 		}
 		// expecting generic onboarding redirect
-		if got, want := iosHTTPResp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications"; !strings.Contains(got, want) {
+		if got, want := unknownHTTPResp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications"; !strings.Contains(got, want) {
 			renderJSONError(w, r, h, fmt.Errorf("expected unknown redirect location %q to contain %q", got, want))
 			return
 		}

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -100,10 +100,10 @@
       dataType: 'json',
     })
     .done(function(data, status, xhr) {
-      $slider.attr('max', data.statistics.length);
-      $slider.attr('value',data.statistics.length);
-      $onsetSlider.attr('max', data.statistics.length);
-      $onsetSlider.attr('value',data.statistics.length);
+      $slider.attr('max', data.length);
+      $slider.attr('value',data.length);
+      $onsetSlider.attr('max', data.length);
+      $onsetSlider.attr('value',data.length);
 
       drawStatsChart(data);
       drawOSChart(data);
@@ -118,11 +118,11 @@
   function drawStatsChart(data) {
     let $div = $('#keyserver_chart_div');
 
-    if (!data.statistics) {
+    if (!data.length) {
       $div.find('p').text('No data yet.');
       return;
     }
-    stats = data.statistics;
+    stats = data;
 
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
@@ -170,11 +170,11 @@
   function drawOSChart(data) {
     let $div = $('#keyserver_os_chart_div');
 
-    if (!data.statistics) {
+    if (!data.length) {
       $div.find('p').text('No data yet.');
       return;
     }
-    stats = data.statistics;
+    stats = data;
 
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
@@ -237,11 +237,11 @@
   function drawTEKAgeChart(data) {
     let $div = $('#keyserver_tek_chart_div');
 
-    if (!data.statistics) {
+    if (!data.length) {
       $div.find('p').text('No data yet.');
       return;
     }
-    stats = data.statistics;
+    stats = data;
 
     tekOptions = {
       colors: ['#329262'],
@@ -305,11 +305,11 @@
   function drawOnsetToUploadChart(data) {
     let $div = $('#keyserver_onset_chart_div');
 
-    if (!data.statistics) {
+    if (!data.length) {
       $div.find('p').text('No data yet.');
       return;
     }
-    stats = data.statistics;
+    stats = data;
 
     onsetOptions = {
       colors: ['#316395'],

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -18,7 +18,7 @@
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
   </div>
   <div class="card-body">
-    <h5 class="card-title">TEK age distribution</h5>
+    <h5 class="card-title">TEK age distribution (last 7 days)</h5>
   </div>
   <div id="keyserver_tek_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -26,7 +26,7 @@
   <div class="slidecontainer" id="tek_slide_div">
   </div>
   <div class="card-body">
-    <h5 class="card-title">Onset to upload distribution</h5>
+    <h5 class="card-title">Onset to upload distribution (last 7 days)</h5>
   </div>
   <div id="keyserver_onset_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -89,10 +89,10 @@
   });
 
   let $slider =
-    $(`<input type="range" min="1" class="slider w-100" id="tek_slider">`);
+    $(`<input type="range" min="8" class="slider w-100" id="tek_slider">`);
 
   let $onsetSlider =
-    $(`<input type="range" min="1" class="slider w-100" id="onset_slider">`);
+    $(`<input type="range" min="8" class="slider w-100" id="onset_slider">`);
 
   function drawRealmCharts() {
     $.ajax({
@@ -286,10 +286,19 @@
     dataTable.addColumn({type:'string', role:'style'})
     dataTable.addColumn({type:'string', role:'annotation'})
 
-    let row = stats[dateIndex];
+    // sum over last 7 days for smoothing
+    let table = new Array(stats[dateIndex].tek_age_distribution.length).fill(0);
     let i;
-    for (i = 0; i < row.tek_age_distribution.length; i++) {
-      let r = [i+1, row.tek_age_distribution[i],"",""]
+    for (i = dateIndex; i >= 0 && i >= dateIndex - 7; i--) {
+      let row = stats[i];
+      let j;
+      for (j = 0; j < row.tek_age_distribution.length; j++) {
+        table[j] += row.tek_age_distribution[j];
+      }
+    }
+
+    for (i = 0; i < table.length; i++) {
+      let r = [i+1, table[i],"",""]
       if (i == 15) {
         r[2] = "#6c757d";
         r[3] = ">15 days";
@@ -349,10 +358,19 @@
     dataTable.addColumn({type:'string', role:'style'})
     dataTable.addColumn({type:'string', role:'annotation'})
 
-    let row = stats[dateIndex];
+    // sum over last 7 days for smoothing
+    let table = new Array(stats[dateIndex].onset_to_upload_distribution.length).fill(0);
     let i;
-    for (i = 0; i < row.onset_to_upload_distribution.length; i++) {
-      let r = [i+1, row.onset_to_upload_distribution[i],"",""]
+    for (i = dateIndex; i >= 0 && i >= dateIndex - 7; i--) {
+      let row = stats[i];
+      let j;
+      for (j = 0; j < row.onset_to_upload_distribution.length; j++) {
+        table[j] += row.onset_to_upload_distribution[j];
+      }
+    }
+
+    for (i = 0; i < table.length; i++) {
+      let r = [i+1, table[i],"",""]
       if (i == 30) {
         r[2] = "#6c757d";
         r[3] = ">30 days";

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -18,7 +18,7 @@
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
   </div>
   <div class="card-body">
-    <h5 class="card-title">TEK age distribution (last 7 days)</h5>
+    <h5 class="card-title">TEK age distribution (7 day sum)</h5>
   </div>
   <div id="keyserver_tek_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -26,7 +26,7 @@
   <div class="slidecontainer" id="tek_slide_div">
   </div>
   <div class="card-body">
-    <h5 class="card-title">Onset to upload distribution (last 7 days)</h5>
+    <h5 class="card-title">Onset to upload distribution (7 day sum)</h5>
   </div>
   <div id="keyserver_onset_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -266,7 +266,7 @@
         showTextEvery: 1,
       },
       titlePosition: "out",
-      title: stats[0].day.split("T")[0],
+      title: "7 days from " + stats[0].day.split("T")[0],
     };
 
     tekChart = new google.visualization.ColumnChart($div.get(0));
@@ -338,7 +338,7 @@
         showTextEvery: 1,
       },
       titlePosition: "out",
-      title: stats[0].day.split("T")[0],
+      title: "7 days from " + stats[0].day.split("T")[0],
     };
 
     onsetChart = new google.visualization.ColumnChart($div.get(0));
@@ -384,7 +384,7 @@
     $('#tek_slide_div').append($slider)
     $slider.on("input", function(event) {
         let indx = stats.length - $slider.val();
-        tekOptions.title = stats[indx].day.split("T")[0];
+        tekOptions.title = "7 days from " + stats[indx].day.split("T")[0];
         tekOptions.animation = {
           startup: false,
           duration: 500,
@@ -398,7 +398,7 @@
     $('#onset_slide_div').append($onsetSlider)
     $onsetSlider.on("input", function(event) {
         let indx = stats.length - $onsetSlider.val();
-        onsetOptions.title = stats[indx].day.split("T")[0];
+        onsetOptions.title = "7 days from " + stats[indx].day.split("T")[0];
         onsetOptions.animation = {
           startup: false,
           duration: 500,

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -289,7 +289,7 @@
     // sum over last 7 days for smoothing
     let table = new Array(stats[dateIndex].tek_age_distribution.length).fill(0);
     let i;
-    for (i = dateIndex; i >= 0 && i >= dateIndex - 7; i--) {
+    for (i = dateIndex; i <= dateIndex + 7 && i < stats.length; i++) {
       let row = stats[i];
       let j;
       for (j = 0; j < row.tek_age_distribution.length; j++) {
@@ -361,7 +361,7 @@
     // sum over last 7 days for smoothing
     let table = new Array(stats[dateIndex].onset_to_upload_distribution.length).fill(0);
     let i;
-    for (i = dateIndex; i >= 0 && i >= dateIndex - 7; i--) {
+    for (i = dateIndex; i <= dateIndex + 7 && i < stats.length; i++) {
       let row = stats[i];
       let j;
       for (j = 0; j < row.onset_to_upload_distribution.length; j++) {


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1512

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* The distribution tables now sum the last 7 days from that slider stat date
    * This should provide smoother charts esp if there is day-of-the-week variance in user behavior

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Show distributions as 7 day sums
```
