### PR TITLE
Add more debug output when chromedp fails

### DIFF
--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -65,19 +65,25 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 	yesterday := time.Now().Add(-24 * time.Hour).Format(project.RFC3339Date)
 
 	var code string
+	var html string
 	if err := chromedp.Run(taskCtx,
 		browser.SetCookie(cookie),
 		chromedp.Navigate(`http://`+harness.Server.Addr()+`/codes/issue`),
+		chromedp.InnerHTML("html", &html, chromedp.ByQuery),
 		chromedp.WaitVisible(`body#codes-issue`, chromedp.ByQuery),
+		chromedp.InnerHTML("html", &html, chromedp.ByQuery),
 
 		chromedp.SetValue(`input#test-date`, yesterday, chromedp.ByQuery),
 		chromedp.SetValue(`input#symptom-date`, yesterday, chromedp.ByQuery),
+		chromedp.InnerHTML("html", &html, chromedp.ByQuery),
 		chromedp.Click(`#submit`, chromedp.ByQuery),
 
+		chromedp.InnerHTML("html", &html, chromedp.ByQuery),
 		chromedp.WaitVisible(`#short-code`, chromedp.ByQuery),
 		chromedp.TextContent(`#short-code`, &code, chromedp.ByQuery),
+		chromedp.InnerHTML("html", &html, chromedp.ByQuery),
 	); err != nil {
-		t.Fatal(err)
+		t.Fatalf("failed to issue code: %s\nlast html:\n\n%s", err, html)
 	}
 
 	// Verify code length.


### PR DESCRIPTION
Not sure _why_ it sporadically fails, but this will print out the html source of the page and give us a better idea about at which stage it is failing.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
