### PR TITLE
Lower in-memory cache time and return a warning about cached values

### DIFF
--- a/pkg/controller/issueapi/controller.go
+++ b/pkg/controller/issueapi/controller.go
@@ -44,7 +44,7 @@ type Controller struct {
 
 // New creates a new IssueAPI controller.
 func New(cfg config.IssueAPIConfig, db *database.Database, limiter limiter.Store, smsSigner keys.KeyManager, h *render.Renderer) *Controller {
-	localCache, _ := cache.New(5 * time.Minute)
+	localCache, _ := cache.New(30 * time.Second)
 
 	return &Controller{
 		config:     cfg,

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -369,6 +369,8 @@ func (c *Controller) HandleSettings() http.Handler {
 					controller.InternalError(w, r, c.h, err)
 					return
 				}
+
+				flash.Warning("It can take up to 5 minutes for the new SMS configuration to be fully propagated.")
 			}
 		}
 
@@ -408,6 +410,8 @@ func (c *Controller) HandleSettings() http.Handler {
 					controller.InternalError(w, r, c.h, err)
 					return
 				}
+
+				flash.Warning("It can take up to 5 minutes for the new email configuration to be fully propagated.")
 			}
 		}
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -247,6 +247,7 @@ func (db *Database) OpenWithCacher(ctx context.Context, cacher cache.Cacher) err
 		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
 		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:realms:by_id", callbackPurgeCache(ctx, cacher, "realms:by_id", "realms", "id"))
 
+		// Stats
 		rawDB.Callback().Update().After("gorm:update").Register("purge_cache:stats:key_server", callbackPurgeCache(ctx, cacher, "stats:realm:key_server_enabled", "key_server_stats", "realm_id"))
 		rawDB.Callback().Delete().After("gorm:delete").Register("purge_cache:stats:key_server", callbackPurgeCache(ctx, cacher, "stats:realm:key_server_enabled", "key_server_stats", "realm_id"))
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1924

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Lower in-memory cache time and return a warning about cached values
```
