### PR TITLE
Add translations to change/select password pages

### DIFF
--- a/assets/server/login/_loginscripts.html
+++ b/assets/server/login/_loginscripts.html
@@ -87,37 +87,37 @@
     {{if gt .requirements.Length 0}}
       <div id="length-req">
         <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-        At least {{.requirements.Length}} characters long
+        {{t $.locale "password.requirements-length" .requirements.Length}}
       </div>
     {{end}}
     {{if gt .requirements.Uppercase 0}}
       <div id="upper-req">
         <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-        Contain {{.requirements.Uppercase}} uppercase letter
+        {{t $.locale "password.requirements-uppercase" .requirements.Uppercase}}
       </div>
     {{end}}
     {{if gt .requirements.Lowercase 0}}
       <div id="lower-req">
         <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-        Contain {{.requirements.Lowercase}} lowercase letter
+        {{t $.locale "password.requirements-lowercase" .requirements.Lowercase}}
       </div>
     {{end}}
     {{if gt .requirements.Number 0}}
       <div id="num-req">
         <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-        Contain {{.requirements.Number}} number
+        {{t $.locale "password.requirements-number" .requirements.Number}}
       </div>
     {{end}}
     {{if gt .requirements.Special 0}}
       <div id="special-req">
         <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-        Contain {{.requirements.Special}} special character
+        {{t $.locale "password.requirements-special" .requirements.Special}}
       </div>
     {{end}}
   {{end}}
   <div id="retyped">
     <span class="oi oi-circle-x pr-1 small" aria-hidden="true"></span>
-    Retyped password must match password
+    {{t $.locale "password.requirements-match"}}
   </div>
 </div>
 {{end}}

--- a/assets/server/login/change-password.html
+++ b/assets/server/login/change-password.html
@@ -18,15 +18,17 @@
       <div class="card-body">
         <form id="password-form" class="floating-form" action="/login/change-password" method="POST">
           {{.csrfField}}
+
           <div class="form-label-group">
-            <input type="email" id="email" name="email" class="form-control" placeholder="Email address"
+            <input type="email" id="email" name="email" class="form-control" placeholder="{{t $.locale "login.email-address"}}"
               value="{{.currentUser.Email}}" required autofocus disabled />
-            <label for="email">Email address</label>
+            <label for="email">{{t $.locale "login.email-address"}}</label>
           </div>
+
           <div class="form-label-group">
-            <input type="password" id="password" class="form-control" placeholder="Old password"
+            <input type="password" id="password" class="form-control" placeholder="{{t $.locale "password.old-password"}}"
               autocomplete="password" required />
-            <label for="password">Old password</label>
+            <label for="password">{{t $.locale "password.old-password"}}</label>
           </div>
 
           <hr>
@@ -34,17 +36,19 @@
           {{template "login/pwd-validate" .}}
 
           <div class="form-label-group mb-2">
-            <input type="password" id="new-password" class="form-control" placeholder="New password"
+            <input type="password" id="new-password" class="form-control" placeholder="{{t $.locale "password.new-password"}}"
               autocomplete="new-password" required />
-            <label for="password">New password</label>
+            <label for="password">{{t $.locale "password.new-password"}}</label>
           </div>
           <div class="form-label-group">
-            <input type="password" id="retype" class="form-control" placeholder="Retype new password"
+            <input type="password" id="retype" class="form-control" placeholder="{{t $.locale "password.confirm-new-password"}}"
               autocomplete="new-password" required />
-            <label for="retype">Retype new password</label>
+            <label for="retype">{{t $.locale "password.confirm-new-password"}}</label>
           </div>
 
-          <button type="submit" id="submit" class="btn btn-primary btn-block" disabled>Set password</button>
+          <button type="submit" id="submit" class="btn btn-primary btn-block" disabled>
+            {{t $.locale "account.change-password"}}
+          </button>
         </form>
       </div>
     </div>

--- a/assets/server/login/select-password.html
+++ b/assets/server/login/select-password.html
@@ -12,46 +12,51 @@
 
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center align-self-center">
-        <div class="col-sm-6">
-          <div class="card shadow-sm">
-            <div class="card-header">Select new password</div>
+        <div class="login-container">
+          <div class="card shadow-sm" id="login-div">
+            <div class="card-header">
+              {{t $.locale "password.reset-password"}}
+            </div>
+
             <div class="card-body">
               <form id="loginForm" class="floating-form" action="/login/manage-account?mode=resetPassword&oobCode={{.code}}" method="POST">
                 {{.csrfField}}
