### PR TITLE
add self report charts

### DIFF
--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -93,7 +93,11 @@
         Allow user initiated report
         <small class="form-text text-muted mb-3">
           Allow users to initiate a COVID-19 diagnosis from their mobile application before
-          receiving a verification code from this health authority.
+          receiving a verification code from this health authority. <strong>Before enabling:
+            Ensure that your application is prepared and that your risk scoring correctly handles
+            the <code>SELF_REPORT</code> report type. If you are an Exposure Notifications Express
+            customer, please work with Apple and Google before enabling this feature.
+          </strong>
         </small>
       </label>
     </div>

--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -5,7 +5,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    Codes Issued &amp; Usage
+    {{if $realm.AllowsUserReport}} Total {{end}} Codes Issued &amp; Usage
   </div>
   <div id="dashboard_div">
     <div id="realm_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -185,6 +185,10 @@
         <p>
           This graph reflects the total number of codes issued and usage
           of those codes for this realm, grouped by UTC day.
+          {{if $realm.AllowsUserReport}}
+          This includes both PHA (manual or automated) codes issued and
+          user reported cases together in the same chart.
+          {{end}}
         </p>
 
         <strong>Codes Issued</strong>

--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -1,5 +1,7 @@
 {{define "realmadmin/_stats_codes"}}
 
+{{$realm := .currentMembership.Realm}}
+
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
@@ -25,6 +27,48 @@
     </span>
   </small>
 </div>
+
+{{if $realm.AllowsUserReport}}
+<div class="card shadow-sm mb-3">
+  <div class="card-header">
+    <span class="oi oi-bar-chart mr-2 ml-n1"></span>
+    User Report Codes &amp; Usage
+  </div>
+  <div id="user_issued_dashboard_div">
+    <div id="user_issued_realm_chart_div" class="h-100 w-100" style="min-height:325px;">
+      <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
+    </div>
+    <div id="user_issued_realm_filter_div" class="text-right" style="height: 75px;"></div>
+  </div>
+  <small class="card-footer d-flex justify-content-between text-muted">
+    <a href="#" data-toggle="modal" data-target="#realm-user-codes-modal">Learn more about this chart</a>
+    <span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>       
+    </span>
+  </small>
+</div>
+
+<div class="card shadow-sm mb-3">
+  <div class="card-header">
+    <span class="oi oi-bar-chart mr-2 ml-n1"></span>
+    System &amp; User Report
+  </div>
+  <div id="comparison_dashboard_div">
+    <div id="comparison_chart_div" class="h-100 w-100" style="min-height:325px;">
+      <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
+    </div>
+    <div id="comparison_filter_div" class="text-right" style="height: 75px;"></div>
+  </div>
+  <small class="card-footer d-flex justify-content-between text-muted">
+    <a href="#" data-toggle="modal" data-target="#comparison-codes-modal">Learn more about this chart</a>
+    <span>
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a>       
+    </span>
+  </small>
+</div>
+{{end}}
 
 <div class="card shadow-sm mb-3">
   <div class="card-header">
@@ -68,6 +112,65 @@
     </span>
   </small>
 </div>
