### PR TITLE
Switch to short date, less b64 in returned SMS signature

### DIFF
--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -58,7 +58,7 @@ func SignSMS(signer crypto.Signer, keyID string, t time.Time, purpose SMSPurpose
 	}
 
 	date := t.Format("0102")
-	return newBody + b64([]byte(date)) + colon + b64([]byte(keyID)) + colon + b64(sig), nil
+	return newBody + date + colon + keyID + colon + b64(sig), nil
 }
 
 // smsSignatureString builds the string that is to be signed. The provided date

--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -57,7 +57,7 @@ func SignSMS(signer crypto.Signer, keyID string, t time.Time, purpose SMSPurpose
 		return "", fmt.Errorf("failed to sign sms: %w", err)
 	}
 
-	date := t.Format(project.RFC3339Date)
+	date := t.Format("0102")
 	return newBody + b64([]byte(date)) + colon + b64([]byte(keyID)) + colon + b64(sig), nil
 }
 

--- a/pkg/signatures/sms_test.go
+++ b/pkg/signatures/sms_test.go
@@ -71,22 +71,13 @@ func Test_SMSSignature(t *testing.T) {
 					}
 				case 1:
 					// Next is date
-					b, err := base64.RawStdEncoding.DecodeString(part)
-					if err != nil {
-						t.Fatal(err)
-					}
-
 					date := tc.time.UTC().Format("0102")
-					if got, want := string(b), date; got != want {
+					if got, want := part, date; got != want {
 						t.Errorf("expected %q to be %q", got, want)
 					}
 				case 2:
 					// Next is key id
-					b, err := base64.RawStdEncoding.DecodeString(part)
-					if err != nil {
-						t.Fatal(err)
-					}
-					if got, want := string(b), tc.keyID; got != want {
+					if got, want := part, tc.keyID; got != want {
 						t.Errorf("expected %q to be %q", got, want)
 					}
 				case 3:

--- a/pkg/signatures/sms_test.go
+++ b/pkg/signatures/sms_test.go
@@ -76,7 +76,7 @@ func Test_SMSSignature(t *testing.T) {
 						t.Fatal(err)
 					}
 
-					date := tc.time.UTC().Format("2006-01-02")
+					date := tc.time.UTC().Format("0102")
 					if got, want := string(b), date; got != want {
 						t.Errorf("expected %q to be %q", got, want)
 					}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch to short date with less base64-encoding in returned SMS signature
```

/hold for final sign-off from Apple

/assign @mikehelmick 
