### PR TITLE
Use last column instead of 3 for coverage

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -57,7 +57,7 @@ jobs:
         shell: bash
         run: |-
           OUTPUT="$(make test-coverage)"
-          TOTAL="$(echo $OUTPUT | awk 'END{print $3}')"
+          TOTAL="$(echo $OUTPUT | awk 'END{print $NF}')"
           echo "::group::Coverage (${TOTAL})"
           echo "${OUTPUT}"
           echo "::endgroup::"


### PR DESCRIPTION
I think this coincidentally works today because of our package name lengths. NF will always work.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
