### PR TITLE
More internationalization

### DIFF
--- a/assets/enx-redirect/404.html
+++ b/assets/enx-redirect/404.html
@@ -1,6 +1,6 @@
 {{define "404"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>
@@ -12,7 +12,7 @@
       <code>{{.requestURI}}</code> was not found on this server.
     </p>
     <p>
-      If you are trying to submit your anonymous data for exposure notifications,
+      If you are trying to submit your anonymous data for Exposure Notifications,
       please contact the public health authority that issued your verification code.
     </p>
   </main>

--- a/assets/enx-redirect/500.html
+++ b/assets/enx-redirect/500.html
@@ -1,6 +1,6 @@
 {{define "500"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/400.html
+++ b/assets/server/400.html
@@ -1,6 +1,6 @@
 {{define "400"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/401.html
+++ b/assets/server/401.html
@@ -1,6 +1,6 @@
 {{define "401"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/404.html
+++ b/assets/server/404.html
@@ -1,6 +1,6 @@
 {{define "404"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/500.html
+++ b/assets/server/500.html
@@ -1,6 +1,6 @@
 {{define "500"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/caches/index.html
+++ b/assets/server/admin/caches/index.html
@@ -3,7 +3,7 @@
 {{$caches := .caches}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/email/show.html
+++ b/assets/server/admin/email/show.html
@@ -3,7 +3,7 @@
 {{$emailConfig := .emailConfig}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/events/index.html
+++ b/assets/server/admin/events/index.html
@@ -4,7 +4,7 @@
 {{$events := .events}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/info.html
+++ b/assets/server/admin/info.html
@@ -1,7 +1,7 @@
 {{define "admin/info"}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/mobileapps/index.html
+++ b/assets/server/admin/mobileapps/index.html
@@ -3,7 +3,7 @@
 {{$apps := .apps}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -7,7 +7,7 @@
 {{$systemEmailConfig := .systemEmailConfig}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -5,7 +5,7 @@
 {{$realmChaffEvents := .realmChaffEvents}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/realms/new.html
+++ b/assets/server/admin/realms/new.html
@@ -4,7 +4,7 @@
 {{$systemSMSConfig := .systemSMSConfig}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/sms/show.html
+++ b/assets/server/admin/sms/show.html
@@ -4,7 +4,7 @@
 {{$smsFromNumbers := .smsFromNumbers}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/users/index.html
+++ b/assets/server/admin/users/index.html
@@ -4,7 +4,7 @@
 {{$users := .users}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/admin/users/new.html
+++ b/assets/server/admin/users/new.html
@@ -3,7 +3,7 @@
 {{$user := .user}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/admin/users/show.html
+++ b/assets/server/admin/users/show.html
@@ -4,7 +4,7 @@
 {{$memberships := .memberships}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/apikeys/edit.html
+++ b/assets/server/apikeys/edit.html
@@ -3,7 +3,7 @@
 {{$authApp := .authApp}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/apikeys/index.html
+++ b/assets/server/apikeys/index.html
@@ -6,7 +6,7 @@
 {{$canWrite := $currentMembership.Can rbac.APIKeyWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/apikeys/new.html
+++ b/assets/server/apikeys/new.html
@@ -3,7 +3,7 @@
 {{$authApp := .authApp}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/apikeys/show.html
+++ b/assets/server/apikeys/show.html
@@ -8,7 +8,7 @@
 {{$canWrite := $currentMembership.Can rbac.APIKeyWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/codes/bulk-issue.html
+++ b/assets/server/codes/bulk-issue.html
@@ -5,7 +5,7 @@
 {{$hasSMSConfig := .hasSMSConfig}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}
@@ -18,7 +18,7 @@
 <body id="bulk-issue" class="tab-content">
   {{template "navbar" .}}
 
-  <main role="main" class="container {{$.localeAlign}}">
+  <main role="main" class="container">
     {{template "flash" .}}
 
     <div class="card mb-3 shadow-sm">

--- a/assets/server/codes/index.html
+++ b/assets/server/codes/index.html
@@ -3,7 +3,7 @@
 {{$code := .code}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/codes/issue.html
+++ b/assets/server/codes/issue.html
@@ -5,7 +5,7 @@
 {{$hasSMSConfig := .hasSMSConfig}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 
@@ -27,7 +27,7 @@
 <body id="codes-issue" class="tab-content">
   {{template "navbar" .}}
 
-  <main role="main" class="container {{$.localeAlign}}">
+  <main role="main" class="container">
     {{template "flash" .}}
 
     {{if .welcomeMessage}}

--- a/assets/server/codes/show.html
+++ b/assets/server/codes/show.html
@@ -4,7 +4,7 @@
 {{$canWrite := $currentMembership.Can rbac.CodeExpire}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -69,21 +69,21 @@
         <div class="collapse navbar-collapse mt-2" id="navbar">
           <ul class="nav mr-auto flex-column flex-md-row">
             {{if $currentMembership.Can rbac.CodeIssue}}
-              <li class="nav-item {{$.localeAlign}}">
+              <li class="nav-item">
                 <a class="nav-link {{if .currentPath.IsDir "/codes/issue"}}active{{end}}" href="/codes/issue">
                   {{t $.locale "nav.issue-code"}}
                 </a>
               </li>
             {{end}}
             {{if and $currentMembership.Realm.AllowBulkUpload ($currentMembership.Can rbac.CodeBulkIssue)}}
-              <li class="nav-item {{$.localeAlign}}">
+              <li class="nav-item">
                 <a class="nav-link {{if .currentPath.IsDir "/codes/bulk-issue"}}active{{end}}" href="/codes/bulk-issue">
                   {{t $.locale "nav.bulk-issue-codes"}}
                 </a>
               </li>
             {{end}}
             {{if $currentMembership.Can rbac.CodeRead}}
-              <li class="nav-item {{$.localeAlign}}">
+              <li class="nav-item">
                 <a class="nav-link {{if .currentPath.IsDir "/codes/status"}}active{{end}}" href="/codes/status">
                   {{t $.locale "nav.check-code-status"}}
                 </a>
@@ -120,7 +120,7 @@ aria-expanded="false" aria-label="Toggle navigation">
         <span class="oi oi-person"></span>
       </a>
 
-      <div class="dropdown-menu dropdown-menu-right {{$.localeAlign}}" aria-labelledby="profile-menu">
+      <div class="dropdown-menu dropdown-menu-right" aria-labelledby="profile-menu">
         {{if $currentMembership}}
           {{$showRealmMenu := false}}
           {{if $currentMembership.Can rbac.APIKeyRead}}

--- a/assets/server/login/account.html
+++ b/assets/server/login/account.html
@@ -51,7 +51,7 @@
           {{end}}
         </li>
         <li class="list-group-item">
-          {{if .mfa_enabled}}
+          {{if .mfaEnabled}}
             <span class="oi oi-circle-check mr-1 ml-n1 text-success small" aria-hidden="true"></span>
             {{t $.locale "account.mfa-enabled"}}
             <a href="/login/register-phone" class="float-right">{{t $.locale "account.manage-mfa"}}</a>

--- a/assets/server/login/account.html
+++ b/assets/server/login/account.html
@@ -4,11 +4,10 @@
 {{$currentMemberships := .currentMemberships}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}
-  {{template "firebase" .}}
 </head>
 
 <body id="account">
@@ -17,103 +16,75 @@
   <main role="main" class="container">
     {{template "flash" .}}
 
-    <h1>My Account</h1>
-    <p>Information and settings for your account.</p>
-
     <div class="card mb-3 shadow-sm">
-      <div class="card-header">Details</div>
+      <div class="card-header">
+        <span class="oi oi-person mr-2 ml-n1" aria-hidden="true"></span>
+        {{t $.locale "account.header-details"}}
+      </div>
       <div class="card-body">
-        <h6 class="card-title">Name</h6>
+        <h6 class="card-title">{{t $.locale "account.full-name" }}</h6>
         <div class="card-text mb-3 mt-n2">
           {{$user.Name}}
         </div>
 
-        <h6 class="card-title">Email</h6>
+        <h6 class="card-title">{{t $.locale "login.email-address"}}</h6>
         <div class="card-text mt-n2">
           {{$user.Email}}
         </div>
-
-        {{if $user.SystemAdmin}}
-        <h6 class="card-title  mt-3">System admin</h6>
-        <div class="card-text text-success mt-n2">Enabled</div>
-        {{end}}
       </div>
     </div>
 
     <div class="card mb-3 shadow-sm">
-      <div class="card-header">Authentication</div>
+      <div class="card-header">
+        <span class="oi oi-lock-locked mr-2 ml-n1" aria-hidden="true"></span>
+        {{t $.locale "account.header-authentication"}}
+      </div>
       <ul class="list-group list-group-flush">
         <li class="list-group-item">
-          <div class="card-text" id="email-verified">loading</div>
-        </li>
-        <li class="list-group-item">
-          <div class="card-text" id="phone-registered">loading</div>
-          <a href="/login/register-phone" id='register-link' class="card-link">Register phone</a>
-        </li>
-        <li class="list-group-item">
-          <div class="card-text">Password was last changed <span class="text-info">{{$user.PasswordAgeString}}</span>
-            ago.</div>
-          <a href="/login/change-password" class="card-link">Change password</a>
-        </li>
-      </ul>
-    </div>
-
-    <div class="card mb-3 shadow-sm">
-      <div class="card-header">Member of realms</div>
-      <ul class="list-group list-group-flush">
-        {{range $membership := $currentMemberships}}
-        <li class="list-group-item">
-          {{$membership.Realm.Name}}
-
-          {{- /* system admins can remove themselves from realms */ -}}
-          {{if $user.SystemAdmin}}
-            <a href="/realm/users/{{$membership.Realm.ID}}" class="d-block text-danger float-right" data-method="DELETE"
-              data-confirm="Are you sure you want to leave {{$membership.Realm.Name}}?">
-              <span class="oi oi-account-logout" aria-hidden="true"></span>
-              Leave realm
-            </a>
+          {{if .emailVerified}}
+            <span class="oi oi-circle-check mr-1 ml-n1 text-success small" aria-hidden="true"></span>
+            {{t $.locale "account.email-verified"}}
+          {{else}}
+            <span class="oi oi-circle-x mr-1 ml-n1 text-danger small" aria-hidden="true"></span>
+            {{t $.locale "account.email-not-verified"}}
+            <a href="/login/manage-account?mode=verifyEmail" class="float-right">{{t $.locale "account.verify-email-address"}}</a>
           {{end}}
         </li>
-        {{end}}
+        <li class="list-group-item">
+          {{if .mfa_enabled}}
+            <span class="oi oi-circle-check mr-1 ml-n1 text-success small" aria-hidden="true"></span>
+            {{t $.locale "account.mfa-enabled"}}
+            <a href="/login/register-phone" class="float-right">{{t $.locale "account.manage-mfa"}}</a>
+          {{else}}
+            <span class="oi oi-circle-x mr-1 ml-n1 text-danger small" aria-hidden="true"></span>
+            {{t $.locale "account.mfa-disabled"}}
+            <a href="/login/register-phone" class="float-right">{{t $.locale "account.enable-mfa"}}</a>
+          {{end}}
+        </li>
+        <li class="list-group-item">
+          <span class="oi oi-clock mr-1 ml-n1 text-secondary small" aria-hidden="true"></span>
+          {{t $.locale "account.password-last-changed" $user.PasswordAgeString}}
+          <a href="/login/change-password" class="float-right">{{t $.locale "account.change-password"}}</a>
+        </li>
       </ul>
     </div>
+
+    {{if $currentMemberships}}
+      <div class="card mb-3 shadow-sm">
+        <div class="card-header">
+          <span class="oi oi-home mr-2 ml-n1" aria-hidden="true"></span>
+          {{t $.locale "account.header-realm-memberships"}}
+        </div>
+        <ul class="list-group list-group-flush">
+          {{range $membership := $currentMemberships}}
+          <li class="list-group-item">
+            {{$membership.Realm.Name}}
+          </li>
+          {{end}}
+        </ul>
+      </div>
+    {{end}}
   </main>
-
-  <script type="text/javascript">
-    $(function() {
-      let $emailVer = $('#email-verified');
-      let $emailVerLink = $('#email-verified-link');
-      let $phoneReg = $('#phone-registered');
-      let $phoneRegLink = $('#register-phone-link');
-
-      firebase.auth().onAuthStateChanged(function(user) {
-        if (!user) {
-          return
-        }
-
-        if (user.multiFactor.enrolledFactors.length > 0) {
-          $phoneReg.html('Multi-factor auth is <span class="text-success">enabled</span>');
-          $('#register-link').text('Manage auth factors');
-        } else {
-          $phoneReg.addClass("text-danger");
-          $phoneReg.html('No second auth factor registered');
-        }
-
-        if (user.emailVerified) {
-          $emailVer.html('Email address is <span class="text-success">verified</span>');
-        } else {
-          $emailVer.addClass("text-danger");
-          $emailVer.html('Email address is <strong>not</strong> verified');
-
-          let $link = $('<a/>');
-          $link.addClass('card-link');
-          $link.attr('href','/login/manage-account?mode=verifyEmail');
-          $link.text('Verify email');
-          $emailVer.after($link);
-        }
-      });
-    });
-  </script>
 </body>
 
 </html>

--- a/assets/server/login/change-password.html
+++ b/assets/server/login/change-password.html
@@ -1,6 +1,6 @@
 {{define "login/change-password"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/login.html
+++ b/assets/server/login/login.html
@@ -3,7 +3,7 @@
 {{$currentUser := .currentUser}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/register-phone.html
+++ b/assets/server/login/register-phone.html
@@ -5,7 +5,7 @@
 {{$currentMembership := .currentMembership}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/reset-password.html
+++ b/assets/server/login/reset-password.html
@@ -1,6 +1,6 @@
 {{define "login/reset-password"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/select-password.html
+++ b/assets/server/login/select-password.html
@@ -1,6 +1,6 @@
 {{define "login/select-password"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/select-realm.html
+++ b/assets/server/login/select-realm.html
@@ -6,7 +6,7 @@
 {{$memberships := .memberships}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/login/signout.html
+++ b/assets/server/login/signout.html
@@ -1,6 +1,6 @@
 {{define "signout"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/verify-email-check.html
+++ b/assets/server/login/verify-email-check.html
@@ -1,6 +1,6 @@
 {{define "login/verify-email-check"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/login/verify-email.html
+++ b/assets/server/login/verify-email.html
@@ -1,6 +1,6 @@
 {{define "login/verify-email"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/mobileapps/edit.html
+++ b/assets/server/mobileapps/edit.html
@@ -3,7 +3,7 @@
 {{$app := .app}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/mobileapps/index.html
+++ b/assets/server/mobileapps/index.html
@@ -6,7 +6,7 @@
 {{$canWrite := $currentMembership.Can rbac.MobileAppWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/mobileapps/new.html
+++ b/assets/server/mobileapps/new.html
@@ -3,7 +3,7 @@
 {{$app := .app}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/mobileapps/show.html
+++ b/assets/server/mobileapps/show.html
@@ -6,7 +6,7 @@
 {{$canWrite := $currentMembership.Can rbac.MobileAppWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/realmadmin/edit.html
+++ b/assets/server/realmadmin/edit.html
@@ -9,7 +9,7 @@
 {{$canWrite := $currentMembership.Can rbac.SettingsWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/realmadmin/events.html
+++ b/assets/server/realmadmin/events.html
@@ -3,7 +3,7 @@
 {{$events := .events}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/realmadmin/keys.html
+++ b/assets/server/realmadmin/keys.html
@@ -75,7 +75,7 @@
 {{$canWrite := $currentMembership.Can rbac.SettingsWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/realmadmin/smskeys.html
+++ b/assets/server/realmadmin/smskeys.html
@@ -8,7 +8,7 @@
 {{$canWrite := $currentMembership.Can rbac.SettingsWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/realmadmin/stats.html
+++ b/assets/server/realmadmin/stats.html
@@ -4,7 +4,7 @@
 {{$realm := $currentMembership.Realm}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
   <script src="https://www.gstatic.com/charts/loader.js"></script>
@@ -45,7 +45,7 @@
         {{template "realmadmin/_stats_external_issuers" .}}
       </div>
     </div>
- 
+
     {{if .hasKeyServerStats}}
     {{template "realmadmin/_stats_keyserver" .}}
     {{end}}

--- a/assets/server/users/edit.html
+++ b/assets/server/users/edit.html
@@ -1,6 +1,6 @@
 {{define "users/edit"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/users/import.html
+++ b/assets/server/users/import.html
@@ -4,7 +4,7 @@
 {{$permissions := .permissions}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/users/index.html
+++ b/assets/server/users/index.html
@@ -8,7 +8,7 @@
 {{$canWrite := $currentMembership.Can rbac.UserWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
 <head>
   {{template "head" .}}

--- a/assets/server/users/new.html
+++ b/assets/server/users/new.html
@@ -1,6 +1,6 @@
 {{define "users/new"}}
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
 </head>

--- a/assets/server/users/show.html
+++ b/assets/server/users/show.html
@@ -9,7 +9,7 @@
 {{$canWrite := $currentMembership.Can rbac.UserWrite}}
 
 <!doctype html>
-<html lang="en">
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 <head>
   {{template "head" .}}
   <script src="https://www.gstatic.com/charts/loader.js"></script>

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -28,6 +28,45 @@ msgstr "هل نسيت كلمة السر"
 msgid "login.about-exposure-notifications"
 msgstr "Exposure Notifications حول"
 
+msgid "account.full-name"
+msgstr "الاسم الكامل"
+
+msgid "account.header-details"
+msgstr "تفاصيل الحساب"
+
+msgid "account.header-authentication"
+msgstr "المصادقة"
+
+msgid "account.header-realm-memberships"
+msgstr "عضويات العالم"
+
+msgid "account.email-verified"
+msgstr "تم التحقق من عنوان البريد الإلكتروني"
+
+msgid "account.email-not-verified"
+msgstr "لم يتم التحقق من عنوان البريد الإلكتروني"
+
+msgid "account.verify-email-address"
+msgstr "تحقق من عنوان البريد الإلكتروني"
+
+msgid "account.mfa-enabled"
+msgstr "تم تمكين المصادقة متعددة العوامل (MFA)"
+
+msgid "account.mfa-disabled"
+msgstr "تم تعطيل المصادقة متعددة العوامل (MFA)"
+
+msgid "account.manage-mfa"
+msgstr "إدارة MFA"
+
+msgid "account.enable-mfa"
+msgstr "تمكين MFA"
+
+msgid "account.password-last-changed"
+msgstr "تم تغيير كلمة المرور آخر مرة منذ %s"
+
+msgid "account.change-password"
+msgstr "تغيير كلمة المرور"
+
 msgid "mfa.mfa"
 msgstr "مصادقة متعددة العوامل"
 

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -28,6 +28,45 @@ msgstr "Passwort vergessen"
 msgid "login.about-exposure-notifications"
 msgstr "Informationen zu Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Vollständiger Name"
+
+msgid "account.header-details"
+msgstr "Kontodaten"
+
+msgid "account.header-authentication"
+msgstr "Authentifizierung"
+
+msgid "account.header-realm-memberships"
+msgstr "Realm Mitgliedschaften"
+
+msgid "account.email-verified"
+msgstr "E-Mail-Adresse wird überprüft"
+
+msgid "account.email-not-verified"
+msgstr "E-Mail-Adresse wird nicht überprüft"
+
+msgid "account.verify-email-address"
+msgstr "E-Mail-Adresse überprüfen"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor-Authentifizierung (MFA) ist aktiviert"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor-Authentifizierung (MFA) ist deaktiviert"
+
+msgid "account.manage-mfa"
+msgstr "MFA verwalten"
+
+msgid "account.enable-mfa"
+msgstr "MFA aktivieren"
+
+msgid "account.password-last-changed"
+msgstr "Passwort wurde zuletzt vor %s geändert"
+
+msgid "account.change-password"
+msgstr "Passwort ändern"
+
 msgid "mfa.mfa"
 msgstr "Multi-Faktor-Authentifizierung"
 

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -29,6 +29,45 @@ msgstr "Forgot password"
 msgid "login.about-exposure-notifications"
 msgstr "About Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Full name"
+
+msgid "account.header-details"
+msgstr "Account details"
+
+msgid "account.header-authentication"
+msgstr "Authentication"
+
+msgid "account.header-realm-memberships"
+msgstr "Realm memberships"
+
+msgid "account.email-verified"
+msgstr "Email address is verified"
+
+msgid "account.email-not-verified"
+msgstr "Email address is not verified"
+
+msgid "account.verify-email-address"
+msgstr "Verify email address"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor Authentication (MFA) is enabled"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor Authentication (MFA) is disabled"
+
+msgid "account.manage-mfa"
+msgstr "Manage MFA"
+
+msgid "account.enable-mfa"
+msgstr "Enable MFA"
+
+msgid "account.password-last-changed"
+msgstr "Password was last changed %s ago"
+
+msgid "account.change-password"
+msgstr "Change password"
+
 msgid "mfa.mfa"
 msgstr "Multi-Factor Authentication"
 

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -28,6 +28,45 @@ msgstr "Contraseña olvidada"
 msgid "login.about-exposure-notifications"
 msgstr "Acerca de las Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Nombre completo"
+
+msgid "account.header-details"
+msgstr "Detalles de la cuenta"
+
+msgid "account.header-authentication"
+msgstr "Autenticación"
+
+msgid "account.header-realm-memberships"
+msgstr "Membresías de reino"
+
+msgid "account.email-verified"
+msgstr "Dirección de correo electrónico está verificada"
+
+msgid "account.email-not-verified"
+msgstr "Dirección de correo electrónico no está verificada"
+
+msgid "account.verify-email-address"
+msgstr "Verificar"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor de autenticación (AMF) está activado"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor de autenticación (AMF) está desactivada"
+
+msgid "account.manage-mfa"
+msgstr "Administrar MFA"
+
+msgid "account.enable-mfa"
+msgstr "Habilitar MFA"
+
+msgid "account.password-last-changed"
+msgstr "La contraseña se cambió por última vez hace %s"
+
+msgid "account.change-password"
+msgstr "Cambiar contraseña"
+
 msgid "mfa.mfa"
 msgstr "Autenticación multifactor"
 

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -1,6 +1,6 @@
 msgid ""
 msgstr ""
-"Language: ph\n"
+"Language: fil\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
@@ -28,6 +28,45 @@ msgstr "Nakalimutan ang password"
 
 msgid "login.about-exposure-notifications"
 msgstr "Tungkol sa Exposure Notifications"
+
+msgid "account.full-name"
+msgstr "Buong pangalan"
+
+msgid "account.header-details"
+msgstr "Mga detalye ng account"
+
+msgid "account.header-authentication"
+msgstr "Pagpapatotoo"
+
+msgid "account.header-realm-memberships"
+msgstr "Mga membership sa realm"
+
+msgid "account.email-verified"
+msgstr "Na-verify ang email address"
+
+msgid "account.email-not-verified"
+msgstr "Hindi na-verify ang email address"
+
+msgid "account.verify-email-address"
+msgstr "Patunayan ang email address"
+
+msgid "account.mfa-enabled"
+msgstr "Pinagana ang Multi-Factor Authentication (MFA)"
+
+msgid "account.mfa-disabled"
+msgstr "Ang Multi-Factor Authentication (MFA) ay hindi pinagana"
+
+msgid "account.manage-mfa"
+msgstr "Pamahalaan ang MFA"
+
+msgid "account.enable-mfa"
+msgstr "Paganahin ang MFA"
+
+msgid "account.password-last-changed"
+msgstr "Ang password ay huling nabago %s ago"
+
+msgid "account.change-password"
+msgstr "Palitan ang password"
 
 msgid "mfa.mfa"
 msgstr "Multi-Factor Authentication"

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -29,6 +29,45 @@ msgstr "Mot de passe oublié"
 msgid "login.about-exposure-notifications"
 msgstr "À propos des Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Nom complet"
+
+msgid "account.header-details"
+msgstr "Détails du compte"
+
+msgid "account.header-authentication"
+msgstr "Authentification"
+
+msgid "account.header-realm-memberships"
+msgstr "Adhésions au royaume"
+
+msgid "account.email-verified"
+msgstr "L'adresse e-mail est vérifiée"
+
+msgid "account.email-not-verified"
+msgstr "L'adresse e-mail n'est pas vérifiée"
+
+msgid "account.verify-email-address"
+msgstr "Vérifier l'adresse e-mail"
+
+msgid "account.mfa-enabled"
+msgstr "L'authentification multifacteur (MFA) est activée"
+
+msgid "account.mfa-disabled"
+msgstr "L'authentification multifacteur (MFA) est désactivée"
+
+msgid "account.manage-mfa"
+msgstr "Gérer MFA"
+
+msgid "account.enable-mfa"
+msgstr "Activer MFA"
+
+msgid "account.password-last-changed"
+msgstr "Le mot de passe a été modifié pour la dernière fois il y a %s"
+
+msgid "account.change-password"
+msgstr "Changer"
+
 msgid "mfa.mfa"
 msgstr "Authentification multifacteur"
 

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -29,6 +29,45 @@ msgstr "Lupa sandi"
 msgid "login.about-exposure-notifications"
 msgstr "Tentang Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Nama lengkap"
+
+msgid "account.header-details"
+msgstr "Detail akun"
+
+msgid "account.header-authentication"
+msgstr "Otentikasi"
+
+msgid "account.header-realm-memberships"
+msgstr "Keanggotaan Realm"
+
+msgid "account.email-verified"
+msgstr "Alamat email diverifikasi"
+
+msgid "account.email-not-verified"
+msgstr "Alamat email tidak diverifikasi"
+
+msgid "account.verify-email-address"
+msgstr "Verifikasi alamat email"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor Authentication (MFA) diaktifkan"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor Authentication (MFA) dinonaktifkan"
+
+msgid "account.manage-mfa"
+msgstr "Kelola MFA"
+
+msgid "account.enable-mfa"
+msgstr "Aktifkan MFA"
+
+msgid "account.password-last-changed"
+msgstr "Kata sandi terakhir diubah %s lalu"
+
+msgid "account.change-password"
+msgstr "Ubah sandi"
+
 msgid "mfa.mfa"
 msgstr "Otentikasi Multi-Faktor"
 

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -29,6 +29,45 @@ msgstr "Password dimenticata"
 msgid "login.about-exposure-notifications"
 msgstr "Informazioni sulle Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Nome completo"
+
+msgid "account.header-details"
+msgstr "Dettagli account"
+
+msgid "account.header-authentication"
+msgstr "Autenticazione"
+
+msgid "account.header-realm-memberships"
+msgstr "Iscrizioni al reame"
+
+msgid "account.email-verified"
+msgstr "L'indirizzo email è verificato"
+
+msgid "account.email-not-verified"
+msgstr "L'indirizzo email non è verificato"
+
+msgid "account.verify-email-address"
+msgstr "Verifica indirizzo email"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor Authentication (MFA) è abilitato"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor Authentication (MFA) è disabilitato"
+
+msgid "account.manage-mfa"
+msgstr "Gestisci MFA"
+
+msgid "account.enable-mfa"
+msgstr "Abilita MFA"
+
+msgid "account.password-last-changed"
+msgstr "La password è stata cambiata l'ultima volta %s fa"
+
+msgid "account.change-password"
+msgstr "Cambia password"
+
 msgid "mfa.mfa"
 msgstr "Autenticazione a più fattori"
 

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -29,6 +29,45 @@ msgstr "パスワードを忘れた"
 msgid "login.about-exposure-notifications"
 msgstr "について学ぶ Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "フルネーム"
+
+msgid "account.header-details"
+msgstr "アカウントの詳細"
+
+msgid "account.header-authentication"
+msgstr "認証"
+
+msgid "account.header-realm-memberships"
+msgstr "レルムメンバーシップ"
+
+msgid "account.email-verified"
+msgstr "メールアドレスが確認されました"
+
+msgid "account.email-not-verified"
+msgstr "メールアドレスが確認されていません"
+
+msgid "account.verify-email-address"
+msgstr "メールアドレスを確認する"
+
+msgid "account.mfa-enabled"
+msgstr "多要素認証（MFA）が有効になっています"
+
+msgid "account.mfa-disabled"
+msgstr "多要素認証（MFA）が無効になっています"
+
+msgid "account.manage-mfa"
+msgstr "MFAの管理"
+
+msgid "account.enable-mfa"
+msgstr "MFAを有効にする"
+
+msgid "account.password-last-changed"
+msgstr "パスワードは %s 前に最後に変更されました"
+
+msgid "account.change-password"
+msgstr "パスワードの変更"
+
 msgid "mfa.mfa"
 msgstr "多要素認証"
 

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -29,6 +29,45 @@ msgstr "Нууц үгээ мартсан"
 msgid "login.about-exposure-notifications"
 msgstr "Тухай Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Овог нэр"
+
+msgid "account.header-details"
+msgstr "Дансны дэлгэрэнгүй мэдээлэл"
+
+msgid "account.header-authentication"
+msgstr "Баталгаажуулалт"
+
+msgid "account.header-realm-memberships"
+msgstr "Хүрээний гишүүнчлэл"
+
+msgid "account.email-verified"
+msgstr "Имэйл хаягийг баталгаажуулсан"
+
+msgid "account.email-not-verified"
+msgstr "Имэйл хаягийг баталгаажуулаагүй байна"
+
+msgid "account.verify-email-address"
+msgstr "Баталгаажуулах"
+
+msgid "account.mfa-enabled"
+msgstr "Олон хүчин зүйлийн баталгаажуулалт (MFA) идэвхжсэн"
+
+msgid "account.mfa-disabled"
+msgstr "Олон хүчин зүйлийн баталгаажуулалт (MFA) идэвхгүйжсэн"
+
+msgid "account.manage-mfa"
+msgstr "Удирдах"
+
+msgid "account.enable-mfa"
+msgstr "Идэвхжүүлэх"
+
+msgid "account.password-last-changed"
+msgstr "Нууц үгийг хамгийн сүүлд %s өмнө өөрчилсөн"
+
+msgid "account.change-password"
+msgstr "Нууц үгээ өөрчлөх"
+
 msgid "mfa.mfa"
 msgstr "Олон хүчин зүйлт нэвтрэлт танилт"
 

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -29,6 +29,45 @@ msgstr "Esqueci a senha"
 msgid "login.about-exposure-notifications"
 msgstr "Sobre Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Nome completo"
+
+msgid "account.header-details"
+msgstr "Detalhes da conta"
+
+msgid "account.header-authentication"
+msgstr "Autenticação"
+
+msgid "account.header-realm-memberships"
+msgstr "Membros do reino"
+
+msgid "account.email-verified"
+msgstr "O endereço de e-mail foi verificado"
+
+msgid "account.email-not-verified"
+msgstr "O endereço de e-mail não foi verificado"
+
+msgid "account.verify-email-address"
+msgstr "Verificar endereço de e-mail"
+
+msgid "account.mfa-enabled"
+msgstr "A autenticação multifator (MFA) está ativada"
+
+msgid "account.mfa-disabled"
+msgstr "A autenticação multifator (MFA) está desativada"
+
+msgid "account.manage-mfa"
+msgstr "Gerenciar MFA"
+
+msgid "account.enable-mfa"
+msgstr "Habilitar MFA"
+
+msgid "account.password-last-changed"
+msgstr "A última senha foi alterada %s atrás"
+
+msgid "account.change-password"
+msgstr "Alterar senha"
+
 msgid "mfa.mfa"
 msgstr "Autenticação multifator"
 

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -29,6 +29,45 @@ msgstr "Şifremi unuttum"
 msgid "login.about-exposure-notifications"
 msgstr "About Exposure Notifications"
 
+msgid "account.full-name"
+msgstr "Tam ad"
+
+msgid "account.header-details"
+msgstr "Hesap ayrıntıları"
+
+msgid "account.header-authentication"
+msgstr "Kimlik Doğrulama"
+
+msgid "account.header-realm-memberships"
+msgstr "Bölge üyelikleri"
+
+msgid "account.email-verified"
+msgstr "E-posta adresi doğrulandı"
+
+msgid "account.email-not-verified"
+msgstr "E-posta adresi doğrulanmadı"
+
+msgid "account.verify-email-address"
+msgstr "E-posta adresini doğrula"
+
+msgid "account.mfa-enabled"
+msgstr "Multi-Factor Authentication (MFA) etkinleştirildi"
+
+msgid "account.mfa-disabled"
+msgstr "Multi-Factor Authentication (MFA) devre dışı bırakıldı"
+
+msgid "account.manage-mfa"
+msgstr "MFA'yı Yönet"
+
+msgid "account.enable-mfa"
+msgstr "MFA'yı Etkinleştir"
+
+msgid "account.password-last-changed"
+msgstr "Parola en son %s önce değiştirildi"
+
+msgid "account.change-password"
+msgstr "Parolayı değiştir"
+
 msgid "mfa.mfa"
 msgstr "Çok Faktörlü Kimlik Doğrulama"
 

--- a/pkg/controller/login/account.go
+++ b/pkg/controller/login/account.go
@@ -45,8 +45,8 @@ func (c *Controller) HandleAccountSettings() http.Handler {
 
 		m := controller.TemplateMapFromContext(ctx)
 		m.Title("My account")
-		m["email_verified"] = emailVerified
-		m["mfa_enabled"] = mfaEnabled
+		m["emailVerified"] = emailVerified
+		m["mfaEnabled"] = mfaEnabled
 
 		m["firebase"] = c.config.Firebase
 		c.h.RenderHTML(w, "account", m)

--- a/pkg/controller/middleware/i18n.go
+++ b/pkg/controller/middleware/i18n.go
@@ -27,7 +27,8 @@ const (
 	HeaderAcceptLanguage = "Accept-Language"
 	QueryKeyLanguage     = "lang"
 
-	RightAlign = "text-right"
+	LeftAlign  = "ltr"
+	RightAlign = "rtl"
 )
 
 var rightAlignLanguages = map[string]struct{}{
@@ -53,11 +54,13 @@ func ProcessLocale(locales *i18n.LocaleMap) mux.MiddlewareFunc {
 			m["locale"] = locale
 
 			// by default, no CSS is needed for left aligned languages.
-			textAlign := ""
-			if _, ok := rightAlignLanguages[i18n.TranslatorLanguage(locale)]; ok {
-				textAlign = RightAlign
+			textLanguage := i18n.TranslatorLanguage(locale)
+			textDirection := LeftAlign
+			if _, ok := rightAlignLanguages[textLanguage]; ok {
+				textDirection = RightAlign
 			}
-			m["localeAlign"] = textAlign
+			m["textDirection"] = textDirection
+			m["textLanguage"] = textLanguage
 
 			// Save the template map on the context.
 			ctx = controller.WithTemplateMap(ctx, m)


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1970

This commit does 5 separate things:

1. Switch to using dir="rtl" and correctly setting the HTML lang attribute instead of relying on CSS to do the styling. This is needed for user stylesheets, but also sets us up better to migrate to bootstrap 5 which has better support for RTL languages.

2. Fix i18n reloading in development. In DEV_MODE, templates are automatically reloaded without the need to restart the server.

3. Fix the naming for Filipino. PH is not the correct code, it's FIL.

4. Pull account information from the Firebase cookie instead of doing a runtime lookup. The reduces the change of hitting firebase quota limits.

5. Add new translations for the account page.

**Release Note**

```release-note
Switch to using `dir="rtl"` for right-to-left languages.
```

```release-note
Fix naming for Filipino language translations.
```

```release-note
Add new translations for the /account page.
```
