### PR TITLE
change chart combos

### DIFF
--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -3,7 +3,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Codes issued, claimed, &amp; invalid
+    Codes Issued &amp; Usage
   </div>
   <div id="dashboard_div">
     <div id="realm_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -17,6 +17,12 @@
       <span class="mr-1">Export as:</span>
       <a href="/stats/realm.csv" class="mr-1">CSV</a>
       <a href="/stats/realm.json" target="_blank">JSON</a>
+      {{if .hasKeyServerStats}}
+      (legacy code data) |
+      <span class="mr-1">Composite Data:</span>
+      <a href="/stats/composite.csv" class="mr-1">CSV</a>
+      <a href="/stats/composite.json" target="_blank">JSON</a>  
+      {{end}}
     </span>
   </small>
 </div>
@@ -68,41 +74,57 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Codes issued, claimed, &amp; invalid</h5>
+        <h5 class="modal-title">Codes Issued &amp; Usage</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
       </div>
       <div class="modal-body mb-n3">
         <p>
-          This graph reflects the total number of codes issued and claimed
-          for this realm, grouped by UTC day.
+          This graph reflects the total number of codes issued and usage
+          of those codes for this realm, grouped by UTC day.
         </p>
 
-        <strong>Issued</strong>
+        <strong>Codes Issued</strong>
         <p>
           This line tracks the total number of codes issued. Codes can be
           issued via the web interface or via the API. Both types of codes
           are included in this count.
         </p>
 
-        <strong>Claimed</strong>
+        <strong>Codes Claimed</strong>
         <p>
           This line tracks the total number of codes claimed. Codes can only
           be claimed by the end user using the API. Typically the iOS or
           Android application is responsible for claiming the code.
         </p>
 
-        <strong>Invalid</strong>
+        <strong>Invalid Codes</strong>
         <p>
           This line tracks the total number of codes that were rejected by the
           system. This includes codes that were incorrectly entered
           (typographical error) and codes that have expired.
         </p>
 
+       
+        <strong>Tokens Claimed</strong>
+        <p>
+          This line tracks the total number of users that successfully
+          claimed a verification code and then consented to key release.
+        </p>
+
+        {{if .hasKeyServerStats}}
+        <strong>Publish Requests</strong>
+        <p>
+          The number of users that followed the flow all the way through
+          and successfully completed uploading of temporary exposure keys.          
+        </p>
+        {{end}}
+
         <hr>
 
         <strong>Inferring this data</strong>
+        <p><em>All statistics are captured on a best effort basis.</em></p>
         <ul>
           <li>
             <em>Issued codes</em> does not necessarily correspond to the number
@@ -119,6 +141,17 @@
             The delta between <em>codes issued</em> and <em>codes claimed</em>
             can be used as a rudimentary measure of adoption.
           </li>
+          <li>
+            The delta between codes claimed and tokens claimed indicates users
+            that enter a valid verification code but don't get through the consent
+            to share data screen.
+          </li>
+          {{if .hasKeyServerStats}}
+          <li>
+            The delta between tokens claimed and publish requests indicates that
+            a user got past the consent screen but keys were not uploaded.
+          </li>
+          {{end}}
         </ul>
       </div>
     </div>
