### PR TITLE
user report messaging and signing

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -133,7 +133,7 @@
         <a class="dropdown-item" id="sms-template-new" href="#">New SMS template</a>
       </div>
       {{if $realm.AllowsUserReport}}
-        <small class="form-text text-muted">User initiated report is enabled, which always uses the <code>User Report</code> template.</small>
+        <small class="form-text text-muted">&nbsp;User initiated report is enabled, which always uses the <code>User Report</code> template.</small>
       {{end}}
     </div>
     {{if $realm.ErrorsFor "smsTextTemplate"}}
@@ -157,6 +157,12 @@
       <div class="invalid-feedback d-block mt-n2 mb-3">
         {{joinStrings ($realm.ErrorsFor $v.Label) ", "}}
       </div>
+      {{end}}
+      {{if (eq "User Report" $v.Label)}}
+        <div class="alert alert-warning" role="alert">
+          For the <strong>User Report</strong> template it is strongly recommended that you
+          indicate that the user should not use the code if they did not request it.
+        </div>
       {{end}}
       {{if or (not $realm.AllowsUserReport) (ne "User Report" $v.Label)}}
       <button class="btn btn-danger mb-3 {{if eq $i 0}}d-none{{end}}" type="button" {{if ne $i 0}}onClick="removeTemplate('sms-template-{{$i}}');"{{end}}>Delete template</button>

--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -96,7 +96,11 @@ func (c *Controller) doSend(ctx context.Context, realm *database.Realm, smsProvi
 	// SMS signing.
 	if signer != nil {
 		var err error
-		message, err = signatures.SignSMS(signer, keyID, smsStart, signatures.SMSPurposeENReport, request.Phone, message)
+		purpose := signatures.SMSPurposeENReport
+		if request.TestType == api.TestTypeUserReport {
+			purpose = signatures.SMSPurposeUserReport
+		}
+		message, err = signatures.SignSMS(signer, keyID, smsStart, purpose, request.Phone, message)
 		if err != nil {
 			defer func() {
 				if err := stats.RecordWithOptions(ctx,

--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -40,7 +40,8 @@ type SMSPurpose string
 
 const (
 	// SMSPurposeENReport is an SMS purpose for EN reporting.
-	SMSPurposeENReport SMSPurpose = "EN Report"
+	SMSPurposeENReport   SMSPurpose = "EN Report"
+	SMSPurposeUserReport SMSPurpose = "User Report"
 )
 
 // SignSMS returns a new SMS message with the embedded signature using the


### PR DESCRIPTION
Towards: #1928

## Proposed Changes

* Add guidance for user report template
* Use `User Report` in the preamble only for User Report types.

**Release Note**

```release-note
Add guidance for user report SMS template 
```