+
                 <div class="form-label-group">
-                  <input type="email" name="email" class="form-control" placeholder="Email address" value="{{.email}}"
-                  required readonly/>
-                  <label for="email">Email address</label>
+                  <input type="email" name="email" class="form-control" placeholder="{{t $.locale "login.email-address"}}" value="{{.email}}"
+                    required readonly />
+                  <label for="email">{{t $.locale "login.email-address"}}</label>
                 </div>
 
+                <hr>
+
                 <div class="form-label-group mb-2">
-                  <input type="password" name="password" id="password" class="form-control" placeholder="Password"
+                  <input type="password" name="password" id="password" class="form-control" placeholder="{{t $.locale "password.new-password"}}"
                     autocomplete="new-password" required {{if .codeInvalid}}disabled{{end}}/>
-                  <label for="password">Password</label>
+                  <label for="password">{{t $.locale "password.new-password"}}</label>
                 </div>
                 <div class="form-label-group">
-                  <input type="password" id="retype" class="form-control" placeholder="Retype password"
+                  <input type="password" id="retype" class="form-control" placeholder="{{t $.locale "password.confirm-new-password"}}"
                     autocomplete="new-password" required {{if .codeInvalid}}disabled{{end}}/>
-                  <label for="retype">Retype password</label>
+                  <label for="retype">{{t $.locale "password.confirm-new-password"}}</label>
                 </div>
 
                 {{template "login/pwd-validate" .}}
 
-                <button type="submit" id="submit" class="btn btn-primary btn-block mb-3"{{if .codeInvalid}}disabled{{end}}>
-                  Set password
+                <button type="submit" id="submit" class="btn btn-primary btn-block" disabled>
+                  {{t $.locale "account.change-password"}}
                 </button>
-
-                {{if .codeInvalid}}
-                <a class="card-link" href="/login/reset-password">
-                  Resend password reset email
-                </a>
-                {{end}}
               </form>
             </div>
-            <div class="card-body">
-              <a class="card-link" href="/">&larr; Login</a>
-            </div>
           </div>
+
+          {{if .codeInvalid}}
+            <div class="text-center pt-1">
+              <a class="text-muted small" target="_blank" href="/login/reset-password">
+                {{t $.locale "password.send-reset-password"}}
+              </a>
+            </div>
+          {{end}}
         </div>
       </div>
     </div>
