### PR TITLE
Add test for realmkeys endpoints

### DIFF
--- a/cmd/server/assets/realmadmin/keys.html
+++ b/cmd/server/assets/realmadmin/keys.html
@@ -80,7 +80,7 @@
   {{template "head" .}}
 </head>
 
-<body class="tab-content">
+<body id="keys" class="tab-content">
   {{template "navbar" .}}
 
   <main role="main" class="container">

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -138,12 +138,12 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 	}
 
 	config := &config.AdminAPIServerConfig{}
-	h, err := render.New(ctx, project.Root()+"/cmd/server/assets", true)
+	h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
 	if err != nil {
 		t.Fatalf("failed to create renderer: %v", err)
 	}
 	c := codes.NewAPI(ctx, config, harness.Database, h)
-	handleFunc := c.HandleExpireAPI()
+	handler := c.HandleExpireAPI()
 
 	// not-authorized
 	func() {
@@ -158,7 +158,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		req.Header.Add("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()
-		handleFunc.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 		result := w.Result()
 		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
 
@@ -181,7 +181,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		req.Header.Add("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()
-		handleFunc.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 		result := w.Result()
 		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
 
@@ -206,7 +206,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		}
 
 		w := httptest.NewRecorder()
-		handleFunc.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 		result := w.Result()
 		defer result.Body.Close()
 		if result.StatusCode != http.StatusBadRequest {
@@ -227,7 +227,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		req.Header.Add("Content-Type", "application/json")
 
 		w := httptest.NewRecorder()
-		handleFunc.ServeHTTP(w, req)
+		handler.ServeHTTP(w, req)
 		result := w.Result()
 		defer result.Body.Close() // likely no-op for test, but we have a presubmit looking for it
 

--- a/pkg/controller/issueapi/send_sms_test.go
+++ b/pkg/controller/issueapi/send_sms_test.go
@@ -168,6 +168,8 @@ func TestSMS_sendSMS(t *testing.T) {
 	c.SendSMS(ctx, realm, failingSMSProvider, nil, "", request, result)
 	if result.ErrorReturn == nil {
 		t.Fatal("expected failed SMS, but got no error response")
+	} else if result.ErrorReturn.ErrorCode != api.ErrSMSFailure {
+		t.Fatal("expected SMS failure code")
 	}
 	if _, err := realm.FindVerificationCodeByUUID(db, result.VerCode.UUID); !database.IsNotFound(err) {
 		t.Errorf("expected SMS failure to roll-back and delete code. got %v", err)

--- a/pkg/controller/login/verify_email_send.go
+++ b/pkg/controller/login/verify_email_send.go
@@ -55,6 +55,10 @@ func (c *Controller) HandleSubmitVerifyEmail() http.Handler {
 		flash := controller.Flash(session)
 
 		membership := controller.MembershipFromContext(ctx)
+		if membership == nil {
+			controller.MissingMembership(w, r, c.h)
+			return
+		}
 		currentUser := membership.User
 
 		var form FormData

--- a/pkg/controller/realmkeys/activate.go
+++ b/pkg/controller/realmkeys/activate.go
@@ -21,9 +21,10 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
+// HandleActivate handles the endpoint for activating signing keys
 func (c *Controller) HandleActivate() http.Handler {
 	type FormData struct {
-		SigningKeyID uint `form:"id"`
+		SigningKeyID uint `form:"id,required"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/controller/realmkeys/create.go
+++ b/pkg/controller/realmkeys/create.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
+// HandleCreateKey creates a new signing key version.
 func (c *Controller) HandleCreateKey() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/controller/realmkeys/create_test.go
+++ b/pkg/controller/realmkeys/create_test.go
@@ -15,10 +15,8 @@
 package realmkeys_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -33,7 +31,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-func TestRealmKeys_SubmitActivate(t *testing.T) {
+func TestRealmKeys_SubmitCreate(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -56,7 +54,7 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-	handler := c.HandleActivate()
+	handler := c.HandleCreateKey()
 
 	envstest.ExerciseSessionMissing(t, handler)
 	envstest.ExerciseMembershipMissing(t, handler)
@@ -68,59 +66,9 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		Permissions: rbac.SettingsWrite,
 	})
 
-	// no form bound
-	func() {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		result := w.Result()
-		defer result.Body.Close()
-
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
-		}
-	}()
-
-	// no key exists
-	func() {
-		form := url.Values{}
-		form.Add("id", "1")
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		result := w.Result()
-		defer result.Body.Close()
-
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
-		}
-	}()
-
-	if _, err := realm.CreateSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
-		t.Fatal(err)
-	}
-	list, err := realm.ListSigningKeys(harness.Database)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// success
 	func() {
-		form := url.Values{}
-		form.Add("id", fmt.Sprint(list[0].ID))
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/controller/realmkeys/destroy.go
+++ b/pkg/controller/realmkeys/destroy.go
@@ -22,6 +22,7 @@ import (
 	"github.com/gorilla/mux"
 )
 
+// HandleDestroy deletes a signing key version
 func (c *Controller) HandleDestroy() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/controller/realmkeys/index.go
+++ b/pkg/controller/realmkeys/index.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
+// HandleIndex renders a page that shows the list of signing keys.
 func (c *Controller) HandleIndex() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/controller/realmkeys/index_test.go
+++ b/pkg/controller/realmkeys/index_test.go
@@ -1,0 +1,53 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realmkeys_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/chromedp/chromedp"
+	"github.com/google/exposure-notifications-verification-server/internal/browser"
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+)
+
+func TestHandleIndex(t *testing.T) {
+	t.Parallel()
+
+	harness := envstest.NewServer(t, testDatabaseInstance)
+
+	_, _, session, err := harness.ProvisionAndLogin()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cookie, err := harness.SessionCookie(session)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	browserCtx := browser.New(t)
+	taskCtx, done := context.WithTimeout(browserCtx, 10*time.Second)
+	defer done()
+
+	if err := chromedp.Run(taskCtx,
+		browser.SetCookie(cookie),
+		chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/keys`),
+		chromedp.WaitVisible(`body#keys`, chromedp.ByQuery),
+	); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/controller/realmkeys/save.go
+++ b/pkg/controller/realmkeys/save.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
+// HandleSave handles saving certificate settings to the current realm.
 func (c *Controller) HandleSave() http.Handler {
 	type FormData struct {
 		Issuer         string `form:"certificateIssuer"`

--- a/pkg/controller/realmkeys/save_test.go
+++ b/pkg/controller/realmkeys/save_test.go
@@ -15,10 +15,8 @@
 package realmkeys_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -33,7 +31,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-func TestRealmKeys_SubmitActivate(t *testing.T) {
+func TestRealmKeys_SubmitSave(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -56,7 +54,7 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-	handler := c.HandleActivate()
+	handler := c.HandleSave()
 
 	envstest.ExerciseSessionMissing(t, handler)
 	envstest.ExerciseMembershipMissing(t, handler)
@@ -68,59 +66,9 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		Permissions: rbac.SettingsWrite,
 	})
 
-	// no form bound
-	func() {
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		result := w.Result()
-		defer result.Body.Close()
-
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
-		}
-	}()
-
-	// no key exists
-	func() {
-		form := url.Values{}
-		form.Add("id", "1")
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
-
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		result := w.Result()
-		defer result.Body.Close()
-
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
-		}
-	}()
-
-	if _, err := realm.CreateSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
-		t.Fatal(err)
-	}
-	list, err := realm.ListSigningKeys(harness.Database)
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	// success
 	func() {
-		form := url.Values{}
-		form.Add("id", fmt.Sprint(list[0].ID))
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/controller/realmkeys/upgrade.go
+++ b/pkg/controller/realmkeys/upgrade.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
 
+// HandleUpgrade handles an endpoint to update a realm to use its own certificate settings.
 func (c *Controller) HandleUpgrade() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()

--- a/pkg/controller/realmkeys/upgrade_test.go
+++ b/pkg/controller/realmkeys/upgrade_test.go
@@ -15,10 +15,8 @@
 package realmkeys_test
 
 import (
-	"fmt"
 	"net/http"
 	"net/http/httptest"
-	"net/url"
 	"strings"
 	"testing"
 
@@ -33,7 +31,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-func TestRealmKeys_SubmitActivate(t *testing.T) {
+func TestRealmKeys_SubmitUpgrade(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -56,7 +54,7 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(cfg, harness.Database, harness.KeyManager, publicKeyCache, h)
-	handler := c.HandleActivate()
+	handler := c.HandleUpgrade()
 
 	envstest.ExerciseSessionMissing(t, handler)
 	envstest.ExerciseMembershipMissing(t, handler)
@@ -68,7 +66,7 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		Permissions: rbac.SettingsWrite,
 	})
 
-	// no form bound
+	// success
 	func() {
 		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
 		if err != nil {
@@ -81,46 +79,17 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		result := w.Result()
 		defer result.Body.Close()
 
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
+		if result.StatusCode != http.StatusSeeOther {
+			t.Errorf("expected status 301 SeeOther, got %d", result.StatusCode)
 		}
 	}()
 
-	// no key exists
+	// success - use realm certificate
 	func() {
-		form := url.Values{}
-		form.Add("id", "1")
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
-		if err != nil {
-			t.Fatal(err)
-		}
-		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
+		realm.CertificateIssuer = "foo"
+		realm.CertificateAudience = "bar"
 
-		w := httptest.NewRecorder()
-		handler.ServeHTTP(w, req)
-		result := w.Result()
-		defer result.Body.Close()
-
-		// shows original page with error flash
-		if result.StatusCode != http.StatusOK {
-			t.Errorf("expected status 200 OK, got %d", result.StatusCode)
-		}
-	}()
-
-	if _, err := realm.CreateSigningKeyVersion(ctx, harness.Database, database.SystemTest); err != nil {
-		t.Fatal(err)
-	}
-	list, err := realm.ListSigningKeys(harness.Database)
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	// success
-	func() {
-		form := url.Values{}
-		form.Add("id", fmt.Sprint(list[0].ID))
-		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(form.Encode()))
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "", strings.NewReader(""))
 		if err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1373,7 +1373,7 @@ func (r *Realm) CreateSigningKeyVersion(ctx context.Context, db *Database, actor
 	return r.createManagedSigningKey(ctx, db, r.certificateSigningKMSKeyName(), &SigningKey{}, actor)
 }
 
-// CreateSMSSigningKeyVersion creates a new SMS signing key versino on the key manager
+// CreateSMSSigningKeyVersion creates a new SMS signing key version on the key manager
 // and saves a reference to the new key version in the database.
 func (r *Realm) CreateSMSSigningKeyVersion(ctx context.Context, db *Database, actor Auditable) (string, error) {
 	return r.createManagedSigningKey(ctx, db, r.smsSigningKMSKeyName(), &SMSSigningKey{}, actor)


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Add new tests for `/realm/keys` endpoints
    * 36.5% -> 84.6% coverage. Still a few more to write 
* Fix up some other tests with some common checks for session
    * Once I discovered these common test methods I added em to some old ones I wrote

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add test coverage to activate keys and keys index
```
