### PR TITLE
Add custom tooltips for key-server stats

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -309,11 +309,17 @@
 
       dataTable.addRow([utcDate(row.day),
         row.publish_requests.unknown,
-        "<strong>Unknown:</strong>" + row.publish_requests.unknown + " " +(row.publish_requests.unknown / total * 100).toPrecision(3) + "%",
+        "<ul class='chart-tooltip'><li><strong>Unknown:</strong></li>"+
+          "<li>Count: " + row.publish_requests.unknown + "</li>" +
+          "<li>Percent: " + (row.publish_requests.unknown / total * 100).toPrecision(3) + "%</li></ul>",
         row.publish_requests.android,
-        "<strong>Android:</strong>" + row.publish_requests.android + " " + (row.publish_requests.android / total * 10).toPrecision(3) + "%",
+        "<ul class='chart-tooltip'><li><strong>Android:</strong></li>"+
+          "<li>Count: " + row.publish_requests.android + "</li>" +
+          "<li>Percent: " + (row.publish_requests.android / total * 100).toPrecision(3)  + "%</li></ul>",
         row.publish_requests.ios,
-        "<strong>IOS:</strong>" + row.publish_requests.ios + " " + (row.publish_requests.ios / total * 100).toPrecision(3) + "%",
+        "<ul class='chart-tooltip'><li><strong>IOS:</strong></li>"+
+          "<li>Count: " + row.publish_requests.ios + "</li>" +
+          "<li>Percent: " + (row.publish_requests.ios / total * 100).toPrecision(3)  + "%</li></ul>",
       ]);
     });
 
@@ -396,6 +402,7 @@
       },
       titlePosition: "out",
       title: `${smoothing} days from ` + stats[0].day.split("T")[0],
+      tooltip: {isHtml: true},
     };
 
     tekChart = new google.visualization.ColumnChart($div.get(0));
@@ -420,15 +427,18 @@
     dataTable.addColumn('number', 'count');
     dataTable.addColumn({type:'string', role:'style'})
     dataTable.addColumn({type:'string', role:'annotation'})
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
 
     // sum over last ${smoothing} days
     let table = new Array(stats[dateIndex].tek_age_distribution.length).fill(0);
     let i;
+    let total = 0;
     for (i = dateIndex; i < dateIndex + smoothing && i < stats.length; i++) {
       let row = stats[i];
       let j;
       for (j = 0; j < row.tek_age_distribution.length; j++) {
         table[j] += row.tek_age_distribution[j];
+        total += row.tek_age_distribution[j];
       }
     }
 
@@ -437,11 +447,18 @@
         maxVAxisTEKAge = table[i];
       }
 
-      let r = [i+1, table[i],"",""]
+      let r = [i+1, table[i],"","",""]
       if (i == 15) {
         r[2] = "#6c757d";
         r[3] = ">15 days";
       }
+
+      r[4] =
+        "<ul class='chart-tooltip'><li><strong>Days:</strong> "+ r[0] +"</li>"+
+          "<li>Count: " + r[1] + "</li>" +
+          "<li>Percent: " + (r[1] / total * 100).toPrecision(3) + "%</li></ul>";
+
+
       dataTable.addRow(r);
     }
     dataTableCache.set(key, dataTable);
@@ -491,6 +508,7 @@
       },
       titlePosition: "out",
       title: `${smoothing} days from ` + stats[0].day.split("T")[0],
+      tooltip: {isHtml: true},
     };
 
     onsetChart = new google.visualization.ColumnChart($div.get(0));
@@ -515,24 +533,34 @@
     dataTable.addColumn('number', 'count');
     dataTable.addColumn({type:'string', role:'style'})
     dataTable.addColumn({type:'string', role:'annotation'})
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
 
     // sum over last ${smoothing} days
     let table = new Array(stats[dateIndex].onset_to_upload_distribution.length).fill(0);
     let i;
