### PR TITLE
Create session.Values if empty

### DIFF
--- a/pkg/controller/flash.go
+++ b/pkg/controller/flash.go
@@ -23,6 +23,10 @@ import (
 func Flash(session *sessions.Session) *flash.Flash {
 	var values map[interface{}]interface{}
 	if session != nil {
+		if session.Values == nil {
+			session.Values = make(map[interface{}]interface{})
+		}
+
 		values = session.Values
 	}
 


### PR DESCRIPTION
This can't happen in real life - only in tests

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
