### PR TITLE
e2e-default should report client-side http errors

### DIFF
--- a/internal/clients/e2e.go
+++ b/internal/clients/e2e.go
@@ -269,7 +269,7 @@ func RunEndToEnd(ctx context.Context, cfg *config.E2ERunnerConfig) error {
 			}
 			publishResp, err := keyServerClient.Publish(ctx, publishReq)
 			defer logger.Debugw("publish", "request", publishReq, "response", publishResp)
-			if publishResp.ErrorMessage != "" {
+			if err != nil || publishResp.ErrorMessage != "" {
 				result = enobs.ResultNotOK
 				logger.Errorw("failed to publish teks", "error", err, "keys", teks)
 				return nil, fmt.Errorf("publish API error: %+v", publishResp)

--- a/internal/clients/e2e.go
+++ b/internal/clients/e2e.go
@@ -269,7 +269,10 @@ func RunEndToEnd(ctx context.Context, cfg *config.E2ERunnerConfig) error {
 			}
 			publishResp, err := keyServerClient.Publish(ctx, publishReq)
 			defer logger.Debugw("publish", "request", publishReq, "response", publishResp)
-			if err != nil || publishResp.ErrorMessage != "" {
+			if err != nil {
+				result = enobs.ResultNotOK
+				return nil, fmt.Errorf("error uploading teks: %w", err)
+			} else if publishResp.ErrorMessage != "" {
 				result = enobs.ResultNotOK
 				logger.Errorw("failed to publish teks", "error", err, "keys", teks)
 				return nil, fmt.Errorf("publish API error: %+v", publishResp)


### PR DESCRIPTION

## Proposed Changes

* e2e runner default workflow should fail any time httpClient returns an error, instead of only when server responds with error.

**Release Note**

```release-note
e2e runner now fails on httpClient errors (e.g. timeout)
```
