### PR TITLE
capture invalid codes by os in realm_stats

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -59,6 +59,14 @@ func WithHostOverride(host string) Option {
 	}
 }
 
+// WithUserAgent sets a custom User-Agent header
+func WithUserAgent(userAgent string) Option {
+	return func(c *client) *client {
+		c.userAgent = userAgent
+		return c
+	}
+}
+
 type hostOverrideRoundTripper struct {
 	host string
 	def  http.RoundTripper
@@ -83,6 +91,7 @@ type client struct {
 	baseURL     *url.URL
 	apiKey      string
 	maxBodySize int64
+	userAgent   string
 }
 
 // newClient creates a new client.
@@ -129,6 +138,10 @@ func (c *client) newRequest(ctx context.Context, method, pth string, body interf
 
 	if c.apiKey != "" {
 		req.Header.Set("X-API-Key", c.apiKey)
+	}
+
+	if c.userAgent != "" {
+		req.Header.Set("User-Agent", c.userAgent)
 	}
 
 	return req, nil

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -41,30 +41,22 @@ const (
 	contextKeyOS            = contextKey("os")
 )
 
-type OperatingSystem int
-
-const (
-	UnknownOS OperatingSystem = iota
-	Android
-	IOS
-)
-
 // WithOperatingSystem stores the operating system enum in the context.
-func WithOperatingSystem(ctx context.Context, os OperatingSystem) context.Context {
+func WithOperatingSystem(ctx context.Context, os database.OSType) context.Context {
 	return context.WithValue(ctx, contextKeyOS, os)
 }
 
 // OperatingSystemFromContext retrieves the operating system enum from the context. If
 // no value exists, UnknownOS is returned.
-func OperatingSystemFromContext(ctx context.Context) OperatingSystem {
+func OperatingSystemFromContext(ctx context.Context) database.OSType {
 	v := ctx.Value(contextKeyOS)
 	if v == nil {
-		return UnknownOS
+		return database.OSTypeUnknown
 	}
 
-	t, ok := v.(OperatingSystem)
+	t, ok := v.(database.OSType)
 	if !ok {
-		return UnknownOS
+		return database.OSTypeUnknown
 	}
 	return t
 }

--- a/pkg/controller/middleware/operating_system.go
+++ b/pkg/controller/middleware/operating_system.go
@@ -19,14 +19,15 @@ import (
 	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 )
 
 func AddOperatingSystemFromUserAgent() mux.MiddlewareFunc {
-	userAgents := map[string]controller.OperatingSystem{
-		"darwin": controller.IOS,
-		"iphone": controller.IOS,
-		"dalvik": controller.Android,
+	userAgents := map[string]database.OSType{
+		"darwin": database.OSTypeIOS,
+		"iphone": database.OSTypeIOS,
+		"dalvik": database.OSTypeAndroid,
 	}
 
 	return func(next http.Handler) http.Handler {
@@ -34,7 +35,7 @@ func AddOperatingSystemFromUserAgent() mux.MiddlewareFunc {
 			ctx := r.Context()
 			agent := strings.ToLower(r.UserAgent())
 
-			osToSet := controller.UnknownOS
+			osToSet := database.OSTypeUnknown
 			for k, os := range userAgents {
 				if strings.Contains(agent, k) {
 					osToSet = os

--- a/pkg/controller/middleware/operating_system_test.go
+++ b/pkg/controller/middleware/operating_system_test.go
@@ -22,10 +22,11 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
 type CaptureOSHandler struct {
-	OS controller.OperatingSystem
+	OS database.OSType
 }
 
 func (c *CaptureOSHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
@@ -42,27 +43,27 @@ func TestAddOperatingSystemFromUserAgent(t *testing.T) {
 	cases := []struct {
 		name      string
 		userAgent string
-		want      controller.OperatingSystem
+		want      database.OSType
 	}{
 		{
 			name:      "android",
 			userAgent: "Dalvik/2.1.0 (Linux; U; Android S Build/SP1A.210322.002)",
-			want:      controller.Android,
+			want:      database.OSTypeAndroid,
 		},
 		{
 			name:      "iOS_enx",
 			userAgent: "bluetoothd (unknown version) CFNetwork/1237 Darwin/20.5.0",
-			want:      controller.IOS,
+			want:      database.OSTypeIOS,
 		},
 		{
 			name:      "iphone",
 			userAgent: "generic something that contains iPhone in it",
-			want:      controller.IOS,
+			want:      database.OSTypeIOS,
 		},
 		{
 			name:      "unknown",
 			userAgent: "being clever and using a customer user agent causes issues",
-			want:      controller.UnknownOS,
+			want:      database.OSTypeUnknown,
 		},
 	}
 

--- a/pkg/controller/verifyapi/verify.go
+++ b/pkg/controller/verifyapi/verify.go
@@ -126,6 +126,7 @@ func (c *Controller) HandleVerify() http.Handler {
 			AcceptTypes: acceptTypes,
 			ExpireAfter: c.config.VerificationTokenDuration,
 			Nonce:       nonce,
+			OS:          controller.OperatingSystemFromContext(ctx),
 		}
 		// Exchange the short term verification code for a long term verification token.
 		// The token can be used to sign TEKs later.

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2221,6 +2221,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`GRANT UPDATE ON TABLE audit_entries TO CURRENT_USER`)
 			},
 		},
+		{
+			ID: "00101-AddCodesInvalidByOS",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats ADD COLUMN IF NOT EXISTS codes_invalid_by_os BIGINT[]`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS codes_invalid_by_os`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -43,6 +43,10 @@ func (o OSType) Display() string {
 	}
 }
 
+func (o OSType) Len() int {
+	return 3
+}
+
 const (
 	OSTypeUnknown OSType = iota
 	OSTypeIOS

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -51,6 +51,9 @@ type RealmStat struct {
 	CodesClaimed uint `gorm:"column:codes_claimed; type:integer; not null; default:0;"`
 	CodesInvalid uint `gorm:"column:codes_invalid; type:integer; not null; default:0;"`
 
+	// CodesInvalidByOS is an array where the index is the controller.OperatingSystem enums.
+	CodesInvalidByOS pq.Int64Array `gorm:"column:codes_invalid_by_os; type:bigint[];"`
+
 	// UserReportsIssued is the specific number of codes that were issued
 	// because the user initiated a self-report request. These numbers are NOT
 	// included in the overall codes issued and codes claimed.

--- a/tools/get-token/main.go
+++ b/tools/get-token/main.go
@@ -30,6 +30,7 @@ import (
 )
 
 var (
+	userAgent   = flag.String("user-agent", "", "if present, will set as the user agent on the HTTP request")
 	codeFlag    = flag.String("code", "", "verification code to exchange")
 	apikeyFlag  = flag.String("apikey", "", "API Key to use")
 	addrFlag    = flag.String("addr", "http://localhost:8080", "protocol, address and port on which to make the API call")
@@ -59,8 +60,13 @@ func main() {
 func realMain(ctx context.Context) error {
 	logger := logging.FromContext(ctx)
 
-	client, err := clients.NewAPIServerClient(*addrFlag, *apikeyFlag,
-		clients.WithTimeout(*timeoutFlag))
+	opts := make([]clients.Option, 0, 2)
+	opts = append(opts, clients.WithTimeout(*timeoutFlag))
+	if ua := *userAgent; ua != "" {
+		opts = append(opts, clients.WithUserAgent(ua))
+	}
+
+	client, err := clients.NewAPIServerClient(*addrFlag, *apikeyFlag, opts...)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Towards #1972

## Proposed Changes

* capture the OS in ream_stats when an invalid code is attempted to be used

**Release Note**

```release-note
When invalid codes are attempted to be used, the OS is captured in the realm stats [unknown, ios, android]
```
