### PR TITLE
add warning about UR and auth SMS

### DIFF
--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -87,6 +87,16 @@
     </div>
 
     {{if .features.EnableUserReport}}
+    <label>User report</label>
+
+    {{if and $realm.AllowsUserReport (not $realm.UseAuthenticatedSMS)}}
+    <div class="alert alert-warning" role="alert">
+      This realm has user report enabled, but authenticated SMS disabled. It is recommended
+      to enable authenticated SMS is enabled as an extra security measure when using
+      user report. Contact Apple and Google if you have questions about this feature.
+    </div>
+    {{end}}
+
     <div class="form-check mb-3">
       <input type="checkbox" name="allow_user_report" id="allow-user-report" class="form-check-input" value="true" {{checkedIf ($realm.AllowsUserReport)}} />
       <label for="allow-user-report" class="form-check-label">

--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -92,7 +92,7 @@
     {{if and $realm.AllowsUserReport (not $realm.UseAuthenticatedSMS)}}
     <div class="alert alert-warning" role="alert">
       This realm has user report enabled, but authenticated SMS disabled. It is recommended
-      to enable authenticated SMS is enabled as an extra security measure when using
+      to enable authenticated SMS as an extra security measure when using
       user report. Contact Apple and Google if you have questions about this feature.
     </div>
     {{end}}

--- a/assets/server/realmadmin/smskeys.html
+++ b/assets/server/realmadmin/smskeys.html
@@ -25,8 +25,6 @@
       <strong>{{$realm.Name}}</strong> below.
     </p>
 
-    {{template "beta-notice" .}}
-
     {{template "errorSummary" $realm}}
 
     <div class="card mb-3 shadow-sm">


### PR DESCRIPTION

## Proposed Changes

* add warning on settings page

**Release Note**

```release-note
Add a warning on realm settings page that when user report is enabled, authenticated SMS should be enabled too.
```
