### PR TITLE
Next wave of status code changes

### DIFF
--- a/pkg/controller/middleware/apikey_test.go
+++ b/pkg/controller/middleware/apikey_test.go
@@ -76,31 +76,31 @@ func TestRequireAPIKey(t *testing.T) {
 		{
 			name:   "no_key",
 			apiKey: "",
-			code:   401,
+			code:   http.StatusUnauthorized,
 			db:     db,
 		},
 		{
 			name:   "non_existent_key",
 			apiKey: "abcd1234",
-			code:   401,
+			code:   http.StatusUnauthorized,
 			db:     db,
 		},
 		{
 			name:   "bad_database_conn",
 			apiKey: apiKey,
-			code:   500,
+			code:   http.StatusInternalServerError,
 			db:     badDB,
 		},
 		{
 			name:   "wrong_type",
 			apiKey: wrongAPIKey,
-			code:   401,
+			code:   http.StatusUnauthorized,
 			db:     db,
 		},
 		{
 			name:   "valid",
 			apiKey: apiKey,
-			code:   200,
+			code:   http.StatusOK,
 			db:     db,
 			next: func(t *testing.T) http.Handler {
 				return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/controller/middleware/email_verified_test.go
+++ b/pkg/controller/middleware/email_verified_test.go
@@ -44,7 +44,7 @@ func TestRequireEmailVerified(t *testing.T) {
 	requireEmailVerified := middleware.RequireEmailVerified(authProvider, h)
 
 	next := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(200)
+		w.WriteHeader(http.StatusOK)
 	})
 
 	cases := []struct {
@@ -57,7 +57,7 @@ func TestRequireEmailVerified(t *testing.T) {
 		{
 			name:       "missing_membership",
 			membership: nil,
-			code:       400,
+			code:       http.StatusBadRequest,
 		},
 		{
 			name:          "optional_verified",
@@ -67,7 +67,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFAOptional,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:          "optional_not_verified",
@@ -77,7 +77,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFAOptional,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:          "optional_prompt_verified",
@@ -87,7 +87,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:          "optional_prompt_not_verified",
@@ -97,7 +97,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 303,
+			code: http.StatusSeeOther,
 		},
 		{
 			name:          "optional_prompt_not_verified_prompted",
@@ -108,7 +108,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:          "required_verified",
@@ -118,7 +118,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFARequired,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:          "required_not_verified",
@@ -128,7 +128,7 @@ func TestRequireEmailVerified(t *testing.T) {
 					EmailVerifiedMode: database.MFARequired,
 				},
 			},
-			code: 303,
+			code: http.StatusSeeOther,
 		},
 	}
 

--- a/pkg/controller/middleware/firewall_test.go
+++ b/pkg/controller/middleware/firewall_test.go
@@ -48,19 +48,19 @@ func TestProcessFirewall(t *testing.T) {
 		{
 			name: "no_realm",
 			ctx:  ctx,
-			code: 400,
+			code: http.StatusBadRequest,
 		},
 		{
 			name: "realm_in_context",
 			ctx:  controller.WithRealm(ctx, &database.Realm{}),
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name: "membership_in_context",
 			ctx: controller.WithMembership(ctx, &database.Membership{
 				Realm: &database.Realm{},
 			}),
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name: "all_allowed4",
@@ -68,7 +68,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"0.0.0.0/0"},
 			}),
 			remoteAddr: "1.2.3.4",
-			code:       200,
+			code:       http.StatusOK,
 		},
 		{
 			name: "all_allowed6",
@@ -76,7 +76,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"::/0"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
-			code:       200,
+			code:       http.StatusOK,
 		},
 		{
 			name: "single_allowed_ip4",
@@ -84,7 +84,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "1.2.3.4",
-			code:       200,
+			code:       http.StatusOK,
 		},
 		{
 			name: "single_allowed_ip6",
@@ -92,7 +92,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"2001::/0"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
-			code:       200,
+			code:       http.StatusOK,
 		},
 		{
 			name: "single_allowed_xff",
@@ -101,7 +101,7 @@ func TestProcessFirewall(t *testing.T) {
 			}),
 			remoteAddr: "9.8.7.6",
 			xff:        "1.2.3.4, 5.6.7.8",
