### PR TITLE
allow admin /api/issue to issue user-report codes

### DIFF
--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -101,6 +101,19 @@
         </small>
       </label>
     </div>
+
+    <div class="form-check mb-3">
+      <input type="checkbox" name="allow_admin_user_report" id="allow-admin-user-report" class="form-check-input" value="true" {{checkedIf ($realm.AllowAdminUserReport)}} />
+      <label for="allow-admin-user-report" class="form-check-label">
+        Admin API can issue user-report codes
+        <small class="form-text text-muted mb-3">
+          If <code>Allow user initiated report</code> is enabled, this setting allows the admin code issue
+          API to utilize the <code>user-report</code> report type. Doing so, allows for user-report codes to
+          be claimed without the normally required <code>nonce</code>. This setting should only be
+          enabled after consultation with Apple and Google.
+        </small>
+      </label>
+    </div>
     {{end}}
   </div>
 

--- a/pkg/controller/issueapi/handle_issue.go
+++ b/pkg/controller/issueapi/handle_issue.go
@@ -20,10 +20,11 @@ import (
 	"net/http"
 	"time"
 
-	enobs "github.com/google/exposure-notifications-server/pkg/observability"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
+
+	enobs "github.com/google/exposure-notifications-server/pkg/observability"
 )
 
 // HandleIssueAPI responds to the /issue API for issuing verification codes

--- a/pkg/controller/issueapi/handle_user_report.go
+++ b/pkg/controller/issueapi/handle_user_report.go
@@ -109,7 +109,8 @@ func (c *Controller) HandleUserReport() http.Handler {
 				Phone:            request.Phone,
 				SMSTemplateLabel: database.UserReportTemplateLabel,
 			},
