### PR TITLE
Uppercase errors in HTTP status code related tests

### DIFF
--- a/internal/envstest/unit.go
+++ b/internal/envstest/unit.go
@@ -47,7 +47,7 @@ func ExerciseSessionMissing(t *testing.T, h http.Handler) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "session missing in request context"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -76,7 +76,7 @@ func ExerciseMembershipMissing(t *testing.T, h http.Handler) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "/login/select-realm"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -104,7 +104,7 @@ func ExerciseUserMissing(t *testing.T, h http.Handler) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "user missing"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -134,7 +134,7 @@ func ExercisePermissionMissing(t *testing.T, h http.Handler) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -167,7 +167,7 @@ func ExerciseBadPagination(t *testing.T, membership *database.Membership, h http
 		w.Flush()
 
 		if got, want := w.Code, 400; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Bad request"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -200,7 +200,7 @@ func ExerciseIDNotFound(t *testing.T, membership *database.Membership, h http.Ha
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/internal/envstest/unit.go
+++ b/internal/envstest/unit.go
@@ -50,7 +50,7 @@ func ExerciseSessionMissing(t *testing.T, h http.Handler) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "session missing in request context"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }
@@ -79,7 +79,7 @@ func ExerciseMembershipMissing(t *testing.T, h http.Handler) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "/login/select-realm"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }
@@ -107,7 +107,7 @@ func ExerciseUserMissing(t *testing.T, h http.Handler) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "user missing"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }
@@ -137,7 +137,7 @@ func ExercisePermissionMissing(t *testing.T, h http.Handler) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }
@@ -170,7 +170,7 @@ func ExerciseBadPagination(t *testing.T, membership *database.Membership, h http
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Bad request"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }
@@ -203,7 +203,7 @@ func ExerciseIDNotFound(t *testing.T, membership *database.Membership, h http.Ha
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -100,7 +100,7 @@ func TestLocaleMap_Lookup(t *testing.T) {
 
 		name := langOf(localeMap.Lookup("es"))
 		if got, want := name, "es"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -109,7 +109,7 @@ func TestLocaleMap_Lookup(t *testing.T) {
 
 		name := langOf(localeMap.Lookup("totes_not_a_real_language"))
 		if got, want := name, "en"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }
@@ -165,7 +165,7 @@ func TestLocaleMap_Canonicalize(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/internal/project/errors_test.go
+++ b/internal/project/errors_test.go
@@ -31,6 +31,6 @@ func TestErrorsToStrings(t *testing.T) {
 	})
 
 	if got, want := result, []string{"oh no", "goodbye"}; !reflect.DeepEqual(got, want) {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }

--- a/internal/routes/server_test.go
+++ b/internal/routes/server_test.go
@@ -493,7 +493,7 @@ func testRoute(t *testing.T, m *mux.Router, r *http.Request, vars map[string]str
 			}
 
 			if got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		}
 	})

--- a/pkg/api/api_test.go
+++ b/pkg/api/api_test.go
@@ -25,13 +25,13 @@ func TestInternalError(t *testing.T) {
 	result := InternalError()
 
 	if got, want := result.Error, "internal error"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := result.ErrorCode, "internal_server_error"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := result.ErrorCodeLegacy, "internal_server_error"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }
 
@@ -41,10 +41,10 @@ func TestErrorf(t *testing.T) {
 	result := Errorf("hello %s", "world")
 
 	if got, want := result.Error, "hello world"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := result.ErrorCode, ""; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }
 
@@ -55,10 +55,10 @@ func TestError(t *testing.T) {
 		result := Error(fmt.Errorf("oops"))
 
 		if got, want := result.Error, "oops"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := result.ErrorCode, ""; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	}
 

