### PR TITLE
Remove onboarding functionality

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -93,8 +93,7 @@ periodically via a distributed cron.
 
 The ENX redirect server serves Apple/Google `.well-known` association files for
 app links to allow PHAs to gracefully redirect users to an appropriate app store
-in the event their application is not installed. The redirect service also
-handles onboarding domains.
+in the event their application is not installed.
 
 
 ### Modeler Server

--- a/internal/clients/enx_redirect.go
+++ b/internal/clients/enx_redirect.go
@@ -150,7 +150,7 @@ func (c *ENXRedirectClient) RunE2E(ctx context.Context) error {
 	if got, want := unknownHTTPResp.StatusCode, 303; got != want {
 		return fmt.Errorf("expected unknown redirect code %d to be %d", got, want)
 	}
-	// expecting generic onboarding redirect
+	// expecting generic landing redirect
 	if got, want := unknownHTTPResp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications"; !strings.Contains(got, want) {
 		return fmt.Errorf("expected unknown redirect location %q to contain %q", got, want)
 	}

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -44,10 +44,6 @@ type RedirectConfig struct {
 	// auto-reload is enabled.
 	DevMode bool `env:"DEV_MODE"`
 
-	// OnboardingDomain is the top-level ENX redirect domain (e.g. example.com).
-	// Requests routed to this domain trigger the generic onboarding flow.
-	OnboardingDomain string `env:"ONBOARDING_DOMAIN"`
-
 	// A map of hostnames to redirect to ens:// and a mapping to the region.
 	// For example to redirect
 	//   region.example.com to region US-AA

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -318,14 +318,6 @@ func TestDecideRedirect(t *testing.T) {
 			appStoreData: &appLinkNeither,
 			expected:     "",
 		},
-		{
-			name:         "android_onboarding",
-			url:          "https://moosylvania.gov/",
-			enxEnabled:   false,
-			userAgent:    userAgentAndroid,
-			appStoreData: &appLinkNeither,
-			expected:     "market://search?q=exposure%20notifications",
-		},
 
 		// iOS
 		{
@@ -359,14 +351,6 @@ func TestDecideRedirect(t *testing.T) {
 			appStoreData: &appLinkNeither,
 			expected:     "",
 		},
-		{
-			name:         "ios_onboarding",
-			url:          "https://moosylvania.gov/",
-			enxEnabled:   false,
-			userAgent:    userAgentIOS,
-			appStoreData: &appLinkNeither,
-			expected:     "ens://onboarding",
-		},
 
 		// Other
 		{
@@ -375,14 +359,6 @@ func TestDecideRedirect(t *testing.T) {
 			userAgent:    userAgentNeither,
 			appStoreData: &appLinkBoth,
 			expected:     "",
-		},
-		// Other
-		{
-			name:         "other_onboarding",
-			url:          "https://moosylvania.gov/",
-			userAgent:    userAgentNeither,
-			appStoreData: &appLinkBoth,
-			expected:     "https://www.google.com/covid19/exposurenotifications/",
 		},
 	}
 

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -37,22 +37,6 @@ func (c *Controller) HandleIndex() http.Handler {
 			baseHost = host
 		}
 
-		// Check if this is the naked domain.
-		if baseHost == c.config.OnboardingDomain {
-			if isAndroid(r.UserAgent()) {
-				http.Redirect(w, r, androidOnboardingRedirect, http.StatusSeeOther)
-				return
-			}
-
-			if isIOS(r.UserAgent()) {
-				http.Redirect(w, r, iosOnboardingRedirect, http.StatusSeeOther)
-				return
-			}
-
-			http.Redirect(w, r, genericOnboardingRedirect, http.StatusSeeOther)
-			return
-		}
-
 		var hostRegion string = ""
 		for hostname, region := range c.hostnameToRegion {
 			if hostname == baseHost {

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -36,9 +36,8 @@ func TestIndex(t *testing.T) {
 
 	// Create config.
 	cfg := &config.RedirectConfig{
-		AssetsPath:       filepath.Join(project.Root(), "cmd", "enx-redirect", "assets"),
-		DevMode:          true,
-		OnboardingDomain: "onboard.me",
+		AssetsPath: filepath.Join(project.Root(), "cmd", "enx-redirect", "assets"),
+		DevMode:    true,
 		HostnameConfig: map[string]string{
 			"bad":    "nope",
 			"realm1": "aa",
@@ -122,96 +121,6 @@ func TestIndex(t *testing.T) {
 	client.CheckRedirect = func(r *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse
 	}
-
-	// Onboarding, android
-	t.Run("onboarding/android", func(t *testing.T) {
-		t.Parallel()
-
-		req, err := http.NewRequest("GET", srv.URL, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Host = "onboard.me"
-		req.Header.Set("User-Agent", "android")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer resp.Body.Close()
-
-		if got, want := resp.StatusCode, 303; got != want {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Errorf("expected %d to be %d: %s", got, want, body)
-		}
-
-		if got, want := resp.Header.Get("Location"), "market://search?q=exposure%20notifications"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
-		}
-	})
-
-	// Onboarding, ios
-	t.Run("onboarding/ios", func(t *testing.T) {
-		t.Parallel()
-
-		req, err := http.NewRequest("GET", srv.URL, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Host = "onboard.me"
-		req.Header.Set("User-Agent", "iphone")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer resp.Body.Close()
-
-		if got, want := resp.StatusCode, 303; got != want {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Errorf("expected %d to be %d: %s", got, want, body)
-		}
-
-		if got, want := resp.Header.Get("Location"), "ens://onboarding"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
-		}
-	})
-
-	// Onboarding, unknown
-	t.Run("onboarding/unknown", func(t *testing.T) {
-		t.Parallel()
-
-		req, err := http.NewRequest("GET", srv.URL, nil)
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Host = "onboard.me"
-		req.Header.Set("User-Agent", "bananarama")
-
-		resp, err := client.Do(req)
-		if err != nil {
-			t.Fatal(err)
-		}
-		defer resp.Body.Close()
-
-		if got, want := resp.StatusCode, 303; got != want {
-			body, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				t.Fatal(err)
-			}
-			t.Errorf("expected %d to be %d: %s", got, want, body)
-		}
-
-		if got, want := resp.Header.Get("Location"), "https://www.google.com/covid19/exposurenotifications/"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
-		}
-	})
 
 	// Bad path
 	t.Run("bad_path", func(t *testing.T) {

--- a/terraform/redirect-lb.tf
+++ b/terraform/redirect-lb.tf
@@ -17,7 +17,6 @@ locals {
 
   redirect_root_domains = distinct(compact([
     var.enx_redirect_domain,
-    var.enx_onboarding_domain,
   ]))
 }
 

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -102,7 +102,6 @@ locals {
   enx_redirect_config = {
     ASSETS_PATH        = "/assets"
     HOSTNAME_TO_REGION = join(",", [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : format("%s:%s", o.host, o.region)])
-    ONBOARDING_DOMAIN  = var.enx_onboarding_domain
   }
 
   observability_config = {}

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -190,12 +190,6 @@ variable "adminapi_hosts" {
   description = "List of domains upon which the adminapi is served."
 }
 
-variable "enx_onboarding_domain" {
-  type        = string
-  default     = ""
-  description = "Domain on which to serve onboarding redirects."
-}
-
 variable "enx_redirect_domain" {
   type        = string
   default     = ""


### PR DESCRIPTION
This was never included in a release, so I'm marking the release notes as `NONE`. Similarly, I'm going to update the release notes on the PR in which this feature was added.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1727
"Reverts" https://github.com/google/exposure-notifications-verification-server/pull/1635

Note that this isn't a true revert becase:

1. It doesn't revert cleanly
2. There is some functionality in that PR (namely the fallback to redirect to g.co/ens in the event someone hits the URL from their browser) which I think is valuable

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
