### PR TITLE
Make e2e-runner publish a real client

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -192,7 +192,7 @@ func handleEndToEnd(cfg *config.E2ERunnerConfig, h *render.Renderer) http.Handle
 		ctx := r.Context()
 
 		if err := clients.RunEndToEnd(ctx, cfg); err != nil {
-			renderJSONError(w, r, h, err)
+			renderJSONError(w, r, h, fmt.Errorf("failed to run end-to-end: %w", err))
 			return
 		}
 
@@ -213,7 +213,7 @@ func handleENXRedirect(client *clients.ENXRedirectClient, h *render.Renderer) ht
 		ctx := r.Context()
 
 		if err := client.RunE2E(ctx); err != nil {
-			renderJSONError(w, r, h, err)
+			renderJSONError(w, r, h, fmt.Errorf("failed to run enx-redirect: %w", err))
 			return
 		}
 

--- a/internal/clients/key_server.go
+++ b/internal/clients/key_server.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/http"
+	"strings"
 
 	keyserver "github.com/google/exposure-notifications-server/pkg/api/v1"
 )
@@ -34,9 +35,30 @@ func NewKeyServerClient(base string, opts ...Option) (*KeyServerClient, error) {
 		return nil, err
 	}
 
+	// To maintain backwards-compatibility with older implementations that wanted
+	// KEY_SERVER as the full URL to the publish endpoint, strip off anything
+	// after /v1.
+	if idx := strings.Index(client.baseURL.Path, "/v1"); idx != -1 {
+		client.baseURL.Path = client.baseURL.Path[0:idx]
+	}
+
 	return &KeyServerClient{
 		client: client,
 	}, nil
+}
+
+// Publish uploads TEKs to the key server
+func (c *KeyServerClient) Publish(ctx context.Context, in *keyserver.Publish) (*keyserver.PublishResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodPost, "/v1/publish", in)
+	if err != nil {
+		return nil, err
+	}
+
+	var out keyserver.PublishResponse
+	if err := c.doOK(req, &out); err != nil {
+		return &out, err
+	}
+	return &out, nil
 }
 
 // Stats calls the /v1/stats endpoint to get key-server statistics.

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -94,7 +94,7 @@ locals {
 
   e2e_runner_config = {
     HEALTH_AUTHORITY_CODE   = "com.example"
-    KEY_SERVER              = "https://example.com/v1/publish"
+    KEY_SERVER              = "https://example.com"
     VERIFICATION_ADMIN_API  = local.enable_lb ? "https://${var.adminapi_hosts[0]}" : google_cloud_run_service.adminapi.status.0.url
     VERIFICATION_SERVER_API = local.enable_lb ? "https://${var.apiserver_hosts[0]}" : google_cloud_run_service.apiserver.status.0.url
     E2E_SKIP_SMS            = var.e2e_skip_sms


### PR DESCRIPTION
This gives us all the JSON parsing + automatic fallback and nice error messages when something fails. This commit changes the required configuration for `KEY_SERVER` from the full URL to the /publish endpoint to *just* the URL to the key server. Where previously you may have configured `KEY_SERVER=https://foo.bar/v1/publish`, please re-configure with `KEY_SERVER=https://foo.bar`. The system attempts to maintain backwards compatibility by parsing the URL, but this may be removed at a later date.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Upgrade e2e-runner's HTTP client. This changes the required configuration for `KEY_SERVER` from the full URL to the `/publish` endpoint to _just_ the URL to the key server. Where previously you may have configured `KEY_SERVER=https://foo.bar/v1/publish`, please re-configure with `KEY_SERVER=https://foo.bar`. The system attempts to maintain backwards compatibility by parsing the URL, but this may be removed at a later date.
```