### PR TITLE
Use less chromedp and less database churn in API key tests

### DIFF
--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -15,24 +15,17 @@
 package apikey_test
 
 import (
-	"context"
 	"fmt"
 	"net/http"
-	"net/http/httptest"
-	"strings"
 	"testing"
 
-	"github.com/chromedp/chromedp"
-	"github.com/google/exposure-notifications-verification-server/internal/browser"
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/apikey"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
-	"github.com/google/exposure-notifications-verification-server/pkg/render"
 	"github.com/gorilla/mux"
-	"github.com/gorilla/sessions"
 )
 
 func TestHandleDisable(t *testing.T) {
@@ -45,29 +38,21 @@ func TestHandleDisable(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	ctx = controller.WithSession(ctx, session)
 
 	authApp := &database.AuthorizedApp{
 		RealmID: realm.ID,
-		Name:    "Disables app",
+		Name:    "Appy",
 	}
 	if _, err := realm.CreateAuthorizedApp(harness.Database, authApp, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}
 
-	cookie, err := harness.SessionCookie(session)
-	if err != nil {
-		t.Fatal(err)
-	}
+	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
+	handler := c.HandleDisable()
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
-
-		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
-		if err != nil {
-			t.Fatal(err)
-		}
-		c := apikey.New(harness.Cacher, harness.Database, h)
-		handler := c.HandleDisable()
 
 		envstest.ExerciseSessionMissing(t, handler)
 		envstest.ExerciseMembershipMissing(t, handler)
@@ -82,68 +67,41 @@ func TestHandleDisable(t *testing.T) {
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
-		harness := envstest.NewServerConfig(t, testDatabaseInstance)
-		harness.Database.SetRawDB(envstest.NewFailingDatabase())
-
-		h, err := render.New(ctx, envstest.ServerAssetsPath(), true)
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		c := apikey.New(harness.Cacher, harness.Database, h)
-
-		mux := mux.NewRouter()
-		mux.Handle("/{id}", c.HandleDisable()).Methods(http.MethodPut)
+		c := apikey.New(harness.Cacher, harness.BadDatabase, harness.Renderer)
+		handler := c.HandleDisable()
 
 		ctx := ctx
-		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm:       realm,
 			User:        user,
 			Permissions: rbac.APIKeyWrite,
 		})
 
-		r := httptest.NewRequest(http.MethodPut, "/1", nil)
-		r = r.Clone(ctx)
-		r.Header.Set("Content-Type", "text/html")
-
-		w := httptest.NewRecorder()
-
-		mux.ServeHTTP(w, r)
-		w.Flush()
+		w, r := envstest.BuildFormRequest(ctx, t, http.MethodPut, "/", nil)
+		r = mux.SetURLVars(r, map[string]string{"id": fmt.Sprintf("%d", authApp.ID)})
+		handler.ServeHTTP(w, r)
 
 		if got, want := w.Code, http.StatusInternalServerError; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
-		if got, want := w.Body.String(), "Internal server error"; !strings.Contains(got, want) {
-			t.Errorf("Expected %q to contain %q", got, want)
-		}
 	})
 
-	t.Run("disables", func(t *testing.T) {
+	t.Run("success", func(t *testing.T) {
 		t.Parallel()
 
-		browserCtx := browser.New(t)
-		taskCtx, done := context.WithTimeout(browserCtx, project.TestTimeout())
-		defer done()
+		ctx := ctx
+		ctx = controller.WithMembership(ctx, &database.Membership{
+			Realm:       realm,
+			User:        user,
+			Permissions: rbac.APIKeyWrite,
+		})
 
-		// Click "confirm" when it pops up.
-		confirmErrCh := envstest.AutoConfirmDialogs(taskCtx, true)
+		w, r := envstest.BuildFormRequest(ctx, t, http.MethodPut, "/", nil)
+		r = mux.SetURLVars(r, map[string]string{"id": fmt.Sprintf("%d", authApp.ID)})
+		handler.ServeHTTP(w, r)
 
-		if err := chromedp.Run(taskCtx,
-			browser.SetCookie(cookie),
-			chromedp.Navigate(`http://`+harness.Server.Addr()+`/realm/apikeys`),
-			chromedp.WaitVisible(`body#apikeys-index`, chromedp.ByQuery),
-
-			chromedp.Click(fmt.Sprintf(`a#disable-apikey-%d`, authApp.ID), chromedp.ByQuery),
-
-			chromedp.WaitVisible(`body#apikeys-index`, chromedp.ByQuery),
-		); err != nil {
-			t.Fatal(err)
-		}
-
-		if err := <-confirmErrCh; err != nil {
-			t.Fatal(err)
+		if got, want := w.Code, http.StatusSeeOther; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// Ensure disabled


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Use less chromedp and less database churn in API key tests
```
