### PR TITLE
Add translations for signout and realm selection pages

### DIFF
--- a/assets/server/login/select-realm.html
+++ b/assets/server/login/select-realm.html
@@ -17,24 +17,13 @@
   <main role="main" class="container">
     {{template "flash" .}}
 
-    <h1>Select your realm</h1>
-    <p>
-      Use the form below to select a realm.
-    </p>
-
     <div class="card mb-3 shadow-sm">
       <div class="card-header">
-        Realm selector
+        <span id="icon" class="oi oi-globe mr-2 ml-n1" aria-hidden="true"></span>
+        {{t $.locale "login.realm-selection"}}
       </div>
 
       {{if $memberships}}
-        <div class="card-body">
-          <p class="mb-0">
-            You are a member of multiple realms - please select one to continue. You
-            can switch to another realm at any time.
-          </p>
-        </div>
-
         <div class="list-group list-group-flush">
           {{range $membership := $memberships}}
             {{$currentRealm := $membership.Realm}}
@@ -56,8 +45,7 @@
       {{else}}
         <div class="card-body">
           <p class="mb-0">
-            You are not a member of any realms. Contact your realm administrator for
-            assistance.
+            {{t $.locale "login.realm-no-memberships"}}
           </p>
         </div>
       {{end}}
@@ -66,6 +54,7 @@
     {{if $currentUser.SystemAdmin}}
       <div class="card mb-3 shadow-sm">
         <div class="card-header text-bold text-white admin-header">
+          <span id="icon" class="oi oi-cog mr-2 ml-n1" aria-hidden="true"></span>
           System admin
         </div>
         <div class="list-group-item p-0">

--- a/assets/server/login/signout.html
+++ b/assets/server/login/signout.html
@@ -4,26 +4,33 @@
 
 <head>
   {{template "head" .}}
-
   {{template "firebase" .}}
 </head>
 
-<body>
+<body id="login-signout">
   {{template "navbar" .}}
 
-  <main role="main" class="container">
-    <div id="auth-container">
-      <p id="signout">Signing out...</p>
-    </div>
+  <main id="signout" role="main" class="container">
+    <p id="signout-pending">
+      {{t $.locale "login.signing-out"}}
+    </p>
+    <p id="signout-error" class="d-none text-danger">
+      <span id="icon" class="oi oi-circle-x small pr-1" aria-hidden="true"></span>
+      {{t $.locale "login.signing-out-error"}}
+    </p>
   </main>
 
   <script defer type="text/javascript">
