### PR TITLE
Add translations for email verify pages

### DIFF
--- a/assets/server/login/verify-email-check.html
+++ b/assets/server/login/verify-email-check.html
@@ -15,13 +15,20 @@
 
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center">
-        <div class="col-sm-6">
-
-          <div class="card mb-3 shadow-sm">
-            <div class="card-header">Email verification</div>
+        <div class="col-sm-9">
+          <div class="card shadow-sm">
+            <div class="card-header">
+              <span id="icon" class="oi oi-envelope-closed mr-2 ml-n1" aria-hidden="true"></span>
+              {{t $.locale "account.verify-email-address"}}
+            </div>
             <div class="card-body">
-              <p>Verifying email address ownership.</p>
-              <a class="card-link" href="/">&larr; Login</a>
+              <span id="verify-pending">
+                {{t $.locale "account.verifying-email-address"}}
+              </span>
+              <span id="verify-error" class="d-none text-danger">
+                <span id="icon" class="oi oi-circle-x small pr-1" aria-hidden="true"></span>
+                {{t $.locale "account.verify-email-address-error"}}
+              </span>
             </div>
           </div>
         </div>
@@ -31,32 +38,28 @@
 
   <script defer type="text/javascript">
     window.addEventListener('load', (event) => {
+      let verifyPending = document.querySelector('span#verify-pending');
+      let verifyError = document.querySelector('span#verify-error');
+      let showError = () => {
+        verifyPending.classList.add('d-none');
+        verifyError.classList.remove('d-none');
+      }
+
       let urlVars = getUrlVars();
-      let code = urlVars["oobCode"];
+      let code = urlVars['oobCode'];
       if (!code) {
-        code = "";
+        showError();
+        return;
       }
 
       firebase.auth().applyActionCode(code)
         .then(function(resp) {
-          window.location.assign("/");
-        }).catch(function(error) {
-          flash.clear();
-          flash.error("Invalid email verification code. "
-            + "The code may be malformed, expired, or has already been used.");
+          window.location.assign('/');
+        }).catch(function(err) {
+          console.error(err);
+          showError();
         });
     });
-
-    function getUrlVars() {
-      let vars = [], hash;
-      let queryParams = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
-      for (let i = 0; i < queryParams.length; i++) {
-        v = queryParams[i].split('=');
-        vars.push(v[0]);
-        vars[v[0]] = v[1];
-      }
-      return vars;
-    }
   </script>
 </body>
 </html>

--- a/assets/server/login/verify-email.html
+++ b/assets/server/login/verify-email.html
@@ -1,4 +1,7 @@
 {{define "login/verify-email"}}
+
+{{$currentRealm := .currentRealm}}
+
 <!doctype html>
 <html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
 
@@ -15,42 +18,42 @@
 
     <div class="d-flex vh-100">
       <div class="d-flex w-100 justify-content-center">
-        <div class="col-sm-6">
+        <div class="col-sm-9">
+          <div class="card shadow-sm">
+            <div class="card-header">
+              <span id="icon" class="oi oi-envelope-closed mr-2 ml-n1" aria-hidden="true"></span>
+              {{t $.locale "account.verify-email-address"}}
+            </div>
 
-          <div class="card mb-3 shadow-sm">
-            <div class="card-header">Email verification</div>
             <div class="card-body">
-              {{if not .currentRealm}}
-              <div class="alert alert-warning">
-                <span class="oi oi-warning"></span>
-                Email address verification is required to administer with no realm selected.
-              </div>
-              {{else if eq .currentRealm.EmailVerifiedMode.String "required"}}
-              <div class="alert alert-warning">
-                <span class="oi oi-warning"></span>
-                This realm <strong>requires</strong> email address verification.
-              </div>
+              {{if not $currentRealm}}
+                <div class="alert alert-warning">
+                  <!-- This is only for system admins, skip i18n. -->
+                  Email address verification is required.
+                </div>
+              {{else if eq $currentRealm.EmailVerifiedMode.String "required"}}
+                <div class="alert alert-warning">
+                  {{t $.locale "account.verify-email-address-required" $currentRealm.Name}}
+                </div>
               {{end}}
-
-              <p>Email address ownership for <em>{{.currentUser.Email}}</em> is <strong id="not">not</strong> confirmed.</p>
 
               <form method="POST" id="verify-email">
                 {{ .csrfField }}
                 <input type="submit" id="verify-button" class="btn btn-primary btn-block"
-                  value="Send verification email" disabled>
-
-                <small class="form-text text-muted">
-                  Click to send an email containing a verification link.
-                </small>
+                  value="{{t $.locale "account.verify-email-address"}}" disabled>
               </form>
-
-              {{if .currentRealm}}
-              {{if ne .currentRealm.EmailVerifiedMode.String "required"}}
-              <a id="skip" class="card-link float-right mt-3" href="/login/post-authenticate">Skip for now</a>
-              {{end}}
-              {{end}}
             </div>
           </div>
