### PR TITLE
Fallback to a sentinel string if the redis auth is unset

### DIFF
--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "redis-auth" {
 
 resource "google_secret_manager_secret_version" "redis-auth" {
   secret      = google_secret_manager_secret.redis-auth.id
-  secret_data = google_redis_instance.cache.auth_string
+  secret_data = coalesce(google_redis_instance.cache.auth_string, "unused")
 }
 
 # Create secret for the HMAC cache keys


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fallback to a sentinel string if the redis auth is unset. This fixes an issue where Secret Manager fails to create the secret because it has a null value with Redis authentication is disabled.
```
