### PR TITLE
admin API needs signing config to get key manager settings

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -94,6 +94,7 @@ resource "google_cloud_run_service" "adminapi" {
             local.gcp_config,
             local.rate_limit_config,
             local.issue_config,
+            local.signing_config,
             local.observability_config,
 
             // This MUST come last to allow overrides!


### PR DESCRIPTION

## Proposed Changes

* add signing config to admin api
* 
**Release Note**

```release-note
Admin API gets signing config in terraform
```
