### PR TITLE
Add special "_all" key to apply to all service environments

### DIFF
--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "adminapi" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "adminapi", {}),
           )
 

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -98,6 +98,7 @@ resource "google_cloud_run_service" "apiserver" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "apiserver", {}),
           )
 

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -93,6 +93,7 @@ resource "google_cloud_run_service" "appsync" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "appsync", {}),
           )
 

--- a/terraform/service_backup.tf
+++ b/terraform/service_backup.tf
@@ -90,6 +90,7 @@ resource "google_cloud_run_service" "backup" {
             local.database_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "backup", {}),
           )
 

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -104,6 +104,7 @@ resource "google_cloud_run_service" "cleanup" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "cleanup", {}),
           )
 

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -93,6 +93,7 @@ resource "google_cloud_run_service" "e2e-runner" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "e2e-runner", {}),
           )
 

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -89,6 +89,7 @@ resource "google_cloud_run_service" "modeler" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "modeler", {}),
           )
 

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -102,6 +102,7 @@ resource "google_cloud_run_service" "enx-redirect" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "enx-redirect", {}),
           )
 

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -101,6 +101,7 @@ resource "google_cloud_run_service" "rotation" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "rotation", {}),
           )
 

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -114,6 +114,7 @@ resource "google_cloud_run_service" "server" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "server", {}),
           )
 

--- a/terraform/service_stats_puller.tf
+++ b/terraform/service_stats_puller.tf
@@ -95,6 +95,7 @@ resource "google_cloud_run_service" "stats-puller" {
             local.observability_config,
 
             // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
             lookup(var.service_environment, "stats-puller", {}),
           )
 

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -159,7 +159,7 @@ variable "service_environment" {
   type    = map(map(string))
   default = {}
 
-  description = "Per-service environment overrides."
+  description = "Per-service environment overrides The special key \"_all\" will apply to all services. This is useful for common configuration like log-levels. A service-specific configuration overrides a value in \"_all\"."
 }
 
 variable "vpc_access_connector_max_throughput" {


### PR DESCRIPTION
This makes it easier (and less error-prone) to set a common configuration like `LOG_LEVEL` on all services at once.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add special "_all" key to apply to all service environments. The special key `_all` will apply to all services. This is useful for common configuration like log-levels. A service-specific configuration overrides a value in `_all`. There are no default values for `_all`, so the default behavior is unchanged.
```
