### PR TITLE
Unclosed h5 tag. All json/csv as footers

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -13,6 +13,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#realm-codes-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 
@@ -30,6 +35,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#issue-claim-dist-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 
@@ -46,6 +56,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#issue-claim-mean-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -1,12 +1,13 @@
 {{define "realmadmin/_stats_keyserver"}}
 
-<h1 class="pt-5">Key server stats
-  <h6 class="float-right">
+<div class="mt-5">
+  <h6 class="float-right mt-2">
     <span class="mr-1">Export as:</span>
     <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
     <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
   </h6>
-</h1>
+  <h1>Key server stats</h1>
+</div>
 
 <p>
   The data below shows realm statistics and visualizations gathered from the key server.
@@ -115,7 +116,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Publish requests (by device operating system<)/h5>
+        <h5 class="modal-title">Publish requests (by device operating system)</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -1,14 +1,6 @@
 {{define "realmadmin/_stats_keyserver"}}
 
-<div class="mt-5">
-  <h6 class="float-right mt-2">
-    <span class="mr-1">Export as:</span>
-    <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
-    <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
-  </h6>
-  <h1>Key server stats</h1>
-</div>
-
+<h1>Key server stats</h1>
 <p>
   The data below shows realm statistics and visualizations gathered from the key server.
 </p>
@@ -25,6 +17,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#keyserver-stats-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 
@@ -38,6 +35,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#publish-by-os-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 
@@ -55,6 +57,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#tek-age-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 
@@ -72,6 +79,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#onset-to-upload-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm/key-server.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/key-server.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 

--- a/cmd/server/assets/realmadmin/_stats_tokens.html
+++ b/cmd/server/assets/realmadmin/_stats_tokens.html
@@ -10,6 +10,11 @@
   </div>
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-toggle="modal" data-target="#realm-tokens-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>
+    </span>
   </small>
 </div>
 

--- a/cmd/server/assets/realmadmin/stats.html
+++ b/cmd/server/assets/realmadmin/stats.html
@@ -29,14 +29,7 @@
       </div>
     </form>
 
-    <div>
-      <h6 class="float-right mt-2">
-        <span class="mr-1">Export as:</span>
-        <a href="/stats/realm.csv" class="mr-1">CSV</a>
-        <a href="/stats/realm.json" target="_blank">JSON</a>
-      </h6>
-      <h1>Realm stats</h1>
-    </div>
+    <h1>Realm stats</h1>
     <p>
       The data below shows realm statistics and visualizations.
     </p>

--- a/cmd/server/assets/realmadmin/stats.html
+++ b/cmd/server/assets/realmadmin/stats.html
@@ -29,13 +29,14 @@
       </div>
     </form>
 
-    <h1>Realm stats
-      <h6 class="float-right">
+    <div>
+      <h6 class="float-right mt-2">
         <span class="mr-1">Export as:</span>
         <a href="/stats/realm.csv" class="mr-1">CSV</a>
         <a href="/stats/realm.json" target="_blank">JSON</a>
       </h6>
-    </h1>
+      <h1>Realm stats</h1>
+    </div>
     <p>
       The data below shows realm statistics and visualizations.
     </p>


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Fixes and unclosed h5 tag
* Relocate the download link back to every chart footer (how it was before)