### PR TITLE
Centralize X-Forwarded-For processing to get real client IPs

### DIFF
--- a/pkg/controller/middleware/firewall.go
+++ b/pkg/controller/middleware/firewall.go
@@ -21,6 +21,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/realip"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 
 	"github.com/gorilla/mux"
@@ -68,14 +69,7 @@ func ProcessFirewall(h *render.Renderer, typ string) mux.MiddlewareFunc {
 			logger.Debugw("validating ip in cidr block", "type", typ)
 
 			// Get the remote address.
-			ipStr := r.RemoteAddr
-
-			// Check if x-forwarded-for exists, the load balancer sets this, and the
-			// first entry is the real client IP.
-			xff := r.Header.Get("x-forwarded-for")
-			if xff != "" {
-				ipStr = strings.Split(xff, ",")[0]
-			}
+			ipStr := realip.FromGoogleCloud(r)
 
 			// In some cases, the remote addr will include a port. However, Go doesn't
 			// make it easy to distinguish between an ip:port and an IPv6 address.

--- a/pkg/controller/middleware/firewall_test.go
+++ b/pkg/controller/middleware/firewall_test.go
@@ -100,7 +100,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "9.8.7.6",
-			xff:        "1.2.3.4, 5.6.7.8",
+			xff:        "5.6.7.8, 1.2.3.4",
 			code:       http.StatusOK,
 		},
 		{
@@ -125,7 +125,7 @@ func TestProcessFirewall(t *testing.T) {
 				AllowedCIDRsServer: []string{"1.2.3.4/32"},
 			}),
 			remoteAddr: "1.2.3.4",          // xff is preferred over remote ip
-			xff:        "5.6.7.8, 1.2.3.4", // Only trusts the first value in xff
+			xff:        "9.8.7.6, 5.6.7.8", // Only trusts the last value in xff
 			code:       http.StatusUnauthorized,
 		},
 	}

--- a/pkg/realip/realip.go
+++ b/pkg/realip/realip.go
@@ -1,0 +1,49 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package realip attempts to extract the real IP address from a service running
+// behind a load balancer.
+package realip
+
+import (
+	"net/http"
+	"strings"
+)
+
+const headerKeyXForwardedFor = "X-Forwarded-For"
+
+// FromGoogleCloud extracts the best real client IP address from the request,
+// handling xff behind a load balancer. It returns the empty string if no real
+// IP was found.
+func FromGoogleCloud(r *http.Request) string {
+	if r == nil {
+		return ""
+	}
+
+	// Get the remote addr
+	ip := r.RemoteAddr
+
+	// Check if x-forwarded-for exists, the load balancer sets this, and last
+	// entry is the IP. We only check xff if there's at least two values to ensure
+	// that it was, in fact, behind a load balancer.
+	xff := r.Header.Get(headerKeyXForwardedFor)
+	if xff != "" {
+		parts := strings.Split(xff, ",")
+		if len(parts) > 1 {
+			ip = parts[len(parts)-1]
+		}
+	}
+
+	return strings.TrimSpace(ip)
+}

--- a/pkg/realip/realip_test.go
+++ b/pkg/realip/realip_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package realip
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestOnGoogleCloud(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name       string
+		remoteAddr string
+		xff        string
+		exp        string
+	}{
+		{
+			name: "none",
+			exp:  "",
+		},
+		{
+			name:       "remote_addr",
+			remoteAddr: "1.1.1.1",
+			exp:        "1.1.1.1",
+		},
+		{
+			name:       "remote_addr_trim",
+			remoteAddr: "  1.1.1.1  ",
+			exp:        "1.1.1.1",
+		},
+		{
+			name: "xff_single",
+			xff:  "2.2.2.2",
+			exp:  "",
+		},
+		{
+			name: "xff_multi",
+			xff:  "34.1.2.3,231.5.4.3,2.2.2.2",
+			exp:  "2.2.2.2",
+		},
+		{
+			name: "xff_multi_trim",
+			xff:  "     34.1.2.3,  231.5.4.3,2.2.2.2",
+			exp:  "2.2.2.2",
+		},
+		{
+			name:       "remote_addr_with_xff",
+			remoteAddr: "1.1.1.1",
+			xff:        "34.1.2.3,231.5.4.3,2.2.2.2",
+			exp:        "2.2.2.2",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r.RemoteAddr = tc.remoteAddr
+			if tc.xff != "" {
+				r.Header.Set("X-Forwarded-For", tc.xff)
+			}
+
+			if got, want := FromGoogleCloud(r), tc.exp; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Centralize X-Forwarded-For processing to get real client IPs
```
