### PR TITLE
Link out to Twilio splits calculator for advanced calculations

### DIFF
--- a/cmd/server/assets/realmadmin/_form_sms.html
+++ b/cmd/server/assets/realmadmin/_form_sms.html
@@ -167,6 +167,12 @@
         delivered in the order in which they are sent. You should take special
         care to ensure that no links occur across a message boundary.
       </p>
+      <p>
+        If your message contains characters outside of the GSM-7 set, they may
+        be forced to a more expensive encoding, which could increase costs. To
+        see how your message will be encoding, use Twilio's more advanced
+        <a href="https://twiliodeved.github.io/message-segment-calculator/">message split analyzer</a>.
+      </p>
 
       <div id="message-bubbles" class="offset-sm-0 col-sm-12 offset-md-2 col-md-8 offset-lg-3 col-lg-6"></div>
     </div>


### PR DESCRIPTION
This is important for international where PHAs may want to use characters that aren't in GSM-7. I don't want to replicate the Twilio calculator in our system, so let's link out to it.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Link out to Twilio splits calculator for advanced calculations
```
