### PR TITLE
Do not remove ASSETS_PATH and LOCALES_PATH from Terraform yet

### DIFF
--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -106,6 +106,7 @@ resource "google_cloud_run_service" "server" {
             local.firebase_config,
             local.gcp_config,
             local.rate_limit_config,
+            local.server_config,
             local.session_config,
             local.signing_config,
             local.issue_config,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -105,7 +105,13 @@ locals {
   }
 
   enx_redirect_config = {
+    ASSETS_PATH        = "/assets" // TODO(sethvargo): remove in v0.24+
     HOSTNAME_TO_REGION = join(",", [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : format("%s:%s", o.host, o.region)])
+  }
+
+  server_config = {
+    "ASSETS_PATH"  = "/assets"  // TODO(sethvargo): remove in v0.24+
+    "LOCALES_PATH" = "/locales" // TODO(sethvargo): remove in v0.24+
   }
 
   observability_config = {}


### PR DESCRIPTION
This will cause services to fail before the new ones are deployed. We can remove this configuration later. It doesn't hurt to have it, it just isn't used anymore.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Do not remove ASSETS_PATH and LOCALES_PATH from Terraform just yet.
```

/assign @mikehelmick 
