### PR TITLE
fix env var

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -75,7 +75,7 @@ type CleanupConfig struct {
 	// UserReportUnclaimedMaxAge is how long a user report phone hash will be kept if the record goes unclaimed.
 	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=60m"`
 	// UserReportMaxAge is how long a claimed user report phone hash will be kept.
-	UserReportMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=2160h"` // 2160h = 90 days
+	UserReportMaxAge time.Duration `env:"USER_REPORT_MAX_AGE, default=2160h"` // 2160h = 90 days
 }
 
 // NewCleanupConfig returns the environment config for the cleanup server.

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -182,7 +182,7 @@ resource "google_cloud_run_service_iam_member" "cleanup-invoker" {
 resource "google_cloud_scheduler_job" "cleanup-worker" {
   name             = "cleanup-worker"
   region           = var.cloudscheduler_location
-  schedule         = "0 * * * *"
+  schedule         = "*/15 * * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "${google_cloud_run_service.cleanup.template[0].spec[0].timeout_seconds + 60}s"
 


### PR DESCRIPTION

## Proposed Changes

* Fix env var being same for both user-report cleanups
* Run cleanup more frequently

**Release Note**

```release-note
Cleanup job will run every 15 minutes
```
