### PR TITLE
Revert "Make connect and drain timeout configuration"

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -171,15 +171,10 @@ resource "google_compute_backend_service" "adminapi" {
   name     = "adminapi"
   project  = var.project
 
-  security_policy = google_compute_security_policy.cloud-armor.name
-
-  connection_draining_timeout_sec = var.connection_draining_timeout
-  timeout_sec                     = var.connection_timeout
-
   backend {
     group = google_compute_region_network_endpoint_group.adminapi[0].id
   }
-
+  security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
     sample_rate = var.enable_lb_logging ? 1 : null

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -171,15 +171,10 @@ resource "google_compute_backend_service" "apiserver" {
   name     = "apiserver"
   project  = var.project
 
-  security_policy = google_compute_security_policy.cloud-armor.name
-
-  connection_draining_timeout_sec = var.connection_draining_timeout
-  timeout_sec                     = var.connection_timeout
-
   backend {
     group = google_compute_region_network_endpoint_group.apiserver[0].id
   }
-
+  security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
     sample_rate = var.enable_lb_logging ? 1 : null

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -158,15 +158,10 @@ resource "google_compute_backend_service" "modeler" {
   name     = "modeler"
   project  = var.project
 
-  security_policy = google_compute_security_policy.cloud-armor.name
-
-  connection_draining_timeout_sec = var.connection_draining_timeout
-  timeout_sec                     = var.connection_timeout
-
   backend {
     group = google_compute_region_network_endpoint_group.modeler.id
   }
-
+  security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
     sample_rate = var.enable_lb_logging ? 1 : null

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -168,21 +168,15 @@ resource "google_compute_region_network_endpoint_group" "enx-redirect" {
 }
 
 resource "google_compute_backend_service" "enx-redirect" {
-  count = local.enable_lb ? 1 : 0
-
+  count    = local.enable_lb ? 1 : 0
   provider = google-beta
   name     = "enx-redirect"
   project  = var.project
 
-  security_policy = google_compute_security_policy.cloud-armor.name
-
-  connection_draining_timeout_sec = var.connection_draining_timeout
-  timeout_sec                     = var.connection_timeout
-
   backend {
     group = google_compute_region_network_endpoint_group.enx-redirect.id
   }
-
+  security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
     sample_rate = var.enable_lb_logging ? 1 : null

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -189,15 +189,10 @@ resource "google_compute_backend_service" "server" {
   name     = "server"
   project  = var.project
 
-  security_policy = google_compute_security_policy.cloud-armor.name
-
-  connection_draining_timeout_sec = var.connection_draining_timeout
-  timeout_sec                     = var.connection_timeout
-
   backend {
     group = google_compute_region_network_endpoint_group.server[0].id
   }
-
+  security_policy = google_compute_security_policy.cloud-armor.name
   log_config {
     enable      = var.enable_lb_logging
     sample_rate = var.enable_lb_logging ? 1 : null

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -342,18 +342,6 @@ variable "e2e_skip_sms" {
   description = "Skip SMS tests when executing the e2e runner. Set this to true to not send SMS. You must also configure the e2e realm with proper test credentials."
 }
 
-variable "connection_draining_timeout" {
-  type        = number
-  default     = 60
-  description = "Number of seconds to allow connections to drain."
-}
-
-variable "connection_timeout" {
-  type        = number
-  default     = 60
-  description = "Number of seconds to wait for a backend to return a response."
-}
-
 terraform {
   required_version = ">= 0.14.2"
 


### PR DESCRIPTION
Reverts google/exposure-notifications-verification-server#1912

Serverless NEGs don't support timeouts