### PR TITLE
hint that app store redirectect should be off for join iOS enx and cu…

### DIFF
--- a/assets/server/mobileapps/_app.html
+++ b/assets/server/mobileapps/_app.html
@@ -43,6 +43,11 @@
     installed, the system will redirect them to the appropriate store to install
     the application. We recommend keeping this option enabled to help increase
     app adoption.
+
+    <div class="alert alert-warning d-ios-only" role="alert">
+      If you have a custom application and iOS EN Express in the same jurisdiction,
+      then AppStore redirect should be disabled.
+    </div>
   </small>
 </div>
 


### PR DESCRIPTION
…stom app

Fixes #



**Release Note**

```release-note
In the mobile apps screen, provides a user hint that AppStore redirect should be disabled if there is a custom app and iOS ENX in the same region.
```