-    window.addEventListener('load', function() {
+    window.addEventListener('load', () => {
+      let signoutPending = document.querySelector('p#signout-pending');
+      let signoutError = document.querySelector('p#signout-error');
+
       firebase.auth().signOut().then(function() {
-        $('#signout').text("Redirecting to login...")
-        window.location.assign("/");
-      }).catch(function(error) {
-        flash.error('Error signing out, close browser window.');
+        window.location.assign('/');
+      }).catch(function(err) {
+        console.error(err);
+        signoutPending.classList.add('d-none');
+        signoutError.classList.remove('d-none');
       });
     });
   </script>

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -28,6 +28,18 @@ msgstr "هل نسيت كلمة السر"
 msgid "login.about-exposure-notifications"
 msgstr "Exposure Notifications حول"
 
+msgid "login.signing-out"
+msgstr "تسجيل خروج..."
+
+msgid "login.signing-out-error"
+msgstr "فشل تسجيل الخروج. أغلق المتصفح أو امسح ملفات تعريف الارتباط."
+
+msgid "login.realm-selection"
+msgstr "اختيار المجال"
+
+msgid "login.realm-no-memberships"
+msgstr "أنت لست عضوا في أي عالم."
+
 msgid "account.full-name"
 msgstr "الاسم الكامل"
 

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -28,6 +28,18 @@ msgstr "Passwort vergessen"
 msgid "login.about-exposure-notifications"
 msgstr "Informationen zu Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Abmelden..."
+
+msgid "login.signing-out-error"
+msgstr "Abmeldung fehlgeschlagen. Schließen Sie Ihren Browser oder löschen Sie Cookies."
+
+msgid "login.realm-selection"
+msgstr "Reichsauswahl"
+
+msgid "login.realm-no-memberships"
+msgstr "Sie sind kein Mitglied eines Bereichs."
+
 msgid "account.full-name"
 msgstr "Vollständiger Name"
 

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -29,6 +29,18 @@ msgstr "Forgot password"
 msgid "login.about-exposure-notifications"
 msgstr "About Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Signing out..."
+
+msgid "login.signing-out-error"
+msgstr "Failed to sign out. Close your browser or clear cookies."
+
+msgid "login.realm-selection"
+msgstr "Realm selection"
+
+msgid "login.realm-no-memberships"
+msgstr "You are not a member of any realms."
+
 msgid "account.full-name"
 msgstr "Full name"
 

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -28,6 +28,18 @@ msgstr "Contraseña olvidada"
 msgid "login.about-exposure-notifications"
 msgstr "Acerca de las Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Cerrando sesión..."
+
+msgid "login.signing-out-error"
+msgstr "No se pudo cerrar la sesión. Cierre su navegador o borre las cookies."
+
+msgid "login.realm-selection"
+msgstr "Selección de reino"
+
+msgid "login.realm-no-memberships"
+msgstr "No eres miembro de ningún reino."
+
 msgid "account.full-name"
 msgstr "Nombre completo"
 

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -29,6 +29,18 @@ msgstr "Nakalimutan ang password"
 msgid "login.about-exposure-notifications"
 msgstr "Tungkol sa Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Pag-sign out..."
+
+msgid "login.signing-out-error"
+msgstr "Nabigong mag-sign out. Isara ang iyong browser o i-clear ang cookies."
+
+msgid "login.realm-selection"
+msgstr "Pagpili ng realm"
+
+msgid "login.realm-no-memberships"
+msgstr "Hindi ka miyembro ng anumang mga mundo."
+
 msgid "account.full-name"
 msgstr "Buong pangalan"
 

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -29,6 +29,18 @@ msgstr "Mot de passe oublié"
 msgid "login.about-exposure-notifications"
 msgstr "À propos des Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Déconnecter..."
+
+msgid "login.signing-out-error"
+msgstr "Échec de la déconnexion. Fermez votre navigateur ou effacez les cookies."
+
+msgid "login.realm-selection"
+msgstr "Sélection de royaume"
+
+msgid "login.realm-no-memberships"
+msgstr "Vous n'êtes membre d'aucun royaume."
+
 msgid "account.full-name"
 msgstr "Nom complet"
 

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -29,6 +29,18 @@ msgstr "Lupa sandi"
 msgid "login.about-exposure-notifications"
 msgstr "Tentang Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Keluar..."
+
+msgid "login.signing-out-error"
+msgstr "Gagal keluar. Tutup browser Anda atau hapus cookie."
+
+msgid "login.realm-selection"
+msgstr "Pemilihan alam"
+
+msgid "login.realm-no-memberships"
+msgstr "Anda bukan anggota dari alam manapun."
+
 msgid "account.full-name"
 msgstr "Nama lengkap"
 

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -29,6 +29,18 @@ msgstr "Password dimenticata"
 msgid "login.about-exposure-notifications"
 msgstr "Informazioni sulle Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Disconnessione in corso..."
+
+msgid "login.signing-out-error"
+msgstr "Impossibile disconnettersi. Chiudi il browser o cancella i cookie."
+
+msgid "login.realm-selection"
+msgstr "Selezione dei reami"
+
+msgid "login.realm-no-memberships"
+msgstr "Non sei un membro di nessun reame."
+
 msgid "account.full-name"
 msgstr "Nome completo"
 

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -29,6 +29,18 @@ msgstr "パスワードを忘れた"
 msgid "login.about-exposure-notifications"
 msgstr "について学ぶ Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "サインアウト..."
+
+msgid "login.signing-out-error"
+msgstr "サインアウトに失敗しました。 ブラウザを閉じるか、Cookieをクリアしてください。"
+
+msgid "login.realm-selection"
+msgstr "レルムの選択"
+
+msgid "login.realm-no-memberships"
+msgstr "あなたはどのレルムのメンバーでもありません。"
+
 msgid "account.full-name"
 msgstr "フルネーム"
 

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -29,6 +29,18 @@ msgstr "Нууц үгээ мартсан"
 msgid "login.about-exposure-notifications"
 msgstr "Тухай Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Гарч байна..."
+
+msgid "login.signing-out-error"
+msgstr "Гарч чадсангүй. Хөтөчөө хааж эсвэл күүкийг цэвэрлэ."
+
+msgid "login.realm-selection"
+msgstr "Хүрээний сонголт"
+
+msgid "login.realm-no-memberships"
+msgstr "Та ямар ч хүрээний гишүүн биш."
+
 msgid "account.full-name"
 msgstr "Овог нэр"
 

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -29,6 +29,18 @@ msgstr "Esqueci a senha"
 msgid "login.about-exposure-notifications"
 msgstr "Sobre Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Saindo..."
+
+msgid "login.signing-out-error"
+msgstr "Falha ao sair. Feche seu navegador ou limpe os cookies."
+
+msgid "login.realm-selection"
+msgstr "Seleção de reino"
+
+msgid "login.realm-no-memberships"
+msgstr "Você não é membro de nenhum reino."
+
 msgid "account.full-name"
 msgstr "Nome completo"
 

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -29,6 +29,18 @@ msgstr "Şifremi unuttum"
 msgid "login.about-exposure-notifications"
 msgstr "About Exposure Notifications"
 
+msgid "login.signing-out"
+msgstr "Çıkış yapılıyor..."
+
+msgid "login.signing-out-error"
+msgstr "Çıkış yapılamadı. Tarayıcınızı kapatın veya çerezleri temizleyin."
+
+msgid "login.realm-selection"
+msgstr "Bölge seçimi"
+
+msgid "login.realm-no-memberships"
+msgstr "Hiçbir âlemin üyesi değilsiniz."
+
 msgid "account.full-name"
 msgstr "Tam ad"
 

--- a/pkg/controller/login/select_realm_test.go
+++ b/pkg/controller/login/select_realm_test.go
@@ -157,7 +157,7 @@ func TestHandleSelectRealm_ShowSelectRealm(t *testing.T) {
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("expected %d to be %d: %s", got, want, w.Body.String())
 		}
-		if got, want := w.Body.String(), "select a realm"; !strings.Contains(got, want) {
+		if got, want := w.Body.String(), "Realm selection"; !strings.Contains(got, want) {
 			t.Errorf("expected %q to contain %q", got, want)
 		}
 	})


### PR DESCRIPTION
Part of https://github.com/google/exposure-notifications-verification-server/issues/1970

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add translations for signout and realm selection pages.
```
