### PR TITLE
Introduce function for getting the e2e-realm (if one exists)

### DIFF
--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -57,10 +57,10 @@ func (c *Controller) HandleCleanup() http.Handler {
 			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "API_KEYS")
 			if count, err := c.db.PurgeAuthorizedApps(c.config.AuthorizedAppMaxAge); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("failed to purge authorized apps: %w", err))
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge api keys: %w", err))
 				result = enobs.ResultError("FAILED")
 			} else {
-				logger.Infow("purged authorized apps", "count", count)
+				logger.Infow("purged api keys", "count", count)
 				result = enobs.ResultOK
 			}
 		}()

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -306,6 +306,24 @@ func NewRealmWithDefaults(name string) *Realm {
 	}
 }
 
+// E2ERealm gets the end-to-end realm. The end-to-end realm is defined as the
+// realm that has a region_code beginning with E2E-* or a name beginning with
+// e2e-test-*.
+//
+// If no e2e realm is defined, it returns NotFound.
+func (db *Database) E2ERealm() (*Realm, error) {
+	var realm Realm
+	if err := db.db.
+		Model(&Realm{}).
+		Where("region_code ILIKE 'E2E-%' OR name ILIKE 'e2e-test-%'").
+		Order("created_at ASC").
+		First(&realm).
+		Error; err != nil {
+		return nil, fmt.Errorf("failed to find e2e realm: %w", err)
+	}
+	return &realm, nil
+}
+
 // AllowsUserReport returns true if this realm has enabled user initiated
 // test reporting.
 func (r *Realm) AllowsUserReport() bool {

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -393,6 +393,78 @@ func TestRealm_BeforeSave(t *testing.T) {
 	}
 }
 
+func TestDatabase_E2ERealm(t *testing.T) {
+	t.Parallel()
+
+	t.Run("none", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		if _, err := db.E2ERealm(); !IsNotFound(err) {
+			t.Errorf("expected not found, got %#v", err)
+		}
+	})
+
+	t.Run("none_matching", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm := NewRealmWithDefaults("not-the-e2e-realm")
+		realm.RegionCode = "NOT-E2E"
+		if err := db.SaveRealm(realm, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		if _, err := db.E2ERealm(); !IsNotFound(err) {
+			t.Errorf("expected not found, got %#v", err)
+		}
+	})
+
+	t.Run("by_region_code", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm := NewRealmWithDefaults("apple")
+		realm.RegionCode = "E2E-TEST"
+		if err := db.SaveRealm(realm, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		record, err := db.E2ERealm()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if record.ID != realm.ID {
+			t.Errorf("expected %#v to be %#v", record, realm)
+		}
+	})
+
+	t.Run("by_name", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm := NewRealmWithDefaults("e2e-test-realm")
+		realm.RegionCode = "TEST"
+		if err := db.SaveRealm(realm, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		record, err := db.E2ERealm()
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if record.ID != realm.ID {
+			t.Errorf("expected %#v to be %#v", record, realm)
+		}
+	})
+}
+
 func TestRealm_BuildSMSText(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
This removes the purging bits but keeps the e2e realm lookup helper function.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Introduce function for getting the e2e-realm (if one exists).
```
