### PR TITLE
Change rate limiting defaults to 120/min

### DIFF
--- a/pkg/ratelimit/config.go
+++ b/pkg/ratelimit/config.go
@@ -43,7 +43,7 @@ const (
 type Config struct {
 	// Common configuration
 	Type     Type          `env:"RATE_LIMIT_TYPE, default=NOOP"`
-	Tokens   uint64        `env:"RATE_LIMIT_TOKENS, default=60"`
+	Tokens   uint64        `env:"RATE_LIMIT_TOKENS, default=120"`
 	Interval time.Duration `env:"RATE_LIMIT_INTERVAL, default=1m"`
 
 	// HMACKey is the key to use when calculating the HMAC of keys before saving


### PR DESCRIPTION
This doubles the default rate limiting from 60/min to 120/min.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change rate limiting defaults from 60/min to 120/min
```
