### PR TITLE
Upgrade key server to main to pull in KMS fix

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -29,7 +29,7 @@ require (
 	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
-	github.com/google/exposure-notifications-server v0.21.0
+	github.com/google/exposure-notifications-server v0.21.1-0.20210203231836-b0cfb8b1fad8
 	github.com/google/go-cmp v0.5.4
 	github.com/google/uuid v1.1.2
 	github.com/gorilla/csrf v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -597,8 +597,8 @@ github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0 h1:0udJVsspx3VBr5FwtLhQQtuAsVc79tTq0ocGIPAU6qo=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/exposure-notifications-server v0.21.0 h1:WZoFTZlTcOFIShfo4KLK3YuiN5cIohyRKz/vkyRluvE=
-github.com/google/exposure-notifications-server v0.21.0/go.mod h1:4cnmOlzsUjKMWwpw/YT7MR8ApbKIwD0M00piBLwl8WU=
+github.com/google/exposure-notifications-server v0.21.1-0.20210203231836-b0cfb8b1fad8 h1:O7y+PrIyhVRtiC0IYUgATsXezQw12VgzUvPdq4zEoVA=
+github.com/google/exposure-notifications-server v0.21.1-0.20210203231836-b0cfb8b1fad8/go.mod h1:ee6u4XrqV9Xk5jFTXdgNH03aT2Ai0hotITOPdVegAtg=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
To pull in https://github.com/google/exposure-notifications-server/pull/1338

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
