### PR TITLE
Set align rate to 1min

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -194,8 +194,7 @@ resource "google_monitoring_alert_policy" "CloudSchedulerJobFailed" {
       query    = <<-EOT
       fetch cloud_scheduler_job::logging.googleapis.com/log_entry_count
       | filter (metric.severity == 'ERROR')
-      | align rate(15m)
-      | every 1m
+      | align rate(1m)
       | group_by [resource.job_id], [val: aggregate(value.log_entry_count)]
       | condition val > 0
       EOT


### PR DESCRIPTION
This should only notify once for every time the cloud scheduler job fails.
