### PR TITLE
Track API key "last used"

### DIFF
--- a/assets/server/apikeys/index.html
+++ b/assets/server/apikeys/index.html
@@ -49,8 +49,11 @@
             <tr>
               <th scope="col" width="40"></th>
               <th scope="col">App</th>
-              <th scope="col" width="90">Key</th>
-              <th scope="col" width="90">Type</th>
+              <th scope="col" width="90" class="d-none d-md-table-cell">Key</th>
+              <th scope="col" width="90" class="d-none d-md-table-cell">Type</th>
+              {{if $.features.EnableAPIKeyLastUsedAt}}
+                <th scope="col" width="150" class="d-none d-md-table-cell">Last used</th>
+              {{end}}
               {{if $canWrite}}
                 <th scope="col" width="40"></th>
               {{end}}
@@ -71,14 +74,19 @@
               <td class="text-truncate">
                 <a href="/realm/apikeys/{{.ID}}">{{.Name}}</a>
               </td>
-              <td class="text-center text-monospace">
+              <td class="text-center text-monospace d-none d-md-table-cell">
                 {{.APIKeyPreview}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if .IsAdminType}}<span class="badge badge-pill badge-primary" data-toggle="tooltip" title="For issuing verification codes">Admin</span>{{end}}
                 {{if .IsDeviceType}}<span class="badge badge-pill badge-secondary" data-toggle="tooltip" title="For use in mobile apps to verify codes and get certificates">Device</span>{{end}}
                 {{if .IsStatsType}}<span class="badge badge-pill badge-secondary" data-toggle="tooltip" title="For retrieving realm statistics">Stats</span>{{end}}
               </td>
+              {{if $.features.EnableAPIKeyLastUsedAt}}
+                <td class="d-none d-md-table-cell">
+                  {{.LastUsedAt | humanizeTime}}
+                </td>
+              {{end}}
               {{if $canWrite}}
                 <td class="text-center">
                   {{if .DeletedAt}}

--- a/assets/server/apikeys/show.html
+++ b/assets/server/apikeys/show.html
@@ -51,23 +51,36 @@
         {{end}}
       </div>
       <div class="card-body">
-        <strong>App name</strong>
-        <div id="apikey-name" class="mb-3">
-          {{$authApp.Name}}
+        <div>
+          <strong>App name</strong>
+          <div id="apikey-name">
+            {{$authApp.Name}}
+          </div>
         </div>
 
-        <strong>Type</strong>
-        <div>
-          {{if $authApp.IsDeviceType}}
-            Device (can verify codes)
-          {{else if $authApp.IsAdminType}}
-            Admin (can issue codes)
-          {{else if $authApp.IsStatsType}}
-            Stats (can view stats)
-          {{else}}
-            Unknown
-          {{end}}
+        <div class="mt-3">
+          <strong>Type</strong>
+          <div>
+            {{if $authApp.IsDeviceType}}
+              Device (can verify codes)
+            {{else if $authApp.IsAdminType}}
+              Admin (can issue codes)
+            {{else if $authApp.IsStatsType}}
+              Stats (can view stats)
+            {{else}}
+              Unknown
+            {{end}}
+          </div>
         </div>
+
+        {{if $.features.EnableAPIKeyLastUsedAt}}
+          <div class="mt-3">
+            <strong>Last used</strong>
+            <div>
+              {{$authApp.LastUsedAt | humanizeTime}}
+            </div>
+          </div>
+        {{end}}
       </div>
     </div>
 

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/chromedp/cdproto v0.0.0-20210323015217-0942afbea50e
 	github.com/chromedp/chromedp v0.6.10
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
+	github.com/dustin/go-humanize v1.0.0
 	github.com/golang-migrate/migrate/v4 v4.14.1
 	github.com/gonum/blas v0.0.0-20181208220705-f22b278b28ac // indirect
 	github.com/gonum/floats v0.0.0-20181209220543-c233463c7e82 // indirect

