### PR TITLE
add key revisions back to key server chart iff user report is enabled

### DIFF
--- a/assets/server/realmadmin/_stats_keyserver.html
+++ b/assets/server/realmadmin/_stats_keyserver.html
@@ -1,5 +1,7 @@
 {{define "realmadmin/_stats_keyserver"}}
 
+{{$realm := .currentMembership.Realm}}
+
 <h1>Key server stats</h1>
 <p>
   The data below shows realm statistics and visualizations gathered from the key server.
@@ -295,6 +297,9 @@
     dataTable.addColumn('number', 'Total');
     dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'Missing Onset Date');
+    {{if $realm.AllowsUserReport}}
+    dataTable.addColumn('number', 'Key Revision Requests');
+    {{end}}
     dataTable.addColumn('number', 'Unknown OS');
     dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'Android');
@@ -316,6 +321,9 @@
           "<li><strong>iOS:</strong>" + iosCount + "</li>"+
           "<li><strong>Unknown:</strong>" + unknownCount + "</li></ul>",
         row.requests_missing_onset_date,
+        {{if $realm.AllowsUserReport}}
+        row.requests_with_revisions,
+        {{end}}
         row.publish_requests.unknown,
         "<ul class='chart-tooltip'><li><strong>Unknown:</strong></li>"+
           "<li>Count: " + unknownCount + "</li>" +
@@ -354,6 +362,9 @@
       series: {
         0: {type: 'line'},
         1: {type: 'line'},
+        {{if $realm.AllowsUserReport}}
+        2: {type: 'line'},
+        {{end}}
       },
       legend: { position: 'top' },
       isStacked: true,

--- a/assets/server/realmadmin/_stats_keyserver.html
+++ b/assets/server/realmadmin/_stats_keyserver.html
@@ -284,6 +284,8 @@
 
 
   function drawOSChart(data) {
+    let allowsUserReport = {{$realm.AllowsUserReport}};
+
     let $div = $('#keyserver_os_chart_div');
 
     if (!data.length) {
@@ -297,15 +299,15 @@
     dataTable.addColumn('number', 'Total');
     dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'Missing Onset Date');
-    {{if $realm.AllowsUserReport}}
-    dataTable.addColumn('number', 'Key Revision Requests');
-    {{end}}
+    if (allowsUserReport) {
+      dataTable.addColumn('number', 'Key Revision Requests');
+    }
     dataTable.addColumn('number', 'Unknown OS');
     dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'Android');
     dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});
     dataTable.addColumn('number', 'IOS');
-    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});   
+    dataTable.addColumn({type:'string', role:'tooltip', p: {html: true}});  
 
     stats.reverse().forEach(function(row) {
       let total = row.publish_requests.unknown + row.publish_requests.android + row.publish_requests.ios;
@@ -313,17 +315,18 @@
       let androidCount = parseInt(row.publish_requests.android);
       let iosCount = parseInt(row.publish_requests.ios);
 
-      dataTable.addRow([utcDate(row.day),
+      let data = [utcDate(row.day),
         total,        
          "<ul class='chart-tooltip'>"+
           "<li><strong>Total:</strong>" + total + "</li>"+
           "<li><strong>Android:</strong>" + androidCount + "</li>"+
           "<li><strong>iOS:</strong>" + iosCount + "</li>"+
           "<li><strong>Unknown:</strong>" + unknownCount + "</li></ul>",
-        row.requests_missing_onset_date,
-        {{if $realm.AllowsUserReport}}
-        row.requests_with_revisions,
-        {{end}}
+        row.requests_missing_onset_date];
+      if (allowsUserReport) {
+        data.push(row.requests_with_revisions);
+      }  
+      data.push(
         row.publish_requests.unknown,
         "<ul class='chart-tooltip'><li><strong>Unknown:</strong></li>"+
           "<li>Count: " + unknownCount + "</li>" +
@@ -336,7 +339,10 @@
         "<ul class='chart-tooltip'><li><strong>IOS:</strong></li>"+
           "<li>Count: " + iosCount + "</li>" +
           "<li>Percent: " + (iosCount / total * 100).toPrecision(3)  + "%</li></ul>",        
-      ]);
+      );
+
+
+      dataTable.addRow(data);
     });
 
     let dateFormatter = new google.visualization.DateFormat({
@@ -344,8 +350,14 @@
     });
     dateFormatter.format(dataTable, 0);
 
+    let colors = ['#ee8c00', '#ea4335'];
+    if (allowsUserReport) {
+      colors.push('#fcfc3d');
+    }
+    colors.push('#6c757d', '#28a745', '#007bff');
+
     let options = {
-      colors: ['#ee8c00', '#ea4335', '#6c757d', '#28a745', '#007bff'],
+      colors: colors,
       chartArea: {
         left: 60,
         right: 40,
@@ -361,10 +373,8 @@
       seriesType: 'bars',
       series: {
         0: {type: 'line'},
-        1: {type: 'line'},
-        {{if $realm.AllowsUserReport}}
+        1: {type: 'line'},        
         2: {type: 'line'},
-        {{end}}
       },
       legend: { position: 'top' },
       isStacked: true,


### PR DESCRIPTION
Towards #1928

## Proposed Changes

* add revisions back to key sever chart

**Release Note**

```release-note
Number of revision request are shown on key server stats if user initiated reporting is enabled. This is the only EN Express scenario where key revision could occurr.
```
