### PR TITLE
Retry and parallelize stats puller

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -55,6 +55,7 @@ require (
 	go.opencensus.io v0.22.6
 	go.uber.org/zap v1.16.0
 	golang.org/x/oauth2 v0.0.0-20210216194517-16ff1888fd2e // indirect
+	golang.org/x/sync v0.0.0-20201207232520-09787c993a3a
 	golang.org/x/sys v0.0.0-20210216224549-f992740a1bac // indirect
 	golang.org/x/text v0.3.5
 	golang.org/x/tools v0.1.0

--- a/pkg/config/stats_puller_config.go
+++ b/pkg/config/stats_puller_config.go
@@ -59,6 +59,10 @@ type StatsPullerConfig struct {
 	// StatsPullerMinPeriod defines the period for which the stats puller will hold a lock
 	// which prevents other calls from entering.
 	StatsPullerMinPeriod time.Duration `env:"STATS_PULLER_MIN_PERIOD, default=5m"`
+
+	// MaxWorkers is the maximum number of parallel workers to use when pulling
+	// statistics. The value must be greater than 0.
+	MaxWorkers int64 `env:"STATS_PULLER_MAX_WORKERS, default=5"`
 }
 
 // NewStatsPullerConfig returns the config for the stats-puller service.


### PR DESCRIPTION
This updates the stats-puller to retry the HTTP request 3 times. This will make us more resilient to temporary network blips. It also parallelizes pulling (default 5).

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add client-side retry logic and parallelize stats puller. The default parallelize is 5, but it can be customized with `STATS_PULLER_MAX_WORKERS`. There is also a **behavior change**. The stats-puller previously always returned success (but logged errors on failure). This changes the puller to return a non-200 response code if there are still failures after all retries have executed.
```