@@ -173,10 +206,12 @@
 
   function drawRealmCharts() {
     $.ajax({
-      url: '/stats/realm.json',
+      url: '/stats/composite.json',
       dataType: 'json',
     })
     .done(function(data, status, xhr) {
+      console.log(data);
+
       if (data.statistics) {
         $issueAgeSlider.attr('min', Math.min(smoothing, data.statistics.length));
         $issueAgeSlider.attr('max', data.statistics.length);
@@ -212,12 +247,20 @@
 
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
-    dataTable.addColumn('number', 'Issued');
-    dataTable.addColumn('number', 'Claimed');
-    dataTable.addColumn('number', 'Invalid');
+    dataTable.addColumn('number', 'Codes Issued');
+    dataTable.addColumn('number', 'Codes Claimed');
+    dataTable.addColumn('number', 'Invalid Codes');
+    dataTable.addColumn('number', 'Tokens Claimed');
+    {{if .hasKeyServerStats}}
+    dataTable.addColumn('number', 'Publish Requests');
+    {{end}}
 
     data.statistics.reverse().forEach(function(row) {
-      dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid]);
+      {{if .hasKeyServerStats}}
+      dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed, row.data.total_publish_requests]);
+      {{else}}
+      dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed]);
+      {{end}}
     });
 
     let dateFormatter = new google.visualization.DateFormat({
@@ -268,7 +311,7 @@
       chartType: 'LineChart',
       containerId: 'realm_chart_div',
       options: {
-        colors: ['#007bff', '#28a745', '#dc3545'],
+        colors: ['#007bff', '#28a745', '#dc3545', '#6c757d', '#ee8c00'],
         chartArea: {
           left: 60,
           right: 40,

--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -210,8 +210,6 @@
       dataType: 'json',
     })
     .done(function(data, status, xhr) {
-      console.log(data);
-
       if (data.statistics) {
         $issueAgeSlider.attr('min', Math.min(smoothing, data.statistics.length));
         $issueAgeSlider.attr('max', data.statistics.length);

--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -15,13 +15,12 @@
     <a href="#" data-toggle="modal" data-target="#realm-codes-modal">Learn more about this chart</a>
     <span>
       <span class="mr-1">Export as:</span>
-      <a href="/stats/realm.csv" class="mr-1">CSV</a>
-      <a href="/stats/realm.json" target="_blank">JSON</a>
       {{if .hasKeyServerStats}}
-      (legacy code data) |
-      <span class="mr-1">Composite Data:</span>
-      <a href="/stats/composite.csv" class="mr-1">CSV</a>
-      <a href="/stats/composite.json" target="_blank">JSON</a>  
+      <a href="/stats/realm/composite.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/composite.json" target="_blank">JSON</a>  
+      {{else}}
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a> 
       {{end}}
     </span>
   </small>
@@ -206,7 +205,7 @@
 
   function drawRealmCharts() {
     $.ajax({
-      url: '/stats/composite.json',
+      url: '/stats/realm/composite.json',
       dataType: 'json',
     })
     .done(function(data, status, xhr) {
@@ -241,6 +240,7 @@
       return;
     }
 
+    let hasKeyServerStats = data.has_key_server_stats;
     let tenDaysAgo = new Date(data.statistics[data.statistics.length-10].date);
 
     let dataTable = new google.visualization.DataTable();
@@ -249,16 +249,16 @@
     dataTable.addColumn('number', 'Codes Claimed');
     dataTable.addColumn('number', 'Invalid Codes');
     dataTable.addColumn('number', 'Tokens Claimed');
-    {{if .hasKeyServerStats}}
-    dataTable.addColumn('number', 'Publish Requests');
-    {{end}}
+    if (hasKeyServerStats) {
+      dataTable.addColumn('number', 'Publish Requests');
+    }
 
     data.statistics.reverse().forEach(function(row) {
-      {{if .hasKeyServerStats}}
-      dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed, row.data.total_publish_requests]);
-      {{else}}
-      dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed]);
-      {{end}}
+      if (hasKeyServerStats) {
+        dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed, row.data.total_publish_requests]);
+      } else {
+        dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed]);
+      }
     });
 
     let dateFormatter = new google.visualization.DateFormat({

--- a/assets/server/realmadmin/_stats_keyserver.html
+++ b/assets/server/realmadmin/_stats_keyserver.html
@@ -12,7 +12,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    TEK publish metrics
+    Total TEKs Published
   </div>
   <div id="keyserver_chart_div" class="h-100 w-100" style="min-height:325px;">
     <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
@@ -93,7 +93,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">TEK publish metrics</h5>
+        <h5 class="modal-title">Total TEKs Published</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -107,18 +107,6 @@
         <strong>Total # TEKs published</strong>
         <p>
           This line tracks the total number of TEKs published to the key-server.
-        </p>
-
-        <strong>Requests with revisions</strong>
-        <p>
-          This line tracks the total number of publish requests that contained
-          at least one TEK revision
-        </p>
-
-        <strong>Request missing onset</strong>
-        <p>
-          This line tracks the total number of publish requests where no onset date
-          was provided. These request are not included in the onset to upload distribution.
         </p>
       </div>
     </div>
@@ -253,14 +241,10 @@
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
     dataTable.addColumn('number', 'Total # TEKs published');
-    dataTable.addColumn('number', 'Revision requests');
-    dataTable.addColumn('number', 'Requests missing onset');
 
     stats.reverse().forEach(function(row) {
       dataTable.addRow([utcDate(row.day),
-        row.total_teks_published,
-        row.requests_with_revisions,
-        row.requests_missing_onset_date,
+        row.total_teks_published
       ]);
     });
 
@@ -270,7 +254,7 @@
     dateFormatter.format(dataTable, 0);
 
     let options = {
-      colors: ['#28a745', '#a76e28', '#a72898'],
+      colors: ['#28a745'],
       chartArea: {
         left: 60,
         right: 40,
@@ -304,12 +288,15 @@
 
     let dataTable = new google.visualization.DataTable();
     dataTable.addColumn('date', 'Date');
+    dataTable.addColumn('number', 'Total');
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
+    dataTable.addColumn('number', 'Missing Onset Date');
     dataTable.addColumn('number', 'Unknown OS');
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'Android');
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'IOS');
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}})
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});   
 
     stats.reverse().forEach(function(row) {
       let total = row.publish_requests.unknown + row.publish_requests.android + row.publish_requests.ios;
@@ -318,6 +305,13 @@
       let iosCount = parseInt(row.publish_requests.ios);
 
       dataTable.addRow([utcDate(row.day),
+        total,        
+         "<ul class='chart-tooltip'>"+
+          "<li><strong>Total:</strong>" + total + "</li>"+
+          "<li><strong>Android:</strong>" + androidCount + "</li>"+
+          "<li><strong>iOS:</strong>" + iosCount + "</li>"+
+          "<li><strong>Unknown:</strong>" + unknownCount + "</li></ul>",
+        row.requests_missing_onset_date,
         row.publish_requests.unknown,
         "<ul class='chart-tooltip'><li><strong>Unknown:</strong></li>"+
           "<li>Count: " + unknownCount + "</li>" +
@@ -329,7 +323,7 @@
         row.publish_requests.ios,
         "<ul class='chart-tooltip'><li><strong>IOS:</strong></li>"+
           "<li>Count: " + iosCount + "</li>" +
-          "<li>Percent: " + (iosCount / total * 100).toPrecision(3)  + "%</li></ul>",
+          "<li>Percent: " + (iosCount / total * 100).toPrecision(3)  + "%</li></ul>",        
       ]);
     });
 
@@ -339,7 +333,7 @@
     dateFormatter.format(dataTable, 0);
 
     let options = {
-      colors: ['#6c757d', '#28a745', '#007bff'],
+      colors: ['#ee8c00', '#ea4335', '#6c757d', '#28a745', '#007bff'],
       chartArea: {
         left: 60,
         right: 40,
@@ -352,12 +346,17 @@
         format: 'M/d',
         gridlines: { color: 'transparent' },
       },
+      seriesType: 'bars',
+      series: {
+        0: {type: 'line'},
+        1: {type: 'line'},
+      },
       legend: { position: 'top' },
       isStacked: true,
       tooltip: {isHtml: true},
     };
 
