### PR TITLE
Do not store firebase cookie and verify ID token is < 5min old

### DIFF
--- a/assets/server/firebase.html
+++ b/assets/server/firebase.html
@@ -17,6 +17,9 @@
 
   window.addEventListener('load', () => {
     firebase.initializeApp(firebaseConfig);
+
+    // Disable the firebase cookie - we manage the ID token on the server side.
+    firebase.auth().setPersistence(firebase.auth.Auth.Persistence.NONE);
   })
 </script>
 {{end}}


### PR DESCRIPTION
I believe this will address the issue where a user is logged out and then quickly logged back in. We're using server-side sessions, but Firebase is still setting a cookie. So even when the session expires, Firebase re-authenticates automatically. This follows the instructions at https://firebase.google.com/docs/auth/admin/manage-cookies to disable persisting the Firebase cookie. There's also a server-side check that the auth token was created within the past 5 minutes for any Firebase cookies that might already be out in the wild.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Do not store firebase cookie and verify ID token is < 5min old.
```
