### PR TITLE
Set sample_rate to null if lb logging is not enabled.

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -174,7 +174,7 @@ resource "google_compute_backend_service" "adminapi" {
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
-    sample_rate = 1
+    sample_rate = var.enable_lb_logging ? 1 : null
   }
 }
 

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -175,7 +175,7 @@ resource "google_compute_backend_service" "apiserver" {
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
-    sample_rate = 1
+    sample_rate = var.enable_lb_logging ? 1 : null
   }
 }
 

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -162,7 +162,7 @@ resource "google_compute_backend_service" "modeler" {
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
-    sample_rate = 1
+    sample_rate = var.enable_lb_logging ? 1 : null
   }
 }
 

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -177,7 +177,7 @@ resource "google_compute_backend_service" "enx-redirect" {
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
-    sample_rate = 1
+    sample_rate = var.enable_lb_logging ? 1 : null
   }
 }
 

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -194,7 +194,7 @@ resource "google_compute_backend_service" "server" {
   security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
-    sample_rate = 1
+    sample_rate = var.enable_lb_logging ? 1 : null
   }
 }
 


### PR DESCRIPTION
It looks like setting sample_rate while enabled = false is causing some
API error: