### PR TITLE
Add chaff reporting

### DIFF
--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -104,6 +104,34 @@
           {{end}}
 
           <hr>
+          <h6 class="mb-2">Chaff usage</h6>
+          <p>Dates are in UTC</p>
+          <table class="table table-bordered">
+            <thead>
+              <tr>
+                <th scope="col" width="150"></th>
+                {{range .chaffEvents}}
+                  <th scope="col" class="text-center">{{.Date.Format "01/02"}}</th>
+                {{end}}
+              </tr>
+              <tr>
+                <th scope="row">Used chaff</th>
+                {{range .chaffEvents}}
+                  {{if .Present}}
+                    <td class="text-center">
+                      <span class="oi oi-circle-check text-success"></span>
+                    </td>
+                  {{else}}
+                    <td class="text-center">
+                      <span class="oi oi-circle-x text-danger"></span>
+                    </td>
+                  {{end}}
+                {{end}}
+              </tr>
+            </thead>
+          </table>
+
+          <hr>
           <h6 class="mb-2">Abuse prevention</h6>
           {{if $realm.AbusePreventionEnabled}}
           <div class="text-success">Enabled</div>

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -2,6 +2,7 @@
 
 {{$realms := .realms}}
 {{$memberships := .memberships}}
+{{$realmChaffEvents := .realmChaffEvents}}
 
 <!doctype html>
 <html lang="en">
@@ -45,6 +46,7 @@
             <tr>
               <th scope="col" width="50" class="text-center">ID</th>
               <th scope="col">Name</th>
+              <th scope="col" width="75" class="text-center">Chaff</th>
               <th scope="col" width="100" class="text-center">Region</th>
               <th scope="col" width="120" class="text-center">Signing key</th>
             </tr>
@@ -60,6 +62,15 @@
                 {{if (index $memberships .ID)}}
                   <span class="small oi oi-circle-check text-success ml-1" aria-hidden="true"
                     data-toggle="tooltip" title="You have permissions on this realm"></span>
+                {{end}}
+              </td>
+              <td class="text-center">
+                {{if (index $realmChaffEvents .ID)}}
+                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Chaff requests in the past 7 days"></span>
+                {{else}}
+                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="NO sent a chaff requests in the past 7 days"></span>
                 {{end}}
               </td>
               <td class="text-center">{{.RegionCode}}</td>

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -51,6 +51,10 @@ type CleanupConfig struct {
 	KeyServerStatsMaxAge time.Duration `env:"KEY_SERVER_STATS_MAX_AGE, default=720h"`
 	MobileAppMaxAge      time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
 
+	// RealmChaffEventMaxAge is the maximum amount of time to store whether a
+	// realm had received a chaff request.
+	RealmChaffEventMaxAge time.Duration `env:"REALM_CHAFF_EVENT_MAX_AGE, default=168h"` // 7 days
+
 	// SigningTokenKeyMaxAge is the maximum amount of time that a rotated signing
 	// token key should remain unpurged.
 	SigningTokenKeyMaxAge time.Duration `env:"SIGNING_TOKEN_KEY_MAX_AGE, default=36h"`

--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -167,7 +167,7 @@ func (c *Controller) HandleCleanup() http.Handler {
 			}
 		}()
 
-		// Verification signing key references.
+		// Verification signing key references
 		func() {
 			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "VERIFICATION_SIGNING_KEY")
@@ -189,6 +189,19 @@ func (c *Controller) HandleCleanup() http.Handler {
 				result = enobs.ResultError("FAILED")
 			} else {
 				logger.Infow("purged key-server stats", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// Realm chaff events
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "REALM_CHAFF_EVENT")
+			if count, err := c.db.PurgeRealmChaffEvents(c.config.RealmChaffEventMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge realm chaff events: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged realm chaff events", "count", count)
 				result = enobs.ResultOK
 			}
 		}()

