### PR TITLE
Refactor Terraform secrets and key management

### DIFF
--- a/terraform/binary_authorization.tf
+++ b/terraform/binary_authorization.tf
@@ -79,7 +79,7 @@ resource "google_binary_authorization_attestor" "built-by-ci" {
 resource "google_project_iam_member" "ci-notes" {
   project = var.project
   role    = "roles/containeranalysis.notes.attacher"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -90,7 +90,7 @@ resource "google_binary_authorization_attestor_iam_member" "ci-attestor" {
   project  = var.project
   attestor = google_binary_authorization_attestor.built-by-ci.id
   role     = "roles/binaryauthorization.attestorsViewer"
-  member   = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member   = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -127,7 +127,7 @@ resource "google_kms_crypto_key_iam_binding" "ci-attest" {
   role          = "roles/cloudkms.signerVerifier"
 
   members = [
-    "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com",
+    "serviceAccount:${data.google_service_account.cloudbuild.email}",
   ]
 
   depends_on = [

--- a/terraform/build.tf
+++ b/terraform/build.tf
@@ -39,5 +39,15 @@ resource "google_storage_bucket" "cloudbuild-cache" {
 resource "google_storage_bucket_iam_member" "cloudbuild-cache" {
   bucket = google_storage_bucket.cloudbuild-cache.name
   role   = "roles/storage.objectAdmin"
-  member = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member = "serviceAccount:${data.google_service_account.cloudbuild.email}"
+}
+
+
+data "google_service_account" "cloudbuild" {
+  account_id = "${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+
+  depends_on = [
+    google_project_service.services["iam.googleaips.com"],
+    google_project_service.services["cloudbuild.googleaips.com"],
+  ]
 }

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -12,6 +12,21 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  # database_secrets is the list of secrets required to connect to and utilize
+  # the database. It includes the database password as well as access to HMAC
+  # keys.
+  database_secrets = [
+    google_secret_manager_secret.db-secret["sslcert"].id,
+    google_secret_manager_secret.db-secret["sslkey"].id,
+    google_secret_manager_secret.db-secret["sslrootcert"].id,
+    google_secret_manager_secret.db-secret["password"].id,
+    google_secret_manager_secret.db-apikey-db-hmac.id,
+    google_secret_manager_secret.db-apikey-sig-hmac.id,
+    google_secret_manager_secret.db-verification-code-hmac.id,
+  ]
+}
+
 resource "google_sql_database_instance" "db-inst" {
   project          = var.project
   region           = var.region
@@ -239,7 +254,7 @@ resource "google_secret_manager_secret_version" "db-verification-code-hmac" {
 resource "google_secret_manager_secret_iam_member" "cloudbuild-db-pwd" {
   secret_id = google_secret_manager_secret.db-secret["password"].id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member    = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -249,7 +264,7 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild-db-pwd" {
 resource "google_secret_manager_secret_iam_member" "cloudbuild-db-apikey-db-hmac" {
   secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member    = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -259,7 +274,7 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild-db-apikey-db-hmac
 resource "google_secret_manager_secret_iam_member" "cloudbuild-db-apikey-sig-hmac" {
   secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member    = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -269,7 +284,7 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild-db-apikey-sig-hma
 resource "google_secret_manager_secret_iam_member" "cloudbuild-db-verification-code-hmac" {
   secret_id = google_secret_manager_secret.db-verification-code-hmac.id
   role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member    = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],
@@ -280,7 +295,7 @@ resource "google_secret_manager_secret_iam_member" "cloudbuild-db-verification-c
 resource "google_project_iam_member" "cloudbuild-sql" {
   project = var.project
   role    = "roles/cloudsql.client"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"]
@@ -291,7 +306,7 @@ resource "google_project_iam_member" "cloudbuild-sql" {
 resource "google_kms_crypto_key_iam_member" "database-database-encrypter" {
   crypto_key_id = google_kms_crypto_key.database-encrypter.self_link
   role          = "roles/cloudkms.cryptoKeyEncrypterDecrypter"
-  member        = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member        = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"]

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -135,7 +135,7 @@ resource "null_resource" "build" {
 resource "google_project_iam_member" "cloudbuild-deploy" {
   project = var.project
   role    = "roles/run.admin"
-  member  = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+  member  = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 
   depends_on = [
     google_project_service.services["cloudbuild.googleapis.com"],

--- a/terraform/observability.tf
+++ b/terraform/observability.tf
@@ -1,4 +1,4 @@
-# Copyright 2020 Google LLC
+# Copyright 2021 Google LLC
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,23 +12,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-resource "random_id" "csrf-token" {
-  byte_length = 32
-}
 
-resource "google_secret_manager_secret" "csrf-token" {
-  secret_id = "csrf-token"
-
-  replication {
-    automatic = true
-  }
-
-  depends_on = [
-    google_project_service.services["secretmanager.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_version" "csrf-token-version" {
-  secret      = google_secret_manager_secret.csrf-token.id
-  secret_data = random_id.csrf-token.b64_std
+locals {
+  # observability_iam_roles is the list of IAM roles required for the service to
+  # participate in observability.
+  observability_iam_roles = toset([
+    "roles/cloudtrace.agent",
+    "roles/logging.logWriter",
+    "roles/monitoring.metricWriter",
+    "roles/stackdriver.resourceMetadata.writer",
+  ])
 }

--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -12,6 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  # redis_secrets is the list of secrets required to connect to and utilize the
+  # cache.
+  redis_secrets = flatten([
+    google_secret_manager_secret.cache-hmac-key.id,
+    google_secret_manager_secret.ratelimit-hmac-key.id,
+  ])
+}
+
 resource "google_redis_instance" "cache" {
   name           = var.redis_name
   tier           = "STANDARD_HA"

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -21,44 +21,20 @@ resource "google_service_account" "apiserver" {
 resource "google_service_account_iam_member" "cloudbuild-deploy-apiserver" {
   service_account_id = google_service_account.apiserver.id
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.services["cloudbuild.googleapis.com"],
-    google_project_service.services["iam.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_iam_member" "apiserver-db" {
-  for_each = toset([
-    "sslcert",
-    "sslkey",
-    "sslrootcert",
-    "password",
-  ])
-
-  secret_id = google_secret_manager_secret.db-secret[each.key].id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.apiserver.email}"
-}
-
-resource "google_kms_key_ring_iam_member" "kms-signerverifier" {
-  key_ring_id = google_kms_key_ring.verification.self_link
-  role        = "roles/cloudkms.signerVerifier"
-  member      = "serviceAccount:${google_service_account.apiserver.email}"
+  member             = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 }
 
 resource "google_project_iam_member" "apiserver-observability" {
-  for_each = toset([
-    "roles/cloudtrace.agent",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/stackdriver.resourceMetadata.writer",
-  ])
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.apiserver.email}"
+}
 
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.apiserver.email}"
+resource "google_kms_key_ring_iam_member" "apiserver-verification-signer-verifier" {
+  key_ring_id = google_kms_key_ring.verification.self_link
+  role        = "roles/cloudkms.signerVerifier"
+  member      = "serviceAccount:${google_service_account.apiserver.email}"
 }
 
 resource "google_kms_crypto_key_iam_member" "apiserver-database-encrypter" {
@@ -67,32 +43,16 @@ resource "google_kms_crypto_key_iam_member" "apiserver-database-encrypter" {
   member        = "serviceAccount:${google_service_account.apiserver.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "apiserver-db-apikey-db-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.apiserver.email}"
+locals {
+  apiserver_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+  ])
 }
 
-resource "google_secret_manager_secret_iam_member" "apiserver-db-apikey-sig-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.apiserver.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "apiserver-db-verification-code-hmac" {
-  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.apiserver.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "apiserver-cache-hmac-key" {
-  secret_id = google_secret_manager_secret.cache-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.apiserver.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "apiserver-ratelimit-hmac-key" {
-  secret_id = google_secret_manager_secret.ratelimit-hmac-key.id
+resource "google_secret_manager_secret_iam_member" "apiserver-secrets" {
+  count     = length(local.apiserver_secrets)
+  secret_id = element(local.apiserver_secrets, count.index)
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.apiserver.email}"
 }
@@ -161,15 +121,10 @@ resource "google_cloud_run_service" "apiserver" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
 
-    google_secret_manager_secret_iam_member.apiserver-db,
-    google_kms_key_ring_iam_member.kms-signerverifier,
-    google_project_iam_member.apiserver-observability,
     google_kms_crypto_key_iam_member.apiserver-database-encrypter,
-    google_secret_manager_secret_iam_member.apiserver-db-apikey-db-hmac,
-    google_secret_manager_secret_iam_member.apiserver-db-apikey-sig-hmac,
-    google_secret_manager_secret_iam_member.apiserver-db-verification-code-hmac,
-    google_secret_manager_secret_iam_member.apiserver-cache-hmac-key,
-    google_secret_manager_secret_iam_member.apiserver-ratelimit-hmac-key,
+    google_kms_key_ring_iam_member.apiserver-verification-signer-verifier,
+    google_project_iam_member.apiserver-observability,
+    google_secret_manager_secret_iam_member.apiserver-secrets,
 
     null_resource.build,
     null_resource.migrate,
@@ -177,12 +132,12 @@ resource "google_cloud_run_service" "apiserver" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations["client.knative.dev/user-image"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
-      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].spec[0].containers[0].image,
     ]
   }
 }
@@ -214,7 +169,8 @@ resource "google_compute_backend_service" "apiserver" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = var.enable_lb_logging
+    enable      = var.enable_lb_logging
+    sample_rate = 1
   }
 }
 

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -21,38 +21,14 @@ resource "google_service_account" "appsync" {
 resource "google_service_account_iam_member" "cloudbuild-deploy-appsync" {
   service_account_id = google_service_account.appsync.id
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.services["cloudbuild.googleapis.com"],
-    google_project_service.services["iam.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_iam_member" "appsync-db" {
-  for_each = toset([
-    "sslcert",
-    "sslkey",
-    "sslrootcert",
-    "password",
-  ])
-
-  secret_id = google_secret_manager_secret.db-secret[each.key].id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.appsync.email}"
+  member             = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 }
 
 resource "google_project_iam_member" "appsync-observability" {
-  for_each = toset([
-    "roles/cloudtrace.agent",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/stackdriver.resourceMetadata.writer",
-  ])
-
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.appsync.email}"
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.appsync.email}"
 }
 
 resource "google_kms_crypto_key_iam_member" "appsync-database-encrypter" {
@@ -61,32 +37,16 @@ resource "google_kms_crypto_key_iam_member" "appsync-database-encrypter" {
   member        = "serviceAccount:${google_service_account.appsync.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "appsync-db-apikey-db-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.appsync.email}"
+locals {
+  appsync_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+  ])
 }
 
-resource "google_secret_manager_secret_iam_member" "appsync-db-apikey-sig-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.appsync.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "appsync-db-verification-code-hmac" {
-  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.appsync.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "appsync-cache-hmac-key" {
-  secret_id = google_secret_manager_secret.cache-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.appsync.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "appsync-ratelimit-hmac-key" {
-  secret_id = google_secret_manager_secret.ratelimit-hmac-key.id
+resource "google_secret_manager_secret_iam_member" "appsync-secrets" {
+  count     = length(local.appsync_secrets)
+  secret_id = element(local.appsync_secrets, count.index)
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.appsync.email}"
 }
@@ -154,14 +114,9 @@ resource "google_cloud_run_service" "appsync" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
 
-    google_secret_manager_secret_iam_member.appsync-db,
-    google_project_iam_member.appsync-observability,
     google_kms_crypto_key_iam_member.appsync-database-encrypter,
-    google_secret_manager_secret_iam_member.appsync-db-apikey-db-hmac,
-    google_secret_manager_secret_iam_member.appsync-db-apikey-sig-hmac,
-    google_secret_manager_secret_iam_member.appsync-db-verification-code-hmac,
-    google_secret_manager_secret_iam_member.appsync-cache-hmac-key,
-    google_secret_manager_secret_iam_member.appsync-ratelimit-hmac-key,
+    google_project_iam_member.appsync-observability,
+    google_secret_manager_secret_iam_member.appsync-secrets,
 
     null_resource.build,
     null_resource.migrate,
@@ -169,12 +124,12 @@ resource "google_cloud_run_service" "appsync" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations["client.knative.dev/user-image"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
-      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].spec[0].containers[0].image,
     ]
   }
 }

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -21,38 +21,14 @@ resource "google_service_account" "e2e-runner" {
 resource "google_service_account_iam_member" "cloudbuild-deploy-e2e-runner" {
   service_account_id = google_service_account.e2e-runner.id
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.services["cloudbuild.googleapis.com"],
-    google_project_service.services["iam.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_iam_member" "e2e-runner-db" {
-  for_each = toset([
-    "sslcert",
-    "sslkey",
-    "sslrootcert",
-    "password",
-  ])
-
-  secret_id = google_secret_manager_secret.db-secret[each.key].id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.e2e-runner.email}"
+  member             = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 }
 
 resource "google_project_iam_member" "e2e-runner-observability" {
-  for_each = toset([
-    "roles/cloudtrace.agent",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/stackdriver.resourceMetadata.writer",
-  ])
-
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.e2e-runner.email}"
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.e2e-runner.email}"
 }
 
 resource "google_kms_crypto_key_iam_member" "e2e-runner-database-encrypter" {
@@ -61,32 +37,16 @@ resource "google_kms_crypto_key_iam_member" "e2e-runner-database-encrypter" {
   member        = "serviceAccount:${google_service_account.e2e-runner.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "e2e-runner-db-apikey-db-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.e2e-runner.email}"
+locals {
+  e2e_runner_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+  ])
 }
 
-resource "google_secret_manager_secret_iam_member" "e2e-runner-db-apikey-sig-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.e2e-runner.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "e2e-runner-db-verification-code-hmac" {
-  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.e2e-runner.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "e2e-runner-cache-hmac-key" {
-  secret_id = google_secret_manager_secret.cache-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.e2e-runner.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "e2e-runner-ratelimit-hmac-key" {
-  secret_id = google_secret_manager_secret.ratelimit-hmac-key.id
+resource "google_secret_manager_secret_iam_member" "e2e-runner-secrets" {
+  count     = length(local.e2e_runner_secrets)
+  secret_id = element(local.e2e_runner_secrets, count.index)
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.e2e-runner.email}"
 }
@@ -154,14 +114,9 @@ resource "google_cloud_run_service" "e2e-runner" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
 
-    google_secret_manager_secret_iam_member.e2e-runner-db,
-    google_project_iam_member.e2e-runner-observability,
     google_kms_crypto_key_iam_member.e2e-runner-database-encrypter,
-    google_secret_manager_secret_iam_member.e2e-runner-db-apikey-db-hmac,
-    google_secret_manager_secret_iam_member.e2e-runner-db-apikey-sig-hmac,
-    google_secret_manager_secret_iam_member.e2e-runner-db-verification-code-hmac,
-    google_secret_manager_secret_iam_member.e2e-runner-cache-hmac-key,
-    google_secret_manager_secret_iam_member.e2e-runner-ratelimit-hmac-key,
+    google_project_iam_member.e2e-runner-observability,
+    google_secret_manager_secret_iam_member.e2e-runner-secrets,
 
     null_resource.build,
     null_resource.migrate,
@@ -169,12 +124,12 @@ resource "google_cloud_run_service" "e2e-runner" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations["client.knative.dev/user-image"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
-      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].spec[0].containers[0].image,
     ]
   }
 }

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -22,38 +22,14 @@ resource "google_service_account" "enx-redirect" {
 resource "google_service_account_iam_member" "cloudbuild-deploy-enx-redirect" {
   service_account_id = google_service_account.enx-redirect.id
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.services["cloudbuild.googleapis.com"],
-    google_project_service.services["iam.googleapis.com"],
-  ]
+  member             = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "enx-redirect-db" {
-  for_each = toset([
-    "sslcert",
-    "sslkey",
-    "sslrootcert",
-    "password",
-  ])
-
-  secret_id = google_secret_manager_secret.db-secret[each.key].id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "enx-redirect-csrf" {
-  secret_id = google_secret_manager_secret.csrf-token.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "enx-redirect-cookie-hmac-key" {
-  provider  = google-beta
-  secret_id = google_secret_manager_secret.cookie-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
+resource "google_project_iam_member" "enx-redirect-observability" {
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.enx-redirect.email}"
 }
 
 resource "google_kms_key_ring_iam_member" "enx-redirect-verification-key-admin" {
@@ -74,41 +50,19 @@ resource "google_kms_crypto_key_iam_member" "enx-redirect-database-encrypter" {
   member        = "serviceAccount:${google_service_account.enx-redirect.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "enx-redirect-db-apikey-db-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "enx-redirect-db-apikey-sig-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "enx-redirect-db-verification-code-hmac" {
-  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "enx-redirect-cache-hmac-key" {
-  secret_id = google_secret_manager_secret.cache-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
-}
-
-resource "google_project_iam_member" "enx-redirect-observability" {
-  for_each = toset([
-    "roles/cloudtrace.agent",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/stackdriver.resourceMetadata.writer",
+locals {
+  enx_redirect_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+    local.session_secrets,
   ])
+}
 
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.enx-redirect.email}"
+resource "google_secret_manager_secret_iam_member" "enx-redirect-secrets" {
+  count     = length(local.enx_redirect_secrets)
+  secret_id = element(local.enx_redirect_secrets, count.index)
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.enx-redirect.email}"
 }
 
 resource "google_cloud_run_service" "enx-redirect" {
@@ -171,17 +125,11 @@ resource "google_cloud_run_service" "enx-redirect" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
 
-    google_secret_manager_secret_iam_member.enx-redirect-db,
-    google_secret_manager_secret_iam_member.enx-redirect-csrf,
-    google_secret_manager_secret_iam_member.enx-redirect-cookie-hmac-key,
+    google_kms_crypto_key_iam_member.enx-redirect-database-encrypter,
     google_kms_key_ring_iam_member.enx-redirect-verification-key-admin,
     google_kms_key_ring_iam_member.enx-redirect-verification-key-signer-verifier,
-    google_kms_crypto_key_iam_member.enx-redirect-database-encrypter,
-    google_secret_manager_secret_iam_member.enx-redirect-db-apikey-db-hmac,
-    google_secret_manager_secret_iam_member.enx-redirect-db-apikey-sig-hmac,
-    google_secret_manager_secret_iam_member.enx-redirect-db-verification-code-hmac,
-    google_secret_manager_secret_iam_member.enx-redirect-cache-hmac-key,
     google_project_iam_member.enx-redirect-observability,
+    google_secret_manager_secret_iam_member.enx-redirect-secrets,
 
     null_resource.build,
     null_resource.migrate,
@@ -189,12 +137,12 @@ resource "google_cloud_run_service" "enx-redirect" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations["client.knative.dev/user-image"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
-      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].spec[0].containers[0].image,
     ]
   }
 }
@@ -223,7 +171,8 @@ resource "google_compute_backend_service" "enx-redirect" {
   }
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
-    enable = var.enable_lb_logging
+    enable      = var.enable_lb_logging
+    sample_rate = 1
   }
 }
 

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -21,38 +21,14 @@ resource "google_service_account" "rotation" {
 resource "google_service_account_iam_member" "cloudbuild-deploy-rotation" {
   service_account_id = google_service_account.rotation.id
   role               = "roles/iam.serviceAccountUser"
-  member             = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-
-  depends_on = [
-    google_project_service.services["cloudbuild.googleapis.com"],
-    google_project_service.services["iam.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_iam_member" "rotation-db" {
-  for_each = toset([
-    "sslcert",
-    "sslkey",
-    "sslrootcert",
-    "password",
-  ])
-
-  secret_id = google_secret_manager_secret.db-secret[each.key].id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.rotation.email}"
+  member             = "serviceAccount:${data.google_service_account.cloudbuild.email}"
 }
 
 resource "google_project_iam_member" "rotation-observability" {
-  for_each = toset([
-    "roles/cloudtrace.agent",
-    "roles/logging.logWriter",
-    "roles/monitoring.metricWriter",
-    "roles/stackdriver.resourceMetadata.writer",
-  ])
-
-  project = var.project
-  role    = each.key
-  member  = "serviceAccount:${google_service_account.rotation.email}"
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.rotation.email}"
 }
 
 resource "google_kms_key_ring_iam_member" "rotation-verification-key-admin" {
@@ -73,32 +49,16 @@ resource "google_kms_crypto_key_iam_member" "rotation-database-encrypter" {
   member        = "serviceAccount:${google_service_account.rotation.email}"
 }
 
-resource "google_secret_manager_secret_iam_member" "rotation-db-apikey-db-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-db-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.rotation.email}"
+locals {
+  rotation_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+  ])
 }
 
-resource "google_secret_manager_secret_iam_member" "rotation-db-apikey-sig-hmac" {
-  secret_id = google_secret_manager_secret.db-apikey-sig-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.rotation.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "rotation-db-verification-code-hmac" {
-  secret_id = google_secret_manager_secret.db-verification-code-hmac.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.rotation.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "rotation-cache-hmac-key" {
-  secret_id = google_secret_manager_secret.cache-hmac-key.id
-  role      = "roles/secretmanager.secretAccessor"
-  member    = "serviceAccount:${google_service_account.rotation.email}"
-}
-
-resource "google_secret_manager_secret_iam_member" "rotation-ratelimit-hmac-key" {
-  secret_id = google_secret_manager_secret.ratelimit-hmac-key.id
+resource "google_secret_manager_secret_iam_member" "rotation-secrets" {
+  count     = length(local.rotation_secrets)
+  secret_id = element(local.rotation_secrets, count.index)
   role      = "roles/secretmanager.secretAccessor"
   member    = "serviceAccount:${google_service_account.rotation.email}"
 }
@@ -162,14 +122,11 @@ resource "google_cloud_run_service" "rotation" {
   depends_on = [
     google_project_service.services["run.googleapis.com"],
 
-    google_secret_manager_secret_iam_member.rotation-db,
-    google_project_iam_member.rotation-observability,
     google_kms_crypto_key_iam_member.rotation-database-encrypter,
-    google_secret_manager_secret_iam_member.rotation-db-apikey-db-hmac,
-    google_secret_manager_secret_iam_member.rotation-db-apikey-sig-hmac,
-    google_secret_manager_secret_iam_member.rotation-db-verification-code-hmac,
-    google_secret_manager_secret_iam_member.rotation-cache-hmac-key,
-    google_secret_manager_secret_iam_member.rotation-ratelimit-hmac-key,
+    google_kms_key_ring_iam_member.rotation-verification-key-admin,
+    google_kms_key_ring_iam_member.rotation-verification-key-signer-verifier,
+    google_project_iam_member.rotation-observability,
+    google_secret_manager_secret_iam_member.rotation-secrets,
 
     null_resource.build,
     null_resource.migrate,
@@ -177,12 +134,12 @@ resource "google_cloud_run_service" "rotation" {
 
   lifecycle {
     ignore_changes = [
-      template[0].metadata[0].annotations["client.knative.dev/user-image"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
-      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
-      template[0].spec[0].containers[0].image,
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
       metadata[0].annotations["run.googleapis.com/ingress-status"],
       metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].spec[0].containers[0].image,
     ]
   }
 }

--- a/terraform/sessions.tf
+++ b/terraform/sessions.tf
@@ -12,6 +12,35 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+locals {
+  session_secrets = [
+    google_secret_manager_secret.csrf-token.id,
+    google_secret_manager_secret.cookie-hmac-key.id,
+    google_secret_manager_secret.cookie-encryption-key.id,
+  ]
+}
+
+resource "random_id" "csrf-token" {
+  byte_length = 32
+}
+
+resource "google_secret_manager_secret" "csrf-token" {
+  secret_id = "csrf-token"
+
+  replication {
+    automatic = true
+  }
+
+  depends_on = [
+    google_project_service.services["secretmanager.googleapis.com"],
+  ]
+}
+
+resource "google_secret_manager_secret_version" "csrf-token-version" {
+  secret      = google_secret_manager_secret.csrf-token.id
+  secret_data = random_id.csrf-token.b64_std
+}
+
 resource "random_id" "cookie-hmac-key" {
   byte_length = 32
 }


### PR DESCRIPTION
This simplifies our key and secret management management at the Terraform level. We've had a few partial outages when deploying new features because it was previously very easy to mess up. This refactors things to make it clearer which secrets a service needs and to depend on the service's service account having the permission as a dependency.

It also fixes a continuous diff we've been getting with Cloud Run.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Simplify key and secret management in Terraform. Note: this will cause a _very_ large Terraform diff when applying, including deleting IAM bindings. We recommend running `terraform apply` twice to ensure convergence.
```
