### PR TITLE
Add self report

### DIFF
--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -45,7 +45,7 @@
     {{if not $realm.EnableENExpress}}
       <div class="form-check mb-3">
         <input type="radio" name="allowed_test_types" id="test-type-negative" class="form-check-input"
-          value="{{$testTypes.negative}}" {{checkedIf (eq $realm.AllowedTestTypes $testTypes.negative)}} />
+          value="{{$testTypes.negative}}" {{checkedIf (eq .currentTestTypes $testTypes.negative)}} />
         <label for="test-type-negative" class="form-check-label">
           Positive + Likely + Negative
           <small class="form-text text-muted">
@@ -58,7 +58,7 @@
 
       <div class="form-check mb-3">
         <input type="radio" name="allowed_test_types" id="test-type-likely" class="form-check-input"
-          value="{{$testTypes.likely}}" {{checkedIf (eq $realm.AllowedTestTypes $testTypes.likely)}} />
+          value="{{$testTypes.likely}}" {{checkedIf (eq .currentTestTypes $testTypes.likely)}} />
         <label for="test-type-likely" class="form-check-label">
           Positive + Likely
           <small class="form-text text-muted">
@@ -71,7 +71,7 @@
 
     <div class="form-check mb-3">
       <input type="radio" name="allowed_test_types" id="test-type-confirmed"
-        class="form-check-input" value="{{$testTypes.confirmed}}" {{checkedIf (eq $realm.AllowedTestTypes $testTypes.confirmed)}} />
+        class="form-check-input" value="{{$testTypes.confirmed}}" {{checkedIf (eq .currentTestTypes $testTypes.confirmed)}} />
       <label for="test-type-confirmed" class="form-check-label">
         Positive
         <small class="form-text text-muted">
@@ -85,6 +85,19 @@
         </small>
       </label>
     </div>
+
+    {{if .features.EnableUserReport}}
+    <div class="form-check mb-3">
+      <input type="checkbox" name="allow_user_report" id="allow-user-report" class="form-check-input" value="true" {{checkedIf ($realm.AllowsUserReport)}} />
+      <label for="allow-user-report" class="form-check-label">
+        Allow user initiated report
+        <small class="form-text text-muted mb-3">
+          Allow users to initiate a COVID-19 diagnosis from their mobile application before
+          receiving a verification code from this health authority.
+        </small>
+      </label>
+    </div>
+    {{end}}
   </div>
 
   <hr>

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -114,7 +114,7 @@
     </small>
   </div>
 
-  <hr>
+  <hr/>
 
   <div>
     <div class="btn-group dropright pb-2">
@@ -132,6 +132,9 @@
         <div id="sms-template-dropdown-divider" class="dropdown-divider"></div>
         <a class="dropdown-item" id="sms-template-new" href="#">New SMS template</a>
       </div>
+      {{if $realm.AllowsUserReport}}
+        <small class="form-text text-muted">User initiated report is enabled, which always uses the <code>User Report</code> template.</small>
+      {{end}}
     </div>
     {{if $realm.ErrorsFor "smsTextTemplate"}}
     <div class="invalid-feedback d-block mt-n1 pb-2">
@@ -155,7 +158,9 @@
         {{joinStrings ($realm.ErrorsFor $v.Label) ", "}}
       </div>
       {{end}}
+      {{if or (not $realm.AllowsUserReport) (ne "User Report" $v.Label)}}
       <button class="btn btn-danger mb-3 {{if eq $i 0}}d-none{{end}}" type="button" {{if ne $i 0}}onClick="removeTemplate('sms-template-{{$i}}');"{{end}}>Delete template</button>
+      {{end}}
     </div>
     {{end}}
     <span id="templates-end"></span>

--- a/internal/clients/api_server.go
+++ b/internal/clients/api_server.go
@@ -38,6 +38,8 @@ func NewAPIServerClient(base, apiKey string, opts ...Option) (*APIServerClient, 
 	}, nil
 }
 