--- a/pkg/controller/middleware/chaff.go
+++ b/pkg/controller/middleware/chaff.go
@@ -15,8 +15,15 @@
 package middleware
 
 import (
+	"context"
+	"fmt"
 	"net/http"
+	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/cache"
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 	"github.com/mikehelmick/go-chaff"
@@ -30,6 +37,15 @@ func ChaffHeaderDetector() chaff.Detector {
 	return chaff.HeaderDetector(ChaffHeader)
 }
 
+// localChaffCache is a local, in-memory cache of realms that have incremented
+// chaff on the given UTC day. Values are stored as "<utc_day>:<realm_id>" and
+// the cache purges after 48 hours. This exists to alleviate pressure on the
+// database.
+//
+// cache.New only returns an error if the duration is negative, so we ignore the
+// error here.
+var localChaffCache, _ = cache.New(48 * time.Hour)
+
 // ProcessChaff injects the chaff processing middleware. If chaff requests send
 // a value of "daily" (case-insensitive), they will be counted toward the
 // realm's total active users and return a chaff response. Any other values will
@@ -38,6 +54,36 @@ func ChaffHeaderDetector() chaff.Detector {
 // This must come after RequireAPIKey.
 func ProcessChaff(db *database.Database, t *chaff.Tracker, det chaff.Detector) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
-		return t.HandleTrack(det, next)
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			if v := r.Header.Get(ChaffHeader); v != "" {
+				go recordChaffEvent(ctx, controller.RealmFromContext(ctx), db)
+			}
+
+			// Process normal chaff tracking
+			t.HandleTrack(det, next).ServeHTTP(w, r)
+		})
+	}
+}
+
+// recordChaff event annotates that the realm received a chaff request on
+// today's UTC date.
+func recordChaffEvent(ctx context.Context, realm *database.Realm, db *database.Database) {
+	if realm == nil || db == nil {
+		return
+	}
+
+	now := timeutils.UTCMidnight(time.Now().UTC())
+
+	key := fmt.Sprintf("%s:%d", now.Format("2006-01-02"), realm.ID)
+	if _, err := localChaffCache.WriteThruLookup(key, func() (interface{}, error) {
+		if err := realm.RecordChaffEvent(db, now); err != nil {
+			return nil, err
+		}
+		return &struct{}{}, nil
+	}); err != nil {
+		logger := logging.FromContext(ctx).Named("chaff.recordChaffEvent")
+		logger.Errorw("failed to record chaff event", "realm", realm.ID, "error", err)
 	}
 }

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2090,6 +2090,25 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS code_claim_mean_age`)
 			},
 		},
+		{
+			ID: "00094-AddRealmChaffEvents",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`CREATE TABLE realm_chaff_events (
+						realm_id INTEGER NOT NULL REFERENCES realms(id),
+						date DATE NOT NULL,
+						PRIMARY KEY (realm_id, date)
+					)`,
+					`CREATE INDEX idx_realm_chaff_events_realm_id ON realm_chaff_events(realm_id)`,
+					`CREATE INDEX idx_realm_chaff_events_date ON realm_chaff_events(date)`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`DROP TABLE IF EXISTS realm_chaff_events`,
+					`DROP INDEX IF EXISTS idx_realm_chaff_events_realm_id`,
+					`DROP INDEX IF EXISTS idx_realm_chaff_events_date`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm_chaff_event.go
+++ b/pkg/database/realm_chaff_event.go
@@ -1,0 +1,70 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
+)
+
+// RealmChaffEvent is a record that indicates a realm received a chaff event on
+// the given date.
+type RealmChaffEvent struct {
+	// RealmID is the realm for which the chaff request existed.
+	RealmID uint
+
+	// Date is the UTC date (truncated to midnight) for which one or more chaff
+	// request existed.
+	Date time.Time
+
+	// Present indicates whether the chaff event was present.
+	Present bool
+}
+
+// HasRealmChaffEventsMap returns a map of realm IDs that have any chaff events.
+func (db *Database) HasRealmChaffEventsMap() (map[uint]bool, error) {
+	var ids []uint
+	if err := db.db.
+		Model(&RealmChaffEvent{}).
+		Select("DISTINCT(realm_id) AS realm_id").
+		Pluck("realm_id", &ids).
+		Error; err != nil {
+		return nil, fmt.Errorf("failed to pluck ids: %w", err)
+	}
+
+	// This has to be a bool because go text/template doesn't work with struct{}.
+	m := make(map[uint]bool, len(ids))
+	for _, id := range ids {
+		m[id] = true
+	}
+	return m, nil
+}
+
+// PurgeRealmChaffEvents will delete realm chaff events that have exceeded the
+// storage lifetime.
+func (db *Database) PurgeRealmChaffEvents(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	deleteBefore := timeutils.UTCMidnight(time.Now().UTC()).Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("date < ?", deleteBefore).
+		Delete(&RealmChaffEvent{})
+	return result.RowsAffected, result.Error
+}

--- a/pkg/database/realm_chaff_events_test.go
+++ b/pkg/database/realm_chaff_events_test.go
@@ -1,0 +1,93 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
+)
+
+func TestDatabase_HasRealmChaffEventsMap(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	realm, err := db.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		m, err := db.HasRealmChaffEventsMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m == nil {
+			t.Errorf("map should not be nil")
+		}
+		if len(m) != 0 {
+			t.Errorf("map should be empty")
+		}
+	}
+
+	if err := realm.RecordChaffEvent(db, time.Now().UTC().Add(-24*time.Hour)); err != nil {
+		t.Fatal(err)
+	}
+
+	{
+		m, err := db.HasRealmChaffEventsMap()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if m == nil {
+			t.Errorf("map should not be nil")
+		}
+		if _, ok := m[realm.ID]; !ok {
+			t.Errorf("map is missing realm: %#v", m)
+		}
+	}
+}
+
+func TestDatabase_PurgeRealmChaffEvents(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	realm, err := db.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	for i := 1; i < 10; i++ {
+		ts := timeutils.UTCMidnight(time.Now().UTC()).Add(-24 * time.Hour * time.Duration(i))
+		if err := realm.RecordChaffEvent(db, ts); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := db.PurgeRealmChaffEvents(0); err != nil {
+		t.Fatal(err)
+	}
+
+	events, err := realm.ListChaffEvents(db)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, event := range events {
+		if event.Present {
+			t.Errorf("should not be present: %#v", event)
+		}
+	}
+}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1899

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add chaff reporting to system admin page. This will show whether a realm has issue _any_ chaff requests in the past 7 days.
```
