### PR TITLE
Update google provider version.

### DIFF
--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -330,11 +330,11 @@ terraform {
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.51"
+      version = "~> 3.55"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.51"
+      version = "~> 3.55"
     }
     local = {
       source  = "hashicorp/local"


### PR DESCRIPTION
This is required for the google_redis_instance auth_enabled feature.