### PR TITLE
add composite stats handler to adminapi server

### DIFF
--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -126,6 +126,9 @@ func AdminAPI(
 		sub.Handle("/realm.csv", statsController.HandleRealmStats(stats.TypeCSV)).Methods(http.MethodGet)
 		sub.Handle("/realm.json", statsController.HandleRealmStats(stats.TypeJSON)).Methods(http.MethodGet)
 
+		sub.Handle("/realm/composite.csv", statsController.HandleComposite(stats.TypeCSV)).Methods(http.MethodGet)
+		sub.Handle("/realm/composite.json", statsController.HandleComposite(stats.TypeJSON)).Methods(http.MethodGet)
+
 		sub.Handle("/realm/users.csv", statsController.HandleRealmUsersStats(stats.TypeCSV)).Methods(http.MethodGet)
 		sub.Handle("/realm/users.json", statsController.HandleRealmUsersStats(stats.TypeJSON)).Methods(http.MethodGet)
 


### PR DESCRIPTION
Fixes #

## Proposed Changes

* Adds composite.csv/json routes to admin api server, these were left off when composite stats were added

**Release Note**


```release-note
composite stats are now available on the adminapi, `realm/composite.csv` and `realm/composite.json`
```
