### PR TITLE
Update probers to check database for uptime

### DIFF
--- a/terraform/alerting/probers.tf
+++ b/terraform/alerting/probers.tf
@@ -22,7 +22,7 @@ resource "google_monitoring_uptime_check_config" "https" {
   period       = "60s"
 
   http_check {
-    path         = "/health"
+    path         = "/health?service=database"
     port         = "443"
     use_ssl      = true
     validate_ssl = true


### PR DESCRIPTION
This cannot go in until 0.22 or later.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update probers to check database for uptime
```

/hold