### PR TITLE
Disable authenticated sms in tests when the creds are missing

### DIFF
--- a/internal/envstest/integration.go
+++ b/internal/envstest/integration.go
@@ -65,6 +65,12 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 	twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
 	if twilioAccountSid == "" || twilioAuthToken == "" {
 		tb.Logf("🚧 🚧 Skipping sms tests (missing TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN)")
+
+		// Also disable authenticated sms
+		resp.Realm.UseAuthenticatedSMS = false
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+			tb.Fatalf("failed to update realm: %v", err)
+		}
 	} else {
 		has, err := resp.Realm.HasSMSConfig(db)
 		if err != nil {


### PR DESCRIPTION
This fixes an issue where the tests get really sad if you don't set the Twilio creds. There's still a bit more work to be done to unify the integration test and e2e-runner, which will fix the other issue.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Disable authenticated sms in tests when the creds are missing
```
