### PR TITLE
Remove deprecated TOKEN_SIGNING_KEYS

### DIFF
--- a/internal/envstest/apiserver.go
+++ b/internal/envstest/apiserver.go
@@ -100,10 +100,9 @@ func NewAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstan
 			CertificateAudience:   "test-aud",
 		},
 		TokenSigning: config.TokenSigningConfig{
-			Keys:               *harness.KeyManagerConfig,
-			TokenSigningKeys:   []string{tokenSigningKey},
-			TokenSigningKeyIDs: []string{"v1"},
-			TokenIssuer:        "test-iss",
+			Keys:            *harness.KeyManagerConfig,
+			TokenSigningKey: tokenSigningKey,
+			TokenIssuer:     "test-iss",
 		},
 
 		Features: config.FeatureConfig{

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -44,6 +44,9 @@ func (t *TokenSigningConfig) Validate() error {
 	if strings.Contains(t.TokenSigningKey, ",") {
 		return fmt.Errorf("TOKEN_SIGNING_KEY can only contain one element")
 	}
+	if strings.Contains(t.TokenSigningKey, "/cryptoKeyVersions") {
+		return fmt.Errorf("TOKEN_SIGNING_KEY must be the path to a parent crypto key (not the version)")
+	}
 
 	return nil
 }

--- a/pkg/config/token_signing_config.go
+++ b/pkg/config/token_signing_config.go
@@ -28,76 +28,21 @@ type TokenSigningConfig struct {
 	// configuration.
 	Keys keys.Config `env:", prefix=TOKEN_"`
 
-	// TokenSigningKeys is the parent token signing key (not the actual signing
-	// version). It is an array for backwards-compatibility, but in practice it
-	// should only have one element.
-	//
-	// Previously it was a list of all possible signing key versions, but those
-	// have moved into the database.
-	//
-	// TODO(sethvargo): Convert to string in 0.22+.
-	TokenSigningKeys []string `env:"TOKEN_SIGNING_KEY, required"`
-
-	// TokenSigningKeyIDs specifies the list of kids, corresponding to the
-	// TokenSigningKey
-	//
-	// TODO(sethvargo): Remove in 0.22+.
-	//
-	// Deprecated: moved into the database.
-	TokenSigningKeyIDs []string `env:"TOKEN_SIGNING_KEY_ID, default=v1"`
+	// TokenSigningKey is the parent token signing key (not the actual signing
+	// version).
+	TokenSigningKey string `env:"TOKEN_SIGNING_KEY, required"`
 
 	// TokenIssuer is the `iss` field on the JWT.
 	TokenIssuer string `env:"TOKEN_ISSUER, default=diagnosis-verification-example"`
 }
 
-// ParentKeyName returns the name of the parent key.
-func (t *TokenSigningConfig) ParentKeyName() string {
-	// Validation prevents this slice from being empty.
-	value := t.TokenSigningKeys[0]
-
-	// This is Google-specific, but that's the only platform where we can
-	// meaningfully detect this.
-	if idx := strings.Index(t.TokenSigningKeys[0], "/cryptoKeyVersions"); idx != -1 {
-		value = value[0:idx]
-	}
-
-	return value
-}
-
-// FindKeyByKid attempts to find the matching signing key for the given kid. The
-// boolean indicates whether the search was successful.
-//
-// TODO(sethvargo): remove in 0.22+.
-func (t *TokenSigningConfig) FindKeyByKid(kid string) (string, bool) {
-	idx := -1
-	for i, v := range t.TokenSigningKeyIDs {
-		if v == kid {
-			idx = i
-			break
-		}
-	}
-
-	if idx == -1 {
-		return "", false
-	}
-
-	// This is safe to index because the validation check ensures the lengths are
-	// equal.
-	return t.TokenSigningKeys[idx], true
-}
-
 // Validate validates the configuration.
 func (t *TokenSigningConfig) Validate() error {
-	if len(t.TokenSigningKeys) == 0 {
-		return fmt.Errorf("TOKEN_SIGNING_KEY must have at least one element")
+	if t.TokenSigningKey == "" {
+		return fmt.Errorf("TOKEN_SIGNING_KEY is required")
 	}
-
-	if len(t.TokenSigningKeyIDs) == 0 {
-		return fmt.Errorf("TOKEN_SIGNING_KEY_ID must have at least one entry")
-	}
-
-	if len(t.TokenSigningKeys) != len(t.TokenSigningKeyIDs) {
-		return fmt.Errorf("TOKEN_SIGNING_KEY and TOKEN_SIGNING_KEY_ID must be lists of the same length")
+	if strings.Contains(t.TokenSigningKey, ",") {
+		return fmt.Errorf("TOKEN_SIGNING_KEY can only contain one element")
 	}
 
 	return nil

--- a/pkg/controller/certapi/certapi.go
+++ b/pkg/controller/certapi/certapi.go
@@ -85,19 +85,7 @@ func (c *Controller) validateToken(ctx context.Context, verToken string) (string
 
 		tokenSigningKey, err := c.db.FindTokenSigningKeyByUUIDCached(ctx, c.cacher, kid)
 		if err != nil {
-			if database.IsNotFound(err) {
-				// Fallback to searching the pre-database keys, which were specified via
-				// environment variables.
-				//
-				// TODO(sethvargo): remove in 0.22+
-				keyID, ok := c.config.TokenSigning.FindKeyByKid(kid)
-				if !ok {
-					return nil, fmt.Errorf("no key corresponds to kid %q", kid)
-				}
-				tokenSigningKey = &database.TokenSigningKey{KeyVersionID: keyID}
-			} else {
-				return nil, fmt.Errorf("failed to lookup token signing key: %w", err)
-			}
+			return nil, fmt.Errorf("failed to lookup token signing key: %w", err)
 		}
 
 		publicKey, err := c.pubKeyCache.GetPublicKey(ctx, tokenSigningKey.KeyVersionID, c.kms)

--- a/pkg/controller/cleanup/handle_cleanup_test.go
+++ b/pkg/controller/cleanup/handle_cleanup_test.go
@@ -49,7 +49,7 @@ func TestHandleCleanup(t *testing.T) {
 
 	config := &config.CleanupConfig{
 		TokenSigning: config.TokenSigningConfig{
-			TokenSigningKeys: []string{tokenSigningKey},
+			TokenSigningKey: tokenSigningKey,
 		},
 		SigningTokenKeyMaxAge: 1 * time.Second,
 	}

--- a/pkg/controller/rotation/handle_token_rotate.go
+++ b/pkg/controller/rotation/handle_token_rotate.go
@@ -78,7 +78,7 @@ func (c *Controller) HandleRotate() http.Handler {
 				}
 			}
 
-			key, err := c.db.RotateTokenSigningKey(ctx, c.keyManager, c.config.TokenSigning.ParentKeyName(), RotationActor)
+			key, err := c.db.RotateTokenSigningKey(ctx, c.keyManager, c.config.TokenSigning.TokenSigningKey, RotationActor)
 			if err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to rotate token signing key: %w", err))
 				result = enobs.ResultError("FAILED")

--- a/pkg/controller/rotation/handle_token_rotate_test.go
+++ b/pkg/controller/rotation/handle_token_rotate_test.go
@@ -46,8 +46,7 @@ func TestHandleRotate(t *testing.T) {
 
 	cfg := &config.RotationConfig{
 		TokenSigning: config.TokenSigningConfig{
-			TokenSigningKeys:   []string{tokenSigningKey},
-			TokenSigningKeyIDs: []string{"v1"},
+			TokenSigningKey: tokenSigningKey,
 		},
 		TokenSigningKeyMaxAge: 30 * time.Second,
 	}
@@ -120,8 +119,7 @@ func TestHandleRotate(t *testing.T) {
 
 		cfg := &config.RotationConfig{
 			TokenSigning: config.TokenSigningConfig{
-				TokenSigningKeys:   []string{tokenSigningKey},
-				TokenSigningKeyIDs: []string{"v1"},
+				TokenSigningKey: tokenSigningKey,
 			},
 			TokenSigningKeyMaxAge: 30 * time.Second,
 			MinTTL:                5 * time.Minute,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -86,10 +86,8 @@ locals {
     SMS_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
     SMS_FAIL_CLOSED = false
 
-    # TODO(sethvargo): in 0.22+, this should be the parent crypto key (not the
-    # crypto key version).
     TOKEN_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
-    TOKEN_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.token-signer-version.id, "//cloudkms.googleapis.com/v1/")
+    TOKEN_SIGNING_KEY = trimprefix(google_kms_crypto_key.token-signer.id, "//cloudkms.googleapis.com/v1/")
   }
 
   e2e_runner_config = {

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -281,7 +281,7 @@ func realMain(ctx context.Context) error {
 	if !ok {
 		return fmt.Errorf("token signing key manager is not SigningKeyManager (got %T)", tokenKeyManager)
 	}
-	if _, err := db.RotateTokenSigningKey(ctx, tokenKeyManagerTyp, tokenConfig.ParentKeyName(), database.SystemTest); err != nil {
+	if _, err := db.RotateTokenSigningKey(ctx, tokenKeyManagerTyp, tokenConfig.TokenSigningKey, database.SystemTest); err != nil {
 		return fmt.Errorf("failed to rotate token signing key: %w", err)
 	}
 


### PR DESCRIPTION
⚠️ 🛑 Please review with caution 🛑 ⚠️ 

The new value is TOKEN_SIGNING_KEY and it must point to the parent key. Token signing keys have moved into the database since v0.22.

You MUST upgrade to v0.22 for at least 24 hours before applying this release.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove backwards-compatibility for `TOKEN_SIGNING_KEY`. Specifying multiple values has been deprecated since 0.21 and token signing keys have moved into the database. If you are on an older version, you **MUST upgrade to v0.22 for at least 24h before applying this update.** You should ensure that the value of `TOKEN_SIGNING_KEY` points to a key (not a key version) in the service environment before applying this upgrade. Since v0.22, `TOKEN_SIGNING_KEY` accepted a key version or a parent key. This release only accepts a parent key.
```
