### PR TITLE
Move redrawer to static js. Apply to the remaining charts

### DIFF
--- a/cmd/server/assets/apikeys/show.html
+++ b/cmd/server/assets/apikeys/show.html
@@ -126,6 +126,9 @@
   </main>
 
   <script type="text/javascript">
+    var chartData = [];
+    $(() => redrawCharts(chartData, 300));
+
     let $div = $('#apikey_stats_chart');
 
     google.charts.load('current', {
@@ -194,6 +197,11 @@
 
       let chart = new google.visualization.LineChart($div.get(0));
       chart.draw(dataTable, options);
+      chartData.push({
+        chart: chart,
+        data: dataTable,
+        options: options,
+      });
     }
 
     function drawDeviceStats(data) {

--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -177,7 +177,7 @@
 
       dashboard.bind(filter, realmChart);
       dashboard.draw(dataTable);
-      redrawCharts.push({
+      chartData.push({
         chart: dashboard,
         data: dataTable,
       });

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -159,7 +159,7 @@
 
     let chart = new google.visualization.LineChart($div.get(0));
     chart.draw(dataTable, options);
-    redrawCharts.push({
+    chartData.push({
       chart: chart,
       data: dataTable,
       options: options,
@@ -224,7 +224,7 @@
 
     let chart = new google.visualization.ColumnChart($div.get(0));
     chart.draw(dataTable, options);
-    redrawCharts.push({
+    chartData.push({
       chart: chart,
       data: dataTable,
       options: options,
@@ -272,7 +272,7 @@
     tekChart = new google.visualization.ColumnChart($div.get(0));
     tekData = getTEKDataTable(0);
     tekChart.draw(tekData, tekOptions);
-    redrawCharts.push({
+    chartData.push({
       chart: tekChart,
       data: tekData,
       options: tekOptions,
@@ -344,7 +344,7 @@
     onsetChart = new google.visualization.ColumnChart($div.get(0));
     onsetData = getOnsetDataTable(0);
     onsetChart.draw(onsetData, onsetOptions);
-    redrawCharts.push({
+    chartData.push({
       chart: onsetChart,
       data: onsetData,
       options: onsetOptions,

--- a/cmd/server/assets/realmadmin/_stats_tokens.html
+++ b/cmd/server/assets/realmadmin/_stats_tokens.html
@@ -110,7 +110,7 @@
 
       let chart = new google.visualization.LineChart($div.get(0));
       chart.draw(dataTable, options);
-      redrawCharts.push({
+      chartData.push({
         chart: chart,
         data: dataTable,
         options: options,

--- a/cmd/server/assets/realmadmin/stats.html
+++ b/cmd/server/assets/realmadmin/stats.html
@@ -41,38 +41,8 @@
   </main>
 
   <script type="text/javascript">
-  var redrawCharts = [];
-
-  $(function() {
-    let redrawPending = false;
-    let windowWidth = 0;
-    $(window).resize(function() {
-      let w = $(window).width();
-      if (w != windowWidth) {
-        windowWidth = w;
-      } else {
-        return;
-      }
-
-      if (!redrawPending) {
-        redrawPending = true;
-        setTimeout(function(){
-          redraw();
-          redrawPending = false;
-        }, 300);
-      }
-    });
-
-    function redraw(){
-      let c
-      for (c of redrawCharts) {
-        if (c.options) {
-          c.options.animation = null;
-        }
-        c.chart.draw(c.data, c.options)
-      }
-    }
-  });
+    var chartData = [];
+    $(() => redrawCharts(chartData, 300));
   </script>
 </body>
 </html>

--- a/cmd/server/assets/static/js/application.js
+++ b/cmd/server/assets/static/js/application.js
@@ -1021,3 +1021,34 @@ function showSuccessfulCode(request, code, line) {
   $row.append($('<td/>').text(code.uuid));
   $successTableBody.append($row);
 }
+
+function redrawCharts(chartsData, timeout) {
+  let redrawPending = false;
+  let windowWidth = 0;
+  $(window).resize(function() {
+    let w = $(window).width();
+    if (w != windowWidth) {
+      windowWidth = w;
+    } else {
+      return;
+    }
+
+    if (!redrawPending) {
+      redrawPending = true;
+      setTimeout(function() {
+        redraw();
+        redrawPending = false;
+      }, timeout);
+    }
+  });
+
+  function redraw() {
+    let c;
+    for (c of chartsData) {
+      if (c.options) {
+        c.options.animation = null;
+      }
+      c.chart.draw(c.data, c.options);
+    }
+  }
+}

--- a/cmd/server/assets/users/show.html
+++ b/cmd/server/assets/users/show.html
@@ -127,6 +127,9 @@
   </main>
 
   <script type="text/javascript">
+    var chartData = [];
+    $(() => redrawCharts(chartData, 300));
+
     google.charts.load('current', {
       packages: ['corechart'],
       callback: drawRealmCharts,
@@ -172,6 +175,11 @@
 
         let chart = new google.visualization.LineChart($userStatsChart.get(0));
         chart.draw(dataTable, options);
+        chartData.push({
+          chart: chart,
+          data: dataTable,
+          options: options,
+        });
       })
       .fail(function(xhr, status, err) {
         flash.error('Failed to render realm stats: ' + err);


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Moves the redraw charts function to static js so it'll be cached. I think we can do a lot more of that with some of these charts as things settle down
* Apply redraw to the users and keys charts too

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Redraw all charts with window resize. Move some js to application.js
```