+
+<div class="modal fade" id="realm-user-codes-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">User Report Codes &amp; Usage</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body mb-n3">
+        <p>
+          This graph reflects the total number of codes issued and used
+          that are the result of a <strong>user initiated report</strong>
+          for this realm, grouped by UTC day.
+        </p>
+
+        <strong>User Report Codes Issued</strong>
+        <p>
+          This line tracks the total number of codes issued by user report.
+        </p>
+
+        <strong>User Report Codes Claimed</strong>
+        <p>
+          This line tracks the total number of user report codes claimed.
+          Codes can only be claimed by the end user using the API.
+          Typically the iOS or  Android application is responsible for claiming the code.
+        </p>
+
+        <strong>User Report Tokens Claimed</strong>
+        <p>
+          This line tracks the total number of users who initiated a user report
+          and then successfully
+          claimed a verification code and then consented to key release.
+        </p>
+      </div>
+    </div>
+  </div>
+</div>  
+
+<div class="modal fade" id="comparison-codes-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">System &amp; User Report</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body mb-n3">
+        <p>
+          This graph reflects the total number of tokens claimed using stacked area.
+          This can help you determine what the ratio between user reported uploads
+          and uploads where your public health authority initiated the code.
+        </p>
+      </div>
+    </div>
+  </div>
+</div> 
 
 <div class="modal fade" id="realm-codes-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -233,44 +336,91 @@
   }
 
   function drawClaimChart(data) {
-    let $realmChartDiv = $('#realm_chart_div');
-
+    charts = [
+      {
+        chartType: 'LineChart',
+        chartDiv: 'realm_chart_div',
+        dashboardDiv: 'dashboard_div',
+        filterDiv: "filter_div",
+        headerFunc: function(dataTable, hasKeyServerStats) {
+          dataTable.addColumn('date', 'Date');
+          dataTable.addColumn('number', 'Codes Issued');
+          dataTable.addColumn('number', 'Codes Claimed');
+          dataTable.addColumn('number', 'Invalid Codes');
+          dataTable.addColumn('number', 'Tokens Claimed');
+          if (hasKeyServerStats) {
+            dataTable.addColumn('number', 'Publish Requests');
+          }
+        },
+        rowFunc: function(dataTable, row, hasKeyServerStats) {
+          if (hasKeyServerStats) {
+            dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed, row.data.total_publish_requests]);
+          } else {
+            dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed]);
+          }
+        },
+      },
+      {
+        chartType: 'LineChart',
+        chartDiv: 'user_issued_realm_chart_div',
+        dashboardDiv: 'user_issued_dashboard_div',
+        filterDiv: "user_issued_realm_filter_div",
+        headerFunc: function(dataTable, hasKeyServerStats) {
+          dataTable.addColumn('date', 'Date');
+          dataTable.addColumn('number', 'User Report Codes Issued');
+          dataTable.addColumn('number', 'User Report Codes Claimed');
+          dataTable.addColumn('number', 'User Report Tokens Claimed');
+        },
+        rowFunc: function(dataTable, row, hasKeyServerStats) {
+          dataTable.addRow([utcDate(row.date), row.data.user_reports_issued, row.data.user_reports_claimed, row.data.user_report_tokens_claimed]);
+        },
+      },
+      {
+        chartType: 'AreaChart',
+        chartDiv: 'comparison_chart_div',
+        dashboardDiv: 'comparison_dashboard_div',
+        filterDiv: "comparison_filter_div",
+        headerFunc: function(dataTable, hasKeyServerStats) {
+          dataTable.addColumn('date', 'Date');
+          dataTable.addColumn('number', 'System Issued Tokens Claimed');
+          dataTable.addColumn('number', 'User Report Tokens Claimed');
+        },
+        rowFunc: function(dataTable, row, hasKeyServerStats) {
+          dataTable.addRow([utcDate(row.date), row.data.tokens_claimed-row.data.user_report_tokens_claimed, row.data.user_report_tokens_claimed]);
+        },
+      }
+    ]
+    
     if (!data.statistics) {
-      $realmChartDiv.find('p').text('No data yet.');
+      for (i = 0; i < charts.length; i++) {
+        $("#" + charts[i].chartDiv).find('p').text('No data yet.');
+      }
       return;
     }
 
