### PR TITLE
change restrictions on user report SMS template

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -284,6 +284,12 @@
 </form>
 
 <script type="text/javascript">
+  function removeTemplate(name) {
+    $('#sms-template-0').trigger("click");
+    $('#'+name).remove();
+    $('#'+name+'-div').remove();
+  }
+
   //
   // SMS preview builder
   //
@@ -437,12 +443,6 @@
         $(this).on('click', event => selectSMSTemplate($(this), event));
       }
     );
-
-    function removeTemplate(name) {
-      $('#sms-template-0').trigger("click");
-      $('#'+name).remove();
-      $('#'+name+'-div').remove();
-    }
 
     function selectSMSTemplate($elem, event) {
       event.preventDefault();


### PR DESCRIPTION
Towards #1928

## Proposed Changes

* Fix deletion of SMS template bug
* remove length restriction on user report, allow user report template to use ENX deep links

**Release Note**

```release-note
User report can use signed SMS and relax template restrictions.
```