-			code:       200,
+			code:       http.StatusOK,
 		},
 		{
 			name: "single_reject_ip4",
@@ -109,7 +109,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "9.8.7.6",
-			code:       401,
+			code:       http.StatusUnauthorized,
 		},
 		{
 			name: "single_reject_ip6",
@@ -117,7 +117,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"2000::/64"},
 			}),
 			remoteAddr: "2001:db8::8a2e:370:7334",
-			code:       401,
+			code:       http.StatusUnauthorized,
 		},
 		{
 			name: "single_reject_xff",
@@ -126,7 +126,7 @@ func TestProcessFirewall(t *testing.T) {
 			}),
 			remoteAddr: "1.2.3.4",          // xff is preferred over remote ip
 			xff:        "5.6.7.8, 1.2.3.4", // Only trusts the first value in xff
-			code:       401,
+			code:       http.StatusUnauthorized,
 		},
 	}
 

--- a/pkg/controller/middleware/header_test.go
+++ b/pkg/controller/middleware/header_test.go
@@ -42,12 +42,12 @@ func TestRequireHeader(t *testing.T) {
 	}{
 		{
 			name: "missing",
-			code: 401,
+			code: http.StatusUnauthorized,
 		},
 		{
 			name:    "present",
 			headers: map[string]string{"x-custom-header": "1"},
-			code:    200,
+			code:    http.StatusOK,
 		},
 	}
 
@@ -94,17 +94,17 @@ func TestRequireHeaderValues(t *testing.T) {
 	}{
 		{
 			name: "missing",
-			code: 401,
+			code: http.StatusUnauthorized,
 		},
 		{
 			name:    "present_invalid",
 			headers: map[string]string{"x-custom-header": "42"},
-			code:    401,
+			code:    http.StatusUnauthorized,
 		},
 		{
 			name:    "present_valid",
 			headers: map[string]string{"x-custom-header": "1"},
-			code:    200,
+			code:    http.StatusOK,
 		},
 	}
 

