### PR TITLE
Handle gorm log at debug level

### DIFF
--- a/pkg/database/database_logger.go
+++ b/pkg/database/database_logger.go
@@ -74,7 +74,16 @@ func (l *GormZapLogger) Print(v ...interface{}) {
 		msg = strings.TrimSpace(msg)
 
 		l.logger.Debugw(msg)
-	case "log", "error":
+	case "log":
+		msg, ok := v[2].(string)
+		if !ok {
+			l.logger.DPanicf("log result is not string (%T): %#v", v[2], v)
+			return
+		}
+		msg = strings.TrimSpace(msg)
+
+		l.logger.Debugw(msg)
+	case "error":
 		caller, err := l.formatCaller(v[1])
 		if err != nil {
 			l.logger.DPanic(err)

--- a/pkg/database/database_logger_test.go
+++ b/pkg/database/database_logger_test.go
@@ -85,9 +85,9 @@ func TestGormZapLogger(t *testing.T) {
 			in: []interface{}{
 				"log",
 				"pkg/database/mobile_app.go:235",
-				fmt.Errorf("something is broken"),
+				"cleared cache",
 			},
-			exp: "ERROR\tgorm error\t{\"caller\": \"pkg/database/mobile_app.go:235\", \"error\": \"something is broken\"}",
+			exp: "DEBUG\tcleared cache",
 		},
 	}
 


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Handle gorm log at debug level instead of error.
```
