### PR TITLE
Display key-server override on the stats page if one is set

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -12,6 +12,8 @@
   The data below shows realm statistics and visualizations gathered from the key server.
 </p>
 
+{{if .keyServerOverride}}<p>Stats sourced from: "{{.keyServerOverride}}}</p>{{end}}
+
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>

--- a/pkg/controller/realmadmin/stats.go
+++ b/pkg/controller/realmadmin/stats.go
@@ -51,6 +51,9 @@ func (c *Controller) HandleStats() http.Handler {
 
 		m := controller.TemplateMapFromContext(ctx)
 		m["hasKeyServerStats"] = hasKeyServerStats
+		if hasKeyServerStats && membership.Can(rbac.SettingsRead) {
+			m["keyServerOverride"] = s.KeyServerURLOverride
+		}
 		m.Title("Realm stats")
 		c.h.RenderHTML(w, "realmadmin/stats", m)
 	})


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Displays the key-server override URL on the stats page
    * if one is set
    * if Can SettingsRead
