### PR TITLE
Drop UPDATE privileges on audits table

### DIFF
--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2210,6 +2210,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 						DROP COLUMN allow_admin_user_report`)
 			},
 		},
+		{
+			ID: "00100-DropPrivilege",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`REVOKE UPDATE ON TABLE audit_entries FROM CURRENT_USER`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`GRANT UPDATE ON TABLE audit_entries TO CURRENT_USER`)
+			},
+		},
 	}
 }
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/1948

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Drop UPDATE privileges on audits table. This makes audit entries immutable (but still deletable).
```
