### PR TITLE
Make redis_auth optional

### DIFF
--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -34,7 +34,7 @@ resource "google_redis_instance" "cache" {
   connect_mode       = "PRIVATE_SERVICE_ACCESS"
 
   redis_version = "REDIS_5_0"
-  auth_enabled  = true
+  auth_enabled  = var.redis_enable_auth
 
   depends_on = [
     google_project_service.services["redis.googleapis.com"],

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -148,6 +148,13 @@ variable "redis_alternative_location" {
   default = "us-central1-c"
 }
 
+variable "redis_enable_auth" {
+  type    = bool
+  default = false
+
+  description = "Enable Redis authentication. The default is false because not all redis versions support authentication."
+}
+
 variable "service_environment" {
   type    = map(map(string))
   default = {}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make redis_auth optional, default to false for backwards compatibility
```

/assign @mikehelmick 