### PR TITLE
Add structured logger for gorm

### DIFF
--- a/pkg/database/database_logger.go
+++ b/pkg/database/database_logger.go
@@ -1,0 +1,187 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"database/sql/driver"
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"go.uber.org/zap"
+)
+
+// GormZapLogger is a gorm logger than writes to a zap logger for structured
+// logging.
+type GormZapLogger struct {
+	logger   *zap.SugaredLogger
+	spacesRe *regexp.Regexp
+
+	moduleRoot string
+}
+
+// NewGormZapLogger creates a new gorm logger.
+func NewGormZapLogger(logger *zap.SugaredLogger) (*GormZapLogger, error) {
+	spacesRe, err := regexp.Compile(`\s+`)
+	if err != nil {
+		return nil, fmt.Errorf("failed to compile regexp: %w", err)
+	}
+
+	// Disable the caller injection because gorm supplies us the caller.
+	logger = logger.Desugar().WithOptions(zap.WithCaller(false)).Sugar()
+
+	return &GormZapLogger{
+		logger:     logger,
+		spacesRe:   spacesRe,
+		moduleRoot: project.Root() + "/",
+	}, nil
+}
+
+// Print satisfies gorm's interface for a logger.
+func (l *GormZapLogger) Print(v ...interface{}) {
+	if len(v) == 0 {
+		return
+	}
+
+	if len(v) == 1 {
+		l.logger.DPanicf("only 1 element to Print: %#v", v)
+		return
+	}
+
+	switch v[0] {
+	case "info":
+		msg, ok := v[1].(string)
+		if !ok {
+			l.logger.DPanicf("info result is not string (%T): %#v", v[1], v)
+			return
+		}
+		msg = strings.TrimPrefix(msg, "[info]")
+		msg = strings.TrimSpace(msg)
+
+		l.logger.Debugw(msg)
+	case "log":
+		caller, err := l.formatCaller(v[1])
+		if err != nil {
+			l.logger.DPanic(err)
+			return
+		}
+
+		l.logger.Errorw("gorm error",
+			"caller", caller,
+			"error", v[2])
+	case "sql":
+		caller, err := l.formatCaller(v[1])
+		if err != nil {
+			l.logger.DPanic(err)
+			return
+		}
+
+		duration, ok := v[2].(time.Duration)
+		if !ok {
+			l.logger.DPanicf("duration is not time.Duration (%T): %#v", v[2], v)
+		}
+		duration = duration * time.Nanosecond
+
+		sql, err := l.formatSQL(v[3])
+		if err != nil {
+			l.logger.DPanic(err)
+			return
+		}
+
+		values, err := l.formatValues(v[4])
+		if err != nil {
+			l.logger.DPanic(err)
+			return
+		}
+
+		rows, ok := v[5].(int64)
+		if !ok {
+			l.logger.DPanicf("rows is not int64 (%T): %#v", v[5], v)
+			return
+		}
+
+		l.logger.Debugw(sql,
+			"caller", caller,
+			"duration", duration,
+			"values", values,
+			"rows", rows)
+	default:
+		l.logger.DPanicf("unknown log type %v: %#v", v[0], v)
+	}
+}
+
+func (l *GormZapLogger) formatCaller(v interface{}) (string, error) {
+	typ, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("formatCaller: %T is not string", v)
+	}
+
+	typ = strings.TrimPrefix(typ, l.moduleRoot)
+	return typ, nil
+}
+
+// formatSQL makes SQL pretty
+func (l *GormZapLogger) formatSQL(v interface{}) (string, error) {
+	typ, ok := v.(string)
+	if !ok {
+		return "", fmt.Errorf("formatSQL: %T is not string", v)
+	}
+
+	typ = l.spacesRe.ReplaceAllString(typ, " ")
+	typ = strings.TrimSpace(typ)
+	return typ, nil
+}
+
+// formatValues makes SQL input values pretty
+func (l *GormZapLogger) formatValues(v interface{}) ([]string, error) {
+	typ, ok := v.([]interface{})
+	if !ok {
+		return nil, fmt.Errorf("formatValues: %T is not []interface{}", v)
+	}
+
+	result := make([]string, 0, len(typ))
+	for _, v := range typ {
+		ind := reflect.Indirect(reflect.ValueOf(v))
+
+		if !ind.IsValid() {
+			result = append(result, "NULL")
+			continue
+		}
+
+		if t, ok := v.(driver.Valuer); ok {
+			if val, err := t.Value(); err == nil && val != nil {
+				result = append(result, fmt.Sprintf("'%v'", val))
+			} else {
+				result = append(result, "NULL")
+			}
+			continue
+		}
+
+		if t, ok := v.(time.Time); ok {
+			if t.IsZero() {
+				t = time.Unix(0, 0)
+			}
+			result = append(result, t.Format(time.RFC3339))
+			continue
+		}
+
+		result = append(result, fmt.Sprintf("%v", v))
+	}
+
+	return result, nil
+}

