### PR TITLE
Merge e2e tests and integration tests

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -40,9 +40,11 @@ jobs:
         shell: bash
         env:
           # The Twilio credentials are not actually a "secret" (they are test
-          # credentials).
+          # credentials). On pull requests from forks, the secrets are not
+          # available, so skip SMS in the e2e tests.
           TWILIO_ACCOUNT_SID: ${{ secrets.TWILIO_ACCOUNT_SID }}
           TWILIO_AUTH_TOKEN: ${{ secrets.TWILIO_AUTH_TOKEN }}
+          E2E_SKIP_SMS: ${{ secrets.TWILIO_AUTH_TOKEN == '' }}
         run: make test-acc
 
       - name: go-coverage

--- a/internal/envstest/integration.go
+++ b/internal/envstest/integration.go
@@ -18,7 +18,6 @@ import (
 	"os"
 	"testing"
 
-	"github.com/google/exposure-notifications-verification-server/internal/clients"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
@@ -26,8 +25,13 @@ import (
 // IntegrationSuite encompasses a local API server and Admin API server for
 // testing. Both servers run in-memory on the local machine.
 type IntegrationSuite struct {
-	adminAPIServerClient *clients.AdminAPIServerClient
-	apiServerClient      *clients.APIServerClient
+	AdminAPIAddress string
+	AdminAPIKey     string
+
+	APIServerAddress string
+	APIServerKey     string
+
+	ENXRedirectAddress string
 }
 
 // NewIntegrationSuite creates a new test suite for local integration testing.
@@ -38,6 +42,7 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 
 	adminAPIServerConfig := NewAdminAPIServerConfig(tb, testDatabaseInstance)
 	apiServerConfig := NewAPIServerConfig(tb, testDatabaseInstance)
+	enxRedirectConfig := NewENXRedirectServerConfig(tb, testDatabaseInstance)
 
 	// Point everything at the same database, cacher, and key manager.
 	adminAPIServerConfig.Database = apiServerConfig.Database
@@ -45,6 +50,12 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 	adminAPIServerConfig.Cacher = apiServerConfig.Cacher
 	adminAPIServerConfig.KeyManager = apiServerConfig.KeyManager
 	adminAPIServerConfig.RateLimiter = apiServerConfig.RateLimiter
+	adminAPIServerConfig.Renderer = apiServerConfig.Renderer
+
+	enxRedirectConfig.Database = apiServerConfig.Database
+	enxRedirectConfig.BadDatabase = apiServerConfig.BadDatabase
+	enxRedirectConfig.Cacher = apiServerConfig.Cacher
+	enxRedirectConfig.Renderer = apiServerConfig.Renderer
 
 	db := adminAPIServerConfig.Database
 
@@ -61,9 +72,7 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 	realm := resp.Realm
 
 	// Configure SMS
-	twilioAccountSid := os.Getenv("TWILIO_ACCOUNT_SID")
-	twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
-	if twilioAccountSid == "" || twilioAuthToken == "" {
+	if project.SkipE2ESMS {
 		tb.Logf("🚧 🚧 Skipping sms tests (missing TWILIO_ACCOUNT_SID/TWILIO_AUTH_TOKEN)")
 
 		// Also disable authenticated sms
@@ -72,6 +81,15 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 			tb.Fatalf("failed to update realm: %v", err)
 		}
 	} else {
+		twilioAccountSid := os.Getenv("TWILIO_ACCOUNT_SID")
+		if twilioAccountSid == "" {
+			tb.Fatalf("missing TWILIO_ACCOUNT_SID")
+		}
+		twilioAuthToken := os.Getenv("TWILIO_AUTH_TOKEN")
+		if twilioAuthToken == "" {
+			tb.Fatalf("missing TWILIO_AUTH_TOKEN")
+		}
+
 		has, err := resp.Realm.HasSMSConfig(db)
 		if err != nil {
 			tb.Fatalf("failed to check if realm has sms config: %s", err)
@@ -106,29 +124,15 @@ func NewIntegrationSuite(tb testing.TB, testDatabaseInstance *database.TestInsta
 
 	adminAPIServer := adminAPIServerConfig.NewServer(tb)
 	apiServer := apiServerConfig.NewServer(tb)
-
-	adminAPIServerClient, err := clients.NewAdminAPIServerClient("http://"+adminAPIServer.Server.Addr(), resp.AdminAPIKey)
-	if err != nil {
-		tb.Fatal(err)
-	}
-
-	apiServerClient, err := clients.NewAPIServerClient("http://"+apiServer.Server.Addr(), resp.DeviceAPIKey)
-	if err != nil {
-		tb.Fatal(err)
-	}
+	enxRedirectServer := enxRedirectConfig.NewServer(tb)
 
 	return &IntegrationSuite{
-		adminAPIServerClient: adminAPIServerClient,
-		apiServerClient:      apiServerClient,
+		AdminAPIAddress: "http://" + adminAPIServer.Server.Addr(),
+		AdminAPIKey:     resp.AdminAPIKey,
+
+		APIServerAddress: "http://" + apiServer.Server.Addr(),
+		APIServerKey:     resp.DeviceAPIKey,
+
+		ENXRedirectAddress: "http://" + enxRedirectServer.Server.Addr(),
 	}
-}
-
-// AdminAPIServerClient returns the Admin API client.
-func (i *IntegrationSuite) AdminAPIServerClient() *clients.AdminAPIServerClient {
-	return i.adminAPIServerClient
-}
-
-// APIServerClient returns the API server client.
-func (i *IntegrationSuite) APIServerClient() *clients.APIServerClient {
-	return i.apiServerClient
 }

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -18,24 +18,13 @@
 package integration_test
 
 import (
-	"encoding/base64"
 	"testing"
-	"time"
 
-	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
-	"github.com/google/exposure-notifications-server/pkg/util"
-	"github.com/google/exposure-notifications-server/pkg/verification"
-
+	"github.com/google/exposure-notifications-verification-server/internal/clients"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
-	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
-)
-
-const (
-	oneDay         = 24 * time.Hour
-	intervalLength = 10 * time.Minute
-	maxInterval    = 144
 )
 
 var testDatabaseInstance *database.TestInstance
@@ -46,241 +35,22 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestIntegration(t *testing.T) {
+func TestIntegration2(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
 
 	integrationSuite := envstest.NewIntegrationSuite(t, testDatabaseInstance)
-	adminAPIClient := integrationSuite.AdminAPIServerClient()
-	apiServerClient := integrationSuite.APIServerClient()
 
-	now := time.Now().UTC()
-	curDayInterval := timeToInterval(now)
-	nextInterval := curDayInterval
-	symptomDate := time.Now().UTC().Add(-48 * time.Hour).Format(project.RFC3339Date)
-	testType := "confirmed"
-
-	// Test issuing a single code
-	t.Run("issue", func(t *testing.T) {
-		t.Parallel()
-
-		// Generate HMAC
-		tekHMAC := generateHMAC(t, nextInterval)
-
-		// Issue a code
-		issueReq := &api.IssueCodeRequest{
-			TestType:    testType,
-			SymptomDate: symptomDate,
-		}
-		if !project.SkipE2ESMS {
-			issueReq.Phone = project.TestPhoneNumber
-		}
-		issueResp, err := adminAPIClient.IssueCode(ctx, issueReq)
-		if err != nil {
-			t.Fatalf("failed to issue code: %#v\n  req: %#v\n  resp: %#v", err, issueReq, issueResp)
-		}
-		if len(issueResp.Padding) == 0 {
-			t.Error("expected response padding")
-		}
-
-		// Invalid code should fail to verify
-		{
-			verifyReq := &api.VerifyCodeRequest{
-				VerificationCode: "NOT-A-REAL-CODE",
-				AcceptTestTypes:  []string{testType},
-			}
-			verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-			if err == nil {
-				t.Fatalf("expected code to fail to verify (invalid), got no error\n  req: %#v\n  resp: %#v", verifyReq, verifyResp)
-			}
-		}
-
-		// Valid code verifies
-		verifyReq := &api.VerifyCodeRequest{
-			VerificationCode: issueResp.VerificationCode,
-			AcceptTestTypes:  []string{testType},
-		}
-		verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-		if err != nil {
-			t.Fatalf("failed to verify code: %#v\n  req: %#v\n  resp: %#v", err, verifyReq, verifyResp)
-		}
-
-		// Valid code verifies only once
-		{
-			verifyReq := &api.VerifyCodeRequest{
-				VerificationCode: issueResp.VerificationCode,
-				AcceptTestTypes:  []string{testType},
-			}
-			verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-			if err == nil {
-				t.Fatalf("expected code to fail to verify (already used), got no error\n  req: %#v\n  resp: %#v", verifyReq, verifyResp)
-			}
-		}
-
-		// Invalid token should fail to issue a certificate
-		{
-			certReq := &api.VerificationCertificateRequest{
-				VerificationToken: "STILL-TOTALLY-NOT-REAL",
-				ExposureKeyHMAC:   tekHMAC,
-			}
-			certResp, err := apiServerClient.Certificate(ctx, certReq)
-			if err == nil {
-				t.Fatalf("expected certificate to failed to issue (invalid): got no error\n  req: %#v\n  resp: %#v", certReq, certResp)
-			}
-		}
-
-		// Get a certificate
-		certReq := &api.VerificationCertificateRequest{
-			VerificationToken: verifyResp.VerificationToken,
-			ExposureKeyHMAC:   tekHMAC,
-		}
-		certResp, err := apiServerClient.Certificate(ctx, certReq)
-		if err != nil {
-			t.Fatalf("failed to get certificate: %#v\n  req: %#v\n  resp: %#v", err, certReq, certResp)
-		}
-
-		// Valid token issues only once
-		{
-			certReq := &api.VerificationCertificateRequest{
-				VerificationToken: verifyResp.VerificationToken,
-				ExposureKeyHMAC:   tekHMAC,
-			}
-			certResp, err := apiServerClient.Certificate(ctx, certReq)
-			if err == nil {
-				t.Fatalf("expected certificate to failed to issue (already used): got no error\n  req: %#v\n  resp: %#v", certReq, certResp)
-			}
-		}
-	})
-
-	t.Run("issue_batch", func(t *testing.T) {
-		t.Parallel()
-
-		// Generate HMAC
-		tekHMAC := generateHMAC(t, nextInterval)
-
-		// Issue 2 codes
-		issueReq := &api.BatchIssueCodeRequest{
-			Codes: []*api.IssueCodeRequest{
-				{
-					TestType:    testType,
-					SymptomDate: symptomDate,
-				},
-				{
-					TestType:    testType,
-					SymptomDate: symptomDate,
-				},
-			},
-		}
-		outerIssueResp, err := adminAPIClient.BatchIssueCode(ctx, issueReq)
-		if err != nil {
-			t.Fatalf("failed to issue code: %#v\n  req: %#v\n  resp: %#v", err, issueReq, outerIssueResp)
-		}
-		if len(outerIssueResp.Padding) == 0 {
-			t.Error("expected response padding")
-		}
-
-		// Invalid code should fail to verify
-		{
-			verifyReq := &api.VerifyCodeRequest{
-				VerificationCode: "NOT-A-REAL-CODE",
-				AcceptTestTypes:  []string{testType},
-			}
-			verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-			if err == nil {
-				t.Fatalf("expected code to fail to verify (invalid), got no error\n  req: %#v\n  resp: %#v", verifyReq, verifyResp)
-			}
-		}
-
-		// Verify all codes in batch.
-		for _, issueResp := range outerIssueResp.Codes {
-			if len(issueResp.Padding) != 0 {
-				t.Errorf("batch does not expect inner response padding, got %s", string(issueResp.Padding))
-			}
-
-			verifyReq := &api.VerifyCodeRequest{
-				VerificationCode: issueResp.VerificationCode,
-				AcceptTestTypes:  []string{testType},
-			}
-			verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-			if err != nil {
-				t.Fatalf("apiClient.GetToken(%+v) = expected nil, got resp %+v, err %v", verifyReq, verifyResp, err)
-			}
-			if err != nil {
-				t.Fatalf("failed to verify code: %#v\n  req: %#v\n  resp: %#v", err, verifyReq, verifyResp)
-			}
-
-			// Valid code verifies only once
-			{
-				verifyReq := &api.VerifyCodeRequest{
-					VerificationCode: issueResp.VerificationCode,
-					AcceptTestTypes:  []string{testType},
-				}
-				verifyResp, err := apiServerClient.Verify(ctx, verifyReq)
-				if err == nil {
-					t.Fatalf("expected code to fail to verify (already used), got no error\n  req: %#v\n  resp: %#v", verifyReq, verifyResp)
-				}
-			}
-
-			// Invalid token should fail to issue a certificate
-			{
-				certReq := &api.VerificationCertificateRequest{
-					VerificationToken: "STILL-TOTALLY-NOT-REAL",
-					ExposureKeyHMAC:   tekHMAC,
-				}
-				certResp, err := apiServerClient.Certificate(ctx, certReq)
-				if err == nil {
-					t.Fatalf("expected certificate to failed to issue (invalid): got no error\n  req: %#v\n  resp: %#v", certReq, certResp)
-				}
-			}
-
-			certReq := &api.VerificationCertificateRequest{
-				VerificationToken: verifyResp.VerificationToken,
-				ExposureKeyHMAC:   tekHMAC,
-			}
-			certResp, err := apiServerClient.Certificate(ctx, certReq)
-			if err != nil {
-				t.Fatalf("failed to get certificate: %#v\n  req: %#v\n  resp: %#v", err, certReq, certResp)
-			}
-
-			// Valid token issues only once
-			{
-				certReq := &api.VerificationCertificateRequest{
-					VerificationToken: verifyResp.VerificationToken,
-					ExposureKeyHMAC:   tekHMAC,
-				}
-				certResp, err := apiServerClient.Certificate(ctx, certReq)
-				if err == nil {
-					t.Fatalf("expected certificate to failed to issue (already used): got no error\n  req: %#v\n  resp: %#v", certReq, certResp)
-				}
-			}
-		}
-	})
-}
-
-// generateHMAC generates an HMAC of TEKs.
-func generateHMAC(tb testing.TB, nextInterval int32) string {
-	teks := make([]verifyapi.ExposureKey, 14)
-	for i := 0; i < len(teks); i++ {
-		key, err := util.RandomExposureKey(nextInterval, maxInterval, 0)
-		if err != nil {
-			tb.Fatal(err)
-		}
-		teks[i] = key
-		nextInterval -= maxInterval
+	cfg := &config.E2ERunnerConfig{
+		VerificationAdminAPIServer: integrationSuite.AdminAPIAddress,
+		VerificationAdminAPIKey:    integrationSuite.AdminAPIKey,
+		VerificationAPIServer:      integrationSuite.APIServerAddress,
+		VerificationAPIServerKey:   integrationSuite.APIServerKey,
+		DoRevise:                   true,
 	}
 
-	hmacSecret, err := project.RandomBytes(32)
-	if err != nil {
-		tb.Fatal(err)
+	if err := clients.RunEndToEnd(ctx, cfg); err != nil {
+		t.Fatal(err)
 	}
-	hmacValue, err := verification.CalculateExposureKeyHMAC(teks, hmacSecret)
-	if err != nil {
-		tb.Fatal(err)
-	}
-	return base64.StdEncoding.EncodeToString(hmacValue)
-}
-
-func timeToInterval(t time.Time) int32 {
-	return int32(t.UTC().Truncate(oneDay).Unix() / int64(intervalLength.Seconds()))
 }

--- a/pkg/integration/integration_test.go
+++ b/pkg/integration/integration_test.go
@@ -35,7 +35,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestIntegration2(t *testing.T) {
+func TestIntegration(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)


### PR DESCRIPTION
This runs the same e2e tests as the e2e-runner as integration tests. Turns out, there was a _ton_ of duplication we got to remove.

This also fixes an edge case where GitHub secrets are not exposed in runs on PR foks. If the secrets aren't available, the tests skip testing SMS in the integration tests.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1824

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Merge e2e tests and integration tests
```
