### PR TITLE
remove platform for user report API

### DIFF
--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -34,10 +34,6 @@ const (
 	// TestTypeUserReport is the string that represents a user initiated report.
 	TestTypeUserReport = "user-report"
 
-	// Platforms for User Report API
-	PlatformAndroid = "android"
-	PlatformIOS     = "ios"
-
 	// error_code definitions for the APIs.
 
 	// General
@@ -362,9 +358,6 @@ type UserReportRequest struct {
 	TZOffset float32 `json:"tzOffset"`
 	// Phone is required in this API. The verification code will be delivered over SMS.
 	Phone string `json:"phone"`
-
-	// Platform must be one of 'ios' or 'android'
-	Platform string `json:"platform"`
 
 	// Nonce must be 256 bytes of random data, base64 encoded.
 	Nonce string `json:"nonce"`

--- a/pkg/controller/issueapi/handle_user_report_test.go
+++ b/pkg/controller/issueapi/handle_user_report_test.go
@@ -89,7 +89,6 @@ func TestUserReport(t *testing.T) {
 			request: &api.UserReportRequest{
 				SymptomDate: symptomDate,
 				Phone:       "+12068675309",
-				Platform:    "android",
 				Nonce:       nonce,
 			},
 			httpStatusCode: http.StatusOK,
@@ -99,7 +98,6 @@ func TestUserReport(t *testing.T) {
 			request: &api.UserReportRequest{
 				SymptomDate: symptomDate,
 				Phone:       "+12068675309",
-				Platform:    "android",
 				Nonce:       nonce,
 			},
 			httpStatusCode: http.StatusConflict,
@@ -109,7 +107,6 @@ func TestUserReport(t *testing.T) {
 			name: "missing_phone",
 			request: &api.UserReportRequest{
 				SymptomDate: symptomDate,
-				Platform:    "android",
 				Nonce:       nonce,
 			},
 			httpStatusCode: http.StatusBadRequest,
@@ -119,7 +116,6 @@ func TestUserReport(t *testing.T) {
 			name: "missing_nonce",
 			request: &api.UserReportRequest{
 				SymptomDate: symptomDate,
-				Platform:    "android",
 			},
 			httpStatusCode: http.StatusBadRequest,
 			responseErr:    "missing_nonce",

--- a/tools/user-report/main.go
+++ b/tools/user-report/main.go
@@ -32,7 +32,6 @@ import (
 )
 
 var (
-	platform    = flag.String("platform", "android", "platform to emulate, may make a difference in SMS message")
 	nonceSize   = flag.Uint("nonce-size", 256, "size of the nonce to generate, in bytes")
 	phoneNumber = flag.String("phone-number", "", "Phone number to send verification code to")
 	testFlag    = flag.String("test-date", "", "Test date for code issue")
@@ -80,7 +79,6 @@ func realMain(ctx context.Context) error {
 		TestDate:    *testFlag,
 		SymptomDate: *onsetFlag,
 		Phone:       *phoneNumber,
-		Platform:    *platform,
 		Nonce:       base64.StdEncoding.EncodeToString(nonce),
 	})
 	if err != nil {


### PR DESCRIPTION
Towards #1928 

## Proposed Changes

* remove platform flag, android is not going to handle SMS differently in this case

**Release Note**


```release-note
NONE
```
