### PR TITLE
Do not mark PhoneNumberHMAC as required

### DIFF
--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -78,7 +78,7 @@ type Config struct {
 	// PhoneNumberHMAC is the HMAC key to hash phone numbers before storing
 	// in the database. This is only used of user initiated reporting is enabled
 	// at the system and at the realm level.
-	PhoneNumberHMAC []envconfig.Base64Bytes `env:"DB_PHONE_HMAC_KEY,required" json:"-"`
+	PhoneNumberHMAC []envconfig.Base64Bytes `env:"DB_PHONE_HMAC_KEY" json:"-"`
 
 	// Secrets is the secret configuration. This is used to resolve values that
 	// are actually pointers to secrets before returning them to the caller. The

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -132,7 +132,11 @@ func (db *Database) PurgeClaimedUserReports(maxAge time.Duration) (int64, error)
 
 // GeneratePhoneNumberHMAC generates the HMAC of the phone number using the latest key.
 func (db *Database) GeneratePhoneNumberHMAC(phoneNumber string) (string, error) {
-	return initialHMAC(db.config.PhoneNumberHMAC, phoneNumber)
+	s, err := initialHMAC(db.config.PhoneNumberHMAC, phoneNumber)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate phone number HMAC: %w", err)
+	}
+	return s, nil
 }
 
 // generatePhoneNumberHMACs is a helper for generating all possible HMACs of a phone number.


### PR DESCRIPTION
This is guarded by a feature flag, so it should not be required. Furthermore, there's already a runtime check that at least one key is provided to the helper.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Do not mark PhoneNumberHMAC as required
```
