### PR TITLE
capture OS in request context from user agent

### DIFF
--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -139,6 +139,7 @@ func APIServer(
 		sub.Use(processFirewall)
 		sub.Use(middleware.ProcessChaff(db, verifyChaffTracker, middleware.ChaffHeaderDetector()))
 		sub.Use(rateLimit)
+		sub.Use(middleware.AddOperatingSystemFromUserAgent())
 
 		// POST /api/verify
 		verifyapiController := verifyapi.New(cfg, db, cacher, tokenSigner, h)

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -38,7 +38,36 @@ const (
 	contextKeySession       = contextKey("session")
 	contextKeyTemplate      = contextKey("template")
 	contextKeyUser          = contextKey("user")
+	contextKeyOS            = contextKey("os")
 )
+
+type OperatingSystem int
+
+const (
+	UnknownOS OperatingSystem = iota
+	Android
+	IOS
+)
+
+// WithOperatingSystem stores the operating system enum in the context.
+func WithOperatingSystem(ctx context.Context, os OperatingSystem) context.Context {
+	return context.WithValue(ctx, contextKeyOS, os)
+}
+
+// OperatingSystemFromContext retrieves the operating system enum from the context. If
+// no value exists, UnknownOS is returned.
+func OperatingSystemFromContext(ctx context.Context) OperatingSystem {
+	v := ctx.Value(contextKeyOS)
+	if v == nil {
+		return UnknownOS
+	}
+
+	t, ok := v.(OperatingSystem)
+	if !ok {
+		return UnknownOS
+	}
+	return t
+}
 
 // WithAuthorizedApp stores the authorized app on the context.
 func WithAuthorizedApp(ctx context.Context, app *database.AuthorizedApp) context.Context {

--- a/pkg/controller/middleware/operating_system.go
+++ b/pkg/controller/middleware/operating_system.go
@@ -1,0 +1,51 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/gorilla/mux"
+)
+
+func AddOperatingSystemFromUserAgent() mux.MiddlewareFunc {
+	userAgents := map[string]controller.OperatingSystem{
+		"darwin": controller.IOS,
+		"iphone": controller.IOS,
+		"dalvik": controller.Android,
+	}
+
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+			agent := strings.ToLower(r.UserAgent())
+
+			osToSet := controller.UnknownOS
+			for k, os := range userAgents {
+				if strings.Contains(agent, k) {
+					osToSet = os
+					break
+				}
+			}
+
+			ctx = controller.WithOperatingSystem(ctx, osToSet)
+			r = r.Clone(ctx)
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/operating_system_test.go
+++ b/pkg/controller/middleware/operating_system_test.go
@@ -1,0 +1,88 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+)
+
+type CaptureOSHandler struct {
+	OS controller.OperatingSystem
+}
+
+func (c *CaptureOSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	c.OS = controller.OperatingSystemFromContext(r.Context())
+}
+
+func TestAddOperatingSystemFromUserAgent(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	addOS := middleware.AddOperatingSystemFromUserAgent()
+
+	cases := []struct {
+		name      string
+		userAgent string
+		want      controller.OperatingSystem
+	}{
+		{
+			name:      "android",
+			userAgent: "Dalvik/2.1.0 (Linux; U; Android S Build/SP1A.210322.002)",
+			want:      controller.Android,
+		},
+		{
+			name:      "iOS_enx",
+			userAgent: "bluetoothd (unknown version) CFNetwork/1237 Darwin/20.5.0",
+			want:      controller.IOS,
+		},
+		{
+			name:      "iphone",
+			userAgent: "generic something that contains iPhone in it",
+			want:      controller.IOS,
+		},
+		{
+			name:      "unknown",
+			userAgent: "being clever and using a customer user agent causes issues",
+			want:      controller.UnknownOS,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			r := httptest.NewRequest(http.MethodGet, "/", nil)
+			r = r.Clone(ctx)
+			r.Header.Set("User-Agent", tc.userAgent)
+
+			w := httptest.NewRecorder()
+
+			handler := &CaptureOSHandler{}
+			addOS(handler).ServeHTTP(w, r)
+
+			if got := handler.OS; got != tc.want {
+				t.Errorf("Expected OS: %v to be %v", got, tc.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Towards #1972

## Proposed Changes

* Middleware to capture OS by user agent
* install in apiserver:/api/verify path

**Release Note**

```release-note
Middleware to make OS present in request context
```
