### PR TITLE
Add ticks and cache for age chart slider

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -19,6 +19,7 @@
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
   </div>
   <div class="slidecontainer" id="issue_age_slide_div">
+  <datalist id="issue_age_ticks"></datalist>
   </div>
 
   <div class="card-body">
@@ -121,6 +122,15 @@
         $issueAgeSlider.attr('max', data.statistics.length);
         $issueAgeSlider.val(data.statistics.length);
       }
+
+      let $ageTicks = $("#issue_age_ticks");
+      $ageTicks.empty();
+      for (i = 0; i < data.statistics.length; i++) {
+        let $opt = $('<option/>');
+        $opt.val(i);
+        $ageTicks.append($opt);
+      }
+
 
       drawClaimChart(data);
       drawMeanClaimAgeChart(data);
@@ -353,7 +363,13 @@
     });
   }
 
+  let ageCache = new Map();
   function getClaimAgeDataTable(dateIndex) {
+    let key = "s" + smoothing + "i" + dateIndex;
+    if (ageCache.has(key)) {
+      return ageCache.get(key);
+    }
+
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('number', 'days');
     dataTable.addColumn('number', 'count');
@@ -379,6 +395,7 @@
       }
       dataTable.addRow(r);
     }
+    ageCache.set(key, dataTable);
     return dataTable;
   }
 

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -27,7 +27,7 @@
   </div>
   <div class="slidecontainer" id="tek_slide_div">
   </div>
-  <datalist id="tektickmarks"></datalist>
+  <datalist id="tek_slide_ticks"></datalist>
   <div class="card-body">
     <h5 class="card-title">Onset-to-upload distribution <span class="sum-title">(7 day sum)</span></h5>
   </div>
@@ -108,22 +108,22 @@
       $onsetSlider.attr('value',data.length);
       $onsetSlider.attr('step', 1);
       $onsetSlider.val(data.length);
-  
-      let tekTicks = $("#tektickmarks");
-      tekTicks.empty();
+
+      let $tekTicks = $("#tek_slide_ticks");
+      $tekTicks.empty();
       for (i = Math.min(smoothing, data.length); i < data.length; i++) {
-        let opt = $('<option/>');
-        opt.val(i);
-        opt.attr('label', data[i].day.substring(0,10));
-        tekTicks.append(opt);
+        let $opt = $('<option/>');
+        $opt.val(i);
+        $opt.attr('label', data[i].day.substring(0,10));
+        $tekTicks.append($opt);
       }
 
-      let onsetTicks = $("#onset_slide_ticks");
-      onsetTicks.empty();
+      let $tekTicks = $("#onset_slide_ticks");
+      $tekTicks.empty();
       for (i = 0; i < data.length; i++) {
-        let opt = $('<option/>');
-        opt.val(i);
-        onsetTicks.append(opt);
+        let $opt = $('<option/>');
+        $opt.val(i);
+        $onsetTicks.append($opt);
       }
 
       drawStatsChart(data);
@@ -300,8 +300,8 @@
       title: `${smoothing} days from ` + stats[0].day.split("T")[0],
     };
 
-    tekChart = new google.visualization.ColumnChart($div.get(0)); 
-    tekData = getTEKDataTable(0);   
+    tekChart = new google.visualization.ColumnChart($div.get(0));
+    tekData = getTEKDataTable(0);
     tekChart.draw(tekData, tekOptions);
     chartData.push({
       chart: tekChart,
@@ -350,7 +350,7 @@
     return dataTable;
   }
 
-  
+
   let onsetChart;
   let onsetOptions;
   let onsetData;
@@ -396,7 +396,7 @@
     };
 
     onsetChart = new google.visualization.ColumnChart($div.get(0));
-    onsetData = getOnsetDataTable(0);  
+    onsetData = getOnsetDataTable(0);
     onsetChart.draw(onsetData, onsetOptions);
     chartData.push({
       chart: onsetChart,

--- a/cmd/server/assets/realmadmin/stats.html
+++ b/cmd/server/assets/realmadmin/stats.html
@@ -59,11 +59,11 @@
     let smoothing = 7;
 
     let $slider =
-      $(`<input type="range" class="slider w-100" id="tek_slider" list="tektickmarks">`);
+      $(`<input type="range" class="slider w-100" id="tek_slider" list="tek_slide_ticks">`);
     let $onsetSlider =
       $(`<input type="range" class="slider w-100" id="onset_slider" list="onset_slide_ticks">`);
     let $issueAgeSlider =
-      $(`<input type="range" class="slider w-100" id="issue_age_slider">`);
+      $(`<input type="range" class="slider w-100" id="issue_age_slider" list="issue_age_ticks">`);
 
     $(() => redrawCharts(chartData, 300));
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* This is https://github.com/google/exposure-notifications-verification-server/pull/1718/ pasted for one more chart

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Slider tick marks for issue-claim age chart
```