-    let hasKeyServerStats = data.has_key_server_stats;
-    let tenDaysAgo = new Date(data.statistics[data.statistics.length-10].date);
+    for (i = 0; i < charts.length; i++) {
+      let $realmChartDiv = $("#" + charts[i].chartDiv);
 
-    let dataTable = new google.visualization.DataTable();
-    dataTable.addColumn('date', 'Date');
-    dataTable.addColumn('number', 'Codes Issued');
-    dataTable.addColumn('number', 'Codes Claimed');
-    dataTable.addColumn('number', 'Invalid Codes');
-    dataTable.addColumn('number', 'Tokens Claimed');
-    if (hasKeyServerStats) {
-      dataTable.addColumn('number', 'Publish Requests');
-    }
+      let hasKeyServerStats = data.has_key_server_stats;
+      let tenDaysAgo = new Date(data.statistics[data.statistics.length-10].date);
 
-    data.statistics.reverse().forEach(function(row) {
-      if (hasKeyServerStats) {
-        dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed, row.data.total_publish_requests]);
-      } else {
-        dataTable.addRow([utcDate(row.date), row.data.codes_issued, row.data.codes_claimed, row.data.codes_invalid, row.data.tokens_claimed]);
-      }
-    });
+      let dataTable = new google.visualization.DataTable();
+      charts[i].headerFunc(dataTable, hasKeyServerStats);
 
-    let dateFormatter = new google.visualization.DateFormat({
-      pattern: 'MMM dd',
-    });
-    dateFormatter.format(dataTable, 0);
+      data.statistics.reverse().forEach(function(row) {
+        charts[i].rowFunc(dataTable, row, hasKeyServerStats)
+      });
 
-    let dashboard = new google.visualization.Dashboard(document.getElementById('dashboard_div'));
+      let dateFormatter = new google.visualization.DateFormat({
+        pattern: 'MMM dd',
+      });
+      dateFormatter.format(dataTable, 0);
 