-			Nonce: nonce,
+			UserRequested: true,
+			Nonce:         nonce,
 		}
 
 		res := c.IssueOne(ctx, issueRequest)

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -33,7 +33,8 @@ import (
 // optional nonce. If the nonce is provided and the the report type
 // is self_report (user initiated code), then extra safeguards are applied.
 type IssueRequestInternal struct {
-	IssueRequest *api.IssueCodeRequest
+	IssueRequest  *api.IssueCodeRequest
+	UserRequested bool
 	// These files are for user initiated report
 	Nonce []byte
 }
@@ -82,13 +83,14 @@ func (c *Controller) IssueMany(ctx context.Context, requests []*IssueRequestInte
 	// Generate codes
 	results := make([]*IssueResult, len(requests))
 	for i, req := range requests {
-		vCode, result := c.BuildVerificationCode(ctx, req.IssueRequest, realm)
+		vCode, result := c.BuildVerificationCode(ctx, req, realm)
 		if result != nil {
 			results[i] = result
 			continue
 		}
 		vCode.Nonce = req.Nonce
 		vCode.PhoneNumber = req.IssueRequest.Phone
+		vCode.NonceRequired = req.UserRequested
 		results[i] = c.IssueCode(ctx, vCode, realm)
 	}
 

--- a/pkg/controller/issueapi/validate_code_test.go
+++ b/pkg/controller/issueapi/validate_code_test.go
@@ -174,7 +174,7 @@ func TestValidate(t *testing.T) {
 			ctx = controller.WithAuthorizedApp(ctx, authApp)
 			ctx = controller.WithMembership(ctx, &database.Membership{UserID: 456})
 
-			verCode, result := c.BuildVerificationCode(ctx, &tc.request, realm)
+			verCode, result := c.BuildVerificationCode(ctx, &issueapi.IssueRequestInternal{IssueRequest: &tc.request}, realm)
 			if verCode != nil {
 				if tc.request.UUID != "" && tc.request.UUID != verCode.UUID {
 					t.Errorf("expecting stable client-provided uuid. got %s, want %s", verCode.UUID, tc.request.UUID)

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -66,6 +66,7 @@ type formData struct {
 	Codes                 bool              `form:"codes"`
 	AllowedTestTypes      database.TestType `form:"allowed_test_types"`
 	AllowUserReport       bool              `form:"allow_user_report"`
+	AllowAdminUserReport  bool              `form:"allow_admin_user_report"`
 	AllowBulkUpload       bool              `form:"allow_bulk"`
 	RequireDate           bool              `form:"require_date"`
 	CodeLength            uint              `form:"code_length"`
@@ -231,6 +232,9 @@ func (c *Controller) HandleSettings() http.Handler {
 			currentRealm.AllowBulkUpload = form.AllowBulkUpload
 			if c.config.Features.EnableUserReport && form.AllowUserReport {
 				currentRealm.AddUserReportToAllowedTestTypes()
+				currentRealm.AllowAdminUserReport = form.AllowAdminUserReport
+			} else {
+				currentRealm.AllowAdminUserReport = false
 			}
 
 			// These fields can only be set if ENX is disabled

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2181,7 +2181,11 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realm_stats
 						ALTER COLUMN user_reports_issued SET NOT NULL,
 						ALTER COLUMN user_reports_claimed SET NOT NULL,
-						ALTER COLUMN user_report_tokens_claimed SET NOT NULL`)
+						ALTER COLUMN user_report_tokens_claimed SET NOT NULL`,
+					`ALTER TABLE user_reports
+						ADD COLUMN IF NOT EXISTS nonce_required BOOLEAN DEFAULT TRUE`,
+					`ALTER TABLE user_reports
+						ALTER COLUMN nonce_required SET NOT NULL`)
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,
@@ -2189,6 +2193,21 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 						DROP COLUMN user_reports_issued,
 						DROP COLUMN user_reports_claimed,
 						DROP COLUMN user_report_tokens_claimed`)
+			},
+		},
+		{
+			ID: "00099-AdminSelfReportSettings",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						ADD COLUMN IF NOT EXISTS allow_admin_user_report BOOLEAN DEFAULT false`,
+					`ALTER TABLE realms
+						ALTER COLUMN allow_admin_user_report SET NOT NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						DROP COLUMN allow_admin_user_report`)
 			},
 		},
 	}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2181,11 +2181,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realm_stats
 						ALTER COLUMN user_reports_issued SET NOT NULL,
 						ALTER COLUMN user_reports_claimed SET NOT NULL,
-						ALTER COLUMN user_report_tokens_claimed SET NOT NULL`,
-					`ALTER TABLE user_reports
-						ADD COLUMN IF NOT EXISTS nonce_required BOOLEAN DEFAULT TRUE`,
-					`ALTER TABLE user_reports
-						ALTER COLUMN nonce_required SET NOT NULL`)
+						ALTER COLUMN user_report_tokens_claimed SET NOT NULL`)
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,
@@ -2199,6 +2195,10 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			ID: "00099-AdminSelfReportSettings",
 			Migrate: func(tx *gorm.DB) error {
 				return multiExec(tx,
+					`ALTER TABLE user_reports
+						ADD COLUMN IF NOT EXISTS nonce_required BOOLEAN DEFAULT TRUE`,
+					`ALTER TABLE user_reports
+						ALTER COLUMN nonce_required SET NOT NULL`,
 					`ALTER TABLE realms
 						ADD COLUMN IF NOT EXISTS allow_admin_user_report BOOLEAN DEFAULT false`,
 					`ALTER TABLE realms

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -247,6 +247,10 @@ type Realm struct {
 	// value is to allow all test types.
 	AllowedTestTypes TestType `gorm:"type:smallint; not null; default: 14;"`
 
+	// AllowAdminUserReport - is the adminapi:/api/issue allowed to use the user-report
+	// test type if enabled on the realm.
+	AllowAdminUserReport bool
+
 	// RequireDate requires that verifications on this realm require a test or
 	// symptom date (either). The default behavior is to not require a date.
 	RequireDate bool `gorm:"type:boolean; not null; default:false;"`

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -269,9 +269,10 @@ func (db *Database) VerifyCodeAndIssueToken(request *IssueTokenRequest) (*Token,
 		// Check associated UserReport record if necessary.
 		if vc.UserReportID != nil {
 			providedNonce := base64.StdEncoding.EncodeToString(request.Nonce)
+			required := providedNonce != ""
 
 			result := tx.Model(UserReport{}).
-				Where("id = ? AND code_claimed = ? and nonce = ?", *vc.UserReportID, false, providedNonce).
+				Where("id = ? AND code_claimed = ? and nonce = ? and nonce_required = ?", *vc.UserReportID, false, providedNonce, required).
 				Updates(UserReport{CodeClaimed: true})
 			if err := result.Error; err != nil {
 				return fmt.Errorf("unable to look up associated user_report record: %w", err)

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -315,6 +315,7 @@ func TestIssueToken(t *testing.T) {
 					LongExpiresAt: time.Now().Add(time.Hour),
 					PhoneNumber:   "+15138675309",
 					Nonce:         validNonce,
+					NonceRequired: true,
 				}
 			},
 			Nonce:    validNonce,
@@ -334,6 +335,7 @@ func TestIssueToken(t *testing.T) {
 					LongExpiresAt: time.Now().Add(time.Hour),
 					PhoneNumber:   "+12068675309",
 					Nonce:         validNonce,
+					NonceRequired: true,
 				}
 			},
 			Nonce:    []byte{1, 2, 3, 4}, // This is not the right nonce ;)
@@ -345,16 +347,56 @@ func TestIssueToken(t *testing.T) {
 			Name: "user_report_no_nonce",
 			Verification: func() *VerificationCode {
 				return &VerificationCode{
+					Code:          "22112233",
+					LongCode:      "22112233ABC",
+					TestType:      "user-report",
+					SymptomDate:   &symptomDate,
+					ExpiresAt:     time.Now().Add(time.Hour),
+					LongExpiresAt: time.Now().Add(time.Hour),
+					PhoneNumber:   "+13608675309",
+					Nonce:         validNonce,
+					NonceRequired: true,
+				}
+			},
+			Accept:   acceptConfirmedAndSelfReport,
+			Error:    "verification code not found",
+			TokenAge: time.Hour,
+		},
+		{
+			Name: "admin_user_report_no_nonce",
+			Verification: func() *VerificationCode {
+				return &VerificationCode{
 					Code:          "22112211",
 					LongCode:      "22112211ABC",
 					TestType:      "user-report",
 					SymptomDate:   &symptomDate,
 					ExpiresAt:     time.Now().Add(time.Hour),
 					LongExpiresAt: time.Now().Add(time.Hour),
-					PhoneNumber:   "+15558675309",
-					Nonce:         validNonce,
+					PhoneNumber:   "+14258675309",
+					Nonce:         []byte{},
+					NonceRequired: false,
 				}
 			},
+			Accept:   acceptConfirmedAndSelfReport,
+			Error:    "",
+			TokenAge: time.Hour,
+		},
+		{
+			Name: "admin_user_report_with_nonce",
+			Verification: func() *VerificationCode {
+				return &VerificationCode{
+					Code:          "22112244",
+					LongCode:      "22112244ABC",
+					TestType:      "user-report",
+					SymptomDate:   &symptomDate,
+					ExpiresAt:     time.Now().Add(time.Hour),
+					LongExpiresAt: time.Now().Add(time.Hour),
+					PhoneNumber:   "+18128675309",
+					Nonce:         []byte{},
+					NonceRequired: false,
+				}
+			},
+			Nonce:    validNonce,
 			Accept:   acceptConfirmedAndSelfReport,
 			Error:    "verification code not found",
 			TokenAge: time.Hour,

--- a/pkg/database/user_report_test.go
+++ b/pkg/database/user_report_test.go
@@ -48,7 +48,7 @@ func TestFindUserReport(t *testing.T) {
 		t.Parallel()
 
 		phoneNumber := "+12065551234"
-		userReport, err := db.NewUserReport(phoneNumber, generateNonce(t))
+		userReport, err := db.NewUserReport(phoneNumber, generateNonce(t), true)
 		if err != nil {
 			t.Fatalf("error creating user report: %v", err)
 		}
@@ -105,7 +105,7 @@ func TestFindUserReport(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			t.Parallel()
 
-			userReport, err := db.NewUserReport(tc.phone, []byte{0})
+			userReport, err := db.NewUserReport(tc.phone, []byte{0}, true)
 			userReport.Nonce = tc.nonce // override the encoding from NewUserReport for testing errors.
 			if err != nil {
 				t.Fatalf("error creating user report: %v", err)
@@ -149,7 +149,7 @@ func TestPurgeUserReports(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			// tests not parallel because one purge test could interfer with the other.
 			phoneNumber := tc.name
-			userReport, err := db.NewUserReport(phoneNumber, generateNonce(t))
+			userReport, err := db.NewUserReport(phoneNumber, generateNonce(t), true)
 			if err != nil {
 				t.Fatalf("error creating user report: %v", err)
 			}

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -283,6 +283,7 @@ func TestSaveUserReport(t *testing.T) {
 		LongExpiresAt: time.Now().Add(2 * time.Hour),
 		Nonce:         generateNonce(t),
 		PhoneNumber:   "+12068675309",
+		NonceRequired: true,
 	}
 
 	if err := db.SaveVerificationCode(vc, realm); err != nil {

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -495,18 +495,28 @@ func generateKeyServerStats(db *database.Database, realm *database.Realm, maxPer
 		if v, ok := maxPerDay[date.Format("2006-01-02")]; ok {
 			max = v
 		}
-		maxTEKs := int64(max * 14)
-		maxRevs := int64(max/10 + 1)
+		teksPublished := int64(max * 14)
+		if teksPublished > 0 {
+			teksPublished = rand.Int63n(teksPublished)
+		}
+		revisions := int64(max / 10)
+		if revisions > 0 {
+			revisions = rand.Int63n(revisions)
+		}
+		var missingOnset int64
+		if limit := max / 4; limit > 0 {
+			missingOnset = rand.Int63n(int64(limit))
+		}
 
 		day := &database.KeyServerStatsDay{
 			RealmID:                   realm.ID,
 			Day:                       date,
 			PublishRequests:           randArr63n(int64(max), 3),
-			TotalTEKsPublished:        rand.Int63n(maxTEKs),
-			RevisionRequests:          rand.Int63n(maxRevs),
+			TotalTEKsPublished:        teksPublished,
+			RevisionRequests:          revisions,
 			TEKAgeDistribution:        randArr63n(int64(max), 16),
 			OnsetToUploadDistribution: randArr63n(15, 31),
-			RequestsMissingOnsetDate:  rand.Int63n(int64(max / 4)),
+			RequestsMissingOnsetDate:  missingOnset,
 		}
 		if err := db.SaveKeyServerStatsDay(day); err != nil {
 			return fmt.Errorf("failed create stats day: %w", err)
@@ -519,7 +529,9 @@ func generateKeyServerStats(db *database.Database, realm *database.Realm, maxPer
 func randArr63n(n, length int64) []int64 {
 	arr := make([]int64, length)
 	for i := int64(0); i < length; i++ {
-		arr[i] = rand.Int63n(n)
+		if n > 0 {
+			arr[i] = rand.Int63n(n)
+		}
 	}
 	return arr
 }


### PR DESCRIPTION
Towards #1928 

## Proposed Changes

* Add realm setting to enable "admin" API user-reports
  * these don't require a nonce
  * do require a phone number and still de-dupe against the HMAC user_report phone index

**Release Note**


```release-note
All admin actions to issue user-report level verification codes, that can result in SELF_REPORT
```
