### PR TITLE
Updating Scheduler job failed alert

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -190,11 +190,12 @@ resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
   conditions {
     display_name = "Cloud Scheduler Job Error Ratio"
     condition_monitoring_query_language {
-      duration = "1s"
+      duration = "0s"
       query    = <<-EOT
       fetch cloud_scheduler_job::logging.googleapis.com/log_entry_count
       | filter (metric.severity == 'ERROR')
-      | align rate(5m)
+      | align rate(15m)
+      | every 1m
       | group_by [resource.job_id], [val: aggregate(value.log_entry_count)]
       | condition val > 0
       EOT


### PR DESCRIPTION
Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Updated Cloud Scheduler job failed alert
* Set every to 1m
* set duration to 0s

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note

```