-    let filter = new google.visualization.ControlWrapper({
+      let dashboard = new google.visualization.Dashboard(document.getElementById(charts[i].dashboardDiv));
+
+      let filter = new google.visualization.ControlWrapper({
         controlType: 'ChartRangeFilter',
-        containerId: 'filter_div',
+        containerId: charts[i].filterDiv,
         state: {
           range: {
             start: tenDaysAgo,
@@ -295,6 +445,7 @@
                 bottom: 20,
                 left: 60,
               },
+              isStacked: true,
               hAxis: { format: 'M/d' },
             },
             chartView: {
@@ -305,31 +456,32 @@
         },
       });
 
-    let realmChart = new google.visualization.ChartWrapper({
-      chartType: 'LineChart',
-      containerId: 'realm_chart_div',
-      options: {
-        colors: ['#007bff', '#28a745', '#dc3545', '#6c757d', '#ee8c00'],
-        chartArea: {
-          left: 60,
-          right: 40,
-          bottom: 5,
-          top: 40,
+      let realmChart = new google.visualization.ChartWrapper({
+        chartType: charts[i].chartType,
+        containerId: charts[i].chartDiv,
+        options: {
+          colors: ['#007bff', '#28a745', '#dc3545', '#6c757d', '#ee8c00'],
+          chartArea: {
+            left: 60,
+            right: 40,
+            bottom: 5,
+            top: 40,
+            width: '100%',
+            height: '300',
+          },
+          hAxis: { textPosition: 'none' },
+          legend: { position: 'top' },
           width: '100%',
-          height: '300',
         },
-        hAxis: { textPosition: 'none' },
-        legend: { position: 'top' },
-        width: '100%',
-      },
-    });
+      });
 
-    dashboard.bind(filter, realmChart);
-    dashboard.draw(dataTable);
-    chartData.push({
-      chart: dashboard,
-      data: dataTable,
-    });
+      dashboard.bind(filter, realmChart);
+      dashboard.draw(dataTable);
+      chartData.push({
+        chart: dashboard,
+        data: dataTable,
+      });
+    }
   }
 
   function drawMeanClaimAgeChart(data) {

--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -5,7 +5,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    {{if $realm.AllowsUserReport}} Total {{end}} Codes Issued &amp; Usage
+    {{if $realm.AllowsUserReport}} Total {{end}} codes issued &amp; usage
   </div>
   <div id="dashboard_div">
     <div id="realm_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -32,7 +32,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    User Report Codes &amp; Usage
+    User report codes &amp; usage
   </div>
   <div id="user_issued_dashboard_div">
     <div id="user_issued_realm_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -52,7 +52,7 @@
 <div class="card shadow-sm mb-3">
   <div class="card-header">
     <span class="oi oi-bar-chart mr-2 ml-n1"></span>
-    System &amp; User Report
+    Manual / automated code issue &amp; user report
   </div>
   <div id="comparison_dashboard_div">
     <div id="comparison_chart_div" class="h-100 w-100" style="min-height:325px;">
@@ -117,7 +117,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">User Report Codes &amp; Usage</h5>
+        <h5 class="modal-title">User report codes &amp; usage</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -156,7 +156,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">System &amp; User Report</h5>
+        <h5 class="modal-title">Manual / automated code issue &amp; user report</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>
@@ -176,7 +176,7 @@
   <div class="modal-dialog modal-dialog-centered">
     <div class="modal-content">
       <div class="modal-header">
-        <h5 class="modal-title">Codes Issued &amp; Usage</h5>
+        <h5 class="modal-title">Codes issued &amp; usage</h5>
         <button type="button" class="close" data-dismiss="modal" aria-label="Close">
           <span aria-hidden="true">&times;</span>
         </button>

--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,7 @@ require (
 	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
-	github.com/google/exposure-notifications-server v0.24.1-0.20210315191013-2fb67bd61dd7
+	github.com/google/exposure-notifications-server v0.24.1-0.20210322233555-ecf9dee504c1
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/csrf v1.7.0

--- a/go.sum
+++ b/go.sum
@@ -386,6 +386,8 @@ github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Z
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/exposure-notifications-server v0.24.1-0.20210315191013-2fb67bd61dd7 h1:08DPt8x7IVqd0R4K0QgPQsyHVHKKjpVsk0oUyFZCsgU=
 github.com/google/exposure-notifications-server v0.24.1-0.20210315191013-2fb67bd61dd7/go.mod h1:BOl9yGGJ/s6HMmRPbrx9wpNKnqbGKx+D1hdd4h0jZ0U=
+github.com/google/exposure-notifications-server v0.24.1-0.20210322233555-ecf9dee504c1 h1:qifFvWfn5irKtkZ2X+6urTNLsazP57MVIn8BuYq+zzQ=
+github.com/google/exposure-notifications-server v0.24.1-0.20210322233555-ecf9dee504c1/go.mod h1:BOl9yGGJ/s6HMmRPbrx9wpNKnqbGKx+D1hdd4h0jZ0U=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/pkg/database/composite_stats.go
+++ b/pkg/database/composite_stats.go
@@ -84,8 +84,11 @@ func (c CompositeStats) MarshalJSON() ([]byte, error) {
 			data.CodesIssued = stat.RealmStats.CodesIssued
 			data.CodesClaimed = stat.RealmStats.CodesClaimed
 			data.CodesInvalid = stat.RealmStats.CodesInvalid
+			data.UserReportsIssued = stat.RealmStats.UserReportsIssued
+			data.UserReportsClaimed = stat.RealmStats.UserReportsClaimed
 			data.TokensClaimed = stat.RealmStats.TokensClaimed
 			data.TokensInvalid = stat.RealmStats.TokensInvalid
+			data.UserReportTokensClaimed = stat.RealmStats.UserReportTokensClaimed
 			data.CodeClaimMeanAge = uint(stat.RealmStats.CodeClaimMeanAge.Duration.Seconds())
 			data.CodeClaimDistribution = stat.RealmStats.CodeClaimAgeDistribution
 		}
@@ -147,6 +150,7 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		"tokens_claimed", "tokens_invalid", "code_claim_mean_age_seconds", "code_claim_age_distribution",
 		"publish_requests_unknown", "publish_requests_android", "publish_requests_ios",
 		"total_teks_published", "requests_with_revisions", "requests_missing_onset_date", "tek_age_distribution", "onset_to_upload_distribution",
+		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -180,6 +184,10 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 			row = append(row, joinInt64s(stat.KeyServerStats.TEKAgeDistribution, "|"))
 			row = append(row, joinInt64s(stat.KeyServerStats.OnsetToUploadDistribution, "|"))
 		}
+		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsIssued), 10))
+		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsClaimed), 10))
+		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportTokensClaimed), 10))
+		// New stats should always be added to the end to preserve existing external user applications.
 
 		if err := w.Write(row); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)

