### PR TITLE
Cover rendering all of the login pages

### DIFF
--- a/cmd/server/assets/login/account.html
+++ b/cmd/server/assets/login/account.html
@@ -11,7 +11,7 @@
   {{template "firebase" .}}
 </head>
 
-<body>
+<body id="account">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/login/change-password.html
+++ b/cmd/server/assets/login/change-password.html
@@ -7,7 +7,7 @@
   {{template "firebase" .}}
 </head>
 
-<body class="tab-content">
+<body id="change-password" class="tab-content">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/login/reset-password.html
+++ b/cmd/server/assets/login/reset-password.html
@@ -7,7 +7,7 @@
   {{template "firebase" .}}
 </head>
 
-<body class="tab-content">
+<body id="reset-password" class="tab-content">
   {{if .currentUser}}
   {{template "navbar" .}}
   {{end}}

--- a/cmd/server/assets/login/select-password.html
+++ b/cmd/server/assets/login/select-password.html
@@ -6,7 +6,7 @@
   {{template "head" .}}
 </head>
 
-<body class="tab-content">
+<body id="select-password" class="tab-content">
   <main role="main" class="container">
     {{template "flash" .}}
 

--- a/cmd/server/assets/login/select-realm.html
+++ b/cmd/server/assets/login/select-realm.html
@@ -11,7 +11,7 @@
   {{template "head" .}}
 </head>
 
-<body class="tab-content">
+<body id="select-realm" class="tab-content">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/login/verify-email-check.html
+++ b/cmd/server/assets/login/verify-email-check.html
@@ -7,7 +7,7 @@
   {{template "firebase" .}}
 </head>
 
-<body class="tab-content">
+<body id="verify-email-check" class="tab-content">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/cmd/server/assets/login/verify-email.html
+++ b/cmd/server/assets/login/verify-email.html
@@ -7,7 +7,7 @@
   {{template "firebase" .}}
 </head>
 
-<body class="tab-content">
+<body id="verify-email" class="tab-content">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/pkg/controller/login/account_test.go
+++ b/pkg/controller/login/account_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleAccount_ShowAccount(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/account`),
+		chromedp.WaitVisible(`body#account`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/login/change_password_test.go
+++ b/pkg/controller/login/change_password_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleChangePassword_ShowChangePassword(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/change-password`),
+		chromedp.WaitVisible(`body#change-password`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/login/reauth_test.go
+++ b/pkg/controller/login/reauth_test.go
@@ -22,28 +22,30 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleReauth_ShowLogin(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login`),
 		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/login/register_phone_test.go
+++ b/pkg/controller/login/register_phone_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleRegisterPhonne_ShowRegisterPhone(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/register-phone`),
+		chromedp.WaitVisible(`body#login-register-phone`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/login/select_password_test.go
+++ b/pkg/controller/login/select_password_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleSelectPassword_ShowSelectPassword(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/manage-account?mode=resetPassword&oobCode=invalid`),
+		chromedp.WaitVisible(`body#select-password`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/login/signout_test.go
+++ b/pkg/controller/login/signout_test.go
@@ -22,28 +22,30 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleSignout_ShowLogin(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
+		browser.SetCookie(cookie), // start signed-in
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/signout`),
 		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/login/verify_email_receive_test.go
+++ b/pkg/controller/login/verify_email_receive_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleVerifyEmailReceive_ShowVerifyEmail(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/manage-account?mode=verifyEmail&oobCode=invalid`),
+		chromedp.WaitVisible(`body#verify-email-check`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/login/verify_email_send_test.go
+++ b/pkg/controller/login/verify_email_send_test.go
@@ -22,29 +22,31 @@ import (
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-var testDatabaseInstance *database.TestInstance
-
-func TestMain(m *testing.M) {
-	testDatabaseInstance = database.MustTestInstance()
-	defer testDatabaseInstance.MustClose()
-	m.Run()
-}
-
-func TestHandleLogin_ShowLogin(t *testing.T) {
+func TestHandleVerifyEmailSend_ShowVerifyEmail(t *testing.T) {
 	t.Parallel()
 
 	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
 
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
 
 	if err := chromedp.Run(taskCtx,
-		chromedp.Navigate(`http://`+harness.Server.Addr()),
-		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/manage-account?mode=verifyEmail`),
+		chromedp.WaitVisible(`body#verify-email`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1399

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Cover rendering for all of the login pages
    * Takes 6% to 42% coverage of the package. Need to exercise the writes next.