### PR TITLE
Remove warnings about unused environment variables

### DIFF
--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -17,11 +17,9 @@ package config
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
-	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -60,16 +58,9 @@ type RedirectConfig struct {
 
 // NewRedirectConfig initializes and validates a RedirectConfig struct.
 func NewRedirectConfig(ctx context.Context) (*RedirectConfig, error) {
-	logger := logging.FromContext(ctx).Named("RedirectConfig")
-
 	var config RedirectConfig
 	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
 		return nil, err
-	}
-
-	// TODO(sethvargo): remove in 0.24+
-	if v := os.Getenv("ASSETS_PATH"); v != "" {
-		logger.Warnw("ASSETS_PATH is no longer used")
 	}
 	return &config, nil
 }

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -17,7 +17,6 @@ package config
 import (
 	"context"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -28,7 +27,6 @@ import (
 	"github.com/microcosm-cc/bluemonday"
 	"github.com/russross/blackfriday/v2"
 
-	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/observability"
 
 	firebase "firebase.google.com/go"
@@ -110,19 +108,9 @@ type ServerConfig struct {
 
 // NewServerConfig initializes and validates a ServerConfig struct.
 func NewServerConfig(ctx context.Context) (*ServerConfig, error) {
-	logger := logging.FromContext(ctx).Named("ServerConfig")
-
 	var config ServerConfig
 	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
 		return nil, err
-	}
-
-	// TODO(sethvargo): remove in 0.24+
-	if v := os.Getenv("ASSETS_PATH"); v != "" {
-		logger.Warnw("ASSETS_PATH is no longer used")
-	}
-	if v := os.Getenv("LOCALES_PATH"); v != "" {
-		logger.Warnw("LOCALES_PATH is no longer used")
 	}
 
 	// Parse system notice - do this once since it's displayed on every page.

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -110,14 +110,10 @@ locals {
   }
 
   enx_redirect_config = {
-    ASSETS_PATH        = "/assets" // TODO(sethvargo): remove in v0.24+
     HOSTNAME_TO_REGION = join(",", [for o in concat(var.enx_redirect_domain_map, var.enx_redirect_domain_map_add) : format("%s:%s", o.host, o.region)])
   }
 
-  server_config = {
-    "ASSETS_PATH"  = "/assets"  // TODO(sethvargo): remove in v0.24+
-    "LOCALES_PATH" = "/locales" // TODO(sethvargo): remove in v0.24+
-  }
+  server_config = {}
 
   observability_config = {}
 }


### PR DESCRIPTION
These were kept to make the transition from fs to embed easier. It's been a full release cycle, so let's remove these values now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove warnings about unused environment variables.
```