+
+          {{if $currentRealm}}
+            {{if ne $currentRealm.EmailVerifiedMode.String "required"}}
+              <div class="d-flex justify-content-center pt-2">
+                <a id="skip" class="text-muted small" href="/login/post-authenticate">
+                  {{t $.locale "account.continue-without-verifying-email-address"}}
+                </a>
+              </div>
+            {{end}}
+          {{end}}
         </div>
       </div>
     </div>
@@ -60,8 +63,6 @@
   <script>
     let $form = $("#verify-email");
     let $verifyButton = $("#verify-button");
-    let $skip = $("#skip");
-    let $not = $("#not");
 
     firebase.auth().onAuthStateChanged(function(user) {
       if (!user) {

--- a/assets/server/static/js/application.js
+++ b/assets/server/static/js/application.js
@@ -619,6 +619,18 @@ function genRandomString(len) {
   return s;
 }
 
+// getUrlVars gets the URL params.
+function getUrlVars() {
+  let vars = [];
+  let queryParams = window.location.href.slice(window.location.href.indexOf('?') + 1).split('&');
+  for (let i = 0; i < queryParams.length; i++) {
+    v = queryParams[i].split('=');
+    vars.push(v[0]);
+    vars[v[0]] = v[1];
+  }
+  return vars;
+}
+
 // element is expected to be a jquery element or dom query selector, ts is
 // the number of seconds since epoch, UTC.
 function countdown(element, ts, expiredCallback) {

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -61,6 +61,18 @@ msgstr "لم يتم التحقق من عنوان البريد الإلكترون
 msgid "account.verify-email-address"
 msgstr "تحقق من عنوان البريد الإلكتروني"
 
+msgid "account.verify-email-address-required"
+msgstr "يتطلب %s التحقق من عنوان بريدك الإلكتروني."
+
+msgid "account.verifying-email-address"
+msgstr "التحقق من عنوان البريد الإلكتروني ..."
+
+msgid "account.verify-email-address-error"
+msgstr "فشل التحقق من عنوان البريد الإلكتروني"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "تواصل دون التحقق من عنوان البريد الإلكتروني"
+
 msgid "account.mfa-enabled"
 msgstr "تم تمكين المصادقة متعددة العوامل (MFA)"
 

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -61,6 +61,18 @@ msgstr "E-Mail-Adresse wird nicht überprüft"
 msgid "account.verify-email-address"
 msgstr "E-Mail-Adresse überprüfen"
 
+msgid "account.verify-email-address-required"
+msgstr "%s erfordert, dass Sie Ihre E-Mail-Adresse überprüfen."
+
+msgid "account.verifying-email-address"
+msgstr "E-Mail-Adresse überprüfen ..."
+
+msgid "account.verify-email-address-error"
+msgstr "E-Mail-Adresse konnte nicht überprüft werden"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Fahren Sie fort, ohne die E-Mail-Adresse zu überprüfen"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor-Authentifizierung (MFA) ist aktiviert"
 

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -62,6 +62,18 @@ msgstr "Email address is not verified"
 msgid "account.verify-email-address"
 msgstr "Verify email address"
 
+msgid "account.verify-email-address-required"
+msgstr "%s requires you verify your email address."
+
+msgid "account.verifying-email-address"
+msgstr "Verifying email address..."
+
+msgid "account.verify-email-address-error"
+msgstr "Failed to verify email address"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Continue without verifying email address"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor Authentication (MFA) is enabled"
 

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -61,6 +61,18 @@ msgstr "Dirección de correo electrónico no está verificada"
 msgid "account.verify-email-address"
 msgstr "Verificar"
 
+msgid "account.verify-email-address-required"
+msgstr "%s requiere que verifique su dirección de correo electrónico."
+
+msgid "account.verifying-email-address"
+msgstr "Verificando la dirección de correo electrónico..."
+
+msgid "account.verify-email-address-error"
+msgstr "No se pudo verificar la dirección de correo electrónico"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Continuar sin verificar la dirección de correo electrónico"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor de autenticación (AMF) está activado"
 

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -62,6 +62,18 @@ msgstr "Hindi na-verify ang email address"
 msgid "account.verify-email-address"
 msgstr "Patunayan ang email address"
 
+msgid "account.verify-email-address-required"
+msgstr "Hinihiling sa iyo ng %s na i-verify ang iyong email address."
+
+msgid "account.verifying-email-address"
+msgstr "Pinapatunayan ang email address..."
+
+msgid "account.verify-email-address-error"
+msgstr "Nabigong ma-verify ang email address"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Magpatuloy nang hindi napatunayan ang email address"
+
 msgid "account.mfa-enabled"
 msgstr "Pinagana ang Multi-Factor Authentication (MFA)"
 

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -62,6 +62,18 @@ msgstr "L'adresse e-mail n'est pas vérifiée"
 msgid "account.verify-email-address"
 msgstr "Vérifier l'adresse e-mail"
 
+msgid "account.verify-email-address-required"
+msgstr "%s nécessite que vous vérifiiez votre adresse e-mail."
+
+msgid "account.verifying-email-address"
+msgstr "Vérification de l'adresse e-mail..."
+
+msgid "account.verify-email-address-error"
+msgstr "Échec de la vérification de l'adresse e-mail"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Continuer sans vérifier l'adresse e-mail"
+
 msgid "account.mfa-enabled"
 msgstr "L'authentification multifacteur (MFA) est activée"
 

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -62,6 +62,18 @@ msgstr "Alamat email tidak diverifikasi"
 msgid "account.verify-email-address"
 msgstr "Verifikasi alamat email"
 
+msgid "account.verify-email-address-required"
+msgstr "%s mengharuskan Anda memverifikasi alamat email Anda."
+
+msgid "account.verifying-email-address"
+msgstr "Memverifikasi alamat email..."
+
+msgid "account.verify-email-address-error"
+msgstr "Gagal memverifikasi alamat email"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Lanjutkan tanpa memverifikasi alamat email"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor Authentication (MFA) diaktifkan"
 

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -62,6 +62,18 @@ msgstr "L'indirizzo email non è verificato"
 msgid "account.verify-email-address"
 msgstr "Verifica indirizzo email"
 
+msgid "account.verify-email-address-required"
+msgstr "%s richiede la verifica del tuo indirizzo email."
+
+msgid "account.verifying-email-address"
+msgstr "Verifica dell'indirizzo e-mail..."
+
+msgid "account.verify-email-address-error"
+msgstr "Impossibile verificare l'indirizzo e-mail"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Continua senza verificare l'indirizzo email"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor Authentication (MFA) è abilitato"
 

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -62,6 +62,18 @@ msgstr "メールアドレスが確認されていません"
 msgid "account.verify-email-address"
 msgstr "メールアドレスを確認する"
 
+msgid "account.verify-email-address-required"
+msgstr "%s では、メールアドレスを確認する必要があります。"
+
+msgid "account.verifying-email-address"
+msgstr "メールアドレスを確認しています..."
+
+msgid "account.verify-email-address-error"
+msgstr "メールアドレスの確認に失敗しました"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "メールアドレスを確認せずに続行"
+
 msgid "account.mfa-enabled"
 msgstr "多要素認証（MFA）が有効になっています"
 

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -62,6 +62,18 @@ msgstr "Имэйл хаягийг баталгаажуулаагүй байна"
 msgid "account.verify-email-address"
 msgstr "Баталгаажуулах"
 
+msgid "account.verify-email-address-required"
+msgstr "%s нь таны имэйл хаягийг баталгаажуулахыг шаарддаг."
+
+msgid "account.verifying-email-address"
+msgstr "Имэйл хаягийг баталгаажуулж байна..."
+
+msgid "account.verify-email-address-error"
+msgstr "Имэйл хаягийг баталгаажуулж чадсангүй"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Имэйл хаягаа баталгаажуулахгүйгээр үргэлжлүүлээрэй"
+
 msgid "account.mfa-enabled"
 msgstr "Олон хүчин зүйлийн баталгаажуулалт (MFA) идэвхжсэн"
 

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -62,6 +62,18 @@ msgstr "O endereço de e-mail não foi verificado"
 msgid "account.verify-email-address"
 msgstr "Verificar endereço de e-mail"
 
+msgid "account.verify-email-address-required"
+msgstr "%s requer que você verifique seu endereço de e-mail."
+
+msgid "account.verifying-email-address"
+msgstr "Verificando endereço de e-mail..."
+
+msgid "account.verify-email-address-error"
+msgstr "Falha ao verificar o endereço de e-mail"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "Continue sem verificar o endereço de e-mail"
+
 msgid "account.mfa-enabled"
 msgstr "A autenticação multifator (MFA) está ativada"
 

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -62,6 +62,18 @@ msgstr "E-posta adresi doğrulanmadı"
 msgid "account.verify-email-address"
 msgstr "E-posta adresini doğrula"
 
+msgid "account.verify-email-address-required"
+msgstr "%s, e-posta adresinizi doğrulamanızı gerektirir."
+
+msgid "account.verifying-email-address"
+msgstr "E-posta adresi doğrulanıyor..."
+
+msgid "account.verify-email-address-error"
+msgstr "E-posta adresi doğrulanamadı"
+
+msgid "account.continue-without-verifying-email-address"
+msgstr "E-posta adresini doğrulamadan devam edin"
+
 msgid "account.mfa-enabled"
 msgstr "Multi-Factor Authentication (MFA) etkinleştirildi"
 


### PR DESCRIPTION
I think this is the last "login" page that needs translations.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/1970

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add translations for email verify pages.
```
