### PR TITLE
Clarify chaff should be on both endpoints

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -534,6 +534,7 @@ Chaff requests:
 * SHOULD send a valid JSON body with random padding similar in size as the rest
   of the client requests so that chaff requests appear the same on the wire as
   other valid requests.
+* SHOULD send chaff requests for both `/verify` and `/certificate` endpoints.
 
 To initiate a chaff request, set the `X-Chaff` header on your request:
 
@@ -558,7 +559,8 @@ will not be processed). The server will respond with a fake response that your
 client **MUST NOT** process or parse. The response will not be a valid JSON
 object.
 
-Client's should sporadically issue chaff requests to mirror real-world usage.
+Client's should sporadically issue chaff requests to mirror real-world usage
+for both the `/verify` and `/certificate` endpoints.
 
 # Response codes overview
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -535,7 +535,7 @@ Chaff requests:
   of the client requests so that chaff requests appear the same on the wire as
   other valid requests.
 * SHOULD send chaff requests for both `/verify`, `/certificate`, and key server
-  stats endpoints.
+  publish endpoints.
 
 To initiate a chaff request, set the `X-Chaff` header on your request:
 
@@ -561,7 +561,7 @@ client **MUST NOT** process or parse. The response will not be a valid JSON
 object.
 
 Client's should sporadically issue chaff requests to mirror real-world usage
-for both the `/verify`, `/certificate`, and key server stats endpoints.
+for both the `/verify`, `/certificate`, and key server publish endpoints.
 
 # Response codes overview
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -534,7 +534,8 @@ Chaff requests:
 * SHOULD send a valid JSON body with random padding similar in size as the rest
   of the client requests so that chaff requests appear the same on the wire as
   other valid requests.
-* SHOULD send chaff requests for both `/verify` and `/certificate` endpoints.
+* SHOULD send chaff requests for both `/verify`, `/certificate`, and key server
+  stats endpoints.
 
 To initiate a chaff request, set the `X-Chaff` header on your request:
 
@@ -560,7 +561,7 @@ client **MUST NOT** process or parse. The response will not be a valid JSON
 object.
 
 Client's should sporadically issue chaff requests to mirror real-world usage
-for both the `/verify` and `/certificate` endpoints.
+for both the `/verify`, `/certificate`, and key server stats endpoints.
 
 # Response codes overview
 


### PR DESCRIPTION
/assign @mikehelmick 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Clarify chaff should be on both endpoints
```
