### PR TITLE
Add some translations for login and password resets

### DIFF
--- a/assets/server/flash.html
+++ b/assets/server/flash.html
@@ -1,5 +1,5 @@
 {{define "flash"}}
-<div id="alerts-container" style="position:absolute; top:0; right:1rem; z-index:2000;">
+<div id="alerts-container">
   {{- if .flash}}
   {{range $msg := .flash.Errors}}
     <div class="toast bg-white" role="alert" aria-live="assertive" aria-atomic="true" data-autohide="false">

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -35,7 +35,7 @@
   integrity="sha384-qqHEed+7J6B7s1PDZUg0ockDBmE8DsXphZqsNwV2pzkH5kXcNP7ZKRYLxbd5f/WL" crossorigin="anonymous"></script>
 <script src="/static/js/application.js?{{.buildID}}" crossorigin="anonymous"></script>
 
-<title>{{if .title}}{{.title}}{{else}}Diagnosis Verification Server{{end}}</title>
+<title>{{if .title}}{{.title}}{{else}}Exposure Notifications Verification Server{{end}}</title>
 {{end}}
 
 {{/* defines the top navigation bar */}}

--- a/assets/server/login/account.html
+++ b/assets/server/login/account.html
@@ -92,7 +92,7 @@
         }
 
         if (user.multiFactor.enrolledFactors.length > 0) {
-          $phoneReg.html('Two-factor auth is <span class="text-success">enabled</span>');
+          $phoneReg.html('Multi-factor auth is <span class="text-success">enabled</span>');
           $('#register-link').text('Manage auth factors');
         } else {
           $phoneReg.addClass("text-danger");

--- a/assets/server/login/login.html
+++ b/assets/server/login/login.html
@@ -11,38 +11,38 @@
 </head>
 
 <body id="login" class="tab-content">
-  {{if $currentUser}}
-    {{template "navbar" .}}
-  {{end}}
   <main role="main" class="container">
     {{template "flash" .}}
 
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center align-self-center">
-        <div class="col-sm-6">
+        <div class="login-container">
           <div class="card shadow-sm" id="login-div">
-            {{if $currentUser}}
-              <div class="card-header">Refresh authentication</div>
-            {{else}}
-              <div class="card-header">COVID-19 test verification</div>
-            {{end}}
+            <div class="card-header">
+              <span class="d-block text-truncate">{{$.server}}</span>
+            </div>
 
             <div class="card-body">
               <form id="login-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">
-                  <input type="email" id="email" name="email" class="form-control" placeholder="Email address"
-                  autocomplete="username" required autofocus {{if $currentUser}}disabled value="{{$currentUser.Email}}"{{end}}/>
-                  <label for="email">Email address</label>
+                  <input type="email" id="email" name="email" class="form-control" placeholder="{{t $.locale "login.email-address"}}"
+                    autocomplete="username" required autofocus {{if $currentUser}}disabled value="{{$currentUser.Email}}"{{end}}/>
+                  <label for="email">{{t $.locale "login.email-address"}}</label>
                 </div>
 
                 <div class="form-label-group">
-                  <input type="password" id="password" name="password" class="form-control" placeholder="Password"
-                  autocomplete="password" required />
-                  <label for="password">Password</label>
+                  <input type="password" id="password" name="password" class="form-control"
+                    placeholder="{{t $.locale "login.password"}}" autocomplete="password" required />
+                  <label for="password">{{t $.locale "login.password"}}</label>
                 </div>
 
-                <button type="submit" id="submit" class="btn btn-primary btn-block">Login</button>
-                <a class="card-link btn-block" href="/login/reset-password">Forgot password</a>
+                <button type="submit" id="submit" class="btn btn-primary btn-block">
+                  {{if $currentUser}}
+                    {{t $.locale "login.refresh-authentication"}}
+                  {{else}}
+                    {{t $.locale "login.authenticate"}}
+                  {{end}}
+                </button>
               </form>
             </div>
           </div>
@@ -50,14 +50,13 @@
           {{template "login/pindiv" .}}
           {{template "login/factorsdiv" .}}
 
-          {{if .loginRedirect}}
-            <div class="card-body">
-              <a class="card-link" href="/{{.loginRedirect}}">&larr; Back</a>
-            </div>
-          {{end}}
-
-          <div class="d-flex justify-content-center pt-2">
-            <small><a class="text-muted" target="_blank" href="https://www.google.com/covid19/exposurenotifications">About exposure notifications</a></small>
+          <div class="d-flex justify-content-between pt-2 px-1">
+            <a class="text-muted small" target="_blank" href="https://www.google.com/covid19/exposurenotifications">
+              {{t $.locale "login.about-exposure-notifications" }}
+            </a>
+            <a class="small text-muted" href="/login/reset-password">
+              {{t $.locale "login.forgot-password"}}
+            </a>
           </div>
         </div>
       </div>
@@ -73,10 +72,6 @@
       let fn = function loginSuccess() {
         {{if .loginRedirect}}
           window.location.assign('{{.loginRedirect}}');
-        {{else}}
-        {{if $currentUser}}
-          flash.alert('Successfully refreshed auth credentials.');
-        {{end}}
         {{end}}
       }
 

--- a/assets/server/login/register-phone.html
+++ b/assets/server/login/register-phone.html
@@ -1,5 +1,6 @@
 {{define "login/register-phone"}}
 
+{{$currentRealm := .currentRealm}}
 {{$mfaMode := .mfaMode}}
 {{$currentMembership := .currentMembership}}
 
@@ -22,44 +23,40 @@
           {{template "login/factorsdiv" .}}
 
           <div class="card shadow-sm" id="register-div">
-            <div class="card-header">Multi-factor authentication</div>
+            <div class="card-header">{{t $.locale "mfa.mfa"}}</div>
             <div class="card-body">
               {{if $mfaMode}}
                 {{if eq $mfaMode.String "required"}}
                   <div class="alert alert-danger" role="alert">
-                    This realm requires all users enable two-factor authentication.
+                    {{t $.locale "mfa.notice-required" $currentRealm.Name}}
                   </div>
                 {{else if eq $mfaMode.String "prompt"}}
                   <div class="alert alert-warning" role="alert">
-                    This realm recommends all users enable two-factor
-                    authentication. It may be required in the future.
+                    {{t $.locale "mfa.notice-prompt" $currentRealm.Name}}
                   </div>
                 {{else}}
                   <div class="alert alert-info" role="alert">
-                    This realm recommends all users enable two-factor
-                    authentication.
+                    {{t $.locale "mfa.notice-optional" $currentRealm.Name}}
                   </div>
                 {{end}}
               {{end}}
 
               <form id="register-form" class="floating-form" action="/" method="POST">
                 <div class="form-label-group">
-                  <input type="text" id="display" name="display" class="form-control" placeholder="Display name" />
-                  <label for="display">Display name</label>
-                  <small class="form-text text-muted">
-                    Display name for this phone.
-                  </small>
+                  <input type="text" id="display" name="display" class="form-control"
+                    placeholder="{{t $.locale "mfa.phone-display-name"}}" required autofocus />
+                  <label for="display">{{t $.locale "mfa.phone-display-name"}}</label>
+                  <small class="form-text text-muted">{{t $.locale "mfa.phone-display-name-help-text"}}</small>
                 </div>
 
                 <div class="form-group">
-                  <input type="tel" id="phone" name="phone" class="form-control" required autofocus />
-                  <small class="form-text text-muted">
-                    You will be asked to confirm a code using this phone number at login.
-                    Standard SMS rates may apply.
-                  </small>
+                  <input type="tel" id="phone" name="phone" class="form-control" required />
+                  <small class="form-text text-muted">{{t $.locale "mfa.phone-number-help-text"}}</small>
                </div>
 
-                <button type="submit" id="submit-register" class="btn btn-primary btn-block">Register</button>
+                <button type="submit" id="submit-register" class="btn btn-primary btn-block">
+                  {{t $.locale "mfa.enable-mfa"}}
+                </button>
               </form>
             </div>
             {{if $mfaMode}}
@@ -67,7 +64,7 @@
                 <div class="card-footer text-right">
                   <small>
                     <a id="skip" href="/login/post-authenticate" class="text-secondary">
-                      Skip for now &rarr;
+                      {{t $.locale "mfa.continue-without-mfa"}} &rarr;
                     </a>
                   </small>
                 </div>

--- a/assets/server/login/reset-password.html
+++ b/assets/server/login/reset-password.html
@@ -8,38 +8,27 @@
 </head>
 
 <body id="reset-password" class="tab-content">
-  {{if .currentUser}}
-  {{template "navbar" .}}
-  {{end}}
   <main role="main" class="container">
     {{template "flash" .}}
 
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center align-self-center">
-        <div class="col-sm-6">
+        <div class="login-container">
           <div class="card shadow-sm">
-            <div class="card-header">
-              Reset password
-              <a href="/" type="button" class="close" aria-label="Close" id="pinClose">
-                <span aria-hidden="true">&times;</span>
-              </a>
-            </div>
+            <div class="card-header">{{t $.locale "password.reset-password"}}</div>
+
             <div class="card-body">
               <form class="floating-form" action="/login/reset-password" method="POST">
                 {{ .csrfField }}
-                <div class="form-label-group mb-2">
+                <div class="form-label-group">
                   <input type="email" name="email" class="form-control"
-                    placeholder="Email address" value="{{.email}}" required autofocus />
-                  <label for="email">Email address</label>
-                  <small class="form-text text-muted">
-                    A reset link will be sent to this address.
-                  </small>
+                    placeholder="{{t $.locale "login.email-address"}}" value="{{.email}}" required autofocus />
+                  <label for="email">{{t $.locale "login.email-address"}}</label>
                 </div>
 
-                <a href="#"
-                  data-submit-form
-                  data-confirm="Are you sure you want to reset your password?"
-                  class="btn btn-primary btn-block">Send reset email</a>
+                <button type="submit" id="submit" class="btn btn-primary btn-block">
+                  {{t $.locale "password.send-reset-password"}}
+                </button>
               </form>
             </div>
           </div>

--- a/assets/server/static/css/application.css
+++ b/assets/server/static/css/application.css
@@ -16,6 +16,24 @@ main.container[role="main"] {
   position: relative;
 }
 
+.login-container {
+  width: 100%;
+  min-width: 236px;
+  max-width: 466px;
+}
+
+#alerts-container {
+  position: absolute;
+  right: 1rem;
+  top: 0;
+  z-index: 2000;
+}
+
+body#login #alerts-container,
+body#reset-password #alerts-container {
+  top: 1rem;
+}
+
 .floating-form {
   width: 100%;
   height: 100%;

--- a/docs/realm-admin-guide.md
+++ b/docs/realm-admin-guide.md
@@ -1,33 +1,33 @@
 <!-- TOC depthFrom:2 -->
 
 - [Access protection recommendations](#access-protection-recommendations)
-    - [Account protection](#account-protection)
-    - [API key protection](#api-key-protection)
+  - [Account protection](#account-protection)
+  - [API key protection](#api-key-protection)
 - [Settings, enabling EN Express](#settings-enabling-en-express)
 - [Settings, code settings](#settings-code-settings)
-    - [Bulk Issue Codes](#bulk-issue-codes)
-    - [Allowed Test Types](#allowed-test-types)
-    - [Date Configuration](#date-configuration)
-    - [Code Length & Expiration](#code-length--expiration)
+  - [Bulk Issue Codes](#bulk-issue-codes)
+  - [Allowed Test Types](#allowed-test-types)
+  - [Date Configuration](#date-configuration)
+  - [Code Length & Expiration](#code-length--expiration)
 - [Settings, SMS](#settings-sms)
-    - [SMS Text Template](#sms-text-template)
+  - [SMS Text Template](#sms-text-template)
 - [Authenticated SMS](#authenticated-sms)
 - [Adding users](#adding-users)
 - [API keys](#api-keys)
 - [ENX redirector service](#enx-redirector-service)
 - [Mobile apps](#mobile-apps)
 - [Statistics](#statistics)
-    - [Key server statistics](#key-server-statistics)
-    - [All charts available](#all-charts-available)
-        - [Codes issued and used](#codes-issued-and-used)
-        - [Code usage latency](#code-usage-latency)
-        - [Total TEKs published](#total-teks-published)
-        - [Total publish requests](#total-publish-requests)
-        - [EN days active before upload](#en-days-active-before-upload)
-        - [Onset to upload](#onset-to-upload)
+  - [Key server statistics](#key-server-statistics)
+  - [All charts available](#all-charts-available)
+    - [Codes issued and used](#codes-issued-and-used)
+    - [Code usage latency](#code-usage-latency)
+    - [Total TEKs published](#total-teks-published)
+    - [Total publish requests](#total-publish-requests)
+    - [EN days active before upload](#en-days-active-before-upload)
+    - [Onset to upload](#onset-to-upload)
 - [Rotating certificate signing keys](#rotating-certificate-signing-keys)
-    - [Automatic Rotation](#automatic-rotation)
-    - [Manual Rotation](#manual-rotation)
+  - [Automatic Rotation](#automatic-rotation)
+  - [Manual Rotation](#manual-rotation)
 
 <!-- /TOC -->
 
@@ -44,7 +44,7 @@ If you are not a realm administrator, you will not have access to these screens.
 We provide a base level of account protection measures that we urge you to share with your caseworkers that are issuing verification codes.
 
 * All user accounts must verify ownership of their email address before using the system.
-* Two-factor authentication (2FA) is available, we strongly suggest you require your users to enroll in 2FA
+* Multi-factor authentication (MFA) is available, we strongly suggest you require your users to enroll in MFA
   using a mobile device under their sole control.
 * Users should not share logins to the verification system.
 * Users should only issue codes to people who have a verified COVID-19 diagnosis.

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -7,6 +7,62 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "عنوان بريد الكتروني"
+
+msgid "login.password"
+msgstr "كلمة المرور"
+
+msgid "login.authenticate"
+msgstr "المصادقة"
+
+msgid "login.refresh-authentication"
+msgstr "تحديث المصادقة"
+
+msgid "login.forgot-password"
+msgstr "هل نسيت كلمة السر"
+
+msgid "login.about-exposure-notifications"
+msgstr "Exposure Notifications حول"
+
+msgid "mfa.mfa"
+msgstr "مصادقة متعددة العوامل"
+
+msgid "mfa.notice-required"
+msgstr "يتطلب %s تمكين المصادقة متعددة العوامل (MFA) لتحسين أمان حسابك."
+
+msgid "mfa.notice-prompt"
+msgstr "توصي %s بتمكين المصادقة متعددة العوامل (MFA) لتحسين أمان حسابك. قد يكون مطلوبًا في المستقبل."
+
+msgid "mfa.notice-optional"
+msgstr "توصي %s بتمكين المصادقة متعددة العوامل (MFA) لتحسين أمان حسابك."
+
+msgid "mfa.phone-display-name"
+msgstr "اسم العرض"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "هذا هو اسم الجهاز كما سيظهر في صفحة إعدادات حسابك."
+
+msgid "mfa.phone-number-help-text"
+msgstr "سيرسل النظام رمزًا عبر رسالة نصية قصيرة إلى رقم الهاتف هذا في كل مرة تقوم فيها بالمصادقة. سيتم تطبيق الأسعار القياسية للرسائل النصية القصيرة."
+
+msgid "mfa.enable-mfa"
+msgstr "تمكين المصادقة متعددة العوامل"
+
+msgid "mfa.continue-without-mfa"
+msgstr "استمر بدون المصادقة متعددة العوامل"
+
+msgid "password.reset-password"
+msgstr "إعادة تعيين كلمة المرور"
+
+msgid "password.send-reset-password"
+msgstr "إرسال بريد إلكتروني لإعادة تعيين كلمة المرور"
+
+
+#
 # navigation menus
 # ----------------
 

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -7,6 +7,62 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "E-Mail-Addresse"
+
+msgid "login.password"
+msgstr "Passwort"
+
+msgid "login.authenticate"
+msgstr "Authentifizieren"
+
+msgid "login.refresh-authentication"
+msgstr "Authentifizierung aktualisieren"
+
+msgid "login.forgot-password"
+msgstr "Passwort vergessen"
+
+msgid "login.about-exposure-notifications"
+msgstr "Informationen zu Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Multi-Faktor-Authentifizierung"
+
+msgid "mfa.notice-required"
+msgstr "%s erfordert, dass Sie die Multi-Factor-Authentifizierung (MFA) aktivieren, um Ihre Kontosicherheit zu verbessern."
+
+msgid "mfa.notice-prompt"
+msgstr "%s empfiehlt, die Multi-Factor-Authentifizierung (MFA) zu aktivieren, um die Sicherheit Ihres Kontos zu verbessern. Es kann in Zukunft erforderlich sein."
+
+msgid "mfa.notice-optional"
+msgstr "%s empfiehlt, die Multi-Factor-Authentifizierung (MFA) zu aktivieren, um die Sicherheit Ihres Kontos zu verbessern."
+
+msgid "mfa.phone-display-name"
+msgstr "Anzeigename"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Dies ist der Name des Geräts, wie er auf der Seite mit den Kontoeinstellungen angezeigt wird."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Das System sendet bei jeder Authentifizierung einen Code per SMS an diese Telefonnummer. Es gelten die Standard-SMS-Preise."
+
+msgid "mfa.enable-mfa"
+msgstr "Aktivieren Sie die Multi-Faktor-Authentifizierung"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Fahren Sie ohne Multi-Faktor-Authentifizierung fort"
+
+msgid "password.reset-password"
+msgstr "Passwort zurücksetzen"
+
+msgid "password.send-reset-password"
+msgstr "E-Mail zum Zurücksetzen des Passworts senden"
+
+
+#
 # navigation menus
 # ----------------
 

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Email address"
+
+msgid "login.password"
+msgstr "Password"
+
+msgid "login.authenticate"
+msgstr "Authenticate"
+
+msgid "login.refresh-authentication"
+msgstr "Refresh authentication"
+
+msgid "login.forgot-password"
+msgstr "Forgot password"
+
+msgid "login.about-exposure-notifications"
+msgstr "About Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Multi-Factor Authentication"
+
+msgid "mfa.notice-required"
+msgstr "%s requires you enable Multi-Factor Authentication (MFA) to improve your account security."
+
+msgid "mfa.notice-prompt"
+msgstr "%s recommends you enable Multi-Factor Authentication (MFA) to improve your account security. It may be required in the future."
+
+msgid "mfa.notice-optional"
+msgstr "%s recommends you enable Multi-Factor Authentication (MFA) to improve your account security."
+
+msgid "mfa.phone-display-name"
+msgstr "Display name"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "This is the name of the device as it will appear on your account settings page."
+
+msgid "mfa.phone-number-help-text"
+msgstr "The system will send a code via SMS to this phone number each time you authenticate. Standard SMS rates will apply."
+
+msgid "mfa.enable-mfa"
+msgstr "Enable Multi-Factor Authentication"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Continue without Multi-Factor Authentication"
+
+msgid "password.reset-password"
+msgstr "Reset password"
+
+msgid "password.send-reset-password"
+msgstr "Send password reset email"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -7,6 +7,62 @@ msgstr ""
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
 #
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Dirección de correo electrónico"
+
+msgid "login.password"
+msgstr "Contraseña"
+
+msgid "login.authenticate"
+msgstr "Autenticar"
+
+msgid "login.refresh-authentication"
+msgstr "Actualizar autenticación"
+
+msgid "login.forgot-password"
+msgstr "Contraseña olvidada"
+
+msgid "login.about-exposure-notifications"
+msgstr "Acerca de las Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Autenticación multifactor"
+
+msgid "mfa.notice-required"
+msgstr "%s requiere que habilite la autenticación multifactor (MFA) para mejorar la seguridad de su cuenta."
+
+msgid "mfa.notice-prompt"
+msgstr "%s recomienda que habilite la autenticación multifactor (MFA) para mejorar la seguridad de su cuenta. Es posible que sea necesaria en el futuro."
+
+msgid "mfa.notice-optional"
+msgstr "%s recomienda que habilite la autenticación multifactor (MFA) para mejorar la seguridad de su cuenta."
+
+msgid "mfa.phone-display-name"
+msgstr "Nombre para mostrar"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Este es el nombre del dispositivo tal como aparecerá en la página de configuración de su cuenta."
+
+msgid "mfa.phone-number-help-text"
+msgstr "El sistema enviará un código por SMS a este número de teléfono cada vez que se autentique. Se aplicarán las tarifas estándar de SMS."
+
+msgid "mfa.enable-mfa"
+msgstr "Habilitar la autenticación multifactor"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Continuar sin autenticación multifactor"
+
+msgid "password.reset-password"
+msgstr "Restablecer contraseña"
+
+msgid "password.send-reset-password"
+msgstr "Enviar correo electrónico para restablecer la contraseña"
+
+
+#
 # navigation menus
 # ----------------
 

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Adresse e-mail"
+
+msgid "login.password"
+msgstr "Mot de passe"
+
+msgid "login.authenticate"
+msgstr "Authentifier"
+
+msgid "login.refresh-authentication"
+msgstr "Actualiser l'authentification"
+
+msgid "login.forgot-password"
+msgstr "Mot de passe oublié"
+
+msgid "login.about-exposure-notifications"
+msgstr "À propos des Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Authentification multifacteur"
+
+msgid "mfa.notice-required"
+msgstr "%s nécessite que vous activiez l'authentification multifacteur (MFA) pour améliorer la sécurité de votre compte."
+
+msgid "mfa.notice-prompt"
+msgstr "%s vous recommande d'activer l'authentification multifacteur (MFA) pour améliorer la sécurité de votre compte. Cela pourrait être nécessaire à l'avenir."
+
+msgid "mfa.notice-optional"
+msgstr "%s vous recommande d'activer l'authentification multifacteur (MFA) pour améliorer la sécurité de votre compte."
+
+msgid "mfa.phone-display-name"
+msgstr "Afficher le nom"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Il s'agit du nom de l'appareil tel qu'il apparaîtra sur la page des paramètres de votre compte.""
+
+msgid "mfa.phone-number-help-text"
+msgstr "Le système enverra un code par SMS à ce numéro de téléphone chaque fois que vous vous authentifiez. Les tarifs SMS standard s'appliqueront."
+
+msgid "mfa.enable-mfa"
+msgstr "Activer l'authentification multifacteur"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Continuer sans authentification multifacteur"
+
+msgid "password.reset-password"
+msgstr "Réinitialiser le mot de passe"
+
+msgid "password.send-reset-password"
+msgstr "Envoyer un e-mail de réinitialisation du mot de passe"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Alamat email"
+
+msgid "login.password"
+msgstr "Sandi"
+
+msgid "login.authenticate"
+msgstr "Otentikasi"
+
+msgid "login.refresh-authentication"
+msgstr "Segarkan otentikasi"
+
+msgid "login.forgot-password"
+msgstr "Lupa sandi"
+
+msgid "login.about-exposure-notifications"
+msgstr "Tentang Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Otentikasi Multi-Faktor"
+
+msgid "mfa.notice-required"
+msgstr "%s mengharuskan Anda mengaktifkan Multi-Factor Authentication (MFA) untuk meningkatkan keamanan akun Anda."
+
+msgid "mfa.notice-prompt"
+msgstr "%s menyarankan Anda mengaktifkan Multi-Factor Authentication (MFA) untuk meningkatkan keamanan akun Anda. Ini mungkin diperlukan di masa mendatang."
+
+msgid "mfa.notice-optional"
+msgstr "%s menyarankan Anda mengaktifkan Multi-Factor Authentication (MFA) untuk meningkatkan keamanan akun Anda."
+
+msgid "mfa.phone-display-name"
+msgstr "Nama tampilan"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Ini adalah nama perangkat yang akan muncul di halaman pengaturan akun Anda."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Sistem akan mengirimkan kode melalui SMS ke nomor telepon ini setiap kali Anda melakukan otentikasi. Tarif SMS standar akan berlaku."
+
+msgid "mfa.enable-mfa"
+msgstr "Aktifkan Autentikasi Multi-Faktor"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Lanjutkan tanpa Autentikasi Multi-Faktor"
+
+msgid "password.reset-password"
+msgstr "Setel ulang sandi"
+
+msgid "password.send-reset-password"
+msgstr "Kirim email pengaturan ulang kata sandi"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Indirizzo e-mail"
+
+msgid "login.password"
+msgstr "Password"
+
+msgid "login.authenticate"
+msgstr "Autentica"
+
+msgid "login.refresh-authentication"
+msgstr "Aggiorna autenticazione"
+
+msgid "login.forgot-password"
+msgstr "Password dimenticata"
+
+msgid "login.about-exposure-notifications"
+msgstr "Informazioni sulle Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Autenticazione a più fattori"
+
+msgid "mfa.notice-required"
+msgstr "%s richiede che abiliti Multi-Factor Authentication (MFA) per migliorare la sicurezza del tuo account."
+
+msgid "mfa.notice-prompt"
+msgstr "%s consiglia di abilitare Multi-Factor Authentication (MFA) per migliorare la sicurezza del tuo account. Potrebbe essere richiesto in futuro."
+
+msgid "mfa.notice-optional"
+msgstr "%s consiglia di abilitare Multi-Factor Authentication (MFA) per migliorare la sicurezza del tuo account."
+
+msgid "mfa.phone-display-name"
+msgstr "Nome visualizzato"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Questo è il nome del dispositivo come apparirà nella pagina delle impostazioni dell'account."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Il sistema invierà un codice tramite SMS a questo numero di telefono ogni volta che esegui l'autenticazione. Verranno applicate le tariffe standard per gli SMS."
+
+msgid "mfa.enable-mfa"
+msgstr "Abilita autenticazione a più fattori"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Continua senza autenticazione a più fattori"
+
+msgid "password.reset-password"
+msgstr "Reimposta password"
+
+msgid "password.send-reset-password"
+msgstr "Invia email per reimpostare la password"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -38,7 +38,7 @@ msgstr "％s では、アカウントのセキュリティを向上させるた�
 msgid "mfa.notice-prompt"
 msgstr "％s は、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にすることをお勧めします。将来必要になる可能性があります。"
 
-msgid "mfa.notice-オプション"
+msgid "mfa.notice-optional"
 msgstr "％s は、アカウントのセキュリティを向上させるために、多要素認証（MFA）を有効にすることをお勧めします。"
 
 msgid "mfa.phone-display-name"

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -6,6 +6,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=1; plural=0;\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "メールアドレス"
+
+msgid "login.password"
+msgstr "パスワード"
+
+msgid "login.authenticate"
+msgstr "認証"
+
+msgid "login.refresh-authentication"
+msgstr "認証の更新"
+
+msgid "login.forgot-password"
+msgstr "パスワードを忘れた"
+
+msgid "login.about-exposure-notifications"
+msgstr "について学ぶ Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "多要素認証"
+
+msgid "mfa.notice-required"
+msgstr "％s では、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にする必要があります。"
+
+msgid "mfa.notice-prompt"
+msgstr "％s は、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にすることをお勧めします。将来必要になる可能性があります。"
+
+msgid "mfa.notice-オプション"
+msgstr "％s は、アカウントのセキュリティを向上させるために、多要素認証（MFA）を有効にすることをお勧めします。"
+
+msgid "mfa.phone-display-name"
+msgstr "表示名"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "これは、アカウント設定ページに表示されるデバイスの名前です。"
+
+msgid "mfa.phone-number-help-text"
+msgstr "システムは、認証するたびにSMS経由でこの電話番号にコードを送信します。標準のSMS料金が適用されます。"
+
+msgid "mfa.enable-mfa"
+msgstr "多要素認証を有効にする"
+
+msgid "mfa.continue-without-mfa"
+msgstr "多要素認証なしで続行"
+
+msgid "password.reset-password"
+msgstr "パスワードのリセット"
+
+msgid "password.send-reset-password"
+msgstr "パスワードリセットメールを送信する"
+
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -6,6 +6,64 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Имэйл хаяг"
+
+msgid "login.password"
+msgstr "Нууц үг"
+
+msgid "login.authenticate"
+msgstr "Баталгаажуулах"
+
+msgid "login.refresh-authentication"
+msgstr "Баталгаажуулалтыг шинэчлэх"
+
+msgid "login.forgot-password"
+msgstr "Нууц үгээ мартсан"
+
+msgid "login.about-exposure-notifications"
+msgstr "Тухай Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Олон хүчин зүйлт нэвтрэлт танилт"
+
+msgid "mfa.notice-required"
+msgstr "%s нь дансныхаа аюулгүй байдлыг сайжруулахын тулд Олон Факторын Баталгаажуулалт (MFA) -г идэвхжүүлэхийг шаарддаг."
+
+msgid "mfa.notice-prompt"
+msgstr "%s нь дансныхаа аюулгүй байдлыг сайжруулахын тулд Олон Факторын Баталгаажуулалтыг (MFA) идэвхжүүлэхийг зөвлөж байна. Ирээдүйд шаардлагатай байж магадгүй юм."
+
+msgid "mfa.notice-optional"
+msgstr "%s нь дансныхаа аюулгүй байдлыг сайжруулахын тулд Олон Факторын Баталгаажуулалтыг (MFA) идэвхжүүлэхийг зөвлөж байна."
+
+msgid "mfa.phone-display-name"
+msgstr "Нэрийг харуулах"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Энэ бол таны дансны тохиргооны хуудсанд гарч ирэх тул төхөөрөмжийн нэр юм."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Систем таныг баталгаажуулах бүртээ энэ утасны дугаар руу мессежээр код илгээх болно. SMS-ийн стандарт тарифыг дагаж мөрдөх болно."
+
+msgid "mfa.enable-mfa"
+msgstr "Олон хүчин зүйлийн баталгаажуулалтыг идэвхжүүлэх"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Олон хүчин зүйлийн баталгаажуулалтгүйгээр үргэлжлүүлэх"
+
+msgid "password.reset-password"
+msgstr "Нууц үгээ шинэчлэх"
+
+msgid "password.send-reset-password"
+msgstr "Нууц үг шинэчлэх имэйлийг илгээх"
+
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/ph/default.po
+++ b/internal/i18n/locales/ph/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Email address"
+
+msgid "login.password"
+msgstr "Password"
+
+msgid "login.authenticate"
+msgstr "Patunayan"
+
+msgid "login.refresh-authentication"
+msgstr "I-refresh ang pagpapatotoo"
+
+msgid "login.forgot-password"
+msgstr "Nakalimutan ang password"
+
+msgid "login.about-exposure-notifications"
+msgstr "Tungkol sa Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Multi-Factor Authentication"
+
+msgid "mfa.notice-required"
+msgstr "%s kinakailangan mong paganahin ang Multi-Factor Authentication (MFA) upang mapabuti ang seguridad ng iyong account."
+
+msgid "mfa.notice-prompt"
+msgstr "%s inirekomenda mong paganahin ang Multi-Factor Authentication (MFA) upang mapabuti ang seguridad ng iyong account. Maaaring kailanganin ito sa hinaharap."
+
+msgid "mfa.notice-optional"
+msgstr "%s inirekomenda mong paganahin ang Multi-Factor Authentication (MFA) upang mapabuti ang seguridad ng iyong account."
+
+msgid "mfa.phone-display-name"
+msgstr "Pangalan sa pagpapakita"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Ito ang pangalan ng aparato dahil lilitaw ito sa pahina ng mga setting ng iyong account."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Magpapadala ang system ng isang code sa pamamagitan ng SMS sa numero ng teleponong ito sa tuwing nagpapatotoo ka. Malalapat ang mga karaniwang rate ng SMS."
+
+msgid "mfa.enable-mfa"
+msgstr "Paganahin ang Pagpapatotoo ng Multi-Factor"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Magpatuloy nang walang Multi-Factor Authentication"
+
+msgid "password.reset-password"
+msgstr "I-reset ang password"
+
+msgid "password.send-reset-password"
+msgstr "Magpadala ng email sa pag-reset ng password"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "Endereço de email"
+
+msgid "login.password"
+msgstr "Senha"
+
+msgid "login.authenticate"
+msgstr "Autenticar"
+
+msgid "login.refresh-authentication"
+msgstr "Atualizar autenticação"
+
+msgid "login.forgot-password"
+msgstr "Esqueci a senha"
+
+msgid "login.about-exposure-notifications"
+msgstr "Sobre Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Autenticação multifator"
+
+msgid "mfa.notice-required"
+msgstr "%s requer que você habilite a autenticação multifator (MFA) para melhorar a segurança da sua conta."
+
+msgid "mfa.notice-prompt"
+msgstr "%s recomenda que você habilite a autenticação multifator (MFA) para melhorar a segurança da sua conta. Pode ser necessária no futuro."
+
+msgid "mfa.notice-optional"
+msgstr "%s recomenda que você habilite a autenticação multifator (MFA) para melhorar a segurança da sua conta."
+
+msgid "mfa.phone-display-name"
+msgstr "Nome de exibição"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Este é o nome do dispositivo como aparecerá na página de configurações da sua conta."
+
+msgid "mfa.phone-number-help-text"
+msgstr "O sistema enviará um código via SMS para este número de telefone cada vez que você autenticar. Taxas padrão de SMS serão aplicadas."
+
+msgid "mfa.enable-mfa"
+msgstr "Habilitar autenticação multifator"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Continuar sem autenticação multifator"
+
+msgid "password.reset-password"
+msgstr "Redefinir senha"
+
+msgid "password.send-reset-password"
+msgstr "Enviar e-mail de redefinição de senha"
+
+
 #
 # navigation menus
 # ----------------

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -6,6 +6,63 @@ msgstr ""
 "Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: nplurals=2; plural=(n != 1);\n"
 
+
+#
+# login / account
+# ----------------
+
+msgid "login.email-address"
+msgstr "E-posta adresi"
+
+msgid "login.password"
+msgstr "Şifre"
+
+msgid "login.authenticate"
+msgstr "Kimlik Doğrulama"
+
+msgid "login.refresh-authentication"
+msgstr "Kimlik doğrulamasını yenile"
+
+msgid "login.forgot-password"
+msgstr "Şifremi unuttum"
+
+msgid "login.about-exposure-notifications"
+msgstr "About Exposure Notifications"
+
+msgid "mfa.mfa"
+msgstr "Çok Faktörlü Kimlik Doğrulama"
+
+msgid "mfa.notice-required"
+msgstr "%s hesabınızın güvenliğini iyileştirmek için Çok Faktörlü Kimlik Doğrulamayı (MFA) etkinleştirmenizi gerektirir."
+
+msgid "mfa.notice-prompt"
+msgstr "%s hesabınızın güvenliğini artırmak için Çok Faktörlü Kimlik Doğrulamayı (MFA) etkinleştirmenizi önerir. Gelecekte gerekli olabilir."
+
+msgid "mfa.notice-optional"
+msgstr "%s hesabınızın güvenliğini artırmak için Çok Faktörlü Kimlik Doğrulamayı (MFA) etkinleştirmenizi önerir."
+
+msgid "mfa.phone-display-name"
+msgstr "Görünen ad"
+
+msgid "mfa.phone-display-name-help-text"
+msgstr "Bu, hesap ayarları sayfanızda görüneceği şekliyle cihazın adıdır."
+
+msgid "mfa.phone-number-help-text"
+msgstr "Sistem, her kimlik doğrulamanızda bu telefon numarasına SMS yoluyla bir kod gönderecektir. Standart SMS ücretleri uygulanacaktır."
+
+msgid "mfa.enable-mfa"
+msgstr "Çok Faktörlü Kimlik Doğrulamayı Etkinleştir"
+
+msgid "mfa.continue-without-mfa"
+msgstr "Çok Faktörlü Kimlik Doğrulaması Olmadan Devam Et"
+
+msgid "password.reset-password"
+msgstr "Parolayı sıfırla"
+
+msgid "password.send-reset-password"
+msgstr "Parola sıfırlama e-postası gönder"
+
+
 #
 # navigation menus
 # ----------------

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -88,7 +88,7 @@ type ServerConfig struct {
 	CookieDomain string `env:"COOKIE_DOMAIN"`
 
 	// Application Config
-	ServerName string `env:"SERVER_NAME,default=Diagnosis Verification Server"`
+	ServerName string `env:"SERVER_NAME,default=Exposure Notifications Verification Server"`
 
 	// Issue is configuration specific to the code issue APIs.
 	Issue IssueAPIVars

--- a/pkg/controller/admin/caches_test.go
+++ b/pkg/controller/admin/caches_test.go
@@ -20,12 +20,10 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 )
@@ -36,13 +34,8 @@ func TestAdminCaches(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleCachesClear()))
+	handler := harness.WithCommonMiddlewares(c.HandleCachesClear())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -91,7 +84,7 @@ func TestAdminCaches(t *testing.T) {
 		}
 
 		c := admin.New(harness.Config, cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleCachesClear()))
+		handler := harness.WithCommonMiddlewares(c.HandleCachesClear())
 
 		session := &sessions.Session{}
 

--- a/pkg/controller/admin/events_test.go
+++ b/pkg/controller/admin/events_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/gorilla/mux"
@@ -36,13 +34,8 @@ func TestAdminEvents(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleEventsShow()))
+	handler := harness.WithCommonMiddlewares(c.HandleEventsShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -55,7 +48,7 @@ func TestAdminEvents(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleEventsShow()))
+		handler := harness.WithCommonMiddlewares(c.HandleEventsShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -73,7 +66,7 @@ func TestAdminEvents(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleEventsShow()))
+		handler := harness.WithCommonMiddlewares(c.HandleEventsShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/admin/info_test.go
+++ b/pkg/controller/admin/info_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/gorilla/sessions"
 )
 
@@ -33,19 +31,14 @@ func TestAdminInfo(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleEventsShow()))
+	handler := harness.WithCommonMiddlewares(c.HandleEventsShow())
 
 	t.Run("internal_error", func(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleEventsShow()))
+		handler := harness.WithCommonMiddlewares(c.HandleEventsShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/admin/mobile_apps_test.go
+++ b/pkg/controller/admin/mobile_apps_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/gorilla/sessions"
@@ -35,13 +33,8 @@ func TestAdminMobileApps(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleMobileAppsShow()))
+	handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -54,7 +47,7 @@ func TestAdminMobileApps(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleMobileAppsShow()))
+		handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -21,11 +21,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/gorilla/mux"
@@ -38,13 +36,8 @@ func TestHandleRealmsIndex(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsIndex()))
+	handler := harness.WithCommonMiddlewares(c.HandleRealmsIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -59,7 +52,7 @@ func TestHandleRealmsIndex(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsIndex()))
+		handler := harness.WithCommonMiddlewares(c.HandleRealmsIndex())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -95,13 +88,8 @@ func TestHandleRealmsCreate(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsCreate()))
+	handler := harness.WithCommonMiddlewares(c.HandleRealmsCreate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -114,7 +102,7 @@ func TestHandleRealmsCreate(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsCreate()))
+		handler := harness.WithCommonMiddlewares(c.HandleRealmsCreate())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -201,13 +189,8 @@ func TestHandleRealmsUpdate(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsUpdate()))
+	handler := harness.WithCommonMiddlewares(c.HandleRealmsUpdate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -220,7 +203,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsUpdate()))
+		handler := harness.WithCommonMiddlewares(c.HandleRealmsUpdate())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -280,13 +263,8 @@ func TestHandleRealmsAdd(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsAdd()))
+	handler := harness.WithCommonMiddlewares(c.HandleRealmsAdd())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -337,7 +315,7 @@ func TestHandleRealmsAdd(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsAdd()))
+		handler := harness.WithCommonMiddlewares(c.HandleRealmsAdd())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -401,13 +379,8 @@ func TestHandleRealmsRemove(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsRemove()))
+	handler := harness.WithCommonMiddlewares(c.HandleRealmsRemove())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -458,7 +431,7 @@ func TestHandleRealmsRemove(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleRealmsRemove()))
+		handler := harness.WithCommonMiddlewares(c.HandleRealmsRemove())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/admin/users_list_test.go
+++ b/pkg/controller/admin/users_list_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -35,13 +33,8 @@ func TestAdminUsersIndex(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUsersIndex()))
+	handler := harness.WithCommonMiddlewares(c.HandleUsersIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -54,7 +47,7 @@ func TestAdminUsersIndex(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUsersIndex()))
+		handler := harness.WithCommonMiddlewares(c.HandleUsersIndex())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -105,13 +98,8 @@ func TestAdminUserShow(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUserShow()))
+	handler := harness.WithCommonMiddlewares(c.HandleUserShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -124,7 +112,7 @@ func TestAdminUserShow(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUserShow()))
+		handler := harness.WithCommonMiddlewares(c.HandleUserShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/admin/users_operations_test.go
+++ b/pkg/controller/admin/users_operations_test.go
@@ -22,11 +22,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
@@ -38,13 +36,8 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleSystemAdminCreate()))
+	handler := harness.WithCommonMiddlewares(c.HandleSystemAdminCreate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -57,7 +50,7 @@ func TestHandleSystemAdminCreate(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleSystemAdminCreate()))
+		handler := harness.WithCommonMiddlewares(c.HandleSystemAdminCreate())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -140,13 +133,8 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleSystemAdminRevoke()))
+	handler := harness.WithCommonMiddlewares(c.HandleSystemAdminRevoke())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -162,7 +150,7 @@ func TestHandleSystemAdminRevoke(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleSystemAdminRevoke()))
+		handler := harness.WithCommonMiddlewares(c.HandleSystemAdminRevoke())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -264,13 +252,8 @@ func TestHandleUserDelete(t *testing.T) {
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUserDelete()))
+	handler := harness.WithCommonMiddlewares(c.HandleUserDelete())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -286,7 +269,7 @@ func TestHandleUserDelete(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := middleware.InjectCurrentPath()(middleware.ProcessLocale(locales)(c.HandleUserDelete()))
+		handler := harness.WithCommonMiddlewares(c.HandleUserDelete())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/codes/bulk_issue_test.go
+++ b/pkg/controller/codes/bulk_issue_test.go
@@ -19,11 +19,9 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/google/exposure-notifications-verification-server/pkg/sms"
@@ -37,13 +35,8 @@ func TestRenderBulkIssue(t *testing.T) {
 
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := codes.NewServer(harness.Config, harness.Database, harness.Renderer)
-	handler := middleware.ProcessLocale(locales)(c.HandleBulkIssue())
+	handler := harness.WithCommonMiddlewares(c.HandleBulkIssue())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -57,7 +50,7 @@ func TestRenderBulkIssue(t *testing.T) {
 		t.Parallel()
 
 		c := codes.NewServer(harness.Config, harness.BadDatabase, harness.Renderer)
-		handler := middleware.ProcessLocale(locales)(c.HandleBulkIssue())
+		handler := harness.WithCommonMiddlewares(c.HandleBulkIssue())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -20,12 +20,10 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/gorilla/mux"
@@ -52,13 +50,8 @@ func TestHandleExpire_ExpireCode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := codes.NewServer(harness.Config, harness.Database, harness.Renderer)
-	handler := middleware.ProcessLocale(locales)(c.HandleExpirePage())
+	handler := harness.WithCommonMiddlewares(c.HandleExpirePage())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -72,7 +65,7 @@ func TestHandleExpire_ExpireCode(t *testing.T) {
 		t.Parallel()
 
 		c := codes.NewServer(harness.Config, harness.BadDatabase, harness.Renderer)
-		handler := middleware.ProcessLocale(locales)(c.HandleExpirePage())
+		handler := harness.WithCommonMiddlewares(c.HandleExpirePage())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -153,13 +146,8 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := codes.NewServer(harness.Config, harness.Database, harness.Renderer)
-	handler := middleware.ProcessLocale(locales)(c.HandleExpireAPI())
+	handler := harness.WithCommonMiddlewares(c.HandleExpireAPI())
 
 	t.Run("unauthorized", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/codes/index_test.go
+++ b/pkg/controller/codes/index_test.go
@@ -20,11 +20,9 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/gorilla/sessions"
@@ -37,13 +35,8 @@ func TestHandleIndex_ShowRecentCodes(t *testing.T) {
 
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := codes.NewServer(harness.Config, harness.Database, harness.Renderer)
-	handler := middleware.ProcessLocale(locales)(c.HandleIndex())
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -57,7 +50,7 @@ func TestHandleIndex_ShowRecentCodes(t *testing.T) {
 		t.Parallel()
 
 		c := codes.NewServer(harness.Config, harness.BadDatabase, harness.Renderer)
-		handler := middleware.ProcessLocale(locales)(c.HandleIndex())
+		handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/codes/show_test.go
+++ b/pkg/controller/codes/show_test.go
@@ -20,11 +20,9 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
-	"github.com/google/exposure-notifications-verification-server/internal/i18n"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/codes"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/gorilla/mux"
@@ -51,13 +49,8 @@ func TestHandleShow_ShowCodeStatus(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	locales, err := i18n.Load()
-	if err != nil {
-		t.Fatal(err)
-	}
-
 	c := codes.NewServer(harness.Config, harness.Database, harness.Renderer)
-	handler := middleware.ProcessLocale(locales)(c.HandleShow())
+	handler := harness.WithCommonMiddlewares(c.HandleShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -71,7 +64,7 @@ func TestHandleShow_ShowCodeStatus(t *testing.T) {
 		t.Parallel()
 
 		c := codes.NewServer(harness.Config, harness.BadDatabase, harness.Renderer)
-		handler := middleware.ProcessLocale(locales)(c.HandleShow())
+		handler := harness.WithCommonMiddlewares(c.HandleShow())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})

--- a/pkg/controller/login/account_test.go
+++ b/pkg/controller/login/account_test.go
@@ -31,7 +31,7 @@ func TestHandleAccount_ShowAccount(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleAccountSettings()
+	handler := harness.WithCommonMiddlewares(c.HandleAccountSettings())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/change_password_test.go
+++ b/pkg/controller/login/change_password_test.go
@@ -38,7 +38,7 @@ func TestHandleChangePassword_ShowChangePassword(t *testing.T) {
 	}
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleShowChangePassword()
+	handler := harness.WithCommonMiddlewares(c.HandleShowChangePassword())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
@@ -67,7 +67,7 @@ func TestHandleChangePassword_SubmitChangePassword(t *testing.T) {
 	}
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleSubmitChangePassword()
+	handler := harness.WithCommonMiddlewares(c.HandleSubmitChangePassword())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/login_test.go
+++ b/pkg/controller/login/login_test.go
@@ -42,7 +42,7 @@ func TestHandleLogin_ShowLogin(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleLogin()
+	handler := harness.WithCommonMiddlewares(c.HandleLogin())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/post_authenticate_test.go
+++ b/pkg/controller/login/post_authenticate_test.go
@@ -35,7 +35,7 @@ func TestHandlePostAuthenticate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandlePostAuthenticate()
+	handler := harness.WithCommonMiddlewares(c.HandlePostAuthenticate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/reauth_test.go
+++ b/pkg/controller/login/reauth_test.go
@@ -33,7 +33,7 @@ func TestHandleReauth_ShowLogin(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleReauth()
+	handler := harness.WithCommonMiddlewares(c.HandleReauth())
 
 	cases := []struct {
 		name   string

--- a/pkg/controller/login/register_phone_test.go
+++ b/pkg/controller/login/register_phone_test.go
@@ -33,7 +33,7 @@ func TestHandleRegisterPhone_ShowRegisterPhone(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleRegisterPhone()
+	handler := harness.WithCommonMiddlewares(c.HandleRegisterPhone())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/reset_password_test.go
+++ b/pkg/controller/login/reset_password_test.go
@@ -34,7 +34,7 @@ func TestHandleResetPassword_ShowResetPassword(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleShowResetPassword()
+	handler := harness.WithCommonMiddlewares(c.HandleShowResetPassword())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
@@ -58,7 +58,7 @@ func TestHandleResetPassword_SubmitResetPassword(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleSubmitResetPassword()
+	handler := harness.WithCommonMiddlewares(c.HandleSubmitResetPassword())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/select_password_test.go
+++ b/pkg/controller/login/select_password_test.go
@@ -34,7 +34,7 @@ func TestHandleSelectPassword_ShowSelectPassword(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleShowSelectNewPassword()
+	handler := harness.WithCommonMiddlewares(c.HandleShowSelectNewPassword())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
@@ -58,7 +58,7 @@ func TestHandleSelectPassword_SubmitNewPassword(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleSubmitNewPassword()
+	handler := harness.WithCommonMiddlewares(c.HandleSubmitNewPassword())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/select_realm_test.go
+++ b/pkg/controller/login/select_realm_test.go
@@ -36,7 +36,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 		c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-		handler := c.HandleSelectRealm()
+		handler := harness.WithCommonMiddlewares(c.HandleSelectRealm())
 
 		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -60,7 +60,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 		c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-		handler := c.HandleSelectRealm()
+		handler := harness.WithCommonMiddlewares(c.HandleSelectRealm())
 
 		ctx := project.TestContext(t)
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -86,7 +86,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 		c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-		handler := c.HandleSelectRealm()
+		handler := harness.WithCommonMiddlewares(c.HandleSelectRealm())
 
 		session := &sessions.Session{
 			Values: make(map[interface{}]interface{}),
@@ -123,7 +123,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 		c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-		handler := c.HandleSelectRealm()
+		handler := harness.WithCommonMiddlewares(c.HandleSelectRealm())
 
 		session := &sessions.Session{
 			Values: make(map[interface{}]interface{}),

--- a/pkg/controller/login/session_test.go
+++ b/pkg/controller/login/session_test.go
@@ -33,7 +33,7 @@ func TestHandleSession_HandleSubmit(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleCreateSession()
+	handler := harness.WithCommonMiddlewares(c.HandleCreateSession())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/signout_test.go
+++ b/pkg/controller/login/signout_test.go
@@ -33,7 +33,7 @@ func TestHandleSignout_ShowLogin(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleSignOut()
+	handler := harness.WithCommonMiddlewares(c.HandleSignOut())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/verify_email_receive_test.go
+++ b/pkg/controller/login/verify_email_receive_test.go
@@ -34,7 +34,7 @@ func TestHandleVerifyEmailReceive_ShowVerifyEmail(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleReceiveVerifyEmail()
+	handler := harness.WithCommonMiddlewares(c.HandleReceiveVerifyEmail())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/login/verify_email_send_test.go
+++ b/pkg/controller/login/verify_email_send_test.go
@@ -35,7 +35,7 @@ func TestHandleVerifyEmailSend_ShowVerifyEmail(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleShowVerifyEmail()
+	handler := harness.WithCommonMiddlewares(c.HandleShowVerifyEmail())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()
@@ -62,7 +62,7 @@ func TestHandleVerifyEmailSend_SubmitVerifyEmail(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := login.New(harness.AuthProvider, harness.Cacher, harness.Config, harness.Database, harness.Renderer)
-	handler := c.HandleSubmitVerifyEmail()
+	handler := harness.WithCommonMiddlewares(c.HandleSubmitVerifyEmail())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/scripts/dev
+++ b/scripts/dev
@@ -42,7 +42,7 @@ DB_SHA="$(echo -n "${DB_NAME}|${DB_PORT}" | ${MD5CMD} | cut -d' ' -f1)"
 CERTS_DIR="${ROOT}/local/db-tls/${DB_SHA}"
 
 # Other configuration parameters
-SERVER_NAME="DEVELOPMENT verification server"
+SERVER_NAME="[DEV] Exposure Notifications Verification Server"
 
 # error prints a message on stderr and exits immediately.
 function error() {


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1970

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add translations for the login and password reset pages
```
