### PR TITLE
Make per-test timeout a project function

### DIFF
--- a/internal/project/util.go
+++ b/internal/project/util.go
@@ -16,8 +16,10 @@
 package project
 
 import (
+	"os"
 	"path/filepath"
 	"runtime"
+	"time"
 )
 
 const (
@@ -43,4 +45,14 @@ func AllDigits(val string) bool {
 		}
 	}
 	return true
+}
+
+// TestTimeout controls the individual test timeout, primarily used on a context
+// for chromedp tests. By default, it's 2min, but it can be controlled with the
+// TEST_TIMEOUT environment variable.
+func TestTimeout() time.Duration {
+	if v, _ := time.ParseDuration(os.Getenv("TEST_TIMEOUT")); v != 0 {
+		return v
+	}
+	return 120 * time.Second
 }

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -205,7 +204,7 @@ func TestAdminCaches(t *testing.T) {
 
 		// Create a browser runner.
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/admin/email_test.go
+++ b/pkg/controller/admin/email_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -96,7 +95,7 @@ func TestAdminEmail(t *testing.T) {
 
 		// Create a browser runner.
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		wantSMTPAccount := "test=smtp-account"

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -214,7 +214,7 @@ func TestAdminEvents(t *testing.T) {
 
 		// Create a browser runner.
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/admin/info_test.go
+++ b/pkg/controller/admin/info_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -91,7 +90,7 @@ func TestAdminInfo(t *testing.T) {
 
 		// Create a browser runner.
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/admin/mobile_apps_test.go
+++ b/pkg/controller/admin/mobile_apps_test.go
@@ -19,7 +19,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -152,7 +151,7 @@ func TestAdminMobileApps(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -145,7 +144,7 @@ func TestHandleRealmsIndex(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,
@@ -810,7 +809,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 
 // 	// Create a browser runner.
 // 	browserCtx := browser.New(t)
-// 	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+// 	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 // 	defer done()
 
 // 	wantName := "Test Realm"

--- a/pkg/controller/admin/sms_test.go
+++ b/pkg/controller/admin/sms_test.go
@@ -17,10 +17,10 @@ package admin_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 
 	"github.com/chromedp/chromedp"
@@ -59,7 +59,7 @@ func TestShowAdminSMS(t *testing.T) {
 	}
 	// Create a browser runner.
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	wantAccountSid := "abc123"

--- a/pkg/controller/admin/users_list_test.go
+++ b/pkg/controller/admin/users_list_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -165,7 +164,7 @@ func TestAdminUsersIndex(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,
@@ -281,7 +280,7 @@ func TestAdminUserShow(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		var email string

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/gorilla/sessions"
@@ -155,7 +154,7 @@ func TestHandleCreate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		var apiKey string

--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -125,7 +124,7 @@ func TestHandleDisable(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		// Click "confirm" when it pops up.

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -130,7 +130,7 @@ func TestHandleEnable(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		// Click "confirm" when it pops up.

--- a/pkg/controller/apikey/index_test.go
+++ b/pkg/controller/apikey/index_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -121,7 +120,7 @@ func TestHandleIndex(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -125,7 +124,7 @@ func TestHandleShow(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf("http://%s/realm/apikeys/%d", harness.Server.Addr(), authApp.ID)

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -172,7 +171,7 @@ func TestHandleUpdate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf("http://%s/realm/apikeys/%d/edit", harness.Server.Addr(), authApp.ID)

--- a/pkg/controller/codes/bulk_issue_test.go
+++ b/pkg/controller/codes/bulk_issue_test.go
@@ -17,11 +17,11 @@ package codes_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
@@ -63,7 +63,7 @@ func TestRenderBulkIssue(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -74,7 +74,7 @@ func TestHandleExpire_ExpireCode(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	confirmErrCh := envstest.AutoConfirmDialogs(taskCtx, true)

--- a/pkg/controller/codes/index_test.go
+++ b/pkg/controller/codes/index_test.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/chromedp/chromedp"
@@ -55,7 +56,7 @@ func TestHandleIndex_ShowRecentCodes(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -59,7 +59,7 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	yesterday := time.Now().Add(-24 * time.Hour).Format(project.RFC3339Date)

--- a/pkg/controller/codes/show_test.go
+++ b/pkg/controller/codes/show_test.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/chromedp/chromedp"
@@ -64,7 +65,7 @@ func TestHandleShow_ShowCodeStatus(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/account_test.go
+++ b/pkg/controller/login/account_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleAccount_ShowAccount(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleAccount_ShowAccount(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/change_password_test.go
+++ b/pkg/controller/login/change_password_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -47,7 +46,7 @@ func TestHandleChangePassword_ShowChangePassword(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/login_test.go
+++ b/pkg/controller/login/login_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
@@ -39,7 +39,7 @@ func TestHandleLogin_ShowLogin(t *testing.T) {
 	harness := envstest.NewServer(t, testDatabaseInstance)
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/reauth_test.go
+++ b/pkg/controller/login/reauth_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleReauth_ShowLogin(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleReauth_ShowLogin(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/register_phone_test.go
+++ b/pkg/controller/login/register_phone_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleRegisterPhonne_ShowRegisterPhone(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleRegisterPhonne_ShowRegisterPhone(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/reset_password_test.go
+++ b/pkg/controller/login/reset_password_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -48,7 +47,7 @@ func TestHandleResetPassword_ShowResetPassword(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/select_password_test.go
+++ b/pkg/controller/login/select_password_test.go
@@ -21,7 +21,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -48,7 +47,7 @@ func TestHandleSelectPassword_ShowSelectPassword(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/select_realm_test.go
+++ b/pkg/controller/login/select_realm_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 )
@@ -42,7 +42,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	// Member of one realm

--- a/pkg/controller/login/signout_test.go
+++ b/pkg/controller/login/signout_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleSignout_ShowLogin(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleSignout_ShowLogin(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/verify_email_receive_test.go
+++ b/pkg/controller/login/verify_email_receive_test.go
@@ -17,11 +17,11 @@ package login_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleVerifyEmailReceive_ShowVerifyEmail(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleVerifyEmailReceive_ShowVerifyEmail(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/login/verify_email_send_test.go
+++ b/pkg/controller/login/verify_email_send_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -49,7 +48,7 @@ func TestHandleVerifyEmailSend_ShowVerifyEmail(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -155,7 +154,7 @@ func TestHandleCreate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/mobileapps/disable_test.go
+++ b/pkg/controller/mobileapps/disable_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -128,7 +127,7 @@ func TestHandleDisable(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		// Click "confirm" when it pops up.

--- a/pkg/controller/mobileapps/enable_test.go
+++ b/pkg/controller/mobileapps/enable_test.go
@@ -133,7 +133,7 @@ func TestHandleEnable(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		// Click "confirm" when it pops up.

--- a/pkg/controller/mobileapps/index_test.go
+++ b/pkg/controller/mobileapps/index_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -124,7 +123,7 @@ func TestHandleIndex(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -128,7 +127,7 @@ func TestHandleShow(t *testing.T) {
 		}
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf("http://%s/realm/mobile-apps/%d", harness.Server.Addr(), app.ID)

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -175,7 +174,7 @@ func TestHandleUpdate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf("http://%s/realm/mobile-apps/%d/edit", harness.Server.Addr(), app.ID)

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -20,7 +20,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -113,7 +112,7 @@ func TestHandleEvents(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,
@@ -129,7 +128,7 @@ func TestHandleEvents(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/realmadmin/sms_test.go
+++ b/pkg/controller/realmadmin/sms_test.go
@@ -17,7 +17,6 @@ package realmadmin_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -62,7 +61,7 @@ func TestHandleSettings_SMS(t *testing.T) {
 
 	// Create a browser runner.
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	var twilioAccountSid string

--- a/pkg/controller/realmadmin/smtp_test.go
+++ b/pkg/controller/realmadmin/smtp_test.go
@@ -17,7 +17,6 @@ package realmadmin_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -45,7 +44,7 @@ func TestHandleSettings_SMTP(t *testing.T) {
 
 	// Create a browser runner.
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	var smtpAccount string

--- a/pkg/controller/realmadmin/stats_test.go
+++ b/pkg/controller/realmadmin/stats_test.go
@@ -17,7 +17,6 @@ package realmadmin_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -61,7 +60,7 @@ func TestHandleStats(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		errCh := envstest.CaptureJavascriptErrors(taskCtx)

--- a/pkg/controller/realmkeys/index_test.go
+++ b/pkg/controller/realmkeys/index_test.go
@@ -17,11 +17,11 @@ package realmkeys_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 func TestHandleIndex(t *testing.T) {
@@ -40,7 +40,7 @@ func TestHandleIndex(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/user/create_test.go
+++ b/pkg/controller/user/create_test.go
@@ -22,7 +22,6 @@ import (
 	"strconv"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/gorilla/sessions"
@@ -156,7 +155,7 @@ func TestHandleCreate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		var apiKey string

--- a/pkg/controller/user/delete_test.go
+++ b/pkg/controller/user/delete_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -130,7 +129,7 @@ func TestHandleDelete(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		// Click "confirm" when it pops up.

--- a/pkg/controller/user/import_test.go
+++ b/pkg/controller/user/import_test.go
@@ -17,10 +17,10 @@ package user_test
 import (
 	"context"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 
 	"github.com/chromedp/chromedp"
 )
@@ -41,7 +41,7 @@ func TestImportBatch(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/user/index_search_test.go
+++ b/pkg/controller/user/index_search_test.go
@@ -18,10 +18,10 @@ import (
 	"context"
 	"fmt"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 
@@ -56,7 +56,7 @@ func TestHandleSearch(t *testing.T) {
 	}
 
 	browserCtx := browser.New(t)
-	taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+	taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 	defer done()
 
 	if err := chromedp.Run(taskCtx,

--- a/pkg/controller/user/index_test.go
+++ b/pkg/controller/user/index_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -113,7 +112,7 @@ func TestHandleIndex(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		if err := chromedp.Run(taskCtx,

--- a/pkg/controller/user/show_test.go
+++ b/pkg/controller/user/show_test.go
@@ -21,7 +21,6 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/chromedp/chromedp"
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
@@ -117,7 +116,7 @@ func TestHandleShow(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf("http://%s/realm/users/%d", harness.Server.Addr(), user.ID)

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -22,7 +22,6 @@ import (
 	"net/url"
 	"strings"
 	"testing"
-	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
@@ -178,7 +177,7 @@ func TestHandleUpdate(t *testing.T) {
 		t.Parallel()
 
 		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, 120*time.Second)
+		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
 		defer done()
 
 		u := fmt.Sprintf(`http://`+harness.Server.Addr()+`/realm/users/%d/edit`, user.ID)


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make per-test timeout a project function
```
