### PR TITLE
Drop support for crypto/dsa in public key parsing

### DIFF
--- a/pkg/keyutils/public_keys.go
+++ b/pkg/keyutils/public_keys.go
@@ -18,7 +18,6 @@ package keyutils
 import (
 	"context"
 	"crypto"
-	"crypto/dsa"
 	"crypto/ecdsa"
 	"crypto/ed25519"
 	"crypto/rsa"
@@ -68,8 +67,6 @@ func (c *PublicKeyCache) GetPublicKey(ctx context.Context, id string, kms keys.K
 
 	switch pub := raw.(type) {
 	case *rsa.PublicKey:
-		return pub, nil
-	case *dsa.PublicKey:
 		return pub, nil
 	case *ecdsa.PublicKey:
 		return pub, nil


### PR DESCRIPTION
The system only uses ecdsa keys, so this should not affect anyone.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Drop support for crypto/dsa in public key parsing. The EN system only supports ecdsa keys, so this will not affect the system.
```
