### PR TITLE
chart of invalid codes by OS

### DIFF
--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -28,6 +28,32 @@
   </small>
 </div>
 
+<div class="card shadow-sm mb-3">
+  <div class="card-header">
+    <span class="oi oi-bar-chart mr-2 ml-n1"></span>
+    Invalid codes by OS
+  </div>
+  <div id="invalid_dashboard_div">
+    <div id="invalid_chart_div" class="h-100 w-100" style="min-height:325px;">
+      <p class="text-center font-italic w-100 mt-5">Loading chart...</p>
+    </div>
+    <div id="invalid_filter_div" class="text-right" style="height: 75px;"></div>
+  </div>
+  <small class="card-footer d-flex justify-content-between text-muted">
+    <a href="#" data-toggle="modal" data-target="#invalid-modal">Learn more about this chart</a>
+    <span>
+      <span class="mr-1">Export as:</span>
+      {{if .hasKeyServerStats}}
+      <a href="/stats/realm/composite.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm/composite.json" target="_blank">JSON</a>  
+      {{else}}
+      <a href="/stats/realm.csv" class="mr-1">CSV</a>
+      <a href="/stats/realm.json" target="_blank">JSON</a> 
+      {{end}}
+    </span>
+  </small>
+</div>
+
 {{if $realm.AllowsUserReport}}
 <div class="card shadow-sm mb-3">
   <div class="card-header">
@@ -151,6 +177,25 @@
     </div>
   </div>
 </div>  
+
+<div class="modal fade" id="invalid-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
+  <div class="modal-dialog modal-dialog-centered">
+    <div class="modal-content">
+      <div class="modal-header">
+        <h5 class="modal-title">Invalid codes by OS</h5>
+        <button type="button" class="close" data-dismiss="modal" aria-label="Close">
+          <span aria-hidden="true">&times;</span>
+        </button>
+      </div>
+      <div class="modal-body mb-n3">
+        <p>
+          This graph breaks down the number of invalid code claim attempts
+          by operating system.
+        </p>
+      </div>
+    </div>
+  </div>
+</div> 
 
 <div class="modal fade" id="comparison-codes-modal" data-backdrop="static" tabindex="-1" aria-hidden="true">
   <div class="modal-dialog modal-dialog-centered">
@@ -392,6 +437,21 @@
         rowFunc: function(dataTable, row, hasKeyServerStats) {
           dataTable.addRow([utcDate(row.date), row.data.tokens_claimed-row.data.user_report_tokens_claimed, row.data.user_report_tokens_claimed]);
         },
+      },
+      {
+        chartType: 'AreaChart',
+        chartDiv: 'invalid_chart_div',
+        dashboardDiv: 'invalid_dashboard_div',
+        filterDiv: "invalid_filter_div",
+        headerFunc: function(dataTable, hasKeyServerStats) {
+          dataTable.addColumn('date', 'Date');
+          dataTable.addColumn('number', 'Unknown');
+          dataTable.addColumn('number', 'iOS');
+          dataTable.addColumn('number', 'Android');
+        },
+        rowFunc: function(dataTable, row, hasKeyServerStats) {
+          dataTable.addRow([utcDate(row.date), row.data.codes_invalid_by_os.unknown_os, row.data.codes_invalid_by_os.ios, row.data.codes_invalid_by_os.android]);
+        },
       }
     ]
     
@@ -473,6 +533,7 @@
             width: '100%',
             height: '300',
           },
+          isStacked: true,
           hAxis: { textPosition: 'none' },
           legend: { position: 'top' },
           width: '100%',

--- a/assets/server/static/js/application.js
+++ b/assets/server/static/js/application.js
@@ -37,7 +37,7 @@ $(function() {
     let csrfToken = getCSRFToken();
     let $csrfField = $("<input>")
       .attr("type", "hidden")
-      .attr("name", "gorilla.csrf.Token")
+      .attr("name", "csrf_token")
       .attr("value", csrfToken);
 
     let $inputField = $("<input>")

--- a/pkg/database/composite_stats.go
+++ b/pkg/database/composite_stats.go
@@ -84,6 +84,11 @@ func (c CompositeStats) MarshalJSON() ([]byte, error) {
 			data.CodesIssued = stat.RealmStats.CodesIssued
 			data.CodesClaimed = stat.RealmStats.CodesClaimed
 			data.CodesInvalid = stat.RealmStats.CodesInvalid
+			data.CodesInvalidByOS = CodesInvalidByOSData{
+				UnknownOS: stat.RealmStats.CodesInvalidByOS[OSTypeUnknown],
+				IOS:       stat.RealmStats.CodesInvalidByOS[OSTypeIOS],
+				Android:   stat.RealmStats.CodesInvalidByOS[OSTypeAndroid],
+			}
 			data.UserReportsIssued = stat.RealmStats.UserReportsIssued
 			data.UserReportsClaimed = stat.RealmStats.UserReportsClaimed
 			data.TokensClaimed = stat.RealmStats.TokensClaimed
@@ -151,6 +156,7 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		"publish_requests_unknown", "publish_requests_android", "publish_requests_ios",
 		"total_teks_published", "requests_with_revisions", "requests_missing_onset_date", "tek_age_distribution", "onset_to_upload_distribution",
 		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
+		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -187,6 +193,20 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsIssued), 10))
 		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsClaimed), 10))
 		row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportTokensClaimed), 10))
