### PR TITLE
Chart titles - remove 'age'

### DIFF
--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -24,7 +24,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Days from issue-to-claim distribution <span class="sum-title">(7 day sum)</span>
+    Days from issue to claim distribution <span class="sum-title">(7 day sum)</span>
   </div>
   <div id="issue_age_dist_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -46,7 +46,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Mean days from issue-to-claim
+    Mean days from issue to claim
   </div>
   <div id="mean_claim_age_div">
     <div id="mean_claim_age_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -129,7 +129,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Days from issue-to-claim distribution</h5>
+        <h5 class="modal-title">Days from issue to claim distribution</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -148,7 +148,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Mean days from issue-to-claim</h5>
+        <h5 class="modal-title">Mean days from issue to claim</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/cmd/server/assets/realmadmin/_stats_codes.html
+++ b/cmd/server/assets/realmadmin/_stats_codes.html
@@ -24,7 +24,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Issue-to-claim age distribution <span class="sum-title">(7 day sum)</span>
+    Days from issue-to-claim distribution <span class="sum-title">(7 day sum)</span>
   </div>
   <div id="issue_age_dist_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -46,7 +46,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Mean issue-to-claim age
+    Mean days from issue-to-claim
   </div>
   <div id="mean_claim_age_div">
     <div id="mean_claim_age_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -129,7 +129,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Issue-to-claim age distribution</h5>
+        <h5 class="modal-title">Days from issue-to-claim distribution</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -148,7 +148,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Mean issue-to-claim age</h5>
+        <h5 class="modal-title">Mean days from issue-to-claim</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -302,7 +302,7 @@
 
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
-    dataTable.addColumn('number', 'Mean issue-claim age');
+    dataTable.addColumn('number', 'Mean issue-claim days');
 
     data.statistics.reverse().forEach(function(row) {
       dataTable.addRow([utcDate(row.date), row.data.code_claim_mean_age_seconds]);


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Remove the word 'age' from chart titles.
    * Feedback from a user was that word is too similar to 'age' as used to describe a person
    * Now `Days from issue to claim`
