### PR TITLE
Skip golang-ci restoring the cache

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -98,6 +98,8 @@ jobs:
         with:
           version: 'v1.37'
           skip-go-installation: true
+          skip-pkg-cache: true
+          skip-build-cache: true
 
       - name: zapw-logger
         shell: bash


### PR DESCRIPTION
We do this manually

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