--- a/pkg/database/database_logger_test.go
+++ b/pkg/database/database_logger_test.go
@@ -1,0 +1,124 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+
+	"go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+)
+
+type customZapWriter struct {
+	bytes.Buffer
+}
+
+func (w *customZapWriter) Sync() error { return nil }
+
+func TestGormZapLogger(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   []interface{}
+		exp  string
+	}{
+		{
+			name: "sql_rows",
+			in: []interface{}{
+				"sql",
+				"pkg/database/authorized_app.go:279",
+				time.Duration(2029786),
+				"INSERT INTO \"authorized_apps\" (\"created_at\",\"updated_at\",\"deleted_at\",\"realm_id\",\"name\",\"api_key_preview\",\"api_key\",\"api_key_type\") VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING \"authorized_apps\".\"id\"",
+				[]interface{}{"2021-02-19T10:08:26.564289-05:00", "2021-02-19T10:08:26.564289-05:00", nil, 2, "Closet Cloud", "CJTCAu", "gj_3Mg_397WDTNI5decfgWostzJWuEvmLxj5UWuC_cfRzF-yflr0fP4D_gnjHpC8SuWZroeWOIIXIQDgQKeeLg", 1},
+				int64(1),
+			},
+			exp: "DEBUG\tINSERT INTO \"authorized_apps\" (\"created_at\",\"updated_at\",\"deleted_at\",\"realm_id\",\"name\",\"api_key_preview\",\"api_key\",\"api_key_type\") VALUES ($1,$2,$3,$4,$5,$6,$7,$8) RETURNING \"authorized_apps\".\"id\"\t{\"caller\": \"pkg/database/authorized_app.go:279\", \"duration\": \"2.029786ms\", \"values\": [\"2021-02-19T10:08:26.564289-05:00\", \"2021-02-19T10:08:26.564289-05:00\", \"NULL\", \"2\", \"Closet Cloud\", \"CJTCAu\", \"gj_3Mg_397WDTNI5decfgWostzJWuEvmLxj5UWuC_cfRzF-yflr0fP4D_gnjHpC8SuWZroeWOIIXIQDgQKeeLg\", \"1\"], \"rows\": 1}",
+		},
+		{
+			name: "sql_no_rows",
+			in: []interface{}{
+				"sql",
+				"pkg/database/mobile_app.go:235",
+				time.Duration(3268414),
+				"SELECT * FROM \"mobile_apps\"    WHERE (id = $1) ORDER BY \"mobile_apps\".\"id\" ASC LIMIT 1",
+				[]interface{}{0},
+				int64(0),
+			},
+			exp: "DEBUG\tSELECT * FROM \"mobile_apps\" WHERE (id = $1) ORDER BY \"mobile_apps\".\"id\" ASC LIMIT 1\t{\"caller\": \"pkg/database/mobile_app.go:235\", \"duration\": \"3.268414ms\", \"values\": [\"0\"], \"rows\": 0}",
+		},
+		{
+			name: "info",
+			in: []interface{}{
+				"info",
+				"[info] the british are coming",
+			},
+			exp: "DEBUG\tthe british are coming",
+		},
+		{
+			name: "log",
+			in: []interface{}{
+				"log",
+				"pkg/database/mobile_app.go:235",
+				fmt.Errorf("something is broken"),
+			},
+			exp: "ERROR\tgorm error\t{\"caller\": \"pkg/database/mobile_app.go:235\", \"error\": \"something is broken\"}",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			var b customZapWriter
+			out := zapcore.Lock(&b)
+
+			lvl := zap.LevelEnablerFunc(func(lvl zapcore.Level) bool {
+				return true
+			})
+
+			enc := zap.NewDevelopmentEncoderConfig()
+			enc.EncodeTime = func(t time.Time, enc zapcore.PrimitiveArrayEncoder) {
+				// do nothing to make the test output predicatable
+			}
+
+			core := zapcore.NewCore(
+				zapcore.NewConsoleEncoder(enc), out, lvl)
+
+			logger := zap.New(core).Sugar()
+
+			gormLogger, err := NewGormZapLogger(logger)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			gormLogger.Print(tc.in...)
+
+			if err := logger.Sync(); err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := strings.TrimSpace(b.String()), tc.exp; got != want {
+				t.Errorf("invalid result:\n+%q\n-%q\n", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Looking at logs to debug an issue this morning, they are littered with gorm output that has ANSI color sequences embedded (that don't render well). I wrote a custom logger that makes the data structured. 

The existing logger has a bunch of type assertions and things than can panic. I tried to handle more edge cases in this one.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add structured logger for gorm
```
