### PR TITLE
Set cache headers on static assets, do not apply middlewares

### DIFF
--- a/pkg/controller/middleware/static.go
+++ b/pkg/controller/middleware/static.go
@@ -1,0 +1,43 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+// ConfigureStaticAssets configures headers for static assets.
+func ConfigureStaticAssets(devMode bool) mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			// Do not cache assets in dev mode.
+			if devMode {
+				w.Header().Set("Cache-Control", "private, no-cache, max-age=0")
+				w.Header().Set("Expires", time.Now().Add(-30*time.Minute).Format(http.TimeFormat))
+				w.Header().Set("Vary", "Accept-Encoding")
+				next.ServeHTTP(w, r)
+				return
+			}
+
+			w.Header().Set("Cache-Control", "public, max-age=604800")
+			w.Header().Set("Expires", time.Now().AddDate(1, 0, 0).Format(http.TimeFormat))
+			w.Header().Set("Vary", "Accept-Encoding")
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/static_test.go
+++ b/pkg/controller/middleware/static_test.go
@@ -1,0 +1,45 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+)
+
+func TestConfigureStaticAssets(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	handler := middleware.ConfigureStaticAssets(false)(emptyHandler())
+
+	w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
+	handler.ServeHTTP(w, r)
+
+	if got, want := w.Header().Get("Cache-Control"), "public, max-age=604800"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+	if got := w.Header().Get("Expires"); got == "" {
+		t.Errorf("expected Expires to be set")
+	}
+	if got, want := w.Header().Get("Vary"), "Accept-Encoding"; got != want {
+		t.Errorf("expected %q to be %q", got, want)
+	}
+}


### PR DESCRIPTION
It's fine to cache these for a year because we embed the build ID in the actual request as a query param.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1985

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Set cache headers on static assets, do not apply middlewares.
```
