### PR TITLE
UTC time for test

### DIFF
--- a/pkg/controller/user/export_test.go
+++ b/pkg/controller/user/export_test.go
@@ -136,7 +136,7 @@ func TestHandleExport(t *testing.T) {
 			t.Errorf("expected %d to be %d", got, want)
 		}
 
-		d := time.Now().Format(project.RFC3339Date)
+		d := time.Now().UTC().Format(project.RFC3339Date)
 		exp := fmt.Sprintf(`name,email,joined
 System admin,super@example.com,%s
 User,user@example.com,%s


### PR DESCRIPTION
/assign @whaught 

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use UTC time in stats-puller test
```