--- a/pkg/controller/middleware/membership_test.go
+++ b/pkg/controller/middleware/membership_test.go
@@ -60,20 +60,20 @@ func TestLoadCurrentMembership(t *testing.T) {
 		{
 			name: "no_user",
 			user: nil,
-			code: 500,
+			code: http.StatusInternalServerError,
 		},
 		{
 			name:  "no_realm",
 			user:  user,
 			realm: nil,
-			code:  200,
+			code:  http.StatusOK,
 		},
 		{
 			name:        "no_memberships",
 			user:        user,
 			realm:       realm,
 			memberships: nil,
-			code:        200,
+			code:        http.StatusOK,
 		},
 		{
 			name:  "memberships_missing",
@@ -82,7 +82,7 @@ func TestLoadCurrentMembership(t *testing.T) {
 			memberships: []*database.Membership{
 				{RealmID: 2, Realm: nil},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:  "memberships_found",
@@ -92,7 +92,7 @@ func TestLoadCurrentMembership(t *testing.T) {
 				{RealmID: realm.ID, Realm: realm},
 			},
 			found: true,
-			code:  200,
+			code:  http.StatusOK,
 		},
 	}
 
@@ -168,7 +168,7 @@ func TestRequireMembership(t *testing.T) {
 		{
 			name:       "missing",
 			membership: nil,
-			code:       400,
+			code:       http.StatusBadRequest,
 		},
 		{
 			name: "default",
@@ -176,7 +176,7 @@ func TestRequireMembership(t *testing.T) {
 				User:  &database.User{},
 				Realm: &database.Realm{},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 	}
 

--- a/pkg/controller/middleware/mfa_test.go
+++ b/pkg/controller/middleware/mfa_test.go
@@ -54,7 +54,7 @@ func TestRequireMFA(t *testing.T) {
 		{
 			name:       "missing_membership",
 			membership: nil,
-			code:       400,
+			code:       http.StatusBadRequest,
 		},
 		{
 			name:        "optional_verified",
@@ -64,7 +64,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptional,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "optional_not_verified",
@@ -74,7 +74,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptional,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "optional_prompt_verified",
@@ -84,7 +84,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "optional_prompt_not_verified",
@@ -94,7 +94,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 303,
+			code: http.StatusSeeOther,
 		},
 		{
 			name:        "optional_prompt_not_verified_prompted",
@@ -105,7 +105,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "required_verified",
@@ -115,7 +115,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "required_not_verified",
@@ -125,7 +125,7 @@ func TestRequireMFA(t *testing.T) {
 					MFAMode: database.MFAOptionalPrompt,
 				},
 			},
-			code: 303,
+			code: http.StatusSeeOther,
 		},
 		{
 			name:        "required_not_grace_allowed",
@@ -138,7 +138,7 @@ func TestRequireMFA(t *testing.T) {
 				},
 				CreatedAt: time.Now().UTC(),
 			},
-			code: 200,
+			code: http.StatusOK,
 		},
 		{
 			name:        "required_not_grace_expired",
@@ -151,7 +151,7 @@ func TestRequireMFA(t *testing.T) {
 				},
 				CreatedAt: time.Now().UTC().Add(-30 * 24 * time.Hour),
 			},
-			code: 303,
+			code: http.StatusSeeOther,
 		},
 	}
 
@@ -193,7 +193,7 @@ func TestRequireMFA(t *testing.T) {
 			if got, want := w.Code, tc.code; got != want {
 				t.Errorf("Expected %d to be %d", got, want)
 			}
-			if tc.code == 200 {
+			if tc.code == http.StatusOK {
 				stored := controller.MFAPromptedFromSession(session)
 				if !stored {
 					t.Errorf("expected mfa prompted to have been stored")

--- a/pkg/controller/middleware/recovery_test.go
+++ b/pkg/controller/middleware/recovery_test.go
@@ -43,14 +43,14 @@ func TestRecovery(t *testing.T) {
 		{
 			name:    "default",
 			handler: emptyHandler(),
-			code:    200,
+			code:    http.StatusOK,
 		},
 		{
 			name: "panic",
 			handler: http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 				panic("oops")
 			}),
-			code: 500,
+			code: http.StatusInternalServerError,
 		},
 	}
 

--- a/pkg/render/json.go
+++ b/pkg/render/json.go
@@ -59,7 +59,7 @@ func (r *Renderer) RenderJSON(w http.ResponseWriter, code int, data interface{})
 		w.WriteHeader(code)
 
 		// Return an OK response.
-		if code >= 200 && code < 300 {
+		if code >= http.StatusOK && code < http.StatusMultipleChoices {
 			fmt.Fprint(w, jsonOKResp)
 			return
 		}

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -24,6 +24,7 @@ import (
 	htmltemplate "html/template"
 	"io"
 	"io/fs"
+	"net/http"
 	"reflect"
 	"strconv"
 	"strings"
@@ -42,16 +43,16 @@ import (
 // primarily here to catch if someone, in the future, accidentally includes a
 // bad status code.
 var allowedResponseCodes = map[int]struct{}{
-	200: {},
-	400: {},
-	401: {},
-	404: {},
-	405: {},
-	409: {},
-	412: {},
-	413: {},
-	429: {},
-	500: {},
+	http.StatusOK:                    {},
+	http.StatusBadRequest:            {},
+	http.StatusUnauthorized:          {},
+	http.StatusNotFound:              {},
+	http.StatusMethodNotAllowed:      {},
+	http.StatusConflict:              {},
+	http.StatusPreconditionFailed:    {},
+	http.StatusRequestEntityTooLarge: {},
+	http.StatusTooManyRequests:       {},
+	http.StatusInternalServerError:   {},
 }
 
 // Renderer is responsible for rendering various content and templates like HTML

--- a/pkg/sms/twilio.go
+++ b/pkg/sms/twilio.go
@@ -79,7 +79,7 @@ func (p *Twilio) SendSMS(ctx context.Context, to, message string) error {
 		return fmt.Errorf("failed to read response body: %w", err)
 	}
 
-	if code := resp.StatusCode; code < 200 || code > 299 {
+	if code := resp.StatusCode; code < http.StatusOK || code >= http.StatusMultipleChoices {
 		var terr TwilioError
 		if err := json.Unmarshal(respBody, &terr); err != nil {
 			return fmt.Errorf("twilio error %d: %s", code, respBody)


### PR DESCRIPTION
🧹 

I think I've covered most of the status codes that were left as constants around the code.
It's 99% `sed`, so somethings might be amiss :-)