--- a/pkg/cache/cacher_test.go
+++ b/pkg/cache/cacher_test.go
@@ -91,7 +91,7 @@ func TestKeyCompute(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -164,7 +164,7 @@ func TestMultiKeyFunc(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -216,7 +216,7 @@ func TestHashKeyFunc(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -256,7 +256,7 @@ func TestHMACKeyFunc(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -106,7 +106,7 @@ func TestAdminCaches(t *testing.T) {
 			t.Errorf("expected %d errors, got %d", want, got)
 		}
 		if got, want := errs[0], "Unknown cache type"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -157,7 +157,7 @@ func TestAdminCaches(t *testing.T) {
 			t.Errorf("expected %d errors, got %d", want, got)
 		}
 		if got, want := errs[0], "Failed to clear cache"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -103,7 +103,7 @@ func TestAdminCaches(t *testing.T) {
 		flash := controller.Flash(session)
 		errs := flash.Errors()
 		if got, want := len(errs), 1; got != want {
-			t.Errorf("expected %d errors, got %d", want, got)
+			t.Errorf("Expected %d errors, got %d", want, got)
 		}
 		if got, want := errs[0], "Unknown cache type"; !strings.Contains(got, want) {
 			t.Errorf("Expected %q to contain %q", got, want)
@@ -154,7 +154,7 @@ func TestAdminCaches(t *testing.T) {
 		flash := controller.Flash(session)
 		errs := flash.Errors()
 		if got, want := len(errs), 1; got != want {
-			t.Errorf("expected %d errors, got %d", want, got)
+			t.Errorf("Expected %d errors, got %d", want, got)
 		}
 		if got, want := errs[0], "Failed to clear cache"; !strings.Contains(got, want) {
 			t.Errorf("Expected %q to contain %q", got, want)

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -94,7 +94,7 @@ func TestAdminCaches(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -145,7 +145,7 @@ func TestAdminCaches(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -182,7 +182,7 @@ func TestAdminCaches(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -97,7 +97,7 @@ func TestAdminCaches(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		flash := controller.Flash(session)
@@ -148,7 +148,7 @@ func TestAdminCaches(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		flash := controller.Flash(session)
@@ -185,7 +185,7 @@ func TestAdminCaches(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/email_test.go
+++ b/pkg/controller/admin/email_test.go
@@ -76,7 +76,7 @@ func TestAdminEmail(t *testing.T) {
 			t.Errorf("expected %d to be %d: %#v", got, want, w.Header())
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -99,7 +99,7 @@ func TestAdminEvents(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -129,7 +129,7 @@ func TestAdminEvents(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -154,7 +154,7 @@ func TestAdminEvents(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -179,7 +179,7 @@ func TestAdminEvents(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/info_test.go
+++ b/pkg/controller/admin/info_test.go
@@ -71,7 +71,7 @@ func TestAdminInfo(t *testing.T) {
 			t.Errorf("expected %d to be %d: %#v", got, want, w.Header())
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/mobile_apps_test.go
+++ b/pkg/controller/admin/mobile_apps_test.go
@@ -96,7 +96,7 @@ func TestAdminMobileApps(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -121,7 +121,7 @@ func TestAdminMobileApps(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -256,7 +256,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -318,7 +318,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/realms/2/edit"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }
@@ -447,7 +447,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/realms/1/edit"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }
@@ -601,7 +601,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(1)
@@ -772,7 +772,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(1)

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -101,7 +101,7 @@ func TestHandleRealmsIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -126,7 +126,7 @@ func TestHandleRealmsIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -225,7 +225,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -253,7 +253,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -281,7 +281,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -315,7 +315,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/realms/2/edit"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -390,7 +390,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -415,7 +415,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -444,7 +444,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/realms/1/edit"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -514,7 +514,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -540,7 +540,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -571,7 +571,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -598,7 +598,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -685,7 +685,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -711,7 +711,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -742,7 +742,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -769,7 +769,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "https://example.com/foo/bar"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/admin/sms_test.go
+++ b/pkg/controller/admin/sms_test.go
@@ -123,17 +123,17 @@ func TestShowAdminSMS(t *testing.T) {
 
 	aaa := smsFromNumbers[0]
 	if got, want := aaa.Label, "aaa"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := aaa.Value, wantFromNumber1; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 
 	zzz := smsFromNumbers[1]
 	if got, want := zzz.Label, "zzz"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := zzz.Value, wantFromNumber2; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }

--- a/pkg/controller/admin/users_list_test.go
+++ b/pkg/controller/admin/users_list_test.go
@@ -96,7 +96,7 @@ func TestAdminUsersIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -121,7 +121,7 @@ func TestAdminUsersIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -146,7 +146,7 @@ func TestAdminUsersIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -237,7 +237,7 @@ func TestAdminUserShow(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -262,7 +262,7 @@ func TestAdminUserShow(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/users_list_test.go
+++ b/pkg/controller/admin/users_list_test.go
@@ -294,7 +294,7 @@ func TestAdminUserShow(t *testing.T) {
 		}
 
 		if got, want := email, admin.Email; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/admin/users_operations_test.go
+++ b/pkg/controller/admin/users_operations_test.go
@@ -313,7 +313,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 
 		flash := controller.Flash(session)
 		if got, want := strings.Join(flash.Errors(), ", "), "Cannot remove yourself"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -483,7 +483,7 @@ func TestHandleUserDelete(t *testing.T) {
 
 		flash := controller.Flash(session)
 		if got, want := strings.Join(flash.Errors(), ", "), "Cannot delete yourself"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/admin/users_operations_test.go
+++ b/pkg/controller/admin/users_operations_test.go
@@ -102,7 +102,7 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -131,7 +131,7 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %s to contain %s", got, want)
@@ -160,7 +160,7 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -194,7 +194,7 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 }
@@ -262,7 +262,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -305,7 +305,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -352,7 +352,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -432,7 +432,7 @@ func TestHandleUserDelete(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -475,7 +475,7 @@ func TestHandleUserDelete(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -508,7 +508,7 @@ func TestHandleUserDelete(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/admin/users_operations_test.go
+++ b/pkg/controller/admin/users_operations_test.go
@@ -308,7 +308,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		flash := controller.Flash(session)
@@ -355,7 +355,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		updatedUser, err := harness.Database.FindUser(user.ID)
@@ -478,7 +478,7 @@ func TestHandleUserDelete(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		flash := controller.Flash(session)
@@ -511,7 +511,7 @@ func TestHandleUserDelete(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/admin/users"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -107,7 +107,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -146,7 +146,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -104,7 +104,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -143,7 +143,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -116,7 +116,7 @@ func TestHandleDisable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -113,7 +113,7 @@ func TestHandleDisable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -106,7 +106,7 @@ func TestHandleEnable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -109,7 +109,7 @@ func TestHandleEnable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/index_test.go
+++ b/pkg/controller/apikey/index_test.go
@@ -101,7 +101,7 @@ func TestHandleIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/apikey/index_test.go
+++ b/pkg/controller/apikey/index_test.go
@@ -104,7 +104,7 @@ func TestHandleIndex(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -142,7 +142,7 @@ func TestHandleShow(t *testing.T) {
 		}
 
 		if got, want := strings.TrimSpace(name), authApp.Name; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -113,7 +113,7 @@ func TestHandleShow(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -116,7 +116,7 @@ func TestHandleShow(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -196,7 +196,7 @@ func TestHandleUpdate(t *testing.T) {
 		}
 
 		if got, want := record.Name, "Updated name"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -121,7 +121,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -163,7 +163,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -118,7 +118,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -160,7 +160,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/appsync/handle_sync_test.go
+++ b/pkg/controller/appsync/handle_sync_test.go
@@ -91,13 +91,13 @@ func TestHandleSync(t *testing.T) {
 
 		c.HandleSync().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// again
 		c.HandleSync().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -127,7 +127,7 @@ func TestHandleSync(t *testing.T) {
 
 		c.HandleSync().ServeHTTP(w, r)
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -153,7 +153,7 @@ func TestHandleSync(t *testing.T) {
 		c.HandleSync().ServeHTTP(w, r)
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 }

--- a/pkg/controller/associated/android_test.go
+++ b/pkg/controller/associated/android_test.go
@@ -144,10 +144,10 @@ func TestAndroidData(t *testing.T) {
 		})
 
 		if got, want := data[0].Target.Fingerprints, []string{app1.SHA}; !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := data[1].Target.Fingerprints, []string{app2.SHA}; !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/associated/ios_test.go
+++ b/pkg/controller/associated/ios_test.go
@@ -141,10 +141,10 @@ func TestIOSData(t *testing.T) {
 		})
 
 		if got, want := details[0].AppID, app1.AppID; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := details[1].AppID, app2.AppID; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		// Apps should exist, but be empty (Apple requirement)

--- a/pkg/controller/login/post_authenticate_test.go
+++ b/pkg/controller/login/post_authenticate_test.go
@@ -133,7 +133,7 @@ func TestHandlePostAuthenticate(t *testing.T) {
 			w.Flush()
 
 			if got, want := w.Code, 303; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 			if got, want := w.Header().Get("Location"), tc.exp; !strings.Contains(got, want) {
 				t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/login/post_authenticate_test.go
+++ b/pkg/controller/login/post_authenticate_test.go
@@ -136,7 +136,7 @@ func TestHandlePostAuthenticate(t *testing.T) {
 				t.Errorf("Expected %d to be %d", got, want)
 			}
 			if got, want := w.Header().Get("Location"), tc.exp; !strings.Contains(got, want) {
-				t.Errorf("expected %q to contain %q", got, want)
+				t.Errorf("Expected %q to contain %q", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/apikey_test.go
+++ b/pkg/controller/middleware/apikey_test.go
@@ -151,7 +151,7 @@ func TestRequireAPIKey(t *testing.T) {
 			w.Flush()
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/email_verified_test.go
+++ b/pkg/controller/middleware/email_verified_test.go
@@ -169,7 +169,7 @@ func TestRequireEmailVerified(t *testing.T) {
 			w.Flush()
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/firewall_test.go
+++ b/pkg/controller/middleware/firewall_test.go
@@ -153,7 +153,7 @@ func TestProcessFirewall(t *testing.T) {
 			w.Flush()
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/header_test.go
+++ b/pkg/controller/middleware/header_test.go
@@ -69,7 +69,7 @@ func TestRequireHeader(t *testing.T) {
 			requireHeader(emptyHandler()).ServeHTTP(w, r)
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}
@@ -126,7 +126,7 @@ func TestRequireHeaderValues(t *testing.T) {
 			requireHeaderValues(emptyHandler()).ServeHTTP(w, r)
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/i18n_test.go
+++ b/pkg/controller/middleware/i18n_test.go
@@ -98,7 +98,7 @@ func TestProcessLocale(t *testing.T) {
 				}
 
 				if got, want := locale.Get("nav.issue-code"), tc.exp; got != want {
-					t.Errorf("expected %q to be %q", got, want)
+					t.Errorf("Expected %q to be %q", got, want)
 				}
 			})).ServeHTTP(w, r)
 		})

--- a/pkg/controller/middleware/membership_test.go
+++ b/pkg/controller/middleware/membership_test.go
@@ -144,7 +144,7 @@ func TestLoadCurrentMembership(t *testing.T) {
 			})).ServeHTTP(w, r)
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}
@@ -204,7 +204,7 @@ func TestRequireMembership(t *testing.T) {
 			requireMembership(emptyHandler()).ServeHTTP(w, r)
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/controller/middleware/method_test.go
+++ b/pkg/controller/middleware/method_test.go
@@ -71,7 +71,7 @@ func TestMutateMethod(t *testing.T) {
 			w := httptest.NewRecorder()
 			mutateMethod(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				if got, want := r.Method, tc.exp; got != want {
-					t.Errorf("expected %q to be %q", got, want)
+					t.Errorf("Expected %q to be %q", got, want)
 				}
 			})).ServeHTTP(w, r)
 		})

--- a/pkg/controller/middleware/mfa_test.go
+++ b/pkg/controller/middleware/mfa_test.go
@@ -191,7 +191,7 @@ func TestRequireMFA(t *testing.T) {
 			w.Flush()
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 			if tc.code == 200 {
 				stored := controller.MFAPromptedFromSession(session)

--- a/pkg/controller/middleware/template_test.go
+++ b/pkg/controller/middleware/template_test.go
@@ -48,10 +48,10 @@ func TestPopulateTemplateVariables(t *testing.T) {
 		m := controller.TemplateMapFromContext(ctx)
 
 		if got, want := m["server"], cfg.ServerName; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := m["title"], cfg.ServerName; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if _, ok := m["buildID"]; !ok {
 			t.Errorf("expected buildID to be populated in template map")

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -106,7 +106,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -143,7 +143,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -109,7 +109,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -146,7 +146,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/mobileapps/disable_test.go
+++ b/pkg/controller/mobileapps/disable_test.go
@@ -108,7 +108,7 @@ func TestHandleDisable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/mobileapps/disable_test.go
+++ b/pkg/controller/mobileapps/disable_test.go
@@ -105,7 +105,7 @@ func TestHandleDisable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/enable_test.go
+++ b/pkg/controller/mobileapps/enable_test.go
@@ -106,7 +106,7 @@ func TestHandleEnable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/enable_test.go
+++ b/pkg/controller/mobileapps/enable_test.go
@@ -109,7 +109,7 @@ func TestHandleEnable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/mobileapps/index_test.go
+++ b/pkg/controller/mobileapps/index_test.go
@@ -101,7 +101,7 @@ func TestHandleIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/index_test.go
+++ b/pkg/controller/mobileapps/index_test.go
@@ -104,7 +104,7 @@ func TestHandleIndex(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -108,7 +108,7 @@ func TestHandleShow(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -145,7 +145,7 @@ func TestHandleShow(t *testing.T) {
 		}
 
 		if got, want := strings.TrimSpace(name), app.Name; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -105,7 +105,7 @@ func TestHandleShow(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -121,7 +121,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -163,7 +163,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -199,7 +199,7 @@ func TestHandleUpdate(t *testing.T) {
 		}
 
 		if got, want := record.Name, "Updated name"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := record.DisableRedirect, true; got != want {
 			t.Errorf("expected %t to be %t", got, want)

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -124,7 +124,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -166,7 +166,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -104,7 +104,7 @@ func TestHandleEvents(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -101,7 +101,7 @@ func TestHandleEvents(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -85,7 +85,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -118,7 +118,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "not current enrolled in EN Express"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -151,7 +151,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -191,7 +191,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -88,7 +88,7 @@ func TestHandleDisableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -121,7 +121,7 @@ func TestHandleDisableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "not current enrolled in EN Express"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -154,7 +154,7 @@ func TestHandleDisableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -85,7 +85,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -118,7 +118,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "is already enrolled in EN Express"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -151,7 +151,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -190,7 +190,7 @@ func TestHandleEnableExpress(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 			t.Errorf("%#v", realm.ErrorMessages())
 		}
 

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -88,7 +88,7 @@ func TestHandleEnableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -121,7 +121,7 @@ func TestHandleEnableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "is already enrolled in EN Express"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -154,7 +154,7 @@ func TestHandleEnableExpress(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -89,7 +89,7 @@ func TestHandleSettings(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -347,7 +347,7 @@ func TestHandleSettings(t *testing.T) {
 				}
 
 				if got, want := errs[0], "invalid CIDR address"; !strings.Contains(got, want) {
-					t.Errorf("expected %q to contain %q", got, want)
+					t.Errorf("Expected %q to contain %q", got, want)
 				}
 			})
 		}
@@ -574,7 +574,7 @@ func TestHandleSettings(t *testing.T) {
 		}
 
 		if got, want := errs[0], "must be at least 6"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -608,7 +608,7 @@ func TestHandleSettings(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -137,13 +137,13 @@ func TestHandleSettings(t *testing.T) {
 		}
 
 		if got, want := realm.Name, "new-realmy"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.RegionCode, "TT2"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.WelcomeMessage, "hello there"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -196,7 +196,7 @@ func TestHandleSettings(t *testing.T) {
 		}
 
 		if got, want := realm.AllowedTestTypes, database.TestTypeConfirmed; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.RequireDate, true; got != want {
 			t.Errorf("expected %t to be %t", got, want)
@@ -208,13 +208,13 @@ func TestHandleSettings(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := realm.CodeDuration.Duration, 60*time.Minute; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.LongCodeLength, uint(22); got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := realm.LongCodeDuration.Duration, 24*time.Hour; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -268,28 +268,28 @@ func TestHandleSettings(t *testing.T) {
 		}
 
 		if got, want := realm.EmailVerifiedMode, database.MFAOptional; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.MFAMode, database.MFAOptional; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.MFARequiredGracePeriod.Duration, 24*time.Hour; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.PasswordRotationPeriodDays, uint(7); got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.PasswordRotationWarningDays, uint(3); got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.AllowedCIDRsAdminAPI, pq.StringArray([]string{"0.0.0.0/0", "1.1.1.1/0"}); !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.AllowedCIDRsAPIServer, pq.StringArray([]string{"0.0.0.0/0", "2.2.2.2/0"}); !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := realm.AllowedCIDRsServer, pq.StringArray([]string{"0.0.0.0/0", "3.3.3.3/0"}); !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -449,7 +449,7 @@ func TestHandleSettings(t *testing.T) {
 		}
 
 		if got, want := realm.SMSTextTemplate, "[longcode]"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -86,7 +86,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 401; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Unauthorized"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -128,7 +128,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)
@@ -187,7 +187,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)
@@ -205,13 +205,13 @@ func TestHandleSettings(t *testing.T) {
 			t.Errorf("expected %t to be %t", got, want)
 		}
 		if got, want := realm.CodeLength, uint(7); got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := realm.CodeDuration.Duration, 60*time.Minute; got != want {
 			t.Errorf("expected %q to be %q", got, want)
 		}
 		if got, want := realm.LongCodeLength, uint(22); got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := realm.LongCodeDuration.Duration, 24*time.Hour; got != want {
 			t.Errorf("expected %q to be %q", got, want)
@@ -259,7 +259,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)
@@ -338,7 +338,7 @@ func TestHandleSettings(t *testing.T) {
 				w.Flush()
 
 				if got, want := w.Code, 422; got != want {
-					t.Errorf("expected %d to be %d", got, want)
+					t.Errorf("Expected %d to be %d", got, want)
 				}
 
 				errs := realm.ErrorsFor(tc.column)
@@ -389,7 +389,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)
@@ -440,7 +440,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		realm, err := harness.Database.FindRealm(realm.ID)
@@ -489,7 +489,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "all must be specified or all must be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %s to include %s", got, want)
@@ -530,7 +530,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "all must be specified or all must be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %s to include %s", got, want)
@@ -565,7 +565,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		errs := realm.ErrorsFor("codeLength")
@@ -605,7 +605,7 @@ func TestHandleSettings(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/realmadmin/sms_test.go
+++ b/pkg/controller/realmadmin/sms_test.go
@@ -99,13 +99,13 @@ func TestHandleSettings_SMS(t *testing.T) {
 
 	// Check form
 	if got, want := twilioAccountSid, "accountSid"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := twilioAuthToken, project.PasswordSentinel; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := twilioFromNumber, "+1234567890"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 
 	{
@@ -119,13 +119,13 @@ func TestHandleSettings_SMS(t *testing.T) {
 		}
 
 		if got, want := smsConfig.TwilioAccountSid, "accountSid"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := smsConfig.TwilioAuthToken, "authToken"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := smsConfig.TwilioFromNumber, "+1234567890"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	}
 
@@ -164,14 +164,14 @@ func TestHandleSettings_SMS(t *testing.T) {
 		}
 
 		if got, want := smsConfig.TwilioAccountSid, "accountSid-new"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := smsConfig.TwilioAuthToken, "authToken"; got != want {
 			// should not change
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := smsConfig.TwilioFromNumber, "+1987654320"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	}
 

--- a/pkg/controller/realmadmin/smtp_test.go
+++ b/pkg/controller/realmadmin/smtp_test.go
@@ -82,13 +82,13 @@ func TestHandleSettings_SMTP(t *testing.T) {
 
 	// Check form
 	if got, want := smtpAccount, "myAccount"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := smtpPassword, project.PasswordSentinel; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 	if got, want := smtpHost, "1.1.1.1"; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 
 	{
@@ -102,13 +102,13 @@ func TestHandleSettings_SMTP(t *testing.T) {
 		}
 
 		if got, want := emailConfig.SMTPAccount, "myAccount"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := emailConfig.SMTPPassword, "superSecret"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := emailConfig.SMTPHost, "1.1.1.1"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	}
 
@@ -147,13 +147,13 @@ func TestHandleSettings_SMTP(t *testing.T) {
 		}
 
 		if got, want := emailConfig.SMTPAccount, "myAccount-new"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := emailConfig.SMTPPassword, "superSecret"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := emailConfig.SMTPHost, "1.1.1.1-new"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	}
 

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -221,7 +221,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		updatedRealm, err := harness.Database.FindRealm(realm.ID)

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -94,7 +94,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "must upgrade to realm-specific signing keys"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -134,7 +134,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "is already enabled"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -177,7 +177,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -91,7 +91,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "must upgrade to realm-specific signing keys"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -131,7 +131,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "is already enabled"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -174,7 +174,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -218,7 +218,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -173,7 +173,7 @@ func TestHandleManualRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		updatedRealm, err := harness.Database.FindRealm(realm.ID)

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -92,7 +92,7 @@ func TestHandleManualRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Already in manual key rotation mode"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -132,7 +132,7 @@ func TestHandleManualRotate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -89,7 +89,7 @@ func TestHandleManualRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Already in manual key rotation mode"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -129,7 +129,7 @@ func TestHandleManualRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -170,7 +170,7 @@ func TestHandleManualRotate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -91,7 +91,7 @@ func TestBuildEnsURL(t *testing.T) {
 
 			got, want := buildEnsURL(tc.path, tc.query, tc.region), tc.exp
 			if got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -171,7 +171,7 @@ func TestBuildIntentURL(t *testing.T) {
 			fallback := "https://play.google.com/store/apps/details?id=gov.moosylvania.app"
 			got, want := buildIntentURL(tc.path, tc.query, tc.region, appID, fallback), tc.exp
 			if got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -243,7 +243,7 @@ func TestIndex(t *testing.T) {
 
 		exp := "https://www.google.com/covid19/exposurenotifications/"
 		if got, want := resp.Header.Get("Location"), exp; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -298,7 +298,7 @@ func TestIndex(t *testing.T) {
 
 		exp := "intent://app?c=123456&r=BB#Intent;scheme=ens;package=com.example.app2;action=android.intent.action.VIEW;category=android.intent.category.BROWSABLE;S.browser_fallback_url=https%3A%2F%2Fapp2.example.com%2F;end"
 		if got, want := resp.Header.Get("Location"), exp; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -327,7 +327,7 @@ func TestIndex(t *testing.T) {
 		}
 
 		if got, want := resp.Header.Get("Location"), "ens://app?c=123456&r=CC"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -356,7 +356,7 @@ func TestIndex(t *testing.T) {
 		}
 
 		if got, want := resp.Header.Get("Location"), "https://app1.example.com/"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 
@@ -385,7 +385,7 @@ func TestIndex(t *testing.T) {
 		}
 
 		if got, want := resp.Header.Get("Location"), "ens://app?c=123456&r=CC"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/rotation/handle_token_rotate_test.go
+++ b/pkg/controller/rotation/handle_token_rotate_test.go
@@ -164,13 +164,13 @@ func TestHandleRotate(t *testing.T) {
 
 		c.HandleRotate().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// again
 		c.HandleRotate().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -192,7 +192,7 @@ func TestHandleRotate(t *testing.T) {
 		c.HandleRotate().ServeHTTP(w, r)
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 }

--- a/pkg/controller/rotation/handle_verification_rotate_test.go
+++ b/pkg/controller/rotation/handle_verification_rotate_test.go
@@ -116,13 +116,13 @@ func TestHandleVerificationRotation(t *testing.T) {
 
 		c.HandleVerificationRotate().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// again
 		c.HandleVerificationRotate().ServeHTTP(w, r)
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 
@@ -150,7 +150,7 @@ func TestHandleVerificationRotation(t *testing.T) {
 		c.HandleVerificationRotate().ServeHTTP(w, r)
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 }

--- a/pkg/controller/smskeys/activate_test.go
+++ b/pkg/controller/smskeys/activate_test.go
@@ -97,7 +97,7 @@ func TestHandleActivate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -131,7 +131,7 @@ func TestHandleActivate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "does not exist"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -178,7 +178,7 @@ func TestHandleActivate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/smskeys/activate_test.go
+++ b/pkg/controller/smskeys/activate_test.go
@@ -100,7 +100,7 @@ func TestHandleActivate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -134,7 +134,7 @@ func TestHandleActivate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "does not exist"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -181,7 +181,7 @@ func TestHandleActivate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 
 		// Check key was marked active

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -92,7 +92,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -123,7 +123,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -95,7 +95,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -126,7 +126,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		updatedRealm, err := harness.Database.FindRealm(realm.ID)

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -150,7 +150,7 @@ func TestHandleDestroy(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 
 		updatedRealm, err := harness.Database.FindRealm(realm.ID)

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -96,7 +96,7 @@ func TestHandleDestroy(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -147,7 +147,7 @@ func TestHandleDestroy(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 303; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Header().Get("Location"), "/realm/sms-keys"; got != want {
 			t.Errorf("expected %q to be %q", got, want)

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -99,7 +99,7 @@ func TestHandleDestroy(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/smskeys/disable_test.go
+++ b/pkg/controller/smskeys/disable_test.go
@@ -93,7 +93,7 @@ func TestHandleDisable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/smskeys/disable_test.go
+++ b/pkg/controller/smskeys/disable_test.go
@@ -90,7 +90,7 @@ func TestHandleDisable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/smskeys/enable_test.go
+++ b/pkg/controller/smskeys/enable_test.go
@@ -90,7 +90,7 @@ func TestHandleEnable(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/smskeys/enable_test.go
+++ b/pkg/controller/smskeys/enable_test.go
@@ -93,7 +93,7 @@ func TestHandleEnable(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -92,7 +92,7 @@ func TestHandleIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		if !strings.Contains(w.Body.String(), "There are no SMS signing keys active for this realm.") {

--- a/pkg/controller/user/create_test.go
+++ b/pkg/controller/user/create_test.go
@@ -147,7 +147,7 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/user/create_test.go
+++ b/pkg/controller/user/create_test.go
@@ -105,7 +105,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %s to contain %q", got, want)
@@ -144,7 +144,7 @@ func TestHandleCreate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/user/delete_test.go
+++ b/pkg/controller/user/delete_test.go
@@ -121,7 +121,7 @@ func TestHandleDelete(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/user/delete_test.go
+++ b/pkg/controller/user/delete_test.go
@@ -118,7 +118,7 @@ func TestHandleDelete(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/user/export_test.go
+++ b/pkg/controller/user/export_test.go
@@ -100,7 +100,7 @@ func TestHandleExport(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -133,7 +133,7 @@ func TestHandleExport(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 200; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		d := time.Now().UTC().Format(project.RFC3339Date)

--- a/pkg/controller/user/export_test.go
+++ b/pkg/controller/user/export_test.go
@@ -103,7 +103,7 @@ func TestHandleExport(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -142,7 +142,7 @@ System admin,super@example.com,%s
 User,user@example.com,%s
 `, d, d)
 		if got, want := w.Body.String(), exp; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/user/index_test.go
+++ b/pkg/controller/user/index_test.go
@@ -101,7 +101,7 @@ func TestHandleIndex(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/user/index_test.go
+++ b/pkg/controller/user/index_test.go
@@ -104,7 +104,7 @@ func TestHandleIndex(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/user/show_test.go
+++ b/pkg/controller/user/show_test.go
@@ -108,7 +108,7 @@ func TestHandleShow(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/user/show_test.go
+++ b/pkg/controller/user/show_test.go
@@ -136,10 +136,10 @@ func TestHandleShow(t *testing.T) {
 		}
 
 		if got, want := strings.TrimSpace(name), user.Name; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 		if got, want := strings.TrimSpace(email), user.Email; got != want {
-			t.Errorf("expected %q to be %q", got, want)
+			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})
 }

--- a/pkg/controller/user/show_test.go
+++ b/pkg/controller/user/show_test.go
@@ -105,7 +105,7 @@ func TestHandleShow(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -127,7 +127,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 
@@ -169,7 +169,7 @@ func TestHandleUpdate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
-			t.Errorf("expected %q to contain %q", got, want)
+			t.Errorf("Expected %q to contain %q", got, want)
 		}
 	})
 

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -124,7 +124,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 500; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
@@ -166,7 +166,7 @@ func TestHandleUpdate(t *testing.T) {
 		w.Flush()
 
 		if got, want := w.Code, 422; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 		if got, want := w.Body.String(), "cannot be blank"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -74,7 +74,7 @@ func TestAPIKeyType_Display(t *testing.T) {
 			t.Parallel()
 
 			if got, want := tc.t.Display(), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -47,7 +47,7 @@ func TestAPIKeyType(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int(tc.t), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}
@@ -141,7 +141,7 @@ func TestAuthorizedApp_Realm(t *testing.T) {
 		t.Fatal(err)
 	}
 	if got, want := gotRealm.ID, realm.ID; got != want {
-		t.Errorf("expected %d to be %d", got, want)
+		t.Errorf("Expected %d to be %d", got, want)
 	}
 }
 

--- a/pkg/database/lock_test.go
+++ b/pkg/database/lock_test.go
@@ -69,7 +69,7 @@ func TestDatabase_CreateLock(t *testing.T) {
 	}
 
 	if got, want := cleanup1.ID, cleanup2.ID; got != want {
-		t.Errorf("expected %d to be %d", got, want)
+		t.Errorf("Expected %d to be %d", got, want)
 	}
 }
 
@@ -89,7 +89,7 @@ func TestDatabase_FindLockStatus(t *testing.T) {
 	}
 
 	if got, want := got.ID, want.ID; got != want {
-		t.Errorf("expected %d to be %d", got, want)
+		t.Errorf("Expected %d to be %d", got, want)
 	}
 }
 

--- a/pkg/database/mobile_app_test.go
+++ b/pkg/database/mobile_app_test.go
@@ -70,7 +70,7 @@ func TestOSType_Display(t *testing.T) {
 			t.Parallel()
 
 			if got, want := tc.t.Display(), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/pkg/database/mobile_app_test.go
+++ b/pkg/database/mobile_app_test.go
@@ -44,7 +44,7 @@ func TestOSType(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int(tc.t), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -77,7 +77,7 @@ func TestTestType_Display(t *testing.T) {
 			t.Parallel()
 
 			if got, want := tc.t.Display(), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -129,7 +129,7 @@ func TestAuthRequirement_String(t *testing.T) {
 			t.Parallel()
 
 			if got, want := tc.t.String(), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -383,7 +383,7 @@ func TestRealm_BeforeSave(t *testing.T) {
 			if err := tc.Input.BeforeSave(&gorm.DB{}); err != nil {
 				if tc.Error != "" {
 					if got, want := strings.Join(tc.Input.ErrorMessages(), ","), tc.Error; !strings.Contains(got, want) {
-						t.Errorf("expected %q to be %q", got, want)
+						t.Errorf("Expected %q to be %q", got, want)
 					}
 				} else {
 					t.Errorf("bad error: %s", err)
@@ -427,7 +427,7 @@ func TestRealm_BuildInviteEmail(t *testing.T) {
 	realm.EmailInviteTemplate = "Welcome to [realmname] [invitelink]."
 
 	if got, want := realm.BuildInviteEmail("https://join.now"), "Welcome to test https://join.now."; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }
 
@@ -438,7 +438,7 @@ func TestRealm_BuildPasswordResetEmail(t *testing.T) {
 	realm.EmailPasswordResetTemplate = "Hey [realmname] reset [passwordresetlink]."
 
 	if got, want := realm.BuildPasswordResetEmail("https://reset.now"), "Hey test reset https://reset.now."; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }
 
@@ -449,7 +449,7 @@ func TestRealm_BuildVerifyEmail(t *testing.T) {
 	realm.EmailVerifyTemplate = "Hey [realmname] verify [verifylink]."
 
 	if got, want := realm.BuildVerifyEmail("https://verify.now"), "Hey test verify https://verify.now."; got != want {
-		t.Errorf("expected %q to be %q", got, want)
+		t.Errorf("Expected %q to be %q", got, want)
 	}
 }
 

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -51,7 +51,7 @@ func TestTestType(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int(tc.t), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}
@@ -104,7 +104,7 @@ func TestAuthRequirement(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int(tc.t), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}
@@ -565,7 +565,7 @@ func TestRealm_FindVerificationCodeByUUID(t *testing.T) {
 
 			if code != nil {
 				if got, want := code.ID, tc.expID; got != want {
-					t.Errorf("expected %d to be %d", got, want)
+					t.Errorf("Expected %d to be %d", got, want)
 				}
 			}
 		})
@@ -878,7 +878,7 @@ func TestRealm_ListMemberships(t *testing.T) {
 		t.Fatalf("expected %#v to have 1 element", memberships)
 	}
 	if got, want := memberships[0].UserID, user.ID; got != want {
-		t.Errorf("expected %d to be %d", got, want)
+		t.Errorf("Expected %d to be %d", got, want)
 	}
 }
 

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -718,7 +718,7 @@ func TestRealm_CreateSigningKeyVersion(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	if got, want := err.Error(), "too many available certificate signing keys"; !strings.Contains(got, want) {
-		t.Errorf("expected %q to contain %q", got, want)
+		t.Errorf("Expected %q to contain %q", got, want)
 	}
 
 	// Delete one
@@ -793,7 +793,7 @@ func TestRealm_CreateSMSSigningKeyVersion(t *testing.T) {
 		t.Fatal("expected error")
 	}
 	if got, want := err.Error(), "too many available SMS signing keys"; !strings.Contains(got, want) {
-		t.Errorf("expected %q to contain %q", got, want)
+		t.Errorf("Expected %q to contain %q", got, want)
 	}
 
 	// Delete one

--- a/pkg/database/sms_signing_key_test.go
+++ b/pkg/database/sms_signing_key_test.go
@@ -49,7 +49,7 @@ func TestDatabase_FindSMSSigningKey(t *testing.T) {
 			t.Fatal(err)
 		}
 		if got, want := result.RealmID, realm.ID; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	}
 }

--- a/pkg/database/token_signing_keys_test.go
+++ b/pkg/database/token_signing_keys_test.go
@@ -51,7 +51,7 @@ func TestDatabase_FindTokenSigningKey(t *testing.T) {
 		}
 
 		if got, want := result.ID, result.ID; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	})
 }
@@ -137,7 +137,7 @@ func TestDatabase_ActiveTokenSigningKey(t *testing.T) {
 		}
 
 		if got, want := result.ID, result.ID; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	}
 }
@@ -177,7 +177,7 @@ func TestDatabase_ListTokenSigningKeys(t *testing.T) {
 		}
 
 		if got, want := list[0].ID, key.ID; got != want {
-			t.Errorf("expected %d to be %d", got, want)
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 	}
 }

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -49,7 +49,7 @@ func TestCodeType(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int(tc.t), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -98,7 +98,7 @@ func TestPermissionNames(t *testing.T) {
 			t.Parallel()
 
 			if got, want := strings.Join(PermissionNames(tc.p), ","), tc.exp; !reflect.DeepEqual(got, want) {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -122,7 +122,7 @@ func TestPermission_String(t *testing.T) {
 			t.Parallel()
 
 			if got, want := tc.p.String(), tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}
@@ -186,7 +186,7 @@ func TestPermission_Description(t *testing.T) {
 			}
 
 			if got, want := result, tc.exp; got != want {
-				t.Errorf("expected %q to be %q", got, want)
+				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
 	}

--- a/pkg/rbac/rbac_test.go
+++ b/pkg/rbac/rbac_test.go
@@ -225,7 +225,7 @@ func TestRBAC_Permissions(t *testing.T) {
 			t.Parallel()
 
 			if got, want := int64(tc.p), tc.exp; got != want {
-				t.Errorf("expected %d to be %d", got, want)
+				t.Errorf("Expected %d to be %d", got, want)
 			}
 		})
 	}

--- a/pkg/signatures/sms_test.go
+++ b/pkg/signatures/sms_test.go
@@ -73,12 +73,12 @@ func Test_SMSSignature(t *testing.T) {
 					// Next is date
 					date := tc.time.UTC().Format("0102")
 					if got, want := part, date; got != want {
-						t.Errorf("expected %q to be %q", got, want)
+						t.Errorf("Expected %q to be %q", got, want)
 					}
 				case 2:
 					// Next is key id
 					if got, want := part, tc.keyID; got != want {
-						t.Errorf("expected %q to be %q", got, want)
+						t.Errorf("Expected %q to be %q", got, want)
 					}
 				case 3:
 					// Next is signature


### PR DESCRIPTION
The go `t.Error|Fatal` text messages are final errors shown to users and as such are expected to be complete sentences according to general Go guidelines.
This fixes all http status code related (and its neighboring) errors.

