### PR TITLE
Handle sms errors in the function

### DIFF
--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -63,52 +63,53 @@ func ScrubPhoneNumbers(s string) string {
 	return noScrubs
 }
 
-func (c *Controller) SendSMS(ctx context.Context, realm *database.Realm, smsProvider sms.Provider, signer crypto.Signer, keyID string, request *api.IssueCodeRequest, result *IssueResult) error {
+// SendSMS sends the sms mesage with the given provider and wraps any seen errors into the IssueResult
+func (c *Controller) SendSMS(ctx context.Context, realm *database.Realm, smsProvider sms.Provider, signer crypto.Signer, keyID string, request *api.IssueCodeRequest, result *IssueResult) {
 	if request.Phone == "" {
-		return nil
+		return
+	}
+
+	if err := c.doSend(ctx, realm, smsProvider, signer, keyID, request, result); err != nil {
+		result.HTTPCode = http.StatusBadRequest
+		if sms.IsSMSQueueFull(err) {
+			result.ErrorReturn = result.ErrorReturn.WithCode(api.ErrSMSQueueFull)
+		} else {
+			result.ErrorReturn = api.Errorf("failed to send sms: %s", err).WithCode(api.ErrSMSFailure)
+		}
+	}
+}
+
+func (c *Controller) doSend(ctx context.Context, realm *database.Realm, smsProvider sms.Provider, signer crypto.Signer, keyID string, request *api.IssueCodeRequest, result *IssueResult) error {
+	smsStart := time.Now()
+	defer enobs.RecordLatency(ctx, smsStart, mSMSLatencyMs, &result.obsResult)
+
+	message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+	if err != nil {
+		result.obsResult = enobs.ResultError("FAILED_TO_BUILD_SMS")
+		return err
+	}
+
+	// A signer will only be provided if the realm has configured and enabled
+	// SMS signing.
+	if signer != nil {
+		var err error
+		message, err = signatures.SignSMS(signer, keyID, smsStart, signatures.SMSPurposeENReport, request.Phone, message)
+		if err != nil {
+			result.obsResult = enobs.ResultError("FAILED_TO_SIGN_SMS")
+			return err
+		}
 	}
 
 	logger := logging.FromContext(ctx).Named("issueapi.sendSMS")
-	smsStart := time.Now()
-	err := func() error {
-		message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
-		if err != nil {
-			result.obsResult = enobs.ResultError("FAILED_TO_BUILD_SMS")
-			return err
+	if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
+		// Delete the token
+		if err := c.db.DeleteVerificationCode(result.VerCode.Code); err != nil {
+			logger.Errorw("failed to delete verification code", "error", err)
+			// fallthrough to the error
 		}
 
-		// A signer will only be provided if the realm has configured and enabled
-		// SMS signing.
-		if signer != nil {
-			var err error
-			message, err = signatures.SignSMS(signer, keyID, smsStart, signatures.SMSPurposeENReport, request.Phone, message)
-			if err != nil {
-				result.obsResult = enobs.ResultError("FAILED_TO_SIGN_SMS")
-				return err
-			}
-		}
-
-		if err := smsProvider.SendSMS(ctx, request.Phone, message); err != nil {
-			// Delete the token
-			if err := c.db.DeleteVerificationCode(result.VerCode.Code); err != nil {
-				logger.Errorw("failed to delete verification code", "error", err)
-				// fallthrough to the error
-			}
-
-			logger.Infow("failed to send sms", "error", ScrubPhoneNumbers(err.Error()))
-			result.obsResult = enobs.ResultError("FAILED_TO_SEND_SMS")
-			return err
-		}
-		return nil
-	}()
-	enobs.RecordLatency(ctx, smsStart, mSMSLatencyMs, &result.obsResult)
-	if err != nil {
-		result.HTTPCode = http.StatusBadRequest
-		result.ErrorReturn = api.Errorf("failed to send sms: %s", err).WithCode(api.ErrSMSFailure)
-
-		if sms.IsSMSQueueFull(err) {
-			result.ErrorReturn = result.ErrorReturn.WithCode(api.ErrSMSQueueFull)
-		}
+		logger.Infow("failed to send sms", "error", ScrubPhoneNumbers(err.Error()))
+		result.obsResult = enobs.ResultError("FAILED_TO_SEND_SMS")
 		return err
 	}
 	return nil

--- a/pkg/controller/issueapi/send_sms_test.go
+++ b/pkg/controller/issueapi/send_sms_test.go
@@ -56,6 +56,10 @@ func TestSMS_scrubPhoneNumber(t *testing.T) {
 
 	for k, pattern := range patterns {
 		for i, tc := range cases {
+			k := k
+			pattern := pattern
+			tc := tc
+
 			t.Run(fmt.Sprintf("case_%s_%2d", k, i), func(t *testing.T) {
 				t.Parallel()
 
@@ -87,7 +91,7 @@ func TestSMS_sendSMS(t *testing.T) {
 
 	smsConfig := &database.SMSConfig{
 		RealmID:      realm.ID,
-		ProviderType: sms.ProviderType(sms.ProviderTypeNoop),
+		ProviderType: sms.ProviderTypeNoop,
 	}
 	if err := db.SaveSMSConfig(smsConfig); err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Seth found that this function attempts to [both handle an error and return it](https://github.com/google/exposure-notifications-verification-server/pull/1801#discussion_r574837896) which is ambiguous as to what the caller should do.
    * The new code might swallow the `api.ErrSMSQueueFull` errorReturn and needs the `.WithCode(api.ErrSMSFailure)` to give the proper enum error code
    * Instead we fully handle the errors inside sendSMS and don't return the error.
    * Move the anonymous function to a fully named `doSend` for readability
