### PR TITLE
Introduce configurable Authenticated SMS failure modes

### DIFF
--- a/docs/playbooks/alerts/AuthenticatedSMSFailure.md
+++ b/docs/playbooks/alerts/AuthenticatedSMSFailure.md
@@ -1,0 +1,30 @@
+# AuthenticatedSMSFailure
+
+This alert fires when a realm with Authenticated SMS enabled has an increase in
+the number of SMS signature failures. This metric is incremented regardless of
+whether the system is configured to fail open or fail closed on failed attempts
+to sign the SMS.
+
+## Triage Steps
+
+Go to Logs Explorer, use the following filter:
+
+```
+resource.type="cloud_run_revision"
+jsonPayload.logger="issueapi.sendSMS"
+jsonPayload.message="failed to sign sms"
+```
+
+The most common cause for this error is upstream key unavailability. If the
+upstream key management system is unavailable, the system will fail to sign
+SMS messages. In most cases, the error self-resolves.
+
+## Mitigation
+
+In the event the error does not self-resolve after a time, you may want to
+configure the system to fail open (continue on error) for authenticated SMS
+failures. Note: the default behavior is to fail open, so unless you have changed
+the default behavior, no action is required.
+
+To re-configure the system to fail open, set `SMS_FAIL_CLOSED=false` on the
+`adminapi` and `server` components in the environment and restart the services.

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -120,3 +120,7 @@ func (c *AdminAPIServerConfig) ObservabilityExporterConfig() *observability.Conf
 func (c *AdminAPIServerConfig) IsMaintenanceMode() bool {
 	return c.MaintenanceMode
 }
+
+func (c *AdminAPIServerConfig) GetAuthenticatedSMSFailClosed() bool {
+	return c.SMSSigning.FailClosed
+}

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -29,4 +29,8 @@ type IssueAPIConfig interface {
 	GetRateLimitConfig() *ratelimit.Config
 	GetENXRedirectDomain() string
 	IsMaintenanceMode() bool
+
+	// GetAuthenticatedSMSFailClosed indicates how the system should behave when
+	// authenticated SMS fails.
+	GetAuthenticatedSMSFailClosed() bool
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -165,6 +165,10 @@ func (c *ServerConfig) IsMaintenanceMode() bool {
 	return c.MaintenanceMode
 }
 
+func (c *ServerConfig) GetAuthenticatedSMSFailClosed() bool {
+	return c.SMSSigning.FailClosed
+}
+
 // FirebaseConfig represents configuration specific to firebase auth.
 type FirebaseConfig struct {
 	APIKey          string `env:"FIREBASE_API_KEY,required"`

--- a/pkg/config/sms_signing_config.go
+++ b/pkg/config/sms_signing_config.go
@@ -23,4 +23,14 @@ type SMSSigningConfig struct {
 	// Keys determines the key manager configuration for this SMS signing
 	// configuration.
 	Keys keys.Config `env:", prefix=SMS_"`
+
+	// FailClosed indicates whether authenticated SMS signature errors should fail
+	// open (continue on error) or fail closed (halt and return error). In both
+	// cases, a metric is logged and can be tracked for monitoring.
+	//
+	// This configuration only applies if authenticated SMS is enabled at the
+	// system level AND a realm has configured authenticated SMS.
+	//
+	// The default behavior is to continue on error.
+	FailClosed bool `env:"SMS_FAIL_CLOSED, default=false"`
 }

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -28,6 +28,8 @@ const metricPrefix = observability.MetricRoot + "/api/issue"
 var (
 	mLatencyMs = stats.Float64(metricPrefix+"/request", "# of code issue requests", stats.UnitMilliseconds)
 
+	mAuthenticatedSMSFailure = stats.Int64(metricPrefix+"/authenticated_sms_failure", "# of failed attempts to sign authenticated sms", stats.UnitDimensionless)
+
 	mSMSLatencyMs = stats.Float64(metricPrefix+"/sms_request", "# of sms requests", stats.UnitMilliseconds)
 
 	mRealmTokenUsed = stats.Int64(metricPrefix+"/realm_token_used", "# of realm token used.", stats.UnitDimensionless)
@@ -48,6 +50,13 @@ func init() {
 			Description: "The latency distribution of code issue requests",
 			TagKeys:     observability.APITagKeys(),
 			Aggregation: ochttp.DefaultLatencyDistribution,
+		},
+		{
+			Name:        metricPrefix + "/authenticated_sms_failure_count",
+			Measure:     mAuthenticatedSMSFailure,
+			Description: "Count of failed attempts to sign authenticated SMS",
+			TagKeys:     append(observability.CommonTagKeys(), enobs.ResultTagKey),
+			Aggregation: view.Count(),
 		},
 		{
 			Name:        metricPrefix + "/sms_request_count",

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -84,6 +84,7 @@ locals {
     CERTIFICATE_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")
 
     SMS_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
+    SMS_FAIL_CLOSED = false
 
     # TODO(sethvargo): in 0.22+, this should be the parent crypto key (not the
     # crypto key version).


### PR DESCRIPTION
This introduces a runtime configurable to control how the system behaves when signing an authenticated SMS fails. The default behavior is to "fail open" (continue on error), meaning if the signing fails for any reason, the system still continues and delivers the SMS. Operators can also configure the system to "fail closed" (fail on error) to halt and NOT send SMS unless signing succeeds. To control the behavior, operators must set the `SMS_FAIL_CLOSED` environment variable on the `server` and `adminapi` services. Set the value to `true` to fail closed. The default value is false (fail open).

Regardless of the configuration, an error is logged and a metric is incremented when an SMS fails to sign. There is also a new alerting policy for when more than 5 SMS messages fail to sign in a 60s window by realm. This ensures that, even if the system is configured to fail open, operators are aware of the issue and can respond accordingly. The alert is non-paging since there is rarely action an operator can take if the upstream key management system is unavailable.

The double negative is weird (fail closed false), but that is to ensure the default behavior is false even when envconfig is not used (since Go's default value for bool is false)

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1830

**Release Note**

```release-note
Introduce configurable Authenticated SMS failure modes. The default behavior is to "fail open" (continue on error). Operators can configure the system to "fail closed" (halt on error) by setting the `SMS_FAIL_CLOSED` environment variable on the `server` and `adminapi` services. We recommend leaving the default configuration. Regardless of the configuration, this also introduces a new non-paging alert to inform operators when an out-of-threshold number of failures occur while signing SMS messages, per realm. See the new playbook for more information.
```
