### PR TITLE
Only return a signer if Authenticated SMS is enabled

### DIFF
--- a/internal/envstest/adminapi.go
+++ b/internal/envstest/adminapi.go
@@ -68,9 +68,14 @@ func NewAdminAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestI
 		Observability: *harness.ObservabilityConfig,
 		Cache:         *harness.CacheConfig,
 		RateLimit:     *harness.RateLimiterConfig,
+
 		SMSSigning: config.SMSSigningConfig{
 			Keys:       *harness.KeyManagerConfig,
 			FailClosed: true,
+		},
+
+		Features: config.FeatureConfig{
+			EnableAuthenticatedSMS: true,
 		},
 
 		APIKeyCacheDuration:     5 * time.Second,

--- a/internal/envstest/apiserver.go
+++ b/internal/envstest/apiserver.go
@@ -100,6 +100,11 @@ func NewAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstan
 			TokenSigningKeyIDs: []string{"v1"},
 			TokenIssuer:        "test-iss",
 		},
+
+		Features: config.FeatureConfig{
+			EnableAuthenticatedSMS: true,
+		},
+
 		RateLimit: *harness.RateLimiterConfig,
 		DevMode:   true,
 	}

--- a/internal/envstest/enx_redirect.go
+++ b/internal/envstest/enx_redirect.go
@@ -67,6 +67,10 @@ func NewENXRedirectServerConfig(tb testing.TB, testDatabaseInstance *database.Te
 			"e2e-test.test.local": "e2e-test",
 		},
 
+		Features: config.FeatureConfig{
+			EnableAuthenticatedSMS: true,
+		},
+
 		DevMode: true,
 	}
 

--- a/internal/envstest/server.go
+++ b/internal/envstest/server.go
@@ -223,6 +223,10 @@ func NewServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstance)
 			FailClosed: true,
 		},
 
+		Features: config.FeatureConfig{
+			EnableAuthenticatedSMS: true,
+		},
+
 		AssetsPath:  ServerAssetsPath(),
 		LocalesPath: LocalesPath(),
 

--- a/pkg/config/admin_server_config.go
+++ b/pkg/config/admin_server_config.go
@@ -113,6 +113,10 @@ func (c *AdminAPIServerConfig) GetRateLimitConfig() *ratelimit.Config {
 	return &c.RateLimit
 }
 
+func (c *AdminAPIServerConfig) GetFeatureConfig() *FeatureConfig {
+	return &c.Features
+}
+
 func (c *AdminAPIServerConfig) ObservabilityExporterConfig() *observability.Config {
 	return &c.Observability
 }

--- a/pkg/config/issue.go
+++ b/pkg/config/issue.go
@@ -27,6 +27,7 @@ type IssueAPIConfig interface {
 	GetAllowedSymptomAge() time.Duration
 	GetEnforceRealmQuotas() bool
 	GetRateLimitConfig() *ratelimit.Config
+	GetFeatureConfig() *FeatureConfig
 	GetENXRedirectDomain() string
 	IsMaintenanceMode() bool
 

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -157,6 +157,10 @@ func (c *ServerConfig) GetRateLimitConfig() *ratelimit.Config {
 	return &c.RateLimit
 }
 
+func (c *ServerConfig) GetFeatureConfig() *FeatureConfig {
+	return &c.Features
+}
+
 func (c *ServerConfig) ObservabilityExporterConfig() *observability.Config {
 	return &c.Observability
 }

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -155,7 +155,7 @@ func (c *Controller) smsProviderFor(ctx context.Context, realm *database.Realm) 
 // from a local in-memory cache.
 func (c *Controller) smsSignerFor(ctx context.Context, realm *database.Realm) (crypto.Signer, string, error) {
 	// Do not create a signer if the realm does not sign SMS.
-	if !realm.UseAuthenticatedSMS {
+	if !c.config.GetFeatureConfig().EnableAuthenticatedSMS || !realm.UseAuthenticatedSMS {
 		return nil, "", nil
 	}
 


### PR DESCRIPTION
This handles an edge case where the feature was enabled but then disabled, but a realm has it enabled.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only return a signer if Authenticated SMS is enabled
```
