### PR TITLE
Run more checkers in the same job

### DIFF
--- a/.github/workflows/codereview.yaml
+++ b/.github/workflows/codereview.yaml
@@ -20,9 +20,10 @@ jobs:
           version: v1.36.0
           only-new-issues: true
 
-  only-user-errors:
-    name: errorw-bot
+  reviewdog:
+    name: reviewdog
     runs-on: ubuntu-latest
+    continue-on-error: true
 
     steps:
       - name: Check out code
@@ -30,7 +31,10 @@ jobs:
 
       - uses: reviewdog/action-setup@v1
 
-      - name: Check
+      - name: Install pcregrep
+        run: sudo apt-get -yqq install pcregrep
+
+      - name: errorw
         shell: bash
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -46,20 +50,7 @@ jobs:
             -fail-on-error="false" \
             -level="warning"
 
-  controller-error-without-return:
-    name: controller-returns
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - uses: reviewdog/action-setup@v1
-
-      - name: Install pcregrep
-        run: sudo apt-get -yqq install pcregrep
-
-      - name: Check
+      - name: controller-without-returns
         shell: bash
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}
@@ -80,17 +71,7 @@ jobs:
             -fail-on-error="true" \
             -level="error"
 
-  copyright-check:
-    name: copyright-check
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Check out code
-        uses: actions/checkout@v2
-
-      - uses: reviewdog/action-setup@v1
-
-      - name: Check
+      - name: copyright-check
         shell: bash
         env:
           REVIEWDOG_GITHUB_API_TOKEN: ${{ github.token }}


### PR DESCRIPTION
We have a limit on the number of parallel jobs, and it also doesn't make sense to install reviewdog 3 times.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