+		// Invalid codes by OS
+		if stat.RealmStats == nil {
+			row = append(row, "", "", "")
+		} else {
+			// stats day exists, but the array is nil.
+			if len(stat.RealmStats.CodesInvalidByOS) == 0 {
+				row = append(row, "", "", "")
+			} else {
+				row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalidByOS[OSTypeUnknown]), 10))
+				row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalidByOS[OSTypeIOS]), 10))
+				row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalidByOS[OSTypeAndroid]), 10))
+			}
+		}
+
 		// New stats should always be added to the end to preserve existing external user applications.
 
 		if err := w.Write(row); err != nil {

--- a/pkg/database/composite_stats_test.go
+++ b/pkg/database/composite_stats_test.go
@@ -48,6 +48,7 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesIssued:              10,
 						CodesClaimed:             9,
 						CodesInvalid:             1,
+						CodesInvalidByOS:         []int64{0, 1, 0},
 						UserReportsIssued:        3,
 						UserReportsClaimed:       2,
 						TokensClaimed:            7,
@@ -71,10 +72,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
-2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
+2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2,0,1,0
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":3,"user_reports_claimed":2,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 	}
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1599,7 +1599,8 @@ func (r *Realm) Stats(db *Database) (RealmStats, error) {
 			COALESCE(s.tokens_invalid, 0) AS tokens_invalid,
 			COALESCE(s.user_report_tokens_claimed, 0) AS user_report_tokens_claimed,
 			COALESCE(s.code_claim_age_distribution, array[]::integer[]) AS code_claim_age_distribution,
-			COALESCE(s.code_claim_mean_age, 0) AS code_claim_mean_age
+			COALESCE(s.code_claim_mean_age, 0) AS code_claim_mean_age,
+			COALESCE(s.codes_invalid_by_os, array[0,0,0]::bigint[]) AS codes_invalid_by_os
 		FROM (
 			SELECT date::date FROM generate_series($2, $3, '1 day'::interval) date
 		) d
@@ -1613,6 +1614,7 @@ func (r *Realm) Stats(db *Database) (RealmStats, error) {
 		}
 		return nil, err
 	}
+
 	return stats, nil
 }
 
@@ -1632,6 +1634,7 @@ func (r *Realm) StatsCached(ctx context.Context, db *Database, cacher cache.Cach
 	}); err != nil {
 		return nil, err
 	}
+
 	return stats, nil
 }
 

--- a/pkg/database/realm_stats_test.go
+++ b/pkg/database/realm_stats_test.go
@@ -45,16 +45,17 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodesIssued:              10,
 					CodesClaimed:             9,
 					CodesInvalid:             1,
+					CodesInvalidByOS:         []int64{0, 0, 0},
 					TokensClaimed:            7,
 					TokensInvalid:            2,
 					CodeClaimMeanAge:         FromDuration(time.Minute),
 					CodeClaimAgeDistribution: []int32{1, 3, 4},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
-2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
+2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0,0,0,0
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
 		},
 		{
 			name: "multi",
@@ -65,6 +66,7 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodesIssued:              10,
 					CodesClaimed:             9,
 					CodesInvalid:             1,
+					CodesInvalidByOS:         []int64{1, 2, 3},
 					TokensClaimed:            7,
 					TokensInvalid:            2,
 					CodeClaimMeanAge:         FromDuration(time.Minute),
@@ -76,6 +78,7 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodesIssued:              45,
 					CodesClaimed:             30,
 					CodesInvalid:             29,
+					CodesInvalidByOS:         []int64{0, 20, 9},
 					TokensClaimed:            27,
 					TokensInvalid:            2,
 					CodeClaimMeanAge:         FromDuration(time.Hour),
@@ -89,6 +92,7 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					UserReportsIssued:        2,
 					UserReportsClaimed:       1,
 					CodesInvalid:             0,
+					CodesInvalidByOS:         []int64{0, 0, 0},
 					TokensClaimed:            2,
 					TokensInvalid:            0,
 					UserReportTokensClaimed:  1,
@@ -96,12 +100,12 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{7, 8, 9},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed
-2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0
-2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0
-2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
+2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0,1,2,3
+2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0,0,20,9
+2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1,0,0,0
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"user_reports_issued":2,"user_reports_claimed":1,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":2,"user_reports_claimed":1,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"codes_invalid_by_os":{"unknown_os":0,"ios":20,"android":9},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":1,"ios":2,"android":3},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
 		},
 	}
 

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -404,6 +404,7 @@ func generateCodesAndStats(db *database.Database, realm *database.Realm) (map[st
 				phoneNumber++
 				verificationCode.PhoneNumber = fmt.Sprintf("+%d", phoneNumber)
 				verificationCode.Nonce = nonce
+				verificationCode.NonceRequired = true
 				verificationCode.TestType = api.TestTypeUserReport
 				testType = api.TestTypeUserReport
 			}
@@ -438,12 +439,22 @@ func generateCodesAndStats(db *database.Database, realm *database.Realm) (map[st
 					date = date.Add(time.Duration(rand.Intn(60))*time.Minute + time.Second)
 				}
 
+				os := database.OSTypeUnknown
+				if percentChance(99) {
+					if percentChance(50) {
+						os = database.OSTypeAndroid
+					} else {
+						os = database.OSTypeIOS
+					}
+				}
+
 				request := &database.IssueTokenRequest{
 					Time:        date,
 					AuthApp:     app,
 					VerCode:     longCode,
 					AcceptTypes: accept,
 					ExpireAfter: 24 * time.Hour,
+					OS:          os,
 				}
 				if isUserReport {
 					request.Nonce = nonce


### PR DESCRIPTION
Fixes #1972

## Proposed Changes

* Add display of invalid codes by OS
* Fix CSRF bug for JS submitted links

![image](https://user-images.githubusercontent.com/92319/113459836-9907c700-93cb-11eb-94b0-00f6d713ab6a.png)


**Release Note**

```release-note
New chart on the realm admin stats page showing the invalid codes entered by operating system.
```
