### PR TITLE
Double frequency for stats

### DIFF
--- a/terraform/service_stats_puller.tf
+++ b/terraform/service_stats_puller.tf
@@ -162,7 +162,7 @@ resource "google_cloud_run_service_iam_member" "stats-puller-invoker" {
 resource "google_cloud_scheduler_job" "stats-puller-worker" {
   name             = "stats-puller-worker"
   region           = var.cloudscheduler_location
-  schedule         = "30 * * * *"
+  schedule         = "4, 34 * * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "600s"
 


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* These are very low-cost calls, but could keep things up-to-date if a call fails
* Key-server only updates this once per hour, most of our distributions show daily
