### PR TITLE
Allow customizing log retention period

### DIFF
--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -53,6 +53,7 @@ resource "google_project_service" "services" {
     "firebase.googleapis.com",
     "iam.googleapis.com",
     "identitytoolkit.googleapis.com",
+    "logging.googleapis.com",
     "monitoring.googleapis.com",
     "redis.googleapis.com",
     "run.googleapis.com",
@@ -107,6 +108,18 @@ resource "google_vpc_access_connector" "connector" {
     google_service_networking_connection.private_vpc_connection,
     google_project_service.services["compute.googleapis.com"],
     google_project_service.services["vpcaccess.googleapis.com"],
+  ]
+}
+
+resource "google_logging_project_bucket_config" "basic" {
+  project        = var.project
+  location       = "global"
+  retention_days = var.log_retention_period
+  bucket_id      = "_Default"
+
+  depends_on = [
+    google_project_service.services["logging.googleapis.com"],
+    google_project_service.services["stackdriver.googleapis.com"],
   ]
 }
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -251,6 +251,12 @@ variable "enable_lb_logging" {
   EOT
 }
 
+variable "log_retention_period" {
+  type        = number
+  default     = 14
+  description = "Number of days to retain logs for all services in the project"
+}
+
 // Note: in Cloud Run/Knative, there are two kinds of annotations.
 // - Service level annotations: applies to all revisions in the service. E.g.
 //   the ingress restriction


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1901

Not marking auto-merge because I want to test manually.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Allow customizing global log retention period for all services in the project. The default value is 14 days. **Note: this differs from the unconfigured value of 30 days!**. To retain the existing behavior, set `log_retention_period` to `30` in the Terraform configuration. However, we strongly recommend using a 14-day retention period instead.
```
