### PR TITLE
Change to tmpdir when installing linters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ MD_FILES = $(shell find . -name \*.md)
 # locally. There is a chance that CI detects linter errors that are not found
 # locally, but it should be rare.
 lint:
-	@command -v golangci-lint > /dev/null 2>&1 || GO111MODULE=off go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.36.0
+	@command -v golangci-lint > /dev/null 2>&1 || (cd $${TMPDIR} && go get github.com/golangci/golangci-lint/cmd/golangci-lint@v1.37.1)
 	golangci-lint run --config .golangci.yaml
 .PHONY: lint
 
@@ -57,5 +57,5 @@ test-coverage:
 .PHONY: test-coverage
 
 zapcheck:
-	@command -v zapw > /dev/null 2>&1 || GO111MODULE=off go get github.com/sethvargo/zapw/cmd/zapw
+	@command -v zapw > /dev/null 2>&1 || (cd $${TMPDIR} && go get github.com/sethvargo/zapw/cmd/zapw)
 	@zapw ./...


### PR DESCRIPTION
Upgrade golangci-lint to v0.37.1

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change to tmpdir when installing linters
```