@@ -60,6 +65,7 @@
   <script defer type="text/javascript">
     window.addEventListener('load', (event) => {
       {{template "login/requirements" .}}
+
       let $form = $('#loginForm');
       let $submit = $('#submit');
       let $password = $('#password');
@@ -71,6 +77,8 @@
       $retype.on("change keyup paste", function() {
         $submit.prop('disabled', !checkPasswordValid($password.val(), $retype.val(), requirements));
       });
+
+      checkPasswordValid('', '', requirements);
 
       $form.on('submit', function(event) {
         try {

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -100,6 +100,33 @@ msgstr "إعادة تعيين كلمة المرور"
 msgid "password.send-reset-password"
 msgstr "إرسال بريد إلكتروني لإعادة تعيين كلمة المرور"
 
+msgid "password.old-password"
+msgstr "كلمة المرور القديمة"
+
+msgid "password.new-password"
+msgstr "كلمة مرور جديدة"
+
+msgid "password.confirm-new-password"
+msgstr "تأكيد كلمة المرور الجديدة"
+
+msgid "password.requirements-length"
+msgstr "بطول %d أو أكثر من الأحرف"
+
+msgid "password.requirements-uppercase"
+msgstr "تحتوي على %d أو أكثر من الأحرف الكبيرة"
+
+msgid "password.requirements-lowercase"
+msgstr "تحتوي على %d أو أكثر من الأحرف الصغيرة"
+
+msgid "password.requirements-number"
+msgstr "تحتوي على %d أو أكثر من الأرقام"
+
+msgid "password.requirements-special"
+msgstr "تحتوي على %d أو أكثر من الأحرف الخاصة"
+
+msgid "password.requirements-match"
+msgstr "مطابقة كلمة المرور المؤكدة"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -100,6 +100,33 @@ msgstr "Passwort zurücksetzen"
 msgid "password.send-reset-password"
 msgstr "E-Mail zum Zurücksetzen des Passworts senden"
 
+msgid "password.old-password"
+msgstr "Altes Kennwort"
+
+msgid "password.new-password"
+msgstr "Neues Kennwort"
+
+msgid "password.confirm-new-password"
+msgstr "Bestätige neues Passwort"
+
+msgid "password.requirements-length"
+msgstr "Haben Sie eine Länge von %d oder mehr Zeichen"
+
+msgid "password.requirements-uppercase"
+msgstr "Enthält %d oder mehr Großbuchstaben"
+
+msgid "password.requirements-lowercase"
+msgstr "Enthält %d oder mehr Kleinbuchstaben"
+
+msgid "password.requirements-number"
+msgstr "Enthält %d oder mehr Zahlen"
+
+msgid "password.requirements-special"
+msgstr "Enthält %d oder mehr Sonderzeichen"
+
+msgid "password.requirements-match"
+msgstr "Übereinstimmendes bestätigtes Passwort"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -101,6 +101,33 @@ msgstr "Reset password"
 msgid "password.send-reset-password"
 msgstr "Send password reset email"
 
+msgid "password.old-password"
+msgstr "Old password"
+
+msgid "password.new-password"
+msgstr "New password"
+
+msgid "password.confirm-new-password"
+msgstr "Confirm new password"
+
+msgid "password.requirements-length"
+msgstr "Have a length of %d or more characters"
+
+msgid "password.requirements-uppercase"
+msgstr "Contain %d or more uppercase letters"
+
+msgid "password.requirements-lowercase"
+msgstr "Contain %d or more lowercase letters"
+
+msgid "password.requirements-number"
+msgstr "Contain %d or more numbers"
+
+msgid "password.requirements-special"
+msgstr "Contain %d or more special characters"
+
+msgid "password.requirements-match"
+msgstr "Match confirmed password"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -100,6 +100,33 @@ msgstr "Restablecer contraseña"
 msgid "password.send-reset-password"
 msgstr "Enviar correo electrónico para restablecer la contraseña"
 
+msgid "password.old-password"
+msgstr "Contraseña anterior"
+
+msgid "password.new-password"
+msgstr "Nueva contraseña"
+
+msgid "password.confirm-new-password"
+msgstr "Confirmar nueva contraseña"
+
+msgid "password.requirements-length"
+msgstr "Tener una longitud de %d o más caracteres"
+
+msgid "password.requirements-uppercase"
+msgstr "Contienen %d o más letras mayúsculas"
+
+msgid "password.requirements-lowercase"
+msgstr "Contienen %d o más letras minúsculas"
+
+msgid "password.requirements-number"
+msgstr "Contener %d o más números"
+
+msgid "password.requirements-special"
+msgstr "Contener %d o más caracteres especiales"
+
+msgid "password.requirements-match"
+msgstr "Coincidir con la contraseña confirmada"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -101,6 +101,33 @@ msgstr "I-reset ang password"
 msgid "password.send-reset-password"
 msgstr "Magpadala ng email sa pag-reset ng password"
 
+msgid "password.old-password"
+msgstr "Lumang password"
+
+msgid "password.new-password"
+msgstr "Bagong password"
+
+msgid "password.confirm-new-password"
+msgstr "Kumpirmahin ang bagong password"
+
+msgid "password.requirements-length"
+msgstr "Magkaroon ng haba ng %d o higit pang mga character"
+
+msgid "password.requirements-uppercase"
+msgstr "Naglalaman ng %d o higit pang mga malalaking titik"
+
+msgid "password.requirements-lowercase"
+msgstr "Naglalaman ng %d o higit pang mga maliliit na titik"
+
+msgid "password.requirements-number"
+msgstr "Naglalaman ng %d o higit pang mga numero"
+
+msgid "password.requirements-special"
+msgstr "Naglalaman ng %d o higit pang mga espesyal na character"
+
+msgid "password.requirements-match"
+msgstr "Itugma ang nakumpirmang password"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -101,6 +101,33 @@ msgstr "Réinitialiser le mot de passe"
 msgid "password.send-reset-password"
 msgstr "Envoyer un e-mail de réinitialisation du mot de passe"
 
+msgid "password.old-password"
+msgstr "Ancien mot de passe"
+
+msgid "password.new-password"
+msgstr "Nouveau mot de passe"
+
+msgid "password.confirm-new-password"
+msgstr "Confirmer le nouveau mot de passe"
+
+msgid "password.requirements-length"
+msgstr "Avoir une longueur de %d caractères ou plus"
+
+msgid "password.requirements-uppercase"
+msgstr "Contiennent au moins %d lettres majuscules"
+
+msgid "password.requirements-lowercase"
+msgstr "Contiennent au moins %d lettres minuscules"
+
+msgid "password.requirements-number"
+msgstr "Contiennent au moins %d nombres"
+
+msgid "password.requirements-special"
+msgstr "Contient %d ou plus de caractères spéciaux"
+
+msgid "password.requirements-match"
+msgstr "Faire correspondre le mot de passe confirmé"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -101,6 +101,33 @@ msgstr "Setel ulang sandi"
 msgid "password.send-reset-password"
 msgstr "Kirim email pengaturan ulang kata sandi"
 
+msgid "password.old-password"
+msgstr "Password lama"
+
+msgid "password.new-password"
+msgstr "Kata sandi baru"
+
+msgid "password.confirm-new-password"
+msgstr "Konfirmasi password baru"
+
+msgid "password.requirements-length"
+msgstr "Memiliki panjang %d atau lebih karakter"
+
+msgid "password.requirements-uppercase"
+msgstr "Berisi %d atau lebih huruf besar"
+
+msgid "password.requirements-lowercase"
+msgstr "Berisi %d atau lebih huruf kecil"
+
+msgid "password.requirements-number"
+msgstr "Berisi %d atau lebih angka"
+
+msgid "password.requirements-special"
+msgstr "Berisi %d atau lebih karakter khusus"
+
+msgid "password.requirements-match"
+msgstr "Cocokkan kata sandi yang telah dikonfirmasi"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -101,6 +101,33 @@ msgstr "Reimposta password"
 msgid "password.send-reset-password"
 msgstr "Invia email per reimpostare la password"
 
+msgid "password.old-password"
+msgstr "Vecchia password"
+
+msgid "password.new-password"
+msgstr "Nuova password"
+
+msgid "password.confirm-new-password"
+msgstr "Conferma la nuova password"
+
+msgid "password.requirements-length"
+msgstr "Avere una lunghezza di %d o più caratteri"
+
+msgid "password.requirements-uppercase"
+msgstr "Contenere %d o più lettere maiuscole"
+
+msgid "password.requirements-lowercase"
+msgstr "Contenere %d o più lettere minuscole"
+
+msgid "password.requirements-number"
+msgstr "Contiene %d o più numeri"
+
+msgid "password.requirements-special"
+msgstr "Contiene %d o più caratteri speciali"
+
+msgid "password.requirements-match"
+msgstr "Corrispondenza con la password confermata"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -72,13 +72,13 @@ msgid "mfa.mfa"
 msgstr "多要素認証"
 
 msgid "mfa.notice-required"
-msgstr "％s では、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にする必要があります。"
+msgstr "%s では、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にする必要があります。"
 
 msgid "mfa.notice-prompt"
-msgstr "％s は、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にすることをお勧めします。将来必要になる可能性があります。"
+msgstr "%s は、アカウントのセキュリティを向上させるために多要素認証（MFA）を有効にすることをお勧めします。将来必要になる可能性があります。"
 
 msgid "mfa.notice-optional"
-msgstr "％s は、アカウントのセキュリティを向上させるために、多要素認証（MFA）を有効にすることをお勧めします。"
+msgstr "%s は、アカウントのセキュリティを向上させるために、多要素認証（MFA）を有効にすることをお勧めします。"
 
 msgid "mfa.phone-display-name"
 msgstr "表示名"
@@ -101,6 +101,32 @@ msgstr "パスワードのリセット"
 msgid "password.send-reset-password"
 msgstr "パスワードリセットメールを送信する"
 
+msgid "password.old-password"
+msgstr "以前のパスワード"
+
+msgid "password.new-password"
+msgstr "新しいパスワード"
+
+msgid "password.confirm-new-password"
+msgstr "新しいパスワードを確認"
+
+msgid "password.requirements-length"
+msgstr "%d 以上の文字の長さを持っている"
+
+msgid "password.requirements-uppercase"
+msgstr "%d 以上の大文字を含む"
+
+msgid "password.requirements-lowercase"
+msgstr "%d 以上の小文字を含む"
+
+msgid "password.requirements-number"
+msgstr "%d 以上の数値を含む"
+
+msgid "password.requirements-special"
+msgstr "%d 以上の特殊文字を含む"
+
+msgid "password.requirements-match"
+msgstr "確認済みのパスワードと一致する"
 
 
 #

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -101,6 +101,32 @@ msgstr "Нууц үгээ шинэчлэх"
 msgid "password.send-reset-password"
 msgstr "Нууц үг шинэчлэх имэйлийг илгээх"
 
+msgid "password.old-password"
+msgstr "Хуучин нууц үг"
+
+msgid "password.new-password"
+msgstr "Шинэ нууц үг"
+
+msgid "password.confirm-new-password"
+msgstr "Шинэ нууц үг баталгаажуулах"
+
+msgid "password.requirements-length"
+msgstr "%d ба түүнээс дээш тэмдэгттэй байна"
+
+msgid "password.requirements-uppercase"
+msgstr "%d ба түүнээс дээш том үсгийг агуулна"
+
+msgid "password.requirements-lowercase"
+msgstr "%d ба түүнээс дээш жижиг үсэг агуулна"
+
+msgid "password.requirements-number"
+msgstr "%d ба түүнээс дээш тоог агуулна"
+
+msgid "password.requirements-special"
+msgstr "%d ба түүнээс дээш тусгай тэмдэгт агуулна"
+
+msgid "password.requirements-match"
+msgstr "Тохирох нууц үг"
 
 
 #

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -101,6 +101,33 @@ msgstr "Redefinir senha"
 msgid "password.send-reset-password"
 msgstr "Enviar e-mail de redefinição de senha"
 
+msgid "password.old-password"
+msgstr "Senha antiga"
+
+msgid "password.new-password"
+msgstr "Nova senha"
+
+msgid "password.confirm-new-password"
+msgstr "Confirme a nova senha"
+
+msgid "password.requirements-length"
+msgstr "Têm um comprimento de %d ou mais caracteres"
+
+msgid "password.requirements-uppercase"
+msgstr "Contém %d ou mais letras maiúsculas"
+
+msgid "password.requirements-lowercase"
+msgstr "Contém %d ou mais letras minúsculas"
+
+msgid "password.requirements-number"
+msgstr "Contém %d ou mais números"
+
+msgid "password.requirements-special"
+msgstr "Contém %d ou mais caracteres especiais"
+
+msgid "password.requirements-match"
+msgstr "Senha confirmada de correspondência"
+
 
 #
 # navigation menus

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -101,6 +101,33 @@ msgstr "Parolayı sıfırla"
 msgid "password.send-reset-password"
 msgstr "Parola sıfırlama e-postası gönder"
 
+msgid "password.old-password"
+msgstr "Eski şifre"
+
+msgid "password.new-password"
+msgstr "Yeni şifre"
+
+msgid "password.confirm-new-password"
+msgstr "Yeni şifreyi onayla"
+
+msgid "password.requirements-length"
+msgstr "%d veya daha fazla karakter uzunluğunda"
+
+msgid "password.requirements-uppercase"
+msgstr "%d veya daha fazla büyük harf içerir"
+
+msgid "password.requirements-lowercase"
+msgstr "%d veya daha fazla küçük harf içerir"
+
+msgid "password.requirements-number"
+msgstr "%d veya daha fazla sayı içerir"
+
+msgid "password.requirements-special"
+msgstr "%d veya daha fazla özel karakter içerir"
+
+msgid "password.requirements-match"
+msgstr "Eşleşen onaylanmış şifre"
+
 
 #
 # navigation menus

--- a/pkg/controller/login/select_password.go
+++ b/pkg/controller/login/select_password.go
@@ -44,7 +44,7 @@ func (c *Controller) HandleShowSelectNewPassword() http.Handler {
 		email, err := c.authProvider.VerifyPasswordResetCode(ctx, code)
 		if err != nil {
 			flash.Error("Failed to verify password reset token: %v", err)
-			c.renderShowSelectPassword(ctx, w, "", code, false)
+			c.renderShowSelectPassword(ctx, w, "", code, true)
 			return
 		}
 


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1970

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add translations to change/select password pages.
```