-    let chart = new google.visualization.ColumnChart($div.get(0));
+    let chart = new google.visualization.ComboChart($div.get(0));
     chart.draw(dataTable, options);
     chartData.push({
       chart: chart,

--- a/assets/server/realmadmin/_stats_keyserver.html
+++ b/assets/server/realmadmin/_stats_keyserver.html
@@ -127,6 +127,10 @@
           This graph shows counts of the number of publish requests broken down by the request operating system.
           Hover over columns to see the percentage for each OS segment.
         </p>
+        <p>The <em>total</em> overlay line shows the number of publish requests (sum of stacked bars)</p>
+        <p>The <em>missing onset date</em> overlay line shows the number of publish requests where
+          there was no symptom onset date or test date provided in the publish request.
+        </p>
       </div>
     </div>
   </div>

--- a/assets/server/realmadmin/stats.html
+++ b/assets/server/realmadmin/stats.html
@@ -45,9 +45,7 @@
         {{template "realmadmin/_stats_external_issuers" .}}
       </div>
     </div>
-
-    {{template "realmadmin/_stats_tokens" .}}
-
+ 
     {{if .hasKeyServerStats}}
     {{template "realmadmin/_stats_keyserver" .}}
     {{end}}

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,4 +1,24 @@
-<!-- TOC depthFrom:1 -->autoauto- [API access](#api-access)auto- [API usage](#api-usage)auto    - [Authenticating](#authenticating)auto    - [Error reporting](#error-reporting)auto- [API Methods](#api-methods)auto    - [`/api/verify`](#apiverify)auto    - [`/api/certificate`](#apicertificate)auto- [Admin APIs](#admin-apis)auto    - [`/api/issue`](#apiissue)auto        - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)auto    - [`/api/batch-issue`](#apibatch-issue)auto        - [Handling batch partial success/failure](#handling-batch-partial-successfailure)auto    - [`/api/checkcodestatus`](#apicheckcodestatus)auto    - [`/api/expirecode`](#apiexpirecode)auto    - [`/api/stats/*`](#apistats)auto- [Chaffing requests](#chaffing-requests)auto- [Response codes overview](#response-codes-overview)autoauto<!-- /TOC -->
+<!-- TOC depthFrom:1 -->
+
+- [API access](#api-access)	
+- [API usage](#api-usage)	
+  - [Authenticating](#authenticating)	
+  - [Error reporting](#error-reporting)	
+- [API Methods](#api-methods)	
+  - [`/api/verify`](#apiverify)	
+  - [`/api/certificate`](#apicertificate)	
+- [Admin APIs](#admin-apis)	
+  - [`/api/issue`](#apiissue)	
+    - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)	
+  - [`/api/batch-issue`](#apibatch-issue)	
+    - [Handling batch partial success/failure](#handling-batch-partial-successfailure)	
+  - [`/api/checkcodestatus`](#apicheckcodestatus)	
+  - [`/api/expirecode`](#apiexpirecode)	
+  - [`/api/stats/*`](#apistats)	
+- [Chaffing requests](#chaffing-requests)	
+- [Response codes overview](#response-codes-overview)	
+
+<!-- /TOC -->
 
 # API access
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -1,24 +1,4 @@
-<!-- TOC depthFrom:1 -->
-
-- [API access](#api-access)
-- [API usage](#api-usage)
-  - [Authenticating](#authenticating)
-  - [Error reporting](#error-reporting)
-- [API Methods](#api-methods)
-  - [`/api/verify`](#apiverify)
-  - [`/api/certificate`](#apicertificate)
-- [Admin APIs](#admin-apis)
-  - [`/api/issue`](#apiissue)
-    - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)
-  - [`/api/batch-issue`](#apibatch-issue)
-    - [Handling batch partial success/failure](#handling-batch-partial-successfailure)
-  - [`/api/checkcodestatus`](#apicheckcodestatus)
-  - [`/api/expirecode`](#apiexpirecode)
-  - [`/api/stats/*`](#apistats)
-- [Chaffing requests](#chaffing-requests)
-- [Response codes overview](#response-codes-overview)
-
-<!-- /TOC -->
+<!-- TOC depthFrom:1 -->autoauto- [API access](#api-access)auto- [API usage](#api-usage)auto    - [Authenticating](#authenticating)auto    - [Error reporting](#error-reporting)auto- [API Methods](#api-methods)auto    - [`/api/verify`](#apiverify)auto    - [`/api/certificate`](#apicertificate)auto- [Admin APIs](#admin-apis)auto    - [`/api/issue`](#apiissue)auto        - [Client provided UUID to prevent duplicate SMS](#client-provided-uuid-to-prevent-duplicate-sms)auto    - [`/api/batch-issue`](#apibatch-issue)auto        - [Handling batch partial success/failure](#handling-batch-partial-successfailure)auto    - [`/api/checkcodestatus`](#apicheckcodestatus)auto    - [`/api/expirecode`](#apiexpirecode)auto    - [`/api/stats/*`](#apistats)auto- [Chaffing requests](#chaffing-requests)auto- [Response codes overview](#response-codes-overview)autoauto<!-- /TOC -->
 
 # API access
 
@@ -501,6 +481,9 @@ endpoints without notice.
 -  `/api/stats/realm/key-server.{csv,json}` - Daily statistics gathered from the
    key-server if enabled for the realm. This includes publish requests, EN days
    active before upload, and onset-to-upload distribution.
+  
+-   `/api/stats/realm/composite.{csv,json}` - Daily statistics for the realm
+   including all realm and key server information.
 
 -   `/api/stats/realm/users.{csv,json}` - Daily statistics for codes issued by
     realm user. These statistics only include codes issued by humans logged into

--- a/go.mod
+++ b/go.mod
@@ -63,4 +63,5 @@ require (
 	gopkg.in/gormigrate.v1 v1.6.0
 	gopkg.in/yaml.v3 v3.0.0-20200615113413-eeeca48fe776 // indirect
 	honnef.co/go/tools v0.1.1 // indirect
+	mvdan.cc/gofumpt v0.1.0 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -831,6 +831,7 @@ github.com/remyoudompheng/bigfft v0.0.0-20190728182440-6a916e37a237/go.mod h1:qq
 github.com/rogpeppe/fastuuid v0.0.0-20150106093220-6724a57986af/go.mod h1:XWv6SoW27p1b0cqNHllgS5HIMJraePCO15w5zCzIWYg=
 github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6LYCDYWNEvQ=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
+github.com/rogpeppe/go-internal v1.6.2/go.mod h1:xXDCJY+GAPziupqXw64V24skbSoqbTEfhy4qGm1nDQc=
 github.com/rs/xid v1.2.1/go.mod h1:+uKXf+4Djp6Md1KODXJxgGQPKngRmWyn10oCKFzNHOQ=
 github.com/rs/zerolog v1.13.0/go.mod h1:YbFCdg8HfsridGWAh22vktObvhZbQsZXe4/zB0OKkWU=
 github.com/rs/zerolog v1.15.0/go.mod h1:xYTKnLHcpfU2225ny5qZjxnj9NvkumZYjJHlAThCjNc=
@@ -1251,6 +1252,7 @@ golang.org/x/tools v0.0.0-20201201161351-ac6f37ff4c2a/go.mod h1:emZCQorbCU4vsT4f
 golang.org/x/tools v0.0.0-20201202200335-bef1c476418a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201208233053-a543418bbed2/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20201226215659-b1c90890d22a/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
+golang.org/x/tools v0.0.0-20210101214203-2dba1e4ea05c/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210105154028-b0ab187a4818/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.0.0-20210108195828-e2f9c7f1fc8e/go.mod h1:emZCQorbCU4vsT4fOWvOPXz4eW1wZW4PmDk9uLelYpA=
 golang.org/x/tools v0.1.0 h1:po9/4sTYwZU9lPhi1tOrb4hCv3qrhiQ77LZfGa2OjwY=
@@ -1449,6 +1451,7 @@ modernc.org/ql v1.0.0/go.mod h1:xGVyrLIatPcO2C1JvI/Co8c0sr6y91HKFNy4pt9JXEY=
 modernc.org/sortutil v1.1.0/go.mod h1:ZyL98OQHJgH9IEfN71VsamvJgrtRX9Dj2gX+vH86L1k=
 modernc.org/strutil v1.1.0/go.mod h1:lstksw84oURvj9y3tn8lGvRxyRC1S2+g5uuIzNfIOBs=
 modernc.org/zappy v1.0.0/go.mod h1:hHe+oGahLVII/aTTyWK/b53VDHMAGCBYYeZ9sn83HC4=
+mvdan.cc/gofumpt v0.1.0/go.mod h1:yXG1r1WqZVKWbVRtBWKWX9+CxGYfA51nSomhM0woR48=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -438,6 +438,9 @@ func statsRoutes(r *mux.Router, c *stats.Controller) {
 
 	r.Handle("/realm/key-server.csv", c.HandleKeyServerStats(stats.TypeCSV)).Methods(http.MethodGet)
 	r.Handle("/realm/key-server.json", c.HandleKeyServerStats(stats.TypeJSON)).Methods(http.MethodGet)
+
+	r.Handle("/composite.csv", c.HandleComposite(stats.TypeCSV)).Methods(http.MethodGet)
+	r.Handle("/composite.json", c.HandleComposite(stats.TypeJSON)).Methods(http.MethodGet)
 }
 
 // realmadminRoutes are the realm admin routes.

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -298,7 +298,7 @@ func Server(
 		sub.Use(requireMFA)
 		sub.Use(rateLimit)
 
-		realmadminController := realmadmin.New(cfg, db, limiterStore, h)
+		realmadminController := realmadmin.New(cfg, db, limiterStore, h, cacher)
 		realmadminRoutes(sub, realmadminController)
 
 		publicKeyCache, err := keyutils.NewPublicKeyCache(ctx, cacher, cfg.CertificateSigning.PublicKeyCacheDuration)

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -439,8 +439,8 @@ func statsRoutes(r *mux.Router, c *stats.Controller) {
 	r.Handle("/realm/key-server.csv", c.HandleKeyServerStats(stats.TypeCSV)).Methods(http.MethodGet)
 	r.Handle("/realm/key-server.json", c.HandleKeyServerStats(stats.TypeJSON)).Methods(http.MethodGet)
 
-	r.Handle("/composite.csv", c.HandleComposite(stats.TypeCSV)).Methods(http.MethodGet)
-	r.Handle("/composite.json", c.HandleComposite(stats.TypeJSON)).Methods(http.MethodGet)
+	r.Handle("/realm/composite.csv", c.HandleComposite(stats.TypeCSV)).Methods(http.MethodGet)
+	r.Handle("/realm/composite.json", c.HandleComposite(stats.TypeJSON)).Methods(http.MethodGet)
 }
 
 // realmadminRoutes are the realm admin routes.

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -39,7 +39,7 @@ func TestHandleEvents(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := middleware.InjectCurrentPath()(c.HandleEvents())
 
 	t.Run("middleware", func(t *testing.T) {
@@ -58,7 +58,7 @@ func TestHandleEvents(t *testing.T) {
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
-		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer)
+		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer, harness.Cacher)
 		handler := middleware.InjectCurrentPath()(c.HandleEvents())
 
 		ctx := ctx

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -34,7 +34,7 @@ func TestHandleDisableExpress(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := c.HandleDisableExpress()
 
 	t.Run("middleware", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestHandleDisableExpress(t *testing.T) {
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
-		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer)
+		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer, harness.Cacher)
 		handler := c.HandleDisableExpress()
 
 		ctx := ctx

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -34,7 +34,7 @@ func TestHandleEnableExpress(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := c.HandleEnableExpress()
 
 	t.Run("middleware", func(t *testing.T) {
@@ -48,7 +48,7 @@ func TestHandleEnableExpress(t *testing.T) {
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
-		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer)
+		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer, harness.Cacher)
 		handler := c.HandleEnableExpress()
 
 		ctx := ctx

--- a/pkg/controller/realmadmin/realmadmin.go
+++ b/pkg/controller/realmadmin/realmadmin.go
@@ -16,6 +16,7 @@
 package realmadmin
 
 import (
+	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -27,13 +28,15 @@ type Controller struct {
 	db      *database.Database
 	h       *render.Renderer
 	limiter limiter.Store
+	cacher  cache.Cacher
 }
 
-func New(config *config.ServerConfig, db *database.Database, limiter limiter.Store, h *render.Renderer) *Controller {
+func New(config *config.ServerConfig, db *database.Database, limiter limiter.Store, h *render.Renderer, cacher cache.Cacher) *Controller {
 	return &Controller{
 		config:  config,
 		db:      db,
 		h:       h,
 		limiter: limiter,
+		cacher:  cacher,
 	}
 }

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -46,7 +46,7 @@ func TestHandleSettings(t *testing.T) {
 	}
 	realm.AbusePreventionEnabled = true
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := middleware.InjectCurrentPath()(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {
@@ -471,7 +471,7 @@ func TestHandleSettings(t *testing.T) {
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
-		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer)
+		c := realmadmin.New(harness.Config, harness.BadDatabase, harness.RateLimiter, harness.Renderer, harness.Cacher)
 		handler := c.HandleSettings()
 
 		ctx := ctx

--- a/pkg/controller/realmadmin/sms_test.go
+++ b/pkg/controller/realmadmin/sms_test.go
@@ -40,7 +40,7 @@ func TestHandleSettings_SMS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := middleware.InjectCurrentPath()(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {

--- a/pkg/controller/realmadmin/smtp_test.go
+++ b/pkg/controller/realmadmin/smtp_test.go
@@ -40,7 +40,7 @@ func TestHandleSettings_Email(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := middleware.InjectCurrentPath()(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {

--- a/pkg/controller/realmadmin/stats.go
+++ b/pkg/controller/realmadmin/stats.go
@@ -42,7 +42,7 @@ func (c *Controller) HandleStats() http.Handler {
 			return
 		}
 
-		s, err := c.db.GetKeyServerStats(membership.RealmID)
+		s, err := c.db.GetKeyServerStatsCached(ctx, membership.RealmID, c.cacher)
 		if err != nil && !database.IsNotFound(err) {
 			controller.InternalError(w, r, c.h, err)
 			return

--- a/pkg/controller/realmadmin/stats_test.go
+++ b/pkg/controller/realmadmin/stats_test.go
@@ -33,7 +33,7 @@ func TestHandleStats(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer)
+	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
 	handler := c.HandleStats()
 
 	t.Run("middleware", func(t *testing.T) {

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -144,7 +144,7 @@ func (c CompositeStats) MarshalJSON() ([]byte, error) {
 	return b, nil
 }
 
-func (s *CompositeStats) UnmarshalJSON(b []byte) error {
+func (c *CompositeStats) UnmarshalJSON(b []byte) error {
 	if len(b) == 0 {
 		return nil
 	}

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -241,7 +241,12 @@ func (c *Controller) HandleComposite(typ Type) http.Handler {
 			statsMap[rs.Date] = day
 		}
 
-		if c.db.HasKeyServerStats(currentRealm.ID) {
+		keyServerStats, err := c.db.GetKeyServerStatsCached(ctx, currentRealm.ID, c.cacher)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+		if keyServerStats != nil {
 			days, err := c.db.ListKeyServerStatsDaysCached(ctx, currentRealm.ID, c.cacher)
 			if err != nil {
 				controller.InternalError(w, r, c.h, err)

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -62,7 +62,7 @@ type jsonCompositeStatStats struct {
 }
 
 type jsonCompositeStatStatsData struct {
-	database.JsonRealmStatStatsData
+	database.JSONRealmStatStatsData
 	keyserver.StatsDay
 
 	// the only field that isn't from an embedded struct.

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -61,33 +61,11 @@ type jsonCompositeStatStats struct {
 }
 
 type jsonCompositeStatStatsData struct {
-	// Fields that come from the realm stats
-	CodesIssued           uint    `json:"codes_issued"`
-	CodesClaimed          uint    `json:"codes_claimed"`
-	CodesInvalid          uint    `json:"codes_invalid"`
-	TokensClaimed         uint    `json:"tokens_claimed"`
-	TokensInvalid         uint    `json:"tokens_invalid"`
-	CodeClaimMeanAge      uint    `json:"code_claim_mean_age_seconds"`
-	CodeClaimDistribution []int32 `json:"code_claim_age_distribution"`
+	database.JsonRealmStatStatsData
+	keyserver.StatsDay
 
-	// Fields that come from the key server stats
-	TotalPublishRequests int64                     `json:"total_publish_requests"`
-	PublishRequests      keyserver.PublishRequests `json:"publish_requests"`
-	TotalTEKsPublished   int64                     `json:"total_teks_published"`
-	// RevisionRequests is the number of publish requests that contained at least one TEK revision.
-	RevisionRequests int64 `json:"requests_with_revisions"`
-	// TEKAgeDistribution shows a distribution of the oldest tek in an upload.
-	// The count at index 0-15 represent the number of uploads there the oldest TEK is that value.
-	// Index 16 represents > 15 days.
-	TEKAgeDistribution []int64 `json:"tek_age_distribution"`
-	// OnsetToUploadDistribution shows a distribution of onset to upload, the index is in days.
-	// The count at index 0-29 represents the number of uploads with that symptom onset age.
-	// Index 30 represents > 29 days.
-	OnsetToUploadDistribution []int64 `json:"onset_to_upload_distribution"`
-
-	// RequestsMissingOnsetDate is the number of publish requests where no onset date
-	// was provided. These request are not included in the onset to upload distribution.
-	RequestsMissingOnsetDate int64 `json:"requests_missing_onset_date"`
+	// the only field that isn't from an embedded struct.
+	TotalPublishRequests int64 `json:"total_publish_requests"`
 }
 
 // MarshalJSON is a custom JSON marshaller.

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -1,0 +1,300 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package stats
+
+import (
+	"bytes"
+	"encoding/csv"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/icsv"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+
+	keyserver "github.com/google/exposure-notifications-server/pkg/api/v1"
+)
+
+// Type assertions for CompositeStats
+var _ icsv.Marshaler = (CompositeStats)(nil)
+var _ json.Marshaler = (CompositeStats)(nil)
+
+// CompositeStats is an internal type for collecting unifed realm and key server stats.
+type CompositeStats []*CompositeDay
+
+// CompositeData represents a single day of composite stats.
+type CompositeDay struct {
+	Day            time.Time
+	RealmStats     *database.RealmStat
+	KeyServerStats *keyserver.StatsDay
+}
+
+type jsonCompositeStat struct {
+	RealmID uint                      `json:"realm_id"`
+	Stats   []*jsonCompositeStatStats `json:"statistics"`
+}
+
+type jsonCompositeStatStats struct {
+	Date time.Time                   `json:"date"`
+	Data *jsonCompositeStatStatsData `json:"data"`
+}
+
+type jsonCompositeStatStatsData struct {
+	// Fields that come from the realm stats
+	CodesIssued           uint    `json:"codes_issued"`
+	CodesClaimed          uint    `json:"codes_claimed"`
+	CodesInvalid          uint    `json:"codes_invalid"`
+	TokensClaimed         uint    `json:"tokens_claimed"`
+	TokensInvalid         uint    `json:"tokens_invalid"`
+	CodeClaimMeanAge      uint    `json:"code_claim_mean_age_seconds"`
+	CodeClaimDistribution []int32 `json:"code_claim_age_distribution"`
+
+	// Fields that come from the key server stats
+	TotalPublishRequests int64                     `json:"total_publish_requests"`
+	PublishRequests      keyserver.PublishRequests `json:"publish_requests"`
+	TotalTEKsPublished   int64                     `json:"total_teks_published"`
+	// RevisionRequests is the number of publish requests that contained at least one TEK revision.
+	RevisionRequests int64 `json:"requests_with_revisions"`
+	// TEKAgeDistribution shows a distribution of the oldest tek in an upload.
+	// The count at index 0-15 represent the number of uploads there the oldest TEK is that value.
+	// Index 16 represents > 15 days.
+	TEKAgeDistribution []int64 `json:"tek_age_distribution"`
+	// OnsetToUploadDistribution shows a distribution of onset to upload, the index is in days.
+	// The count at index 0-29 represents the number of uploads with that symptom onset age.
+	// Index 30 represents > 29 days.
+	OnsetToUploadDistribution []int64 `json:"onset_to_upload_distribution"`
+
+	// RequestsMissingOnsetDate is the number of publish requests where no onset date
+	// was provided. These request are not included in the onset to upload distribution.
+	RequestsMissingOnsetDate int64 `json:"requests_missing_onset_date"`
+}
+
+// MarshalJSON is a custom JSON marshaller.
+func (c CompositeStats) MarshalJSON() ([]byte, error) {
+	// Do nothing if there's no records
+	if len(c) == 0 {
+		return json.Marshal(struct{}{})
+	}
+	var realmID uint
+
+	stats := make([]*jsonCompositeStatStats, 0, len(c))
+	for _, stat := range c {
+		data := &jsonCompositeStatStatsData{}
+		if stat.RealmStats != nil {
+			if realmID == 0 {
+				realmID = stat.RealmStats.RealmID
+			}
+
+			data.CodesIssued = stat.RealmStats.CodesIssued
+			data.CodesClaimed = stat.RealmStats.CodesClaimed
+			data.CodesInvalid = stat.RealmStats.CodesInvalid
+			data.TokensClaimed = stat.RealmStats.TokensClaimed
+			data.TokensInvalid = stat.RealmStats.TokensInvalid
+			data.CodeClaimMeanAge = uint(stat.RealmStats.CodeClaimMeanAge.Duration.Seconds())
+			data.CodeClaimDistribution = stat.RealmStats.CodeClaimAgeDistribution
+		}
+		if stat.KeyServerStats != nil {
+			data.TotalPublishRequests = stat.KeyServerStats.PublishRequests.Total()
+			data.PublishRequests = stat.KeyServerStats.PublishRequests
+			data.TotalTEKsPublished = stat.KeyServerStats.TotalTEKsPublished
+			data.RevisionRequests = stat.KeyServerStats.RevisionRequests
+			data.TEKAgeDistribution = stat.KeyServerStats.TEKAgeDistribution
+			data.OnsetToUploadDistribution = stat.KeyServerStats.OnsetToUploadDistribution
+			data.RequestsMissingOnsetDate = stat.KeyServerStats.RequestsMissingOnsetDate
+		}
+
+		stats = append(stats, &jsonCompositeStatStats{
+			Date: stat.Day,
+			Data: data,
+		})
+	}
+
+	// Sort in descending order.
+	sort.Slice(stats, func(i, j int) bool {
+		return stats[i].Date.After(stats[j].Date)
+	})
+
+	var result jsonCompositeStat
+	result.RealmID = realmID
+	result.Stats = stats
+
+	b, err := json.Marshal(result)
+	if err != nil {
+		return nil, fmt.Errorf("failed to marshal json: %w", err)
+	}
+	return b, nil
+}
+
+func (s *CompositeStats) UnmarshalJSON(b []byte) error {
+	if len(b) == 0 {
+		return nil
+	}
+	// This is unused, but required for the interface.
+	return nil
+}
+
+// TODO(mikehelmick) - Make this join part of the public API in key sever, then remove this
+func join(arr []int64, sep string) string {
+	var sb strings.Builder
+	for i, d := range arr {
+		sb.WriteString(strconv.FormatInt(d, 10))
+		if i != len(arr)-1 {
+			sb.WriteString(sep)
+		}
+	}
+	return sb.String()
+}
+
+// MarshalCSV returns bytes in CSV format.
+func (c CompositeStats) MarshalCSV() ([]byte, error) {
+	// Do nothing if there's no records
+	if len(c) == 0 {
+		return nil, nil
+	}
+
+	var b bytes.Buffer
+	w := csv.NewWriter(&b)
+
+	if err := w.Write([]string{
+		"date",
+		"codes_issued", "codes_claimed", "codes_invalid",
+		"tokens_claimed", "tokens_invalid", "code_claim_mean_age_seconds", "code_claim_age_distribution",
+		"publish_requests_unknown", "publish_requests_android", "publish_requests_ios",
+		"total_teks_published", "requests_with_revisions", "requests_missing_onset_date", "tek_age_distribution", "onset_to_upload_distribution",
+	}); err != nil {
+		return nil, fmt.Errorf("failed to write CSV header: %w", err)
+	}
+
+	// Due to the nature of the composite stats, one or the other of the branches could be nil
+	for i, stat := range c {
+		row := make([]string, 0, 16)
+		row = append(row, stat.Day.Format(project.RFC3339Date))
+		if stat.RealmStats == nil {
+			// no realm stats, 7 empty columns
+			row = append(row, "", "", "", "", "", "", "")
+		} else {
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesIssued), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesClaimed), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalid), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.TokensClaimed), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.TokensInvalid), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodeClaimMeanAge.Duration.Seconds()), 10))
+			row = append(row, strings.Join(stat.RealmStats.CodeClaimAgeDistributionAsStrings(), "|"))
+		}
+		if stat.KeyServerStats == nil {
+			// no key sever stats, 8 empty columns
+			row = append(row, "", "", "", "", "", "", "", "")
+		} else {
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.PublishRequests.UnknownPlatform), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.PublishRequests.Android), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.PublishRequests.IOS), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.TotalTEKsPublished), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.RevisionRequests), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.KeyServerStats.RequestsMissingOnsetDate), 10))
+			row = append(row, join(stat.KeyServerStats.TEKAgeDistribution, "|"))
+			row = append(row, join(stat.KeyServerStats.OnsetToUploadDistribution, "|"))
+		}
+
+		if err := w.Write(row); err != nil {
+			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
+		}
+	}
+
+	w.Flush()
+	if err := w.Error(); err != nil {
+		return nil, fmt.Errorf("failed to create CSV: %w", err)
+	}
+
+	return b.Bytes(), nil
+}
+
+// HandleComposite returns composite states for realm + key server
+// The key server stats may be omitted if that is not enabled
+// on the realm.
+func (c *Controller) HandleComposite(typ Type) http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		currentRealm, ok := authorizeFromContext(ctx, rbac.StatsRead)
+		if !ok {
+			controller.Unauthorized(w, r, c.h)
+			return
+		}
+
+		realmStats, err := currentRealm.StatsCached(ctx, c.db, c.cacher)
+		if err != nil {
+			controller.InternalError(w, r, c.h, err)
+			return
+		}
+
+		var stats CompositeStats = make([]*CompositeDay, 0, len(realmStats))
+		statsMap := make(map[time.Time]*CompositeDay, len(realmStats))
+		for _, rs := range realmStats {
+			day := &CompositeDay{
+				Day:        rs.Date,
+				RealmStats: rs,
+			}
+			stats = append(stats, day)
+			statsMap[rs.Date] = day
+		}
+
+		if c.db.HasKeyServerStats(currentRealm.ID) {
+			days, err := c.db.ListKeyServerStatsDaysCached(ctx, currentRealm.ID, c.cacher)
+			if err != nil {
+				controller.InternalError(w, r, c.h, err)
+				return
+			}
+
+			needsSort := false
+			for _, ksDay := range days {
+				compDay, ok := statsMap[ksDay.Day]
+				if !ok {
+					// if key server has stats from a day the realm doesn't, add it in.
+					compDay := &CompositeDay{
+						Day: ksDay.Day,
+					}
+					stats = append(stats, compDay)
+					needsSort = true
+				}
+				compDay.KeyServerStats = ksDay.ToResponse()
+			}
+
+			if needsSort {
+				sort.Slice(stats, func(i, j int) bool {
+					return stats[i].Day.Before(stats[j].Day)
+				})
+			}
+		}
+
+		switch typ {
+		case TypeCSV:
+			c.h.RenderCSV(w, http.StatusOK, csvFilename("composite-stats"), stats)
+			return
+		case TypeJSON:
+			c.h.RenderJSON(w, http.StatusOK, stats)
+			return
+		default:
+			controller.NotFound(w, r, c.h)
+			return
+		}
+	})
+}

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -35,8 +35,10 @@ import (
 )
 
 // Type assertions for CompositeStats
-var _ icsv.Marshaler = (CompositeStats)(nil)
-var _ json.Marshaler = (CompositeStats)(nil)
+var (
+	_ icsv.Marshaler = (CompositeStats)(nil)
+	_ json.Marshaler = (CompositeStats)(nil)
+)
 
 // CompositeStats is an internal type for collecting unifed realm and key server stats.
 type CompositeStats []*CompositeDay

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -247,6 +247,9 @@ func (db *Database) OpenWithCacher(ctx context.Context, cacher cache.Cacher) err
 		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
 		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
 
+		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:stats:key_server", callbackPurgeCache(ctx, cacher, "stats:realm:key_server_enabled", "key_server_stats", "realm_id"))
+		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:stats:key_server", callbackPurgeCache(ctx, cacher, "stats:realm:key_server_enabled", "key_server_stats", "realm_id"))
+
 		// Users
 		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id", "users", "id"))
 		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:users:by_id", callbackPurgeCache(ctx, cacher, "users:by_id", "users", "id"))
@@ -366,6 +369,10 @@ func callbackPurgeCache(ctx context.Context, cacher cache.Cacher, namespace, tab
 
 		if scope.HasError() {
 			return
+		}
+
+		for _, f := range scope.Fields() {
+			log.Printf("field: %v value: %v", f.DBName, f.Field.Interface())
 		}
 
 		keys := make([]string, 0, len(columns))

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -371,10 +371,6 @@ func callbackPurgeCache(ctx context.Context, cacher cache.Cacher, namespace, tab
 			return
 		}
 
-		for _, f := range scope.Fields() {
-			log.Printf("field: %v value: %v", f.DBName, f.Field.Interface())
-		}
-
 		keys := make([]string, 0, len(columns))
 		for _, column := range columns {
 			field, ok := scope.FieldByName(column)

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -92,6 +92,8 @@ func (kssd *KeyServerStatsDay) BeforeSave(tx *gorm.DB) error {
 	return kssd.ErrorOrNil()
 }
 
+// TotalPublishRequests returns the sum of all publish requests for this
+// day, which are stored by operating system.
 func (kssd *KeyServerStatsDay) TotalPublishRequests() int64 {
 	var sum int64
 	for _, v := range kssd.PublishRequests {
@@ -100,6 +102,8 @@ func (kssd *KeyServerStatsDay) TotalPublishRequests() int64 {
 	return sum
 }
 
+// HasKeyServerStats returns true if the provided realm has key
+// server stats enabled.
 func (db *Database) HasKeyServerStats(realmID uint) bool {
 	s, err := db.GetKeyServerStats(realmID)
 	return err == nil && s != nil
@@ -134,7 +138,7 @@ func (db *Database) DeleteKeyServerStats(realmID uint) error {
 func (db *Database) ListKeyServerStats() ([]*KeyServerStats, error) {
 	var stats []*KeyServerStats
 	if err := db.db.
-		Model(&KeyServerStatsDay{}).
+		Model(&KeyServerStats{}).
 		Find(&stats).
 		Error; err != nil {
 		return nil, err

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -144,12 +144,12 @@ func (db *Database) SaveKeyServerStats(stats *KeyServerStats) error {
 
 // DeleteKeyServerStats disables gathering key-server statistics and removes the entry
 func (db *Database) DeleteKeyServerStats(realmID uint) error {
-	kss := KeyServerStats{
+	kss := &KeyServerStats{
 		RealmID: realmID,
 	}
 	return db.db.Unscoped().
 		Set("gorm:delete_option", "RETURNING *").
-		Delete(&kss).
+		Delete(kss).
 		Error
 }
 

--- a/pkg/database/key_server_stats.go
+++ b/pkg/database/key_server_stats.go
@@ -92,6 +92,19 @@ func (kssd *KeyServerStatsDay) BeforeSave(tx *gorm.DB) error {
 	return kssd.ErrorOrNil()
 }
 
+func (kssd *KeyServerStatsDay) TotalPublishRequests() int64 {
+	var sum int64
+	for _, v := range kssd.PublishRequests {
+		sum += v
+	}
+	return sum
+}
+
+func (db *Database) HasKeyServerStats(realmID uint) bool {
+	s, err := db.GetKeyServerStats(realmID)
+	return err == nil && s != nil
+}
+
 // GetKeyServerStats retrieves the configuration for gathering key-server statistics
 func (db *Database) GetKeyServerStats(realmID uint) (*KeyServerStats, error) {
 	var stats KeyServerStats

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -132,10 +132,10 @@ type jsonRealmStat struct {
 
 type jsonRealmStatStats struct {
 	Date time.Time               `json:"date"`
-	Data *jsonRealmStatStatsData `json:"data"`
+	Data *JsonRealmStatStatsData `json:"data"`
 }
 
-type jsonRealmStatStatsData struct {
+type JsonRealmStatStatsData struct {
 	CodesIssued           uint    `json:"codes_issued"`
 	CodesClaimed          uint    `json:"codes_claimed"`
 	CodesInvalid          uint    `json:"codes_invalid"`
@@ -156,7 +156,7 @@ func (s RealmStats) MarshalJSON() ([]byte, error) {
 	for _, stat := range s {
 		stats = append(stats, &jsonRealmStatStats{
 			Date: stat.Date,
-			Data: &jsonRealmStatStatsData{
+			Data: &JsonRealmStatStatsData{
 				CodesIssued:           stat.CodesIssued,
 				CodesClaimed:          stat.CodesClaimed,
 				CodesInvalid:          stat.CodesInvalid,

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -134,10 +134,10 @@ type jsonRealmStat struct {
 
 type jsonRealmStatStats struct {
 	Date time.Time               `json:"date"`
-	Data *JsonRealmStatStatsData `json:"data"`
+	Data *JSONRealmStatStatsData `json:"data"`
 }
 
-type JsonRealmStatStatsData struct {
+type JSONRealmStatStatsData struct {
 	CodesIssued           uint    `json:"codes_issued"`
 	CodesClaimed          uint    `json:"codes_claimed"`
 	CodesInvalid          uint    `json:"codes_invalid"`
@@ -158,7 +158,7 @@ func (s RealmStats) MarshalJSON() ([]byte, error) {
 	for _, stat := range s {
 		stats = append(stats, &jsonRealmStatStats{
 			Date: stat.Date,
-			Data: &JsonRealmStatStatsData{
+			Data: &JSONRealmStatStatsData{
 				CodesIssued:           stat.CodesIssued,
 				CodesClaimed:          stat.CodesClaimed,
 				CodesInvalid:          stat.CodesInvalid,

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -65,6 +65,8 @@ type RealmStat struct {
 	CodeClaimMeanAge DurationSeconds `gorm:"column:code_claim_mean_age; type:bigint; not null; default: 0;"`
 }
 
+// CodeClaimAgeDistributionAsStrings returns CodeClaimAgeDistribution as
+// []string instead of []int32. Useful for serialization.
 func (s *RealmStat) CodeClaimAgeDistributionAsStrings() []string {
 	str := make([]string, len(s.CodeClaimAgeDistribution))
 	for i, v := range s.CodeClaimAgeDistribution {

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -65,6 +65,14 @@ type RealmStat struct {
 	CodeClaimMeanAge DurationSeconds `gorm:"column:code_claim_mean_age; type:bigint; not null; default: 0;"`
 }
 
+func (s *RealmStat) CodeClaimAgeDistributionAsStrings() []string {
+	str := make([]string, len(s.CodeClaimAgeDistribution))
+	for i, v := range s.CodeClaimAgeDistribution {
+		str[i] = strconv.Itoa(int(v))
+	}
+	return str
+}
+
 // MarshalCSV returns bytes in CSV format.
 func (s RealmStats) MarshalCSV() ([]byte, error) {
 	// Do nothing if there's no records


### PR DESCRIPTION

## Proposed Changes

Update stats visualizations based on user input

* remove tokens claimed/tokens invalid - that chart has been confusing
* add tokens claimed and publish requests to make code chart (top of page) -- IF key server metrics are enabled
* separate out revisions and missing onset from TEKs published (different units)
    * don't show revisions at all (to our knowledge, nobody is using that functionality)
* add total publish requests and missing onset as overlays on the publish bar chart

![image](https://user-images.githubusercontent.com/92319/109431248-6298ef80-79ba-11eb-9105-17675fbd7598.png)

![image](https://user-images.githubusercontent.com/92319/109431404-434e9200-79bb-11eb-97c1-81dddc738404.png)


**Release Note**

```release-note
* The tokens claimed/invalid chart has been removed (data is still in exports)
* Add total publish requests to the codes/issued claim chart (if key server stats are enabled)
* Separate out revisions and missing onset from TEKs published
* Add total publish requests and missing onset as overlays on the publish bar chart
```
