### PR TITLE
don't pass redis password when auth disabled

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -191,7 +191,7 @@ export FIREBASE_STORAGE_BUCKET="${data.google_firebase_web_app_config.default.st
 export CACHE_TYPE="REDIS"
 export CACHE_REDIS_HOST="${google_redis_instance.cache.host}"
 export CACHE_REDIS_PORT="${google_redis_instance.cache.port}"
-export CACHE_REDIS_PASSWORD="secret://${google_secret_manager_secret_version.redis-auth.id}"
+export CACHE_REDIS_PASSWORD=var.redis_enable_auth ? "secret://${google_secret_manager_secret_version.redis-auth.id}" : ""
 
 export RATE_LIMIT_TYPE="REDIS"
 export RATE_LIMIT_TOKENS="60"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -198,7 +198,7 @@ export RATE_LIMIT_TOKENS="60"
 export RATE_LIMIT_INTERVAL="1m"
 export RATE_LIMIT_REDIS_HOST="${google_redis_instance.cache.host}"
 export RATE_LIMIT_REDIS_PORT="${google_redis_instance.cache.port}"
-export RATE_LIMIT_REDIS_PASSWORD="secret://${google_secret_manager_secret_version.redis-auth.id}"
+export RATE_LIMIT_REDIS_PASSWORD=var.redis_enable_auth ? "secret://${google_secret_manager_secret_version.redis-auth.id}" : ""
 
 export CERTIFICATE_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")}"
 export TOKEN_SIGNING_KEY="${trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")}"

--- a/terraform/redis.tf
+++ b/terraform/redis.tf
@@ -56,7 +56,7 @@ resource "google_secret_manager_secret" "redis-auth" {
 
 resource "google_secret_manager_secret_version" "redis-auth" {
   secret      = google_secret_manager_secret.redis-auth.id
-  secret_data = google_redis_instance.cache.auth_string
+  secret_data = coalesce(google_redis_instance.cache.auth_string, "unused")
 }
 
 # Create secret for the HMAC cache keys

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -34,7 +34,7 @@ locals {
     CACHE_HMAC_KEY       = "secret://${google_secret_manager_secret_version.cache-hmac-key.id}"
     CACHE_REDIS_HOST     = google_redis_instance.cache.host
     CACHE_REDIS_PORT     = google_redis_instance.cache.port
-    CACHE_REDIS_PASSWORD = "secret://${google_secret_manager_secret_version.redis-auth.id}"
+    CACHE_REDIS_PASSWORD = var.redis_enable_auth ? "secret://${google_secret_manager_secret_version.redis-auth.id}" : ""
   }
 
   database_config = {

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -73,7 +73,7 @@ locals {
     RATE_LIMIT_INTERVAL       = "1m"
     RATE_LIMIT_REDIS_HOST     = google_redis_instance.cache.host
     RATE_LIMIT_REDIS_PORT     = google_redis_instance.cache.port
-    RATE_LIMIT_REDIS_PASSWORD = "secret://${google_secret_manager_secret_version.redis-auth.id}"
+    RATE_LIMIT_REDIS_PASSWORD = var.redis_enable_auth ? "secret://${google_secret_manager_secret_version.redis-auth.id}" : ""
   }
 
   signing_config = {


### PR DESCRIPTION

## Proposed Changes

* Ensures that redis PW isn't passed when auth disabled

**Release Note**

```release-note
Allow for redis auth to be disabled and terraform to apply successfully
```