+    let total = 0;
     for (i = dateIndex; i < dateIndex + smoothing && i < stats.length; i++) {
       let row = stats[i];
       let j;
       for (j = 0; j < row.onset_to_upload_distribution.length; j++) {
         table[j] += row.onset_to_upload_distribution[j];
+        total += row.onset_to_upload_distribution[j];
       }
     }
 
     for (i = 0; i < table.length; i++) {
-      let r = [i+1, table[i],"",""]
+      let r = [i+1, table[i],"","", ""]
       if (i == 30) {
         r[2] = "#6c757d";
         r[3] = ">30 days";
       }
+
+      r[4] =
+        "<ul class='chart-tooltip'><li><strong>Days:</strong> "+ r[0] +"</li>"+
+          "<li>Count: " + r[1] + "</li>" +
+          "<li>Percent: " + (r[1] / total * 100).toPrecision(3) + "%</li></ul>";
+
+
       dataTable.addRow(r);
       if (table[i] > onsetVAxisMax) {
         onsetVAxisMax = table[i];

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -425,9 +425,9 @@
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('number', 'days');
     dataTable.addColumn('number', 'count');
-    dataTable.addColumn({type:'string', role:'style'})
-    dataTable.addColumn({type:'string', role:'annotation'})
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
+    dataTable.addColumn({type:'string', role:'style'});
+    dataTable.addColumn({type:'string', role:'annotation'});
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
 
     // sum over last ${smoothing} days
     let table = new Array(stats[dateIndex].tek_age_distribution.length).fill(0);
@@ -531,9 +531,9 @@
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('number', 'days');
     dataTable.addColumn('number', 'count');
-    dataTable.addColumn({type:'string', role:'style'})
-    dataTable.addColumn({type:'string', role:'annotation'})
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
+    dataTable.addColumn({type:'string', role:'style'});
+    dataTable.addColumn({type:'string', role:'annotation'});
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
 
     // sum over last ${smoothing} days
     let table = new Array(stats[dateIndex].onset_to_upload_distribution.length).fill(0);

--- a/cmd/server/assets/realmadmin/_stats_keyserver.html
+++ b/cmd/server/assets/realmadmin/_stats_keyserver.html
@@ -306,20 +306,23 @@
 
     stats.reverse().forEach(function(row) {
       let total = row.publish_requests.unknown + row.publish_requests.android + row.publish_requests.ios;
+      let unknownCount = parseInt(row.publish_requests.unknown);
+      let androidCount = parseInt(row.publish_requests.android);
+      let iosCount = parseInt(row.publish_requests.ios);
 
       dataTable.addRow([utcDate(row.day),
         row.publish_requests.unknown,
         "<ul class='chart-tooltip'><li><strong>Unknown:</strong></li>"+
-          "<li>Count: " + row.publish_requests.unknown + "</li>" +
-          "<li>Percent: " + (row.publish_requests.unknown / total * 100).toPrecision(3) + "%</li></ul>",
+          "<li>Count: " + unknownCount + "</li>" +
+          "<li>Percent: " + (unknownCount / total * 100).toPrecision(3) + "%</li></ul>",
         row.publish_requests.android,
         "<ul class='chart-tooltip'><li><strong>Android:</strong></li>"+
-          "<li>Count: " + row.publish_requests.android + "</li>" +
-          "<li>Percent: " + (row.publish_requests.android / total * 100).toPrecision(3)  + "%</li></ul>",
+          "<li>Count: " + androidCount  + "</li>" +
+          "<li>Percent: " + (androidCount  / total * 100).toPrecision(3)  + "%</li></ul>",
         row.publish_requests.ios,
         "<ul class='chart-tooltip'><li><strong>IOS:</strong></li>"+
-          "<li>Count: " + row.publish_requests.ios + "</li>" +
-          "<li>Percent: " + (row.publish_requests.ios / total * 100).toPrecision(3)  + "%</li></ul>",
+          "<li>Count: " + iosCount + "</li>" +
+          "<li>Percent: " + (iosCount / total * 100).toPrecision(3)  + "%</li></ul>",
       ]);
     });
 
@@ -437,8 +440,9 @@
       let row = stats[i];
       let j;
       for (j = 0; j < row.tek_age_distribution.length; j++) {
-        table[j] += row.tek_age_distribution[j];
-        total += row.tek_age_distribution[j];
+        let count = parseInt(row.tek_age_distribution[j]);
+        table[j] += count;
+        total += count;
       }
     }
 
@@ -543,8 +547,9 @@
       let row = stats[i];
       let j;
       for (j = 0; j < row.onset_to_upload_distribution.length; j++) {
-        table[j] += row.onset_to_upload_distribution[j];
-        total += row.onset_to_upload_distribution[j];
+        let count = parseInt(row.onset_to_upload_distribution[j]);
+        table[j] += count;
+        total += count;
       }
     }
 

--- a/cmd/server/assets/static/css/application.css
+++ b/cmd/server/assets/static/css/application.css
@@ -121,6 +121,12 @@ main.container[role="main"] {
   color: #777;
 }
 
+ul.chart-tooltip {
+  width: 130px;
+  list-style-type: none;
+  padding: 5px;
+}
+
 /* Fallback for Edge
 -------------------------------------------------- */
 @supports (-ms-ime-align: auto) {


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Custom tooltips for the key-server stats charts
    * Specifically shows the % of total for each bar

![Screen Shot 2021-02-08 at 10 48 12 AM](https://user-images.githubusercontent.com/36240966/107267044-36153780-69fb-11eb-95e2-cd2865154cb7.png)


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Custom chart tooltips with % of total
```
