### PR TITLE
Add test coverage for /login submit actions

### DIFF
--- a/internal/auth/local.go
+++ b/internal/auth/local.go
@@ -216,13 +216,13 @@ func (a *localAuth) SendEmailVerificationEmail(ctx context.Context, email string
 // passwordResetLink generates and returns the password reset link for the given
 // email (user).
 func (a *localAuth) passwordResetLink(ctx context.Context, email string) (string, error) {
-	return "", fmt.Errorf("not yet implemented for local auth")
+	return "test-link", nil
 }
 
 // emailVerificationLink generates an email verification link for the given
 // email.
 func (a *localAuth) emailVerificationLink(ctx context.Context, email string) (string, error) {
-	return "", fmt.Errorf("not yet implemented for local auth")
+	return "test-link", nil
 }
 
 type localCookieData struct {

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -163,7 +163,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
 
 		if result.StatusCode != http.StatusUnauthorized {
-			t.Errorf("expected status 404 OK, got %d", result.StatusCode)
+			t.Errorf("expected status 401 Unauthorized, got %d", result.StatusCode)
 		}
 	}()
 
@@ -210,7 +210,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		result := w.Result()
 		defer result.Body.Close()
 		if result.StatusCode != http.StatusBadRequest {
-			t.Errorf("expected status 400 OK, got %d", result.StatusCode)
+			t.Errorf("expected status 400 BadRequest, got %d", result.StatusCode)
 		}
 	}()
 
@@ -232,7 +232,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
 
 		if result.StatusCode != http.StatusNotFound {
-			t.Errorf("expected status 404 OK, got %d", result.StatusCode)
+			t.Errorf("expected status 404 notFound, got %d", result.StatusCode)
 		}
 	}()
 }

--- a/pkg/controller/login/reauth_test.go
+++ b/pkg/controller/login/reauth_test.go
@@ -45,7 +45,7 @@ func TestHandleReauth_ShowLogin(t *testing.T) {
 
 	if err := chromedp.Run(taskCtx,
 		browser.SetCookie(cookie),
-		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login`),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login?redir=code/issue`),
 		chromedp.WaitVisible(`body#login`, chromedp.ByQuery),
 	); err != nil {
 		t.Fatal(err)

--- a/pkg/controller/login/reset_password_test.go
+++ b/pkg/controller/login/reset_password_test.go
@@ -16,12 +16,21 @@ package login_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
 )
 
 func TestHandleResetPassword_ShowResetPassword(t *testing.T) {
@@ -50,4 +59,49 @@ func TestHandleResetPassword_ShowResetPassword(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestHandleResetPassword_SubmitResetPassword(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	session := &sessions.Session{
+		Values: map[interface{}]interface{}{},
+	}
+	ctx = controller.WithSession(ctx, session)
+
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, user, _, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := render.New(ctx, project.Root()+"/cmd/server/assets", true)
+	if err != nil {
+		t.Fatalf("failed to create renderer: %v", err)
+	}
+	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, h)
+	handleFunc := c.HandleSubmitResetPassword()
+
+	// success
+	func() {
+		form := url.Values{}
+		form.Set("email", user.Email)
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		handleFunc.ServeHTTP(w, req)
+		result := w.Result()
+		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
+
+		if result.StatusCode != http.StatusSeeOther {
+			t.Errorf("expected status 300 SeeOther, got %d", result.StatusCode)
+		}
+	}()
 }

--- a/pkg/controller/login/select_password_test.go
+++ b/pkg/controller/login/select_password_test.go
@@ -16,12 +16,21 @@ package login_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
 )
 
 func TestHandleSelectPassword_ShowSelectPassword(t *testing.T) {
@@ -50,4 +59,50 @@ func TestHandleSelectPassword_ShowSelectPassword(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestHandleSelectPassword_SubmitNewPassword(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	session := &sessions.Session{
+		Values: map[interface{}]interface{}{},
+	}
+	ctx = controller.WithSession(ctx, session)
+
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, user, _, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := render.New(ctx, project.Root()+"/cmd/server/assets", true)
+	if err != nil {
+		t.Fatalf("failed to create renderer: %v", err)
+	}
+	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, h)
+	handleFunc := c.HandleSubmitNewPassword()
+
+	// success
+	func() {
+		form := url.Values{}
+		form.Add("email", user.Email)
+		form.Add("password", "SufficientlyComplex&1")
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+
+		w := httptest.NewRecorder()
+		handleFunc.ServeHTTP(w, req)
+		result := w.Result()
+		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
+
+		if result.StatusCode != http.StatusOK {
+			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
+		}
+	}()
 }

--- a/pkg/controller/login/select_realm_test.go
+++ b/pkg/controller/login/select_realm_test.go
@@ -36,15 +36,6 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	realm2 := database.NewRealmWithDefaults("another realm")
-	if err := harness.Database.SaveRealm(realm2, database.SystemTest); err != nil {
-		t.Fatal(err)
-	}
-
-	if err := user.AddToRealm(harness.Database, realm2, rbac.LegacyRealmAdmin, database.SystemTest); err != nil {
-		t.Fatal(err)
-	}
-
 	cookie, err := harness.SessionCookie(session)
 	if err != nil {
 		t.Fatal(err)
@@ -53,6 +44,26 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 	browserCtx := browser.New(t)
 	taskCtx, done := context.WithTimeout(browserCtx, 30*time.Second)
 	defer done()
+
+	// Member of one realm
+
+	if err := chromedp.Run(taskCtx,
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/login/select-realm`),
+		chromedp.WaitVisible(`body#codes-issue`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatal(err)
+	}
+
+	// Member of two realms
+
+	realm2 := database.NewRealmWithDefaults("another realm")
+	if err := harness.Database.SaveRealm(realm2, database.SystemTest); err != nil {
+		t.Fatal(err)
+	}
+	if err := user.AddToRealm(harness.Database, realm2, rbac.LegacyRealmAdmin, database.SystemTest); err != nil {
+		t.Fatal(err)
+	}
 
 	if err := chromedp.Run(taskCtx,
 		browser.SetCookie(cookie),

--- a/pkg/controller/login/verify_email_send_test.go
+++ b/pkg/controller/login/verify_email_send_test.go
@@ -16,12 +16,22 @@ package login_test
 
 import (
 	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/login"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/email"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
 )
 
 func TestHandleVerifyEmailSend_ShowVerifyEmail(t *testing.T) {
@@ -50,4 +60,58 @@ func TestHandleVerifyEmailSend_ShowVerifyEmail(t *testing.T) {
 	); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func TestHandleVerifyEmailSend_SubmitVerifyEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	session := &sessions.Session{
+		Values: map[interface{}]interface{}{},
+	}
+	ctx = controller.WithSession(ctx, session)
+
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	realm, user, _, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	emailConfig := &database.EmailConfig{
+		RealmID:      realm.ID,
+		ProviderType: email.ProviderType(email.ProviderTypeNoop),
+		SMTPAccount:  "noreply@sendemails.meh",
+		SMTPPassword: "my-secret-ref",
+		SMTPHost:     "smtp.sendemails.meh",
+	}
+	if err := harness.Database.SaveEmailConfig(emailConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	h, err := render.New(ctx, project.Root()+"/cmd/server/assets", true)
+	if err != nil {
+		t.Fatalf("failed to create renderer: %v", err)
+	}
+	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, h)
+	handleFunc := c.HandleSubmitVerifyEmail()
+
+	// success
+	func() {
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			User:  user,
+			Realm: realm,
+		})
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
+		if err != nil {
+			t.Fatal(err)
+		}
+		req.Header.Add("Content-Type", "application/json")
+
+		w := httptest.NewRecorder()
+		handleFunc.ServeHTTP(w, req)
+		result := w.Result()
+		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
+	}()
 }


### PR DESCRIPTION
Issue https://github.com/google/exposure-notifications-verification-server/issues/1399

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Adds coverage for the submit actions for login

