### PR TITLE
Ensure users retain system admin when being added to a realm

### DIFF
--- a/pkg/controller/user/create.go
+++ b/pkg/controller/user/create.go
@@ -70,7 +70,7 @@ func (c *Controller) HandleCreate() http.Handler {
 			return
 		}
 		if existing != nil && existing.ID != 0 {
-			user.ID = existing.ID
+			user = existing
 		}
 
 		// Create or update user.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure users retain system admin when being added to a realm
```