--- a/pkg/database/composite_stats_test.go
+++ b/pkg/database/composite_stats_test.go
@@ -48,8 +48,11 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesIssued:              10,
 						CodesClaimed:             9,
 						CodesInvalid:             1,
+						UserReportsIssued:        3,
+						UserReportsClaimed:       2,
 						TokensClaimed:            7,
 						TokensInvalid:            2,
+						UserReportTokensClaimed:  2,
 						CodeClaimMeanAge:         FromDuration(time.Minute),
 						CodeClaimAgeDistribution: []int32{1, 3, 4},
 					},
@@ -68,10 +71,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution
-2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
+2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"tokens_claimed":7,"tokens_invalid":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":3,"user_reports_claimed":2,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 	}
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2170,6 +2170,27 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`DROP TABLE IF EXISTS user_reports`)
 			},
 		},
+		{
+			ID: "00098-AddUserReportStats",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats
+						ADD COLUMN IF NOT EXISTS user_reports_issued INTEGER DEFAULT 0,
+						ADD COLUMN IF NOT EXISTS user_reports_claimed INTEGER DEFAULT 0,
+						ADD COLUMN IF NOT EXISTS user_report_tokens_claimed INTEGER DEFAULT 0`,
+					`ALTER TABLE realm_stats
+						ALTER COLUMN user_reports_issued SET NOT NULL,
+						ALTER COLUMN user_reports_claimed SET NOT NULL,
+						ALTER COLUMN user_report_tokens_claimed SET NOT NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats
+						DROP COLUMN user_reports_issued,
+						DROP COLUMN user_reports_claimed,
+						DROP COLUMN user_report_tokens_claimed`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1601,8 +1601,11 @@ func (r *Realm) Stats(db *Database) (RealmStats, error) {
 			COALESCE(s.codes_issued, 0) AS codes_issued,
 			COALESCE(s.codes_claimed, 0) AS codes_claimed,
 			COALESCE(s.codes_invalid, 0) AS codes_invalid,
+			COALESCE(s.user_reports_issued, 0) AS user_reports_issued,
+			COALESCE(s.user_reports_claimed, 0) AS user_reports_claimed,
 			COALESCE(s.tokens_claimed, 0) AS tokens_claimed,
 			COALESCE(s.tokens_invalid, 0) AS tokens_invalid,
+			COALESCE(s.user_report_tokens_claimed, 0) AS user_report_tokens_claimed,
 			COALESCE(s.code_claim_age_distribution, array[]::integer[]) AS code_claim_age_distribution,
 			COALESCE(s.code_claim_mean_age, 0) AS code_claim_mean_age
 		FROM (

--- a/pkg/database/realm_stats_test.go
+++ b/pkg/database/realm_stats_test.go
@@ -51,10 +51,10 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{1, 3, 4},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution
-2020-02-03,10,9,1,7,2,60,1|3|4
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
+2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"tokens_claimed":7,"tokens_invalid":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
 		},
 		{
 			name: "multi",
@@ -86,19 +86,22 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					RealmID:                  1,
 					CodesIssued:              15,
 					CodesClaimed:             2,
+					UserReportsIssued:        2,
+					UserReportsClaimed:       1,
 					CodesInvalid:             0,
 					TokensClaimed:            2,
 					TokensInvalid:            0,
+					UserReportTokensClaimed:  1,
 					CodeClaimMeanAge:         FromDuration(time.Millisecond),
 					CodeClaimAgeDistribution: []int32{7, 8, 9},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution
-2020-02-03,10,9,1,7,2,60,1|2|3
-2020-02-04,45,30,29,27,2,3600,4|5|6
-2020-02-05,15,2,0,2,0,0,7|8|9
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
+2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0
+2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0
+2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"tokens_claimed":2,"tokens_invalid":0,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"tokens_claimed":27,"tokens_invalid":2,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"tokens_claimed":7,"tokens_invalid":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"user_reports_issued":2,"user_reports_claimed":1,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
 		},
 	}
 

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -143,6 +143,7 @@ func (t *Token) Subject() *Subject {
 func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID string, subject *Subject) error {
 	t = t.UTC()
 
+	isUserReport := false
 	if err := db.db.Transaction(func(tx *gorm.DB) error {
 		var tok Token
 		if err := tx.
@@ -185,6 +186,10 @@ func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID stri
 			return ErrTokenMetadataMismatch
 		}
 
+		if api.TestTypeUserReport == tok.TestType {
+			isUserReport = true
+		}
+
 		// Save token.
 		tok.Used = true
 		if err := tx.Save(&tok).Error; err != nil {
@@ -199,7 +204,7 @@ func (db *Database) ClaimToken(t time.Time, authApp *AuthorizedApp, tokenID stri
 		return err
 	}
 
-	go db.updateStatsTokenClaimed(t, authApp)
+	go db.updateStatsTokenClaimed(t, authApp, isUserReport)
 	return nil
 }
 
@@ -408,6 +413,9 @@ func (db *Database) updateStatsAgeDistrib(t time.Time, authApp *AuthorizedApp, v
 
 		// Update total codes claimed
 		existing.CodesClaimed++
+		if vc.UserReportID != nil {
+			existing.UserReportsClaimed++
+		}
 
 		sel := tx.Table("realm_stats").
 			Where("realm_id = ?", authApp.RealmID).
@@ -472,16 +480,21 @@ func (db *Database) updateStatsTokenInvalid(t time.Time, authApp *AuthorizedApp)
 
 // updateStatsTokenClaimed updates the statistics, increasing the number of
 // tokens claimed.
-func (db *Database) updateStatsTokenClaimed(t time.Time, authApp *AuthorizedApp) {
+func (db *Database) updateStatsTokenClaimed(t time.Time, authApp *AuthorizedApp, isUserReport bool) {
 	t = timeutils.UTCMidnight(t)
 
 	realmSQL := `
-			INSERT INTO realm_stats(date, realm_id, tokens_claimed)
-					VALUES ($1, $2, 1)
+			INSERT INTO realm_stats(date, realm_id, tokens_claimed, user_report_tokens_claimed)
+					VALUES ($1, $2, 1, $3)
 				ON CONFLICT (date, realm_id) DO UPDATE
-					SET tokens_claimed = realm_stats.tokens_claimed + 1
+					SET tokens_claimed = realm_stats.tokens_claimed + 1,
+					    user_report_tokens_claimed = realm_stats.user_report_tokens_claimed + $3
 			`
-	if err := db.db.Exec(realmSQL, t, authApp.RealmID).Error; err != nil {
+	userReport := 0
+	if isUserReport {
+		userReport = 1
+	}
+	if err := db.db.Exec(realmSQL, t, authApp.RealmID, userReport).Error; err != nil {
 		db.logger.Errorw("failed to update realm stats token claimed", "error", err)
 	}
 

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -374,7 +374,7 @@ func (db *Database) UpdateStats(ctx context.Context, codes ...*VerificationCode)
 		// Count the number of user initiated reports
 		userReports := 0
 		for _, vc := range codes {
-			if verifyapi.ReportTypeSelfReport == vc.TestType {
+			if vc.TestType == verifyapi.ReportTypeSelfReport {
 				userReports++
 			}
 		}

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -21,9 +21,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+
+	verifyapi "github.com/google/exposure-notifications-server/pkg/api/v1"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/timeutils"
-	"github.com/google/exposure-notifications-verification-server/internal/project"
+
 	"github.com/jinzhu/gorm"
 )
 
@@ -327,56 +330,63 @@ func (db *Database) UpdateStats(ctx context.Context, codes ...*VerificationCode)
 
 	// If the issuer was a user, update the user stats for the day.
 	if v.IssuingUserID != 0 {
-		sql := fmt.Sprintf(`
+		sql := `
 			INSERT INTO user_stats (date, realm_id, user_id, codes_issued)
-				VALUES ($1, $2, $3, 1)
+				VALUES ($1, $2, $3, $4)
 			ON CONFLICT (date, realm_id, user_id) DO UPDATE
-				SET codes_issued = user_stats.codes_issued + %d
-		`, issued)
+				SET codes_issued = user_stats.codes_issued + $4`
 
-		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingUserID).Error; err != nil {
+		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingUserID, issued).Error; err != nil {
 			logger.Warnw("failed to update user stats", "error", err)
 		}
 	}
 
 	// If the request was an API request, we might have an external issuer ID.
 	if len(v.IssuingExternalID) != 0 {
-		sql := fmt.Sprintf(`
+		sql := `
 			INSERT INTO external_issuer_stats (date, realm_id, issuer_id, codes_issued)
-				VALUES ($1, $2, $3, 1)
+				VALUES ($1, $2, $3, $4)
 			ON CONFLICT (date, realm_id, issuer_id) DO UPDATE
-				SET codes_issued = external_issuer_stats.codes_issued + %d
-		`, issued)
+				SET codes_issued = external_issuer_stats.codes_issued + $4
+		`
 
-		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingExternalID).Error; err != nil {
+		if err := db.db.Exec(sql, date, v.RealmID, v.IssuingExternalID, issued).Error; err != nil {
 			logger.Warnw("failed to update external-issuer stats", "error", err)
 		}
 	}
 
 	// If the issuer was a app, update the app stats for the day.
 	if v.IssuingAppID != 0 {
-		sql := fmt.Sprintf(`
+		sql := `
 			INSERT INTO authorized_app_stats (date, authorized_app_id, codes_issued)
-				VALUES ($1, $2, 1)
+				VALUES ($1, $2, $3)
 			ON CONFLICT (date, authorized_app_id) DO UPDATE
-				SET codes_issued = authorized_app_stats.codes_issued + %d
-		`, issued)
+				SET codes_issued = authorized_app_stats.codes_issued + $3
+		`
 
-		if err := db.db.Exec(sql, date, v.IssuingAppID).Error; err != nil {
+		if err := db.db.Exec(sql, date, v.IssuingAppID, issued).Error; err != nil {
 			logger.Warnw("failed to update authorized app stats", "error", err)
 		}
 	}
 
 	// Update the per-realm stats.
 	if v.RealmID != 0 {
-		sql := fmt.Sprintf(`
-			INSERT INTO realm_stats(date, realm_id, codes_issued)
-				VALUES ($1, $2, 1)
-			ON CONFLICT (date, realm_id) DO UPDATE
-				SET codes_issued = realm_stats.codes_issued + %d
-		`, issued)
+		// Count the number of user initiated reports
+		userReports := 0
+		for _, vc := range codes {
+			if verifyapi.ReportTypeSelfReport == vc.TestType {
+				userReports++
+			}
+		}
 
-		if err := db.db.Exec(sql, date, v.RealmID).Error; err != nil {
+		sql := `
+			INSERT INTO realm_stats(date, realm_id, codes_issued, user_reports_issued)
+				VALUES ($1, $2, $3, $4)
+			ON CONFLICT (date, realm_id) DO UPDATE
+				SET codes_issued = realm_stats.codes_issued + $3,
+				user_reports_issued = realm_stats.user_reports_issued + $4`
+
+		if err := db.db.Exec(sql, date, v.RealmID, issued, userReports).Error; err != nil {
 			logger.Warnw("failed to update realm stats", "error", err)
 		}
 	}


### PR DESCRIPTION
Towards #1928 

## Proposed Changes

* Add 2 new charts for user-reported codes
* Improve seed script so make the numbers normalized across different types + add user-report generation

![image](https://user-images.githubusercontent.com/92319/112245340-e89d0480-8c0d-11eb-8c3a-c40cde6287e3.png)

**Release Note**

```release-note
Add charts for user-reported codes and claim stats.
```