+// UserReport calls the /user-report endpoint to request a verification code be created
+// with a self-report type, with the code only dispatched via SMS.
 func (c *APIServerClient) UserReport(ctx context.Context, in *api.UserReportRequest) (*api.UserReportResponse, error) {
 	req, err := c.newRequest(ctx, http.MethodPost, "/api/user-report", in)
 	if err != nil {

--- a/internal/clients/api_server.go
+++ b/internal/clients/api_server.go
@@ -38,6 +38,19 @@ func NewAPIServerClient(base, apiKey string, opts ...Option) (*APIServerClient, 
 	}, nil
 }
 
+func (c *APIServerClient) UserReport(ctx context.Context, in *api.UserReportRequest) (*api.UserReportResponse, error) {
+	req, err := c.newRequest(ctx, http.MethodPost, "/api/user-report", in)
+	if err != nil {
+		return nil, err
+	}
+
+	var out api.UserReportResponse
+	if err := c.doOK(req, &out); err != nil {
+		return &out, err
+	}
+	return &out, nil
+}
+
 // Verify calls the /verify endpoint to convert a code into a token.
 func (c *APIServerClient) Verify(ctx context.Context, in *api.VerifyCodeRequest) (*api.VerifyCodeResponse, error) {
 	req, err := c.newRequest(ctx, http.MethodPost, "/api/verify", in)

--- a/internal/envstest/adminapi.go
+++ b/internal/envstest/adminapi.go
@@ -86,9 +86,11 @@ func NewAdminAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestI
 			EnableAuthenticatedSMS: true,
 		},
 
-		APIKeyCacheDuration:     5 * time.Second,
-		ENExpressRedirectDomain: "enx-redirect.local",
-		DevMode:                 true,
+		APIKeyCacheDuration: 5 * time.Second,
+		Issue: config.IssueAPIVars{
+			ENExpressRedirectDomain: "enx-redirect.local",
+		},
+		DevMode: true,
 	}
 
 	// Process the config - this simulates production setups and also ensures we

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -348,7 +348,7 @@ type ExpireCodeResponse struct {
 //
 // A phone number is required. The verification code is only presented over SMS.
 //
-// The nonce field must be a 128 random bytes, base64 encoded.
+// The nonce field must be a 256 random bytes, base64 encoded.
 // This nonce field must be passed back on the VerifyCodeRequest request later.
 //
 // Requires API key in a HTTP header, X-API-Key: APIKEY

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -31,6 +31,12 @@ const (
 	TestTypeLikely = "likely"
 	// TestTypeNegative is the string that represents a negative test.
 	TestTypeNegative = "negative"
+	// TestTypeUserReport is the string that represents a user initiated report.
+	TestTypeUserReport = "user-report"
+
+	// Platforms for User Report API
+	PlatformAndroid = "android"
+	PlatformIOS     = "ios"
 
 	// error_code definitions for the APIs.
 
@@ -74,6 +80,15 @@ const (
 	ErrSMSQueueFull = "sms_queue_full"
 	// ErrSMSFailure indicates that Twilio's responded with a failure.
 	ErrSMSFailure = "sms_failure"
+	// ErrMissingNonce indicates a UserReport request is missing the nonce value.
+	ErrMissingNonce = "missing_nonce"
+	// ErrMissingPhone indicates a UserReport request is missing the phone number.
+	ErrMissingPhone = "missing_phone"
+
+	// User report specific responses
+	// ErrUserReportTryLater indicates that user report is not allowed right now, which could be for several
+	// reasons: phone number already used, PHA hit self report quota, PHA disabled self report.
+	ErrUserReportTryLater = "user_report_try_later"
 
 	// Certificate API responses
 
@@ -322,6 +337,53 @@ type ExpireCodeResponse struct {
 	ErrorCode string `json:"errorCode,omitempty"`
 }
 
+// UserReportRequest defines the structure for a user initiated report.
+// This is a device API hosted on the apiserver.
+//
+// Support level: ALPHA
+// This API is not guaranteed to be backwards compatible until such time it is moved
+// to beta.
+//
+// Inclusion of the test date is required, inclusion of the symptom date is optional.
+//
+// A phone number is required. The verification code is only presented over SMS.
+//
+// The nonce field must be a 128 random bytes, base64 encoded.
+// This nonce field must be passed back on the VerifyCodeRequest request later.
+//
+// Requires API key in a HTTP header, X-API-Key: APIKEY
+type UserReportRequest struct {
+	Padding Padding `json:"padding"`
+
+	SymptomDate string `json:"symptomDate"` // ISO 8601 formatted date, YYYY-MM-DD
+	TestDate    string `json:"testDate"`
+	// TZOffset in minutes of the user's timezone. Positive, negative, 0, or omitted
+	// (using the default of 0) are all valid. 0 is considered to be UTC.
+	TZOffset float32 `json:"tzOffset"`
+	// Phone is required in this API. The verification code will be delivered over SMS.
+	Phone string `json:"phone"`
+
+	// Platform must be one of 'ios' or 'android'
+	Platform string `json:"platform"`
+
+	// Nonce must be 256 bytes of random data, base64 encoded.
+	Nonce string `json:"nonce"`
+}
+
+// UserReportResponse is the reply from a UserReportRequest.
+//
+type UserReportResponse struct {
+	Padding Padding `json:"padding"`
+
+	// LongExpiresAt and LongExpiresAtTimestamp represents the time when the long
+	// code expires, in UTC seconds since epoch.
+	LongExpiresAt          string `json:"longExpiresAt,omitempty"`
+	LongExpiresAtTimestamp int64  `json:"longExpiresAtTimestamp,omitempty"`
+
+	Error     string `json:"error,omitempty"`
+	ErrorCode string `json:"errorCode,omitempty"`
+}
+
 // VerifyCodeRequest is the request structure for exchanging a short term Verification Code
 // (OTP) for a long term token (a JWT) that can later be used to sign TEKs.
 //
@@ -336,7 +398,9 @@ type ExpireCodeResponse struct {
 //   A client can pass in the complete list they accept or the "highest" value they can accept.
 //   If this value is omitted or is empty, the client agrees to accept ALL possible
 //   test types, including test types that may be introduced in the future.
+// The special type of test, '"user-report"' can be added safely to any of the other types.
 //
+// The nonce must be provided when validating a self report key.
 //
 // Requires API key in a HTTP header, X-API-Key: APIKEY
 type VerifyCodeRequest struct {
@@ -344,6 +408,10 @@ type VerifyCodeRequest struct {
 
 	VerificationCode string   `json:"code"`
 	AcceptTestTypes  []string `json:"accept"`
+
+	// Optional: If present must be the same nonce that was used to request the verification code.
+	// base64 encoded.
+	Nonce string `json:"nonce,omitempty"`
 }
 
 // VerifyCodeResponse either contains an error, or contains the test parameters

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -375,10 +375,13 @@ type UserReportRequest struct {
 type UserReportResponse struct {
 	Padding Padding `json:"padding"`
 
-	// LongExpiresAt and LongExpiresAtTimestamp represents the time when the long
-	// code expires, in UTC seconds since epoch.
-	LongExpiresAt          string `json:"longExpiresAt,omitempty"`
-	LongExpiresAtTimestamp int64  `json:"longExpiresAtTimestamp,omitempty"`
+	// ExpiresAt is a RFC1123 formatted string formatted timestamp, in UTC.
+	// After this time the code will no longer be accepted and is eligible for deletion.
+	ExpiresAt string `json:"expiresAt"`
+
+	// ExpiresAtTimestamp represents Unix, seconds since the epoch. Still UTC.
+	// After this time the code will no longer be accepted and is eligible for deletion.
+	ExpiresAtTimestamp int64 `json:"expiresAtTimestamp"`
 
 	Error     string `json:"error,omitempty"`
 	ErrorCode string `json:"errorCode,omitempty"`

--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -41,6 +41,8 @@ func (v *VerifyCodeRequest) GetAcceptedTestTypes() (AcceptTypes, error) {
 			accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely)
 		case TestTypeNegative:
 			accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely, TestTypeNegative)
+		case TestTypeUserReport:
+			accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeUserReport)
 		default:
 			return nil, fmt.Errorf("invalid accepted test type: %v", testType)
 		}

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -71,6 +71,11 @@ type CleanupConfig struct {
 	// and the entry will be purged. This value should be greater than VerificationCodeMaxAge
 	VerificationCodeStatusMaxAge time.Duration `env:"VERIFICATION_CODE_STATUS_MAX_AGE, default=336h"`
 	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
+
+	// UserReportUnclaimedMaxAge is how long a user report phone hash will be kept if the record goes unclaimed.
+	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=60m"`
+	// UserReportMaxAge is how long a claimed user report phone hash will be kept.
+	UserReportMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=2160h"` // 2160h = 90 days
 }
 
 // NewCleanupConfig returns the environment config for the cleanup server.

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -23,6 +23,10 @@ type FeatureConfig struct {
 	// and enable/disable this feature. There is no launch timeline for GA.
 	// This should not be used without prior coordination with Apple/Google.
 	EnableAuthenticatedSMS bool `env:"ENABLE_AUTHENTICATED_SMS, default=false"`
+
+	// EnableUserReport allows for realms to enable user initiated diagnosis reporting,
+	// via API + SMS.
+	EnableUserReport bool `env:"ENABLE_USER_REPORT, default=false"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known

--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -223,9 +223,9 @@ func (c *Controller) HandleCleanup() http.Handler {
 		// Claimed user reports
 		func() {
 			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
-			item = tag.Upsert(itemTagKey, "USER_REPORTS")
-			if count, err := c.db.PurgeUserReports(c.config.UserReportMaxAge); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("failed to purge user reports: %w", err))
+			item = tag.Upsert(itemTagKey, "CLAIMED_USER_REPORTS")
+			if count, err := c.db.PurgeClaimedUserReports(c.config.UserReportMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge claimed user reports: %w", err))
 				result = enobs.ResultError("FAILED")
 			} else {
 				logger.Infow("purged user reports", "count", count)

--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -207,6 +207,32 @@ func (c *Controller) HandleCleanup() http.Handler {
 			}
 		}()
 
+		// Unclaimed user reports
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "UNCLAIMED_USER_REPORTS")
+			if count, err := c.db.PurgeUnclaimedUserReports(c.config.UserReportUnclaimedMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge unclaimed user reports: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged unclaimed user reports", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// Claimed user reports
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "USER_REPORTS")
+			if count, err := c.db.PurgeUserReports(c.config.UserReportMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge user reports: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged user reports", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
 		// If there are any errors, return them
 		if merr != nil {
 			if errs := merr.WrappedErrors(); len(errs) > 0 {

--- a/pkg/controller/codes/issue.go
+++ b/pkg/controller/codes/issue.go
@@ -58,8 +58,8 @@ func (c *Controller) HandleIssue() http.Handler {
 
 		// Set test date params
 		now := time.Now().UTC()
-		pastDaysDuration := -1 * c.serverconfig.AllowedSymptomAge
-		displayAllowedDays := fmt.Sprintf("%.0f", c.serverconfig.AllowedSymptomAge.Hours()/24.0)
+		pastDaysDuration := -1 * c.serverconfig.IssueConfig().AllowedSymptomAge
+		displayAllowedDays := fmt.Sprintf("%.0f", c.serverconfig.IssueConfig().AllowedSymptomAge.Hours()/24.0)
 		m["maxDate"] = now.Format(project.RFC3339Date)
 		m["minDate"] = now.Add(pastDaysDuration).Format(project.RFC3339Date)
 		m["maxSymptomDays"] = displayAllowedDays

--- a/pkg/controller/codes/issue_test.go
+++ b/pkg/controller/codes/issue_test.go
@@ -111,7 +111,14 @@ func TestHandleIssue_IssueCode(t *testing.T) {
 
 	// Exchange the code for a verification certificate.
 	allowedTypes := api.AcceptTypes{api.TestTypeConfirmed: struct{}{}}
-	token, err := harness.Database.VerifyCodeAndIssueToken(now, authApp, code, allowedTypes, 30*time.Minute)
+	request := &database.IssueTokenRequest{
+		Time:        now,
+		AuthApp:     authApp,
+		VerCode:     code,
+		AcceptTypes: allowedTypes,
+		ExpireAfter: 30 * time.Minute,
+	}
+	token, err := harness.Database.VerifyCodeAndIssueToken(request)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/issueapi/gen_code.go
+++ b/pkg/controller/issueapi/gen_code.go
@@ -79,9 +79,10 @@ func (c *Controller) IssueCode(ctx context.Context, vCode *database.Verification
 
 	if err := c.CommitCode(ctx, vCode, realm, c.config.IssueConfig().CollisionRetryCount); err != nil {
 		if errors.Is(err, database.ErrAlreadyReported) {
+			stats.Record(ctx, mUserReportColission.M(1))
 			return &IssueResult{
 				obsResult:   enobs.ResultError("DUPLICATE_USER_REPORT"),
-				HTTPCode:    http.StatusTooManyRequests,
+				HTTPCode:    http.StatusConflict,
 				ErrorReturn: api.Errorf("phone number not current eligible for user report").WithCode(api.ErrUserReportTryLater),
 			}
 		}

--- a/pkg/controller/issueapi/gen_code_test.go
+++ b/pkg/controller/issueapi/gen_code_test.go
@@ -222,7 +222,7 @@ func TestIssueCode(t *testing.T) {
 
 			c := issueapi.New(harness.Config, db, harness.RateLimiter, harness.KeyManager, harness.Renderer)
 
-			harness.Config.EnforceRealmQuotas = tc.enforceRealmQuotas
+			harness.Config.Issue.EnforceRealmQuotas = tc.enforceRealmQuotas
 			result := c.IssueCode(ctx, tc.vCode, realm)
 
 			if tc.responseErr == "" {

--- a/pkg/controller/issueapi/handle_issue.go
+++ b/pkg/controller/issueapi/handle_issue.go
@@ -102,7 +102,10 @@ func (c *Controller) decodeAndIssue(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
-	res := c.IssueOne(ctx, &request)
+	internalRequest := &IssueRequestInternal{
+		IssueRequest: &request,
+	}
+	res := c.IssueOne(ctx, internalRequest)
 	result.HTTPCode = res.HTTPCode
 
 	switch res.HTTPCode {

--- a/pkg/controller/issueapi/handle_issue_batch.go
+++ b/pkg/controller/issueapi/handle_issue_batch.go
@@ -118,7 +118,15 @@ func (c *Controller) decodeAndBulkIssue(ctx context.Context, w http.ResponseWrit
 		return
 	}
 
-	results := c.IssueMany(ctx, request.Codes)
+	internalRequests := make([]*IssueRequestInternal, 0, len(request.Codes))
+	for _, c := range request.Codes {
+		internalRequests = append(internalRequests,
+			&IssueRequestInternal{
+				IssueRequest: c,
+			})
+	}
+
+	results := c.IssueMany(ctx, internalRequests)
 
 	HTTPCode := http.StatusOK
 	batchResp := &api.BatchIssueCodeResponse{}
@@ -153,5 +161,4 @@ func (c *Controller) decodeAndBulkIssue(ctx context.Context, w http.ResponseWrit
 	}
 
 	c.h.RenderJSON(w, HTTPCode, batchResp)
-	return
 }

--- a/pkg/controller/issueapi/handle_user_report.go
+++ b/pkg/controller/issueapi/handle_user_report.go
@@ -1,0 +1,132 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueapi
+
+import (
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+
+	"github.com/google/exposure-notifications-server/pkg/base64util"
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	enobs "github.com/google/exposure-notifications-server/pkg/observability"
+)
+
+func (c *Controller) HandleUserReport() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if c.config.IsMaintenanceMode() {
+			c.h.RenderJSON(w, http.StatusTooManyRequests,
+				api.Errorf("server is read-only for maintenance").WithCode(api.ErrMaintenanceMode))
+			return
+		}
+
+		ctx := r.Context()
+		logger := logging.FromContext(ctx).Named("userreportapi.HandleUserReport")
+
+		blame := enobs.BlameNone
+		result := enobs.ResultOK
+		defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &blame)
+
+		authApp := controller.AuthorizedAppFromContext(ctx)
+		if authApp == nil {
+			blame = enobs.BlameClient
+			result = enobs.ResultError("MISSING_AUTHORIZED_APP")
+			controller.MissingAuthorizedApp(w, r, c.h)
+			return
+		}
+
+		// Parse the UserReportRequest struct.
+		var request api.UserReportRequest
+		if err := controller.BindJSON(w, r, &request); err != nil {
+			logger.Errorw("bad request", "error", err)
+			blame = enobs.BlameClient
+			result = enobs.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
+
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
+			return
+		}
+
+		// Ensure realm allows user report.
+		realm := controller.RealmFromContext(ctx)
+		if !realm.AllowsUserReport() {
+			logger.Warnw("realm is requesting user report, but disabled", "realmID", realm.ID)
+			blame = enobs.BlameClient
+			result = enobs.ResultError("USER_REPORT_NOT_ENABLED")
+
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("user initiated report is not enabled").WithCode(api.ErrUnsupportedTestType))
+			return
+		}
+
+		nonce, err := base64util.DecodeString(request.Nonce)
+		if err != nil {
+			logger.Errorw("bad request", "error", err)
+			blame = enobs.BlameClient
+			result = enobs.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
+
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
+			return
+		}
+		if len(nonce) == 0 {
+			logger.Errorw("bad request", "error", err)
+			blame = enobs.BlameClient
+			result = enobs.ResultError("USER_REQUEST_MISSING_NONCE")
+
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("nonce cannot be empty").WithCode(api.ErrMissingNonce))
+			return
+		}
+
+		if len(request.Phone) == 0 {
+			logger.Errorw("bad request", "error", err)
+			blame = enobs.BlameClient
+			result = enobs.ResultError("USER_REQUEST_MISSING_PHONE")
+
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Errorf("phone cannot be empty").WithCode(api.ErrMissingPhone))
+			return
+		}
+
+		// Issue code and send text.
+		issueRequest := &IssueRequestInternal{
+			IssueRequest: &api.IssueCodeRequest{
+				SymptomDate:      request.SymptomDate,
+				TestDate:         request.TestDate,
+				TestType:         api.TestTypeUserReport, // Always test type of user report.
+				Phone:            request.Phone,
+				SMSTemplateLabel: database.UserReportTemplateLabel,
+			},
+			Nonce: nonce,
+		}
+
+		res := c.IssueOne(ctx, issueRequest)
+
+		switch res.HTTPCode {
+		case http.StatusInternalServerError:
+			controller.InternalError(w, r, c.h, errors.New(res.ErrorReturn.Error))
+			return
+		case http.StatusOK:
+			c.h.RenderJSON(w, http.StatusOK, &api.UserReportResponse{
+				LongExpiresAt:          res.IssueCodeResponse().ExpiresAt,
+				LongExpiresAtTimestamp: res.IssueCodeResponse().LongExpiresAtTimestamp,
+			})
+			return
+		default:
+			c.h.RenderJSON(w, res.HTTPCode, res.ErrorReturn)
+			return
+		}
+	})
+}

--- a/pkg/controller/issueapi/handle_user_report.go
+++ b/pkg/controller/issueapi/handle_user_report.go
@@ -120,8 +120,8 @@ func (c *Controller) HandleUserReport() http.Handler {
 			return
 		case http.StatusOK:
 			c.h.RenderJSON(w, http.StatusOK, &api.UserReportResponse{
-				LongExpiresAt:          res.IssueCodeResponse().ExpiresAt,
-				LongExpiresAtTimestamp: res.IssueCodeResponse().LongExpiresAtTimestamp,
+				ExpiresAt:          res.IssueCodeResponse().ExpiresAt,
+				ExpiresAtTimestamp: res.IssueCodeResponse().ExpiresAtTimestamp,
 			})
 			return
 		default:

--- a/pkg/controller/issueapi/handle_user_report_test.go
+++ b/pkg/controller/issueapi/handle_user_report_test.go
@@ -43,7 +43,7 @@ func TestUserReport(t *testing.T) {
 	}
 	realm.AllowBulkUpload = true
 	realm.AllowedTestTypes = database.TestTypeConfirmed
-	realm.EnableUserReport()
+	realm.AddUserReportToAllowedTestTypes()
 	if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/issueapi/handle_user_report_test.go
+++ b/pkg/controller/issueapi/handle_user_report_test.go
@@ -1,0 +1,176 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueapi_test
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"encoding/json"
+	"net/http"
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/api"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/sms"
+)
+
+func TestUserReport(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServerConfig(t, testDatabaseInstance)
+
+	realm, err := harness.Database.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+	realm.AllowBulkUpload = true
+	realm.AllowedTestTypes = database.TestTypeConfirmed
+	realm.EnableUserReport()
+	if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
+		t.Fatal(err)
+	}
+
+	smsConfig := &database.SMSConfig{
+		RealmID:      realm.ID,
+		ProviderType: sms.ProviderTypeNoop,
+	}
+	if err := harness.Database.SaveSMSConfig(smsConfig); err != nil {
+		t.Fatal(err)
+	}
+
+	authApp := &database.AuthorizedApp{
+		Name:       "Appy",
+		APIKeyType: database.APIKeyTypeAdmin,
+	}
+	if _, err := realm.CreateAuthorizedApp(harness.Database, authApp, database.SystemTest); err != nil {
+		t.Fatal(err)
+	}
+
+	symptomDate := time.Now().UTC().Add(-48 * time.Hour).Format(project.RFC3339Date)
+
+	nonceBytes := make([]byte, database.NonceLength)
+	_, err = rand.Read(nonceBytes)
+	if err != nil {
+		t.Fatal(err)
+	}
+	nonce := base64.StdEncoding.EncodeToString(nonceBytes)
+
+	c := issueapi.New(harness.Config, harness.Database, harness.RateLimiter, harness.KeyManager, harness.Renderer)
+	handler := c.HandleUserReport()
+
+	cases := []struct {
+		name           string
+		request        *api.UserReportRequest
+		responseErr    string
+		httpStatusCode int
+
+		err bool
+	}{
+		{
+			name: "success",
+			request: &api.UserReportRequest{
+				SymptomDate: symptomDate,
+				Phone:       "+12068675309",
+				Platform:    "android",
+				Nonce:       nonce,
+			},
+			httpStatusCode: http.StatusOK,
+		},
+		{
+			name: "too_soon",
+			request: &api.UserReportRequest{
+				SymptomDate: symptomDate,
+				Phone:       "+12068675309",
+				Platform:    "android",
+				Nonce:       nonce,
+			},
+			httpStatusCode: http.StatusTooManyRequests,
+			responseErr:    "user_report_try_later",
+		},
+		{
+			name: "missing_phone",
+			request: &api.UserReportRequest{
+				SymptomDate: symptomDate,
+				Platform:    "android",
+				Nonce:       nonce,
+			},
+			httpStatusCode: http.StatusBadRequest,
+			responseErr:    "missing_phone",
+		},
+		{
+			name: "missing_nonce",
+			request: &api.UserReportRequest{
+				SymptomDate: symptomDate,
+				Platform:    "android",
+			},
+			httpStatusCode: http.StatusBadRequest,
+			responseErr:    "missing_nonce",
+		},
+		{
+			name: "failure",
+			request: &api.UserReportRequest{
+				SymptomDate: "invalid date",
+				Nonce:       nonce,
+				Phone:       "+12068675309",
+			},
+			responseErr:    api.ErrUnparsableRequest,
+			httpStatusCode: http.StatusBadRequest,
+		},
+		{
+			name: "failure",
+			request: &api.UserReportRequest{
+				SymptomDate: "invalid date",
+				Nonce:       "..45",
+				Phone:       "+12068675309",
+			},
+			responseErr:    api.ErrUnparsableRequest,
+			httpStatusCode: http.StatusBadRequest,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			// not parallel so that the tests interfer with each other.
+
+			ctx := ctx
+			ctx = controller.WithRealm(ctx, realm)
+			ctx = controller.WithAuthorizedApp(ctx, authApp)
+
+			w, r := envstest.BuildJSONRequest(ctx, t, http.MethodPost, "/", tc.request)
+			handler.ServeHTTP(w, r)
+
+			if got, want := w.Code, tc.httpStatusCode; got != want {
+				t.Errorf("expected %d to be %d: %s", got, want, w.Body.String())
+			}
+
+			var apiResp api.BatchIssueCodeResponse
+			if err := json.NewDecoder(w.Body).Decode(&apiResp); err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := apiResp.ErrorCode, tc.responseErr; got != want {
+				t.Errorf("expected %#v to be %#v: %#v", got, want, apiResp)
+			}
+		})
+	}
+}

--- a/pkg/controller/issueapi/handle_user_report_test.go
+++ b/pkg/controller/issueapi/handle_user_report_test.go
@@ -102,7 +102,7 @@ func TestUserReport(t *testing.T) {
 				Platform:    "android",
 				Nonce:       nonce,
 			},
-			httpStatusCode: http.StatusTooManyRequests,
+			httpStatusCode: http.StatusConflict,
 			responseErr:    "user_report_try_later",
 		},
 		{

--- a/pkg/controller/issueapi/issue_test.go
+++ b/pkg/controller/issueapi/issue_test.go
@@ -68,24 +68,28 @@ func TestIssueOne(t *testing.T) {
 
 	cases := []struct {
 		name           string
-		request        api.IssueCodeRequest
+		request        *issueapi.IssueRequestInternal
 		responseErr    string
 		httpStatusCode int
 	}{
 		{
-			name: "success",
-			request: api.IssueCodeRequest{
-				TestType:    "confirmed",
-				SymptomDate: symptomDate,
-				Phone:       "+15005550006",
+			name: "confirmed_test",
+			request: &issueapi.IssueRequestInternal{
+				IssueRequest: &api.IssueCodeRequest{
+					TestType:    "confirmed",
+					SymptomDate: symptomDate,
+					Phone:       "+15005550006",
+				},
 			},
 			httpStatusCode: http.StatusOK,
 		},
 		{
-			name: "invalid test type",
-			request: api.IssueCodeRequest{
-				TestType:    "invalid",
-				SymptomDate: symptomDate,
+			name: "invalid_test_type",
+			request: &issueapi.IssueRequestInternal{
+				IssueRequest: &api.IssueCodeRequest{
+					TestType:    "invalid",
+					SymptomDate: symptomDate,
+				},
 			},
 			responseErr:    api.ErrInvalidTestType,
 			httpStatusCode: http.StatusBadRequest,
@@ -98,7 +102,7 @@ func TestIssueOne(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			result := c.IssueOne(ctx, &tc.request)
+			result := c.IssueOne(ctx, tc.request)
 			resp := result.IssueCodeResponse()
 
 			if result.HTTPCode != tc.httpStatusCode {
@@ -108,7 +112,7 @@ func TestIssueOne(t *testing.T) {
 				t.Errorf("did not receive expected errorCode. got %q, want %q", resp.ErrorCode, tc.responseErr)
 			}
 
-			if tc.responseErr == "" && tc.request.Phone != "" && resp.ExpiresAt == resp.LongExpiresAt {
+			if tc.responseErr == "" && tc.request.IssueRequest.Phone != "" && resp.ExpiresAt == resp.LongExpiresAt {
 				t.Errorf("Long expiry should be longer than short when a phone is provided.")
 			}
 		})

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -25,6 +25,8 @@ import (
 
 const metricPrefix = observability.MetricRoot + "/api/issue"
 
+const userReportMetricPrefix = observability.MetricRoot + "/api/userreport"
+
 var (
 	mLatencyMs = stats.Float64(metricPrefix+"/request", "# of code issue requests", stats.UnitMilliseconds)
 
@@ -33,6 +35,11 @@ var (
 	mSMSLatencyMs = stats.Float64(metricPrefix+"/sms_request", "# of sms requests", stats.UnitMilliseconds)
 
 	mRealmTokenUsed = stats.Int64(metricPrefix+"/realm_token_used", "# of realm token used.", stats.UnitDimensionless)
+
+	// separate metrics related to user report API.
+	mUserReportLatencyMs = stats.Float64(userReportMetricPrefix+"/request", "verify requests latency", stats.UnitMilliseconds)
+
+	mUserReportColission = stats.Int64(userReportMetricPrefix+"/phone_colission", "# of attempts to use a phone number multiple times for self report", stats.UnitDimensionless)
 )
 
 func init() {
@@ -77,6 +84,27 @@ func init() {
 			Description: "The count of # of realm token used.",
 			TagKeys:     observability.CommonTagKeys(),
 			Measure:     mRealmTokenUsed,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        userReportMetricPrefix + "/request_count",
+			Measure:     mUserReportLatencyMs,
+			Description: "Count of user report requests",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        userReportMetricPrefix + "/request_latency",
+			Measure:     mUserReportLatencyMs,
+			Description: "Latency distribution of user report requests",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: ochttp.DefaultLatencyDistribution,
+		},
+		{
+			Name:        userReportMetricPrefix + "/phone_colission",
+			Description: "The count of # phone number colissions on user initiated report.",
+			TagKeys:     observability.CommonTagKeys(),
+			Measure:     mUserReportColission,
 			Aggregation: view.Count(),
 		},
 	}...)

--- a/pkg/controller/issueapi/metrics.go
+++ b/pkg/controller/issueapi/metrics.go
@@ -25,7 +25,7 @@ import (
 
 const metricPrefix = observability.MetricRoot + "/api/issue"
 
-const userReportMetricPrefix = observability.MetricRoot + "/api/userreport"
+const userReportMetricPrefix = observability.MetricRoot + "/api/user_report"
 
 var (
 	mLatencyMs = stats.Float64(metricPrefix+"/request", "# of code issue requests", stats.UnitMilliseconds)
@@ -39,7 +39,7 @@ var (
 	// separate metrics related to user report API.
 	mUserReportLatencyMs = stats.Float64(userReportMetricPrefix+"/request", "verify requests latency", stats.UnitMilliseconds)
 
-	mUserReportColission = stats.Int64(userReportMetricPrefix+"/phone_colission", "# of attempts to use a phone number multiple times for self report", stats.UnitDimensionless)
+	mUserReportColission = stats.Int64(userReportMetricPrefix+"/phone_collision", "# of attempts to use a phone number multiple times for self report", stats.UnitDimensionless)
 )
 
 func init() {

--- a/pkg/controller/issueapi/parse_date.go
+++ b/pkg/controller/issueapi/parse_date.go
@@ -71,7 +71,7 @@ func (c *Controller) parseDate(d string, tzOffset int, parseSettings *dateParseS
 	}
 	// Max date is today (UTC time) and min date is AllowedTestAge ago, truncated.
 	maxDate := timeutils.UTCMidnight(time.Now())
-	minDate := timeutils.UTCMidnight(maxDate.Add(-1 * c.config.GetAllowedSymptomAge()))
+	minDate := timeutils.UTCMidnight(maxDate.Add(-1 * c.config.IssueConfig().AllowedSymptomAge))
 
 	validatedDate, err := ValidateDate(parsed, minDate, maxDate, tzOffset)
 	if err != nil {

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -86,7 +86,7 @@ func (c *Controller) doSend(ctx context.Context, realm *database.Realm, smsProvi
 
 	logger := logging.FromContext(ctx).Named("issueapi.sendSMS")
 
-	message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.GetENXRedirectDomain(), request.SMSTemplateLabel)
+	message, err := realm.BuildSMSText(result.VerCode.Code, result.VerCode.LongCode, c.config.IssueConfig().ENExpressRedirectDomain, request.SMSTemplateLabel)
 	if err != nil {
 		result.obsResult = enobs.ResultError("FAILED_TO_BUILD_SMS")
 		return err

--- a/pkg/controller/issueapi/validate_code_test.go
+++ b/pkg/controller/issueapi/validate_code_test.go
@@ -64,7 +64,7 @@ func TestValidate(t *testing.T) {
 	symptomDate := time.Now().UTC().Add(-48 * time.Hour).Format(project.RFC3339Date)
 
 	maxDate := timeutils.UTCMidnight(time.Now())
-	minDate := timeutils.Midnight(maxDate.Add(-1 * harness.Config.GetAllowedSymptomAge()))
+	minDate := timeutils.Midnight(maxDate.Add(-1 * harness.Config.IssueConfig().AllowedSymptomAge))
 
 	cases := []struct {
 		name           string

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -229,8 +229,8 @@ func (c *Controller) HandleSettings() http.Handler {
 			currentRealm.AllowedTestTypes = form.AllowedTestTypes
 			currentRealm.RequireDate = form.RequireDate
 			currentRealm.AllowBulkUpload = form.AllowBulkUpload
-			if form.AllowUserReport {
-				currentRealm.EnableUserReport()
+			if c.config.Features.EnableUserReport && form.AllowUserReport {
+				currentRealm.AddUserReportToAllowedTestTypes()
 			}
 
 			// These fields can only be set if ENX is disabled

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -65,6 +65,7 @@ type formData struct {
 
 	Codes                 bool              `form:"codes"`
 	AllowedTestTypes      database.TestType `form:"allowed_test_types"`
+	AllowUserReport       bool              `form:"allow_user_report"`
 	AllowBulkUpload       bool              `form:"allow_bulk"`
 	RequireDate           bool              `form:"require_date"`
 	CodeLength            uint              `form:"code_length"`
@@ -81,6 +82,7 @@ type formData struct {
 	TwilioFromNumber          string             `form:"twilio_from_number"`
 	SMSTextTemplate           string             `form:"-"`
 	SMSTextAlternateTemplates map[string]*string `form:"-"`
+	SMSTextUserReportAppend   string             `form:"sms_text_user_report_append"`
 
 	Email                      bool   `form:"email"`
 	UseSystemEmailConfig       bool   `form:"use_system_email_config"`
@@ -227,6 +229,9 @@ func (c *Controller) HandleSettings() http.Handler {
 			currentRealm.AllowedTestTypes = form.AllowedTestTypes
 			currentRealm.RequireDate = form.RequireDate
 			currentRealm.AllowBulkUpload = form.AllowBulkUpload
+			if form.AllowUserReport {
+				currentRealm.EnableUserReport()
+			}
 
 			// These fields can only be set if ENX is disabled
 			if !currentRealm.EnableENExpress {

--- a/pkg/controller/realmadmin/settings_show.go
+++ b/pkg/controller/realmadmin/settings_show.go
@@ -123,7 +123,7 @@ func (c *Controller) renderSettings(
 		}
 	}
 
-	m := controller.TemplateMapFromContext(ctx)
+	m := c.config.Features.AddToTemplate(controller.TemplateMapFromContext(ctx))
 	m.Title("Realm settings")
 	m["realm"] = realm
 	m["smsConfig"] = smsConfig
@@ -132,6 +132,8 @@ func (c *Controller) renderSettings(
 	m["emailConfig"] = emailConfig
 	m["statsConfig"] = keyServerStats
 	m["countries"] = database.Countries
+	// User report is handled special and isn't part of the previous test type hierarchy.
+	m["currentTestTypes"] = realm.AllowedTestTypes &^ database.TestTypeUserReport
 	m["testTypes"] = map[string]database.TestType{
 		"confirmed": database.TestTypeConfirmed,
 		"likely":    database.TestTypeConfirmed | database.TestTypeLikely,
@@ -146,7 +148,7 @@ func (c *Controller) renderSettings(
 	m["shortCodeMinutes"] = shortCodeMinutes
 	m["longCodeLengths"] = longCodeLengths
 	m["longCodeHours"] = longCodeHours
-	m["enxRedirectDomain"] = c.config.GetENXRedirectDomain()
+	m["enxRedirectDomain"] = c.config.IssueConfig().ENExpressRedirectDomain
 
 	m["maxSMSTemplate"] = database.SMSTemplateMaxLength
 

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -112,7 +112,7 @@ func (c *Controller) HandleVerify() http.Handler {
 			if err != nil {
 				logger.Errorw("bad request", "error", err)
 				blame = enobs.BlameClient
-				result = enobs.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
+				result = enobs.ResultError("BAD_NONCE")
 
 				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
 				return

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -25,6 +25,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/base64util"
 	enobs "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
@@ -105,9 +106,30 @@ func (c *Controller) HandleVerify() http.Handler {
 			return
 		}
 
+		nonce := []byte{}
+		if request.Nonce != "" {
+			nonce, err = base64util.DecodeString(request.Nonce)
+			if err != nil {
+				logger.Errorw("bad request", "error", err)
+				blame = enobs.BlameClient
+				result = enobs.ResultError("FAILED_TO_PARSE_JSON_REQUEST")
+
+				c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrUnparsableRequest))
+				return
+			}
+		}
+
+		tokenRequest := &database.IssueTokenRequest{
+			Time:        now,
+			AuthApp:     authApp,
+			VerCode:     request.VerificationCode,
+			AcceptTypes: acceptTypes,
+			ExpireAfter: c.config.VerificationTokenDuration,
+			Nonce:       nonce,
+		}
 		// Exchange the short term verification code for a long term verification token.
 		// The token can be used to sign TEKs later.
-		verificationToken, err := c.db.VerifyCodeAndIssueToken(now, authApp, request.VerificationCode, acceptTypes, c.config.VerificationTokenDuration)
+		verificationToken, err := c.db.VerifyCodeAndIssueToken(tokenRequest)
 		if err != nil {
 			blame = enobs.BlameClient
 			switch {

--- a/pkg/database/authorized_app_test.go
+++ b/pkg/database/authorized_app_test.go
@@ -15,7 +15,6 @@
 package database
 
 import (
-	"encoding/base64"
 	"fmt"
 	"strings"
 	"testing"
@@ -263,7 +262,7 @@ func TestDatabase_GenerateVerifyAPIKeySignature(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	key = fmt.Sprintf("%s.%s", key, base64.RawURLEncoding.EncodeToString(sig))
+	key = fmt.Sprintf("%s.%s", key, sig)
 
 	gotAPIKey, gotRealmID, err := db.VerifyAPIKeySignature(key)
 	if err != nil {

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -75,6 +75,11 @@ type Config struct {
 	// them in the database.
 	VerificationCodeDatabaseHMAC []envconfig.Base64Bytes `env:"DB_VERIFICATION_CODE_DATABASE_KEY,required" json:"-"`
 
+	// PhoneNumberHMAC is the HMAC key to hash phone numbers before storing
+	// in the database. This is only used of user initiated reporting is enabled
+	// at the system and at the realm level.
+	PhoneNumberHMAC []envconfig.Base64Bytes `env:"DB_PHONE_HMAC_KEY,required" json:"-"`
+
 	// Secrets is the secret configuration. This is used to resolve values that
 	// are actually pointers to secrets before returning them to the caller. The
 	// table implementation is the source of truth for which values are secrets
@@ -137,6 +142,9 @@ func (c *Config) clone() *Config {
 
 	cfg.VerificationCodeDatabaseHMAC = make([]envconfig.Base64Bytes, len(c.VerificationCodeDatabaseHMAC))
 	copy(cfg.VerificationCodeDatabaseHMAC, c.VerificationCodeDatabaseHMAC)
+
+	cfg.PhoneNumberHMAC = make([]envconfig.Base64Bytes, len(c.PhoneNumberHMAC))
+	copy(cfg.PhoneNumberHMAC, c.PhoneNumberHMAC)
 
 	return cfg
 }

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -717,6 +717,9 @@ func uintDiff(then, now uint) string {
 	return stringDiff(strconv.FormatUint(uint64(then), 10), strconv.FormatUint(uint64(now), 10))
 }
 
+// initialHMAC uses the currently active HMAC key to seed a new record
+// This depends on envconfig.Base64Bytes since the callers are all using items
+// directly from config struct and this avoids unnecessary casing.
 func initialHMAC(keys []envconfig.Base64Bytes, data string) (string, error) {
 	if len(keys) < 1 {
 		return "", fmt.Errorf("expected at least 1 hmac key")
@@ -728,6 +731,10 @@ func initialHMAC(keys []envconfig.Base64Bytes, data string) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(sig.Sum(nil)), nil
 }
 
+// allAllowedHMACs uses all passed in HMAC keys to return al valid
+// results for searching for a previously saved record.
+// This depends on envconfig.Base64Bytes since the callers are all using items
+// directly from config struct and this avoids unnecessary casing.
 func allAllowedHMACs(keys []envconfig.Base64Bytes, data string) ([]string, error) {
 	sigs := make([]string, 0, len(keys))
 	for _, key := range keys {

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -17,6 +17,8 @@ package database
 
 import (
 	"context"
+	"crypto/hmac"
+	"crypto/sha512"
 	"database/sql"
 	"encoding/base64"
 	"errors"
@@ -38,6 +40,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/observability"
 	"github.com/jinzhu/gorm"
+	"github.com/sethvargo/go-envconfig"
 	"github.com/sethvargo/go-retry"
 	"go.opencensus.io/stats"
 	"go.uber.org/zap"
@@ -712,4 +715,27 @@ func uintPtr(v uint) *uint {
 
 func uintDiff(then, now uint) string {
 	return stringDiff(strconv.FormatUint(uint64(then), 10), strconv.FormatUint(uint64(now), 10))
+}
+
+func initialHMAC(keys []envconfig.Base64Bytes, data string) (string, error) {
+	if len(keys) < 1 {
+		return "", fmt.Errorf("expected at least 1 hmac key")
+	}
+	sig := hmac.New(sha512.New, keys[0])
+	if _, err := sig.Write([]byte(data)); err != nil {
+		return "", err
+	}
+	return base64.RawURLEncoding.EncodeToString(sig.Sum(nil)), nil
+}
+
+func allAllowedHMACs(keys []envconfig.Base64Bytes, data string) ([]string, error) {
+	sigs := make([]string, 0, len(keys))
+	for _, key := range keys {
+		sig := hmac.New(sha512.New, key)
+		if _, err := sig.Write([]byte(data)); err != nil {
+			return nil, err
+		}
+		sigs = append(sigs, base64.RawURLEncoding.EncodeToString(sig.Sum(nil)))
+	}
+	return sigs, nil
 }

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -168,6 +168,10 @@ func NewTestInstance() (*TestInstance, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to generate verification code database hmac: %w", err)
 	}
+	phoneHMAC, err := generateKeys(2, 128)
+	if err != nil {
+		return nil, fmt.Errorf("failed to generate phone number database hmac: %w", err)
+	}
 
 	// Create a temporary directory for the key manager,
 	tmpdir, err := os.MkdirTemp("", "")
@@ -181,6 +185,7 @@ func NewTestInstance() (*TestInstance, error) {
 		APIKeyDatabaseHMAC:           apiKeyDatabaseHMAC,
 		APIKeySignatureHMAC:          apiKeySignatureHMAC,
 		VerificationCodeDatabaseHMAC: verificationCodeDatabaseHMAC,
+		PhoneNumberHMAC:              phoneHMAC,
 
 		Host:     container.GetBoundIP("5432/tcp"),
 		Port:     container.GetPort("5432/tcp"),

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -296,7 +296,7 @@ func NewRealmWithDefaults(name string) *Realm {
 		LongCodeLength:      16,
 		LongCodeDuration:    FromDuration(24 * time.Hour),
 		SMSTextTemplate:     DefaultSMSTextTemplate,
-		AllowedTestTypes:    14, // This doesn't include user initiated report by default.
+		AllowedTestTypes:    TestTypeConfirmed | TestTypeLikely | TestTypeNegative,
 		CertificateDuration: FromDuration(15 * time.Minute),
 		RequireDate:         true, // Having dates is really important to risk scoring, encourage this by default true.
 	}
@@ -308,9 +308,9 @@ func (r *Realm) AllowsUserReport() bool {
 	return r.AllowedTestTypes&TestTypeUserReport != 0
 }
 
-// EnableUserReport adds the TestTypeUserReport to this realm.
+// AddUserReportToAllowedTestTypes adds the TestTypeUserReport to this realm.
 // This does not save the realm to the database.
-func (r *Realm) EnableUserReport() {
+func (r *Realm) AddUserReportToAllowedTestTypes() {
 	r.AllowedTestTypes = r.AllowedTestTypes | TestTypeUserReport
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -309,6 +309,7 @@ func (r *Realm) AllowsUserReport() bool {
 }
 
 // EnableUserReport adds the TestTypeUserReport to this realm.
+// This does not save the realm to the database.
 func (r *Realm) EnableUserReport() {
 	r.AllowedTestTypes = r.AllowedTestTypes | TestTypeUserReport
 }

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -52,6 +52,7 @@ const (
 	TestTypeConfirmed
 	TestTypeLikely
 	TestTypeNegative
+	TestTypeUserReport
 )
 
 func (t TestType) Display() string {
@@ -67,6 +68,10 @@ func (t TestType) Display() string {
 
 	if t&TestTypeNegative != 0 {
 		types = append(types, "negative")
+	}
+
+	if t&TestTypeUserReport != 0 {
+		types = append(types, "user-report")
 	}
 
 	return strings.Join(types, ", ")
@@ -114,11 +119,14 @@ const (
 	SMSLongExpires   = "[longexpires]"
 	SMSENExpressLink = "[enslink]"
 
-	SMSTemplateMaxLength    = 800
-	SMSTemplateExpansionMax = 918
+	SMSTemplateMaxLength      = 800
+	SMSTemplateExpansionMax   = 918
+	SMSUserReportExpansionMax = 140
 
-	DefaultTemplateLabel   = "Default SMS template"
-	DefaultSMSTextTemplate = "This is your Exposure Notifications Verification code: [longcode] Expires in [longexpires] hours"
+	DefaultTemplateLabel    = "Default SMS template"
+	DefaultSMSTextTemplate  = "This is your Exposure Notifications Verification code: [longcode] Expires in [longexpires] hours"
+	UserReportTemplateLabel = "User Report"
+	UserReportDefaultText   = "Your Exposure Notifications code expires in [expires] minutes, code #[code]"
 
 	EmailInviteLink        = "[invitelink]"
 	EmailPasswordResetLink = "[passwordresetlink]"
@@ -288,10 +296,21 @@ func NewRealmWithDefaults(name string) *Realm {
 		LongCodeLength:      16,
 		LongCodeDuration:    FromDuration(24 * time.Hour),
 		SMSTextTemplate:     DefaultSMSTextTemplate,
-		AllowedTestTypes:    14,
+		AllowedTestTypes:    14, // This doesn't include user initiated report by default.
 		CertificateDuration: FromDuration(15 * time.Minute),
 		RequireDate:         true, // Having dates is really important to risk scoring, encourage this by default true.
 	}
+}
+
+// AllowsUserReport returns true if this realm has enabled user initiated
+// test reporting.
+func (r *Realm) AllowsUserReport() bool {
+	return r.AllowedTestTypes&TestTypeUserReport != 0
+}
+
+// EnableUserReport adds the TestTypeUserReport to this realm.
+func (r *Realm) EnableUserReport() {
+	r.AllowedTestTypes = r.AllowedTestTypes | TestTypeUserReport
 }
 
 // AfterFind runs after a realm is found.
@@ -357,6 +376,18 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 	}
 
 	r.validateSMSTemplate(DefaultTemplateLabel, r.SMSTextTemplate)
+
+	// See if the user report template needs to be added into the mix.
+	if r.SMSTextAlternateTemplates == nil && r.AllowsUserReport() {
+		r.SMSTextAlternateTemplates = make(postgres.Hstore)
+	}
+	if r.AllowsUserReport() {
+		if _, ok := r.SMSTextAlternateTemplates[UserReportTemplateLabel]; !ok {
+			newText := UserReportDefaultText
+			r.SMSTextAlternateTemplates[UserReportTemplateLabel] = &newText
+		}
+	}
+
 	if r.SMSTextAlternateTemplates != nil {
 		for l, t := range r.SMSTextAlternateTemplates {
 			if t == nil || *t == "" {
@@ -422,7 +453,24 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 // validateSMSTemplate is a helper method to validate a single SMSTemplate.
 // Errors are returned by appending them to the realm's Errorable fields.
 func (r *Realm) validateSMSTemplate(label, t string) {
-	if r.EnableENExpress {
+	userReport := UserReportTemplateLabel == label
+	// There is some special handling for the UserReport template.
+	if userReport || !r.EnableENExpress {
+		// Check that we have exactly one of [code] or [longcode] as template substitutions.
+		if c, lc := strings.Contains(t, SMSCode), strings.Contains(t, SMSLongCode); !(c || lc) || (c && lc) {
+			r.AddError("smsTextTemplate", fmt.Sprintf("must contain exactly one of %q or %q", SMSCode, SMSLongCode))
+			r.AddError(label, fmt.Sprintf("must contain exactly one of %q or %q", SMSCode, SMSLongCode))
+		}
+
+		if userReport {
+			smsEnd := fmt.Sprintf("#%s", SMSCode)
+			smsLongEnd := fmt.Sprintf("#%s", SMSLongCode)
+			if !(strings.HasSuffix(t, smsEnd) || strings.HasSuffix(t, smsLongEnd)) {
+				r.AddError("smsTextTemplate", fmt.Sprintf("must must end with %q or %q", smsEnd, smsLongEnd))
+				r.AddError(label, fmt.Sprintf("must must end with %q or %q", smsEnd, smsLongEnd))
+			}
+		}
+	} else {
 		if !strings.Contains(t, SMSENExpressLink) {
 			r.AddError("smsTextTemplate", fmt.Sprintf("must contain %q", SMSENExpressLink))
 			r.AddError(label, fmt.Sprintf("must contain %q", SMSENExpressLink))
@@ -433,12 +481,6 @@ func (r *Realm) validateSMSTemplate(label, t string) {
 		}
 		if strings.Contains(t, SMSLongCode) {
 			r.AddError("smsTextTemplate", fmt.Sprintf("cannot contain %q - the long code is automatically included in %q", SMSLongCode, SMSENExpressLink))
-			r.AddError(label, fmt.Sprintf("must contain %q", SMSENExpressLink))
-		}
-	} else {
-		// Check that we have exactly one of [code] or [longcode] as template substitutions.
-		if c, lc := strings.Contains(t, SMSCode), strings.Contains(t, SMSLongCode); !(c || lc) || (c && lc) {
-			r.AddError("smsTextTemplate", fmt.Sprintf("must contain exactly one of %q or %q", SMSCode, SMSLongCode))
 			r.AddError(label, fmt.Sprintf("must contain %q", SMSENExpressLink))
 		}
 	}
@@ -458,7 +500,11 @@ func (r *Realm) validateSMSTemplate(label, t string) {
 		r.AddError("smsTextTemplate", fmt.Sprintf("SMS template expansion failed: %s", err))
 		r.AddError(label, fmt.Sprintf("SMS template expansion failed: %s", err))
 	}
-	if l := len(expandedSMSText); l > SMSTemplateExpansionMax {
+	max := SMSTemplateExpansionMax
+	if userReport {
+		max = SMSUserReportExpansionMax
+	}
+	if l := len(expandedSMSText); l > max {
 		r.AddError("smsTextTemplate", fmt.Sprintf("when expanded, the result message is too long (%v characters). The max expanded message is %v characters", l, SMSTemplateExpansionMax))
 		r.AddError(label, fmt.Sprintf("when expanded, the result message is too long (%v characters). The max expanded message is %v characters", l, SMSTemplateExpansionMax))
 	}
@@ -982,6 +1028,8 @@ func (r *Realm) ValidTestType(typ string) bool {
 		return r.AllowedTestTypes&TestTypeLikely != 0
 	case "negative":
 		return r.AllowedTestTypes&TestTypeNegative != 0
+	case "user-report":
+		return r.AllowedTestTypes&TestTypeUserReport != 0
 	default:
 		return false
 	}

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -277,7 +277,7 @@ func (db *Database) VerifyCodeAndIssueToken(request *IssueTokenRequest) (*Token,
 				if IsNotFound(err) {
 					return ErrVerificationCodeNotFound
 				}
-				return err
+				return fmt.Errorf("unable to look up associated user_report record: %w", err)
 			}
 
 			providedNonce := base64.StdEncoding.EncodeToString(request.Nonce)

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -203,6 +203,17 @@ func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID stri
 	return nil
 }
 
+// IssueTokenRequest is used to request the validation of a verification code
+// in order to issue a token
+type IssueTokenRequest struct {
+	Time        time.Time
+	AuthApp     *AuthorizedApp
+	VerCode     string
+	Nonce       []byte
+	AcceptTypes api.AcceptTypes
+	ExpireAfter time.Duration
+}
+
 // VerifyCodeAndIssueToken takes a previously issued verification code and exchanges
 // it for a long term token. The verification code must not have expired and must
 // not have been previously used. Both acctions are done in a single database
@@ -210,10 +221,10 @@ func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID stri
 // The verCode can be the "short code" or the "long code" which impacts expiry time.
 //
 // The long term token can be used later to sign keys when they are submitted.
-func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp, verCode string, acceptTypes api.AcceptTypes, expireAfter time.Duration) (*Token, error) {
-	t = t.UTC()
+func (db *Database) VerifyCodeAndIssueToken(request *IssueTokenRequest) (*Token, error) {
+	t := request.Time.UTC()
 
-	hmacedCodes, err := db.generateVerificationCodeHMACs(verCode)
+	hmacedCodes, err := db.generateVerificationCodeHMACs(request.VerCode)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create hmac: %w", err)
 	}
@@ -225,7 +236,7 @@ func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp,
 		// Also lock the row for update.
 		if err := tx.
 			Set("gorm:query_option", "FOR UPDATE").
-			Where("realm_id = ?", authApp.RealmID).
+			Where("realm_id = ?", request.AuthApp.RealmID).
 			Where("(code IN (?) OR long_code IN (?))", hmacedCodes, hmacedCodes).
 			First(&vc).
 			Error; err != nil {
@@ -236,7 +247,7 @@ func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp,
 		}
 
 		// Validation
-		expired, codeType, err := db.IsCodeExpired(&vc, verCode)
+		expired, codeType, err := db.IsCodeExpired(&vc, request.VerCode)
 		if err != nil {
 			db.logger.Errorw("failed to check code expiration", "ID", vc.ID, "error", err)
 			return ErrVerificationCodeExpired
@@ -250,15 +261,43 @@ func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp,
 			return ErrVerificationCodeUsed
 		}
 
-		if _, ok := acceptTypes[vc.TestType]; !ok {
+		if _, ok := request.AcceptTypes[vc.TestType]; !ok {
 			db.logger.Debugw("checked not of accepted testType", "ID", vc.ID)
 			return ErrUnsupportedTestType
+		}
+
+		// Check associated UserReport record if necessary.
+		if vc.UserReportID != nil {
+			var userReport UserReport
+			if err := tx.
+				Set("gorm:query_option", "FOR UPDATE").
+				Where("id = ?", *vc.UserReportID).
+				First(&userReport).
+				Error; err != nil {
+				if IsNotFound(err) {
+					return ErrVerificationCodeNotFound
+				}
+				return err
+			}
+
+			providedNonce := base64.StdEncoding.EncodeToString(request.Nonce)
+			if userReport.Nonce != providedNonce {
+				// If the code was found, but the nonce is required and doesn't match,
+				// treat this the same as not found.
+				return ErrVerificationCodeNotFound
+			}
+
+			// Mark the user report claimed so that it is not garbage collected.
+			userReport.CodeClaimed = true
+			if err := tx.Save(&userReport).Error; err != nil {
+				return fmt.Errorf("failed to validate user report: %w", err)
+			}
 		}
 
 		// Mark as claimed
 		vc.Claimed = true
 		if err := tx.Save(&vc).Error; err != nil {
-			return fmt.Errorf("failed to claim token: %w", err)
+			return fmt.Errorf("failed to claim verification code: %w", err)
 		}
 
 		buffer := make([]byte, tokenBytes)
@@ -274,20 +313,20 @@ func (db *Database) VerifyCodeAndIssueToken(t time.Time, authApp *AuthorizedApp,
 			SymptomDate: vc.SymptomDate,
 			TestDate:    vc.TestDate,
 			Used:        false,
-			ExpiresAt:   time.Now().UTC().Add(expireAfter),
-			RealmID:     authApp.RealmID,
+			ExpiresAt:   time.Now().UTC().Add(request.ExpireAfter),
+			RealmID:     request.AuthApp.RealmID,
 		}
 
 		return tx.Create(tok).Error
 	}); err != nil {
 		if !errors.Is(err, ErrVerificationCodeUsed) {
-			go db.updateStatsCodeInvalid(t, authApp)
+			go db.updateStatsCodeInvalid(t, request.AuthApp)
 		}
 		return nil, err
 	}
 
-	go db.updateStatsCodeClaimed(t, authApp)
-	go db.updateStatsAgeDistrib(t, authApp, &vc)
+	go db.updateStatsCodeClaimed(t, request.AuthApp)
+	go db.updateStatsAgeDistrib(t, request.AuthApp, &vc)
 	return tok, nil
 }
 

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -144,7 +144,7 @@ func TestIssueToken(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	realm.EnableUserReport()
+	realm.AddUserReportToAllowedTestTypes()
 	if err := db.SaveRealm(realm, SystemTest); err != nil {
 		t.Fatalf("unable to enable user-report on test realm: %v", err)
 	}

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -1,4 +1,4 @@
-// Copyright 2022 Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -72,10 +72,10 @@ func (ur *UserReport) BeforeSave(tx *gorm.DB) error {
 	decoded, err := base64util.DecodeString(ur.Nonce)
 	if err != nil {
 		ur.AddError("nonce", "is not using a valid base64 encoding")
-	}
-
-	if l := len(decoded); l != NonceLength {
-		ur.AddError("nonce", fmt.Sprintf("is not the correct length, want: %v got: %v", NonceLength, l))
+	} else {
+		if l := len(decoded); l != NonceLength {
+			ur.AddError("nonce", fmt.Sprintf("is not the correct length, want: %v got: %v", NonceLength, l))
+		}
 	}
 
 	return ur.ErrorOrNil()

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -1,0 +1,123 @@
+// Copyright 2022 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"encoding/base64"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/base64util"
+	"github.com/jinzhu/gorm"
+)
+
+const (
+	NonceLength = 256
+)
+
+// UserReport is used to de-duplicate phone numbers for user-initiated reporting.
+type UserReport struct {
+	Errorable
+
+	ID uint
+
+	PhoneHash string `json:"-"` // unique
+	Nonce     string
+
+	CodeClaimed bool
+
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}
+
+func (db *Database) NewUserReport(phone string, nonce []byte) (*UserReport, error) {
+	hmac, err := db.GeneratePhoneNumberHMAC(phone)
+	if err != nil {
+		return nil, err
+	}
+
+	nonceB64 := base64.StdEncoding.EncodeToString(nonce)
+
+	return &UserReport{
+		PhoneHash: hmac,
+		Nonce:     nonceB64,
+	}, nil
+}
+
+func (ur *UserReport) BeforeSave(tx *gorm.DB) error {
+	decoded, err := base64util.DecodeString(ur.Nonce)
+	if err != nil {
+		ur.AddError("nonce", "is not using a valid base64 encoding")
+	}
+
+	if l := len(decoded); l != NonceLength {
+		ur.AddError("nonce", fmt.Sprintf("is not the correct length, want: %v got: %v", NonceLength, l))
+	}
+
+	if m := ur.ErrorMessages(); len(m) > 0 {
+		return fmt.Errorf("validation failed: %s", strings.Join(m, ", "))
+	}
+
+	return nil
+}
+
+func (db *Database) FindUserReport(tx *gorm.DB, phoneNumber string) (*UserReport, error) {
+	hmacedCodes, err := db.generatePhoneNumberHMACs(phoneNumber)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create hmac: %w", err)
+	}
+
+	var ur UserReport
+	if err := tx.
+		Where("phone_hash IN (?)", hmacedCodes).
+		First(&ur).
+		Error; err != nil {
+		return nil, err
+	}
+	return &ur, nil
+}
+
+// PurgeUnclaimedUserReports deletes record from the database
+// if the phone number was used in a user report, but the code was never claimed.
+func (db *Database) PurgeUnclaimedUserReports(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	deleteBefore := time.Now().UTC().Add(maxAge)
+	rtn := db.db.Unscoped().
+		Where("created_at < ? AND code_claimed = ?", deleteBefore, false).
+		Delete(&UserReport{})
+	return rtn.RowsAffected, rtn.Error
+}
+
+// PurgeUserReports removes expired user reports.
+func (db *Database) PurgeUserReports(maxAge time.Duration) (int64, error) {
+	deleteBefore := time.Now().UTC()
+	rtn := db.db.Unscoped().
+		Where("created_at < ?", deleteBefore).
+		Delete(&UserReport{})
+	return rtn.RowsAffected, rtn.Error
+}
+
+// GeneratePhoneNumberHMAC generates the HMAC of the phone number using the latest key.
+func (db *Database) GeneratePhoneNumberHMAC(phoneNumber string) (string, error) {
+	return initialHMAC(db.config.PhoneNumberHMAC, phoneNumber)
+}
+
+// generatePhoneNumberHMACs is a helper for generating all possible HMACs of a phone number.
+func (db *Database) generatePhoneNumberHMACs(phoneNumber string) ([]string, error) {
+	return allAllowedHMACs(db.config.PhoneNumberHMAC, phoneNumber)
+}

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -17,7 +17,6 @@ package database
 import (
 	"encoding/base64"
 	"fmt"
-	"strings"
 	"time"
 
 	"github.com/google/exposure-notifications-server/pkg/base64util"
@@ -25,6 +24,10 @@ import (
 )
 
 const (
+	// NonceLength is the required length of an associated user-report request.
+	// Changing this could break outstanding codes in the system.
+	// If the value were to be lowered, uses should change to >= instead of exact match,
+	// including updating associated documentation.
 	NonceLength = 256
 )
 
@@ -75,11 +78,7 @@ func (ur *UserReport) BeforeSave(tx *gorm.DB) error {
 		ur.AddError("nonce", fmt.Sprintf("is not the correct length, want: %v got: %v", NonceLength, l))
 	}
 
-	if m := ur.ErrorMessages(); len(m) > 0 {
-		return fmt.Errorf("validation failed: %s", strings.Join(m, ", "))
-	}
-
-	return nil
+	return ur.ErrorOrNil()
 }
 
 // FindUserReport finds a user report by phone number using any of the currently valid

--- a/pkg/database/user_report_test.go
+++ b/pkg/database/user_report_test.go
@@ -1,0 +1,174 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"crypto/rand"
+	"encoding/base64"
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/errcmp"
+	"github.com/google/go-cmp/cmp"
+	"github.com/google/go-cmp/cmp/cmpopts"
+	"github.com/jinzhu/gorm"
+)
+
+func generateNonce(t testing.TB) []byte {
+	t.Helper()
+	buf := make([]byte, NonceLength)
+	n, err := rand.Read(buf)
+	if err != nil {
+		t.Fatalf("unable to generate nonce")
+	}
+	if n != NonceLength {
+		t.Fatalf("wrong number of bytes read: want: %v got: %v", NonceLength, n)
+	}
+	return buf
+}
+
+func TestFindUserReport(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	t.Run("success", func(t *testing.T) {
+		t.Parallel()
+
+		phoneNumber := "+12065551234"
+		userReport, err := db.NewUserReport(phoneNumber, generateNonce(t))
+		if err != nil {
+			t.Fatalf("error creating user report: %v", err)
+		}
+		if err := db.db.Save(userReport).Error; err != nil {
+			t.Fatalf("error writing user report: %v", err)
+		}
+
+		var got *UserReport
+		err = db.db.Transaction(func(tx *gorm.DB) error {
+			got, err = db.FindUserReport(tx, phoneNumber)
+			if err != nil {
+				return err
+			}
+			return nil
+		})
+		if err != nil {
+			t.Fatalf("error finding user reports: %v", err)
+		}
+
+		if diff := cmp.Diff(userReport, got, ApproxTime, cmpopts.IgnoreUnexported(Errorable{})); diff != "" {
+			t.Fatalf("mismatch (-want, +got):\n%s", diff)
+		}
+	})
+
+	cases := []struct {
+		name  string
+		phone string
+		nonce string
+		want  string
+	}{
+		{
+			name:  "poorly_encoded_nonce",
+			phone: "+12065551235",
+			nonce: ".foo",
+			want:  "nonce is not using a valid base64 encoding",
+		},
+		{
+			name:  "poorly_encoded_nonce",
+			phone: "+12065551235",
+			nonce: base64.RawURLEncoding.EncodeToString([]byte{1, 2, 3}),
+			want:  "nonce is not the correct length",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			userReport, err := db.NewUserReport(tc.phone, []byte{0})
+			userReport.Nonce = tc.nonce // override the encoding from NewUserReport for testing errors.
+			if err != nil {
+				t.Fatalf("error creating user report: %v", err)
+			}
+			err = db.db.Save(userReport).Error
+			errcmp.MustMatch(t, err, tc.want)
+		})
+	}
+}
+
+func TestPurgeUserReports(t *testing.T) {
+	t.Parallel()
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	cases := []struct {
+		name    string
+		claimed bool
+		method  func() (int64, error)
+	}{
+		{
+			name:    "unclaimed",
+			claimed: false,
+			method: func() (int64, error) {
+				return db.PurgeUnclaimedUserReports(500 * time.Millisecond)
+			},
+		},
+		{
+			name:    "claimed",
+			claimed: true,
+			method: func() (int64, error) {
+				return db.PurgeUserReports(500 * time.Millisecond)
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			// tests not parallel because one purge test could interfer with the other.
+			phoneNumber := tc.name
+			userReport, err := db.NewUserReport(phoneNumber, generateNonce(t))
+			if err != nil {
+				t.Fatalf("error creating user report: %v", err)
+			}
+			userReport.CodeClaimed = tc.claimed
+			if err := db.db.Save(userReport).Error; err != nil {
+				t.Fatalf("error writing user report: %v", err)
+			}
+
+			var got *UserReport
+			err = db.db.Transaction(func(tx *gorm.DB) error {
+				got, err = db.FindUserReport(tx, phoneNumber)
+				return err
+			})
+			if err != nil {
+				t.Fatalf("error reading back user report: %v", err)
+			}
+			if diff := cmp.Diff(userReport, got, ApproxTime, cmpopts.IgnoreUnexported(Errorable{})); diff != "" {
+				t.Fatalf("mismatch (-want, +got):\n%s", diff)
+			}
+
+			time.Sleep(1 * time.Second)
+
+			n, err := tc.method()
+			if err != nil {
+				t.Fatalf("error purging user reports: %v", err)
+			}
+			if n != 1 {
+				t.Fatalf("expected 1 record to be removed, got: %v", n)
+			}
+		})
+	}
+}

--- a/pkg/database/user_report_test.go
+++ b/pkg/database/user_report_test.go
@@ -129,7 +129,7 @@ func TestPurgeUserReports(t *testing.T) {
 			name:    "claimed",
 			claimed: true,
 			method: func() (int64, error) {
-				return db.PurgeUserReports(500 * time.Millisecond)
+				return db.PurgeClaimedUserReports(500 * time.Millisecond)
 			},
 		},
 	}

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -55,8 +55,7 @@ var (
 	ErrCodeAlreadyExpired = errors.New("code already expired")
 	ErrCodeAlreadyClaimed = errors.New("code already claimed")
 	ErrCodeTooShort       = errors.New("verification code is too short")
-	// User-report errors
-	ErrAlreadyReported = errors.New("phone number not eligible for user report, try again later.")
+	ErrAlreadyReported    = errors.New("phone number not eligible for user report, try again later")
 )
 
 // VerificationCode represents a verification code in the database.

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -262,11 +262,10 @@ func (db *Database) ExpireCode(uuid string) (*VerificationCode, error) {
 // SaveVerificationCode created or updates a verification code in the database.
 // Max age represents the maximum age of the test date [optional] in the record.
 func (db *Database) SaveVerificationCode(vc *VerificationCode, realm *Realm) error {
+	if err := vc.Validate(realm); err != nil {
+		return err
+	}
 	return db.db.Transaction(func(tx *gorm.DB) error {
-		if err := vc.Validate(realm); err != nil {
-			return err
-		}
-
 		// If there is a nonce present, this verification code requests that
 		// the phone number not exist in the de-duplicate table.
 		var userReport *UserReport

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -17,6 +17,7 @@ package database
 import (
 	"errors"
 	"fmt"
+	"log"
 	"strings"
 	"testing"
 	"time"
@@ -262,6 +263,48 @@ func TestVerificationCode_ExpireVerificationCode(t *testing.T) {
 
 	if _, err := db.ExpireCode(uuid); err == nil {
 		t.Errorf("Expected code already expired, got %v", err)
+	}
+}
+
+func TestSaveUserReport(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	realm := NewRealmWithDefaults("The Grid")
+	realm.EnableUserReport()
+	if err := db.SaveRealm(realm, SystemTest); err != nil {
+		t.Fatal(err)
+	}
+
+	vc := &VerificationCode{
+		Code:          "123456",
+		LongCode:      "defghijk329024",
+		TestType:      "user-report",
+		ExpiresAt:     time.Now().Add(time.Hour),
+		LongExpiresAt: time.Now().Add(2 * time.Hour),
+		Nonce:         generateNonce(t),
+		PhoneNumber:   "+12068675309",
+	}
+
+	if err := db.SaveVerificationCode(vc, realm); err != nil {
+		t.Fatal(err)
+	}
+
+	var userReport *UserReport
+	var err error
+	err = db.db.Transaction(func(tx *gorm.DB) error {
+		userReport, err = db.FindUserReport(tx, vc.PhoneNumber)
+		return err
+	})
+	if err != nil {
+		t.Fatal(err)
+	}
+	log.Printf("%+v", vc)
+	if vc.UserReportID == nil || *vc.UserReportID != userReport.ID {
+		t.Fatalf("userReportID not saved on verification code")
+	}
+	if userReport.CodeClaimed {
+		t.Fatalf("user report was created in a claimed state")
 	}
 }
 

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -17,7 +17,6 @@ package database
 import (
 	"errors"
 	"fmt"
-	"log"
 	"strings"
 	"testing"
 	"time"
@@ -271,7 +270,7 @@ func TestSaveUserReport(t *testing.T) {
 
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	realm := NewRealmWithDefaults("The Grid")
-	realm.EnableUserReport()
+	realm.AddUserReportToAllowedTestTypes()
 	if err := db.SaveRealm(realm, SystemTest); err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +298,6 @@ func TestSaveUserReport(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	log.Printf("%+v", vc)
 	if vc.UserReportID == nil || *vc.UserReportID != userReport.ID {
 		t.Fatalf("userReportID not saved on verification code")
 	}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -191,6 +191,7 @@ export DB_PORT="5432"
 export DB_SSLMODE="disable"
 export DB_USER="${google_sql_user.user.name}"
 export DB_VERIFICATION_CODE_DATABASE_KEY="secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
+export DB_PHONE_HMAC_KEY="secret://${google_secret_manager_secret_version.db-phone-number-hmac.id}"
 
 export FIREBASE_API_KEY="${data.google_firebase_web_app_config.default.api_key}"
 export FIREBASE_APP_ID="${google_firebase_web_app.default.app_id}"

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -56,6 +56,7 @@ locals {
     DB_SSLROOTCERT                    = "secret://${google_secret_manager_secret_version.db-secret-version["sslrootcert"].id}?target=file"
     DB_USER                           = google_sql_user.user.name
     DB_VERIFICATION_CODE_DATABASE_KEY = "secret://${google_secret_manager_secret_version.db-verification-code-hmac.id}"
+    DB_PHONE_HMAC_KEY                 = "secret://${google_secret_manager_secret_version.db-phone-number-hmac.id}"
   }
 
   firebase_config = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -221,6 +221,13 @@ variable "enx_redirect_domain_map_add" {
   description = "Redirect domains and environments to be added to the next cert."
 }
 
+variable "db_phone_number_hmac_count" {
+  type = number
+  default = 1
+
+  description = "Number of HMAC keys to create for HMACing phone numbers in the database. Increase by 1 to force a rotation."
+}
+
 variable "db_apikey_db_hmac_count" {
   type    = number
   default = 1

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -222,7 +222,7 @@ variable "enx_redirect_domain_map_add" {
 }
 
 variable "db_phone_number_hmac_count" {
-  type = number
+  type    = number
   default = 1
 
   description = "Number of HMAC keys to create for HMACing phone numbers in the database. Increase by 1 to force a rotation."

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -412,7 +412,14 @@ func generateCodesAndStats(db *database.Database, realm *database.Realm) error {
 					date = date.Add(time.Duration(rand.Intn(60))*time.Minute + time.Second)
 				}
 
-				token, err := db.VerifyCodeAndIssueToken(date, app, longCode, accept, 24*time.Hour)
+				request := &database.IssueTokenRequest{
+					Time:        date,
+					AuthApp:     app,
+					VerCode:     longCode,
+					AcceptTypes: accept,
+					ExpireAfter: 24 * time.Hour,
+				}
+				token, err := db.VerifyCodeAndIssueToken(request)
 				if err != nil {
 					continue
 				}


### PR DESCRIPTION
Towards #1928

## Proposed Changes

* Adds API for UserReport to request a verification code
* requests are de-duplicated for phone number over 90d

New checkbox to enable user report

![image](https://user-images.githubusercontent.com/92319/111853202-3eed0900-88d7-11eb-87fd-89518ab81452.png)

New SMS template for "User Report"

![image](https://user-images.githubusercontent.com/92319/111853220-4dd3bb80-88d7-11eb-94cd-72b3b47f56d6.png)


**Release Note**


```release-note
Add support for self-report initiation and certification. This feature is disabled by default, enable by setting `ENABLE_USER_REPORT` to `true`
```