--- a/go.sum
+++ b/go.sum
@@ -248,6 +248,7 @@ github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5Xh
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/eapache/go-resiliency v1.1.0/go.mod h1:kFI+JgMyC7bLPUVY133qvEBtVayf5mFgVsvEsIPBvNs=
 github.com/eapache/go-xerial-snappy v0.0.0-20180814174437-776d5712da21/go.mod h1:+020luEh2TKB4/GOp8oxxtq0Daoen/Cii55CzbTV6DU=

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -31,6 +31,12 @@ type FeatureConfig struct {
 	// EnableUserReportWeb will host a web page on the enx-redirect service
 	// under a realm's domain IFF that realm has enabled user report and admin user report
 	EnableUserReportWeb bool `env:"ENABLE_USER_REPORT_WEB, default=false"`
+
+	// EnableAPIKeyLastUsedAt controls whether the UI will show the last_used_at
+	// value for an API key.
+	//
+	// TODO(sethvargo): Move to true in 0.27.0+.
+	EnableAPIKeyLastUsedAt bool `env:"ENABLE_API_KEY_LAST_USED_AT, default=false"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -37,7 +37,7 @@ func TestHandleCreate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleCreate()
+	handler := harness.WithCommonMiddlewares(c.HandleCreate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/apikey/disable_test.go
+++ b/pkg/controller/apikey/disable_test.go
@@ -36,7 +36,7 @@ func TestHandleDisable(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleDisable()
+	handler := harness.WithCommonMiddlewares(c.HandleDisable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/apikey/enable_test.go
+++ b/pkg/controller/apikey/enable_test.go
@@ -38,7 +38,7 @@ func TestHandleEnable(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleEnable()
+	handler := harness.WithCommonMiddlewares(c.HandleEnable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/apikey/index_test.go
+++ b/pkg/controller/apikey/index_test.go
@@ -35,7 +35,7 @@ func TestHandleIndex(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(c.HandleIndex())
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/apikey/show_test.go
+++ b/pkg/controller/apikey/show_test.go
@@ -37,7 +37,7 @@ func TestHandleShow(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(c.HandleShow())
+	handler := harness.WithCommonMiddlewares(c.HandleShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/apikey/update_test.go
+++ b/pkg/controller/apikey/update_test.go
@@ -38,7 +38,7 @@ func TestHandleUpdate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := apikey.New(harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleUpdate()
+	handler := harness.WithCommonMiddlewares(c.HandleUpdate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2232,6 +2232,19 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realm_stats DROP COLUMN IF EXISTS codes_invalid_by_os`)
 			},
 		},
+		{
+			ID: "00102-AddLastUsedAtToAuthorizedApps",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE authorized_apps ADD COLUMN IF NOT EXISTS last_used_at TIMESTAMP WITH TIME ZONE`,
+					`CREATE INDEX idx_authorized_apps_last_used_at ON authorized_apps (last_used_at)`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE authorized_apps DROP COLUMN IF EXISTS last_used_at`,
+					`DROP INDEX IF EXISTS idx_authorized_apps_last_used_at`)
+			},
+		},
 	}
 }
 

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -30,12 +30,13 @@ import (
 	"strings"
 	"sync"
 	texttemplate "text/template"
+	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 	"github.com/leonelquinteros/gotext"
-
 	"go.uber.org/zap"
 )
 
@@ -229,6 +230,21 @@ func translate(t gotext.Translator, key string, vars ...interface{}) (string, er
 	return v, nil
 }
 
+// humanizeTime prints time in a human-readable format.
+func humanizeTime(i interface{}) (string, error) {
+	switch typ := i.(type) {
+	case time.Time:
+		return humanize.Time(typ), nil
+	case *time.Time:
+		if typ == nil {
+			return "never", nil
+		}
+		return humanize.Time(*typ), nil
+	default:
+		return "", fmt.Errorf("unsupported type %T", typ)
+	}
+}
+
 // toStringSlice converts the input slice to strings. The values must be
 // primitive or implement the fmt.Stringer interface.
 func toStringSlice(i interface{}) ([]string, error) {
@@ -317,6 +333,7 @@ func templateFuncs() htmltemplate.FuncMap {
 		"toLower":          strings.ToLower,
 		"toUpper":          strings.ToUpper,
 		"toJSON":           json.Marshal,
+		"humanizeTime":     humanizeTime,
 		"toBase64":         base64.StdEncoding.EncodeToString,
 		"safeHTML":         safeHTML,
 		"checkedIf":        checkedIf,


### PR DESCRIPTION
This isn't an exact timestamp tracker, since we use some pretty aggressive caching to avoid a write on every read. However, this will give realm admins a very clear signal of whether an API key is still being used.

The UI is hidden behind a feature flag because I want to capture this data for a full release until displaying it in the UI. Otherwise it could lead to misleading information about an API having "never" been used.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Track API key "last used"
```
