### PR TITLE
Add audits for signing keys

### DIFF
--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -146,7 +146,7 @@ func (c *Controller) HandleRealmsCreate() http.Handler {
 
 		if realm.UseRealmCertificateKey {
 			// If we are using realm specific keys - we need to create the first one.
-			keyID, err := realm.CreateSigningKeyVersion(ctx, c.db)
+			keyID, err := realm.CreateSigningKeyVersion(ctx, c.db, currentUser)
 			if err != nil {
 				flash.Error("Failed to create signing keys for realm. This can be done from the realm's admin screens.")
 				http.Redirect(w, r, "/admin/realms", http.StatusSeeOther)

--- a/pkg/controller/realmkeys/activate.go
+++ b/pkg/controller/realmkeys/activate.go
@@ -45,7 +45,7 @@ func (c *Controller) HandleActivate() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
-
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
 		var form FormData
@@ -55,7 +55,7 @@ func (c *Controller) HandleActivate() http.Handler {
 			return
 		}
 
-		kid, err := currentRealm.SetActiveSigningKey(c.db, form.SigningKeyID)
+		kid, err := currentRealm.SetActiveSigningKey(c.db, form.SigningKeyID, currentUser)
 		if err != nil {
 			flash.Error("Unable to set active signing key: %v", err)
 			c.renderShow(ctx, w, r, currentRealm)

--- a/pkg/controller/realmkeys/create.go
+++ b/pkg/controller/realmkeys/create.go
@@ -41,9 +41,10 @@ func (c *Controller) HandleCreateKey() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
-		kid, err := currentRealm.CreateSigningKeyVersion(ctx, c.db)
+		kid, err := currentRealm.CreateSigningKeyVersion(ctx, c.db, currentUser)
 		if err != nil {
 			flash.Error("Unable to create a new signing key: %v", err)
 			c.renderShow(ctx, w, r, currentRealm)

--- a/pkg/controller/realmkeys/destroy.go
+++ b/pkg/controller/realmkeys/destroy.go
@@ -43,9 +43,10 @@ func (c *Controller) HandleDestroy() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
-		if err := currentRealm.DestroySigningKeyVersion(ctx, c.db, vars["id"]); err != nil {
+		if err := currentRealm.DestroySigningKeyVersion(ctx, c.db, vars["id"], currentUser); err != nil {
 			flash.Error("Failed to destroy signing key version: %v", err)
 			c.renderShow(ctx, w, r, currentRealm)
 			return

--- a/pkg/controller/rotation/handle_verification_rotate_test.go
+++ b/pkg/controller/rotation/handle_verification_rotate_test.go
@@ -64,7 +64,7 @@ func TestHandleVerificationRotation(t *testing.T) {
 	c := New(config, db, keyManagerSigner, h)
 
 	// create the initial signing key version, which will make it active.
-	if _, err := realm.CreateSigningKeyVersion(ctx, db); err != nil {
+	if _, err := realm.CreateSigningKeyVersion(ctx, db, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 	// Initial state - 1 active signing key.

--- a/pkg/controller/smskeys/activate.go
+++ b/pkg/controller/smskeys/activate.go
@@ -47,6 +47,7 @@ func (c *Controller) HandleActivate() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
 		var form FormData
@@ -57,7 +58,7 @@ func (c *Controller) HandleActivate() http.Handler {
 			return
 		}
 
-		kid, err := currentRealm.SetActiveSMSSigningKey(c.db, form.SigningKeyID)
+		kid, err := currentRealm.SetActiveSMSSigningKey(c.db, form.SigningKeyID, currentUser)
 		if err != nil {
 			if database.IsNotFound(err) || database.IsValidationError(err) {
 				currentRealm.AddError("", fmt.Sprintf("Failed to set active SMS signing key: %s", err))

--- a/pkg/controller/smskeys/activate_test.go
+++ b/pkg/controller/smskeys/activate_test.go
@@ -141,7 +141,7 @@ func TestHandleActivate(t *testing.T) {
 	t.Run("activates", func(t *testing.T) {
 		t.Parallel()
 
-		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database); err != nil {
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/controller/smskeys/create.go
+++ b/pkg/controller/smskeys/create.go
@@ -42,9 +42,10 @@ func (c *Controller) HandleCreateKey() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
-		kid, err := currentRealm.CreateSMSSigningKeyVersion(ctx, c.db)
+		kid, err := currentRealm.CreateSMSSigningKeyVersion(ctx, c.db, currentUser)
 		if err != nil {
 			if database.IsNotFound(err) || database.IsValidationError(err) {
 				currentRealm.AddError("", err.Error())

--- a/pkg/controller/smskeys/destroy.go
+++ b/pkg/controller/smskeys/destroy.go
@@ -44,9 +44,10 @@ func (c *Controller) HandleDestroy() http.Handler {
 			controller.Unauthorized(w, r, c.h)
 			return
 		}
+		currentUser := membership.User
 		currentRealm := membership.Realm
 
-		if err := currentRealm.DestroySMSSigningKeyVersion(ctx, c.db, vars["id"]); err != nil {
+		if err := currentRealm.DestroySMSSigningKeyVersion(ctx, c.db, vars["id"], currentUser); err != nil {
 			if database.IsNotFound(err) || database.IsValidationError(err) {
 				currentRealm.AddError("", err.Error())
 				w.WriteHeader(http.StatusUnprocessableEntity)

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -110,10 +110,10 @@ func TestHandleDestroy(t *testing.T) {
 		handler := c.HandleDestroy()
 
 		// Create 2 signing keys - we need to destroy the non-active one.
-		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database); err != nil {
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
 			t.Fatal(err)
 		}
-		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database); err != nil {
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
 			t.Fatal(err)
 		}
 

--- a/pkg/database/managed_key.go
+++ b/pkg/database/managed_key.go
@@ -17,6 +17,8 @@ package database
 // ManagedKey is an interface that allows for a realm to manage signing keys
 // for different purposes.
 type ManagedKey interface {
+	Auditable
+
 	// GetKID returns the public key version string
 	GetKID() string
 	// ManagedKeyID returns the reference to the key ID in the KMS.

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -702,17 +702,17 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 	}
 
 	// First creates ok
-	if _, err := realm1.CreateSigningKeyVersion(ctx, db); err != nil {
+	if _, err := realm1.CreateSigningKeyVersion(ctx, db, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Second creates ok
-	if _, err := realm1.CreateSigningKeyVersion(ctx, db); err != nil {
+	if _, err := realm1.CreateSigningKeyVersion(ctx, db, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Third fails over quota
-	_, err := realm1.CreateSigningKeyVersion(ctx, db)
+	_, err := realm1.CreateSigningKeyVersion(ctx, db, SystemTest)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -728,12 +728,12 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 	if len(list) < 1 {
 		t.Fatal("empty list")
 	}
-	if err := realm1.DestroySigningKeyVersion(ctx, db, list[0].ID); err != nil {
+	if err := realm1.DestroySigningKeyVersion(ctx, db, list[0].ID, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Third should succeed now
-	thirdKID, err := realm1.CreateSigningKeyVersion(ctx, db)
+	thirdKID, err := realm1.CreateSigningKeyVersion(ctx, db, SystemTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -746,7 +746,7 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 	// Find that key and activate it.
 	for _, k := range list {
 		if k.GetKID() == thirdKID {
-			realm1.SetActiveSigningKey(db, k.ID)
+			realm1.SetActiveSigningKey(db, k.ID, SystemTest)
 		}
 	}
 
@@ -775,17 +775,17 @@ func TestRealm_CreateSMSSigningKeyVersion(t *testing.T) {
 	}
 
 	// First creates ok
-	if _, err := realm1.CreateSMSSigningKeyVersion(ctx, db); err != nil {
+	if _, err := realm1.CreateSMSSigningKeyVersion(ctx, db, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Second creates ok
-	if _, err := realm1.CreateSMSSigningKeyVersion(ctx, db); err != nil {
+	if _, err := realm1.CreateSMSSigningKeyVersion(ctx, db, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Third fails over quota
-	_, err := realm1.CreateSMSSigningKeyVersion(ctx, db)
+	_, err := realm1.CreateSMSSigningKeyVersion(ctx, db, SystemTest)
 	if err == nil {
 		t.Fatal("expected error")
 	}
@@ -801,12 +801,12 @@ func TestRealm_CreateSMSSigningKeyVersion(t *testing.T) {
 	if len(list) < 1 {
 		t.Fatal("empty list")
 	}
-	if err := realm1.DestroySMSSigningKeyVersion(ctx, db, list[0].ID); err != nil {
+	if err := realm1.DestroySMSSigningKeyVersion(ctx, db, list[0].ID, SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
 	// Third should succeed now
-	thirdKID, err := realm1.CreateSMSSigningKeyVersion(ctx, db)
+	thirdKID, err := realm1.CreateSMSSigningKeyVersion(ctx, db, SystemTest)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -819,7 +819,7 @@ func TestRealm_CreateSMSSigningKeyVersion(t *testing.T) {
 	// Find that key and activate it.
 	for _, k := range list {
 		if k.GetKID() == thirdKID {
-			realm1.SetActiveSMSSigningKey(db, k.ID)
+			realm1.SetActiveSMSSigningKey(db, k.ID, SystemTest)
 		}
 	}
 

--- a/pkg/database/signing_key.go
+++ b/pkg/database/signing_key.go
@@ -37,6 +37,16 @@ type SigningKey struct {
 	Active bool
 }
 
+// AuditID is how the signing key is stored in the audit entry.
+func (s *SigningKey) AuditID() string {
+	return fmt.Sprintf("certificate_signing_key:%d", s.ID)
+}
+
+// AuditDisplay is how the signing key will be displayed in audit entries.
+func (s *SigningKey) AuditDisplay() string {
+	return fmt.Sprintf("certificate signing key (%s)", s.GetKID())
+}
+
 // GetKID returns the 'kid' field value to use in signing JWTs.
 func (s *SigningKey) GetKID() string {
 	return fmt.Sprintf("r%dv%d", s.RealmID, s.ID)

--- a/pkg/database/sms_signing_key.go
+++ b/pkg/database/sms_signing_key.go
@@ -50,6 +50,16 @@ func (db *Database) FindSMSSigningKey(id interface{}) (*SMSSigningKey, error) {
 	return &key, nil
 }
 
+// AuditID is how the signing key is stored in the audit entry.
+func (s *SMSSigningKey) AuditID() string {
+	return fmt.Sprintf("sms_signing_key:%d", s.ID)
+}
+
+// AuditDisplay is how the signing key will be displayed in audit entries.
+func (s *SMSSigningKey) AuditDisplay() string {
+	return fmt.Sprintf("sms signing key (%s)", s.GetKID())
+}
+
 // GetKID returns the 'kid' field value to use in signing JWTs.
 func (s *SMSSigningKey) GetKID() string {
 	return fmt.Sprintf("r%dv%dsms", s.RealmID, s.ID)

--- a/pkg/database/sms_signing_key_test.go
+++ b/pkg/database/sms_signing_key_test.go
@@ -38,7 +38,7 @@ func TestDatabase_FindSMSSigningKey(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		if _, err := realm.CreateSMSSigningKeyVersion(ctx, db); err != nil {
+		if _, err := realm.CreateSMSSigningKeyVersion(ctx, db, SystemTest); err != nil {
 			t.Fatal(err)
 		}
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1702

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add audits for signing keys
```
