### PR TITLE
Remove unused csrf token from Terraform

### DIFF
--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -89,7 +89,6 @@ resource "google_cloud_run_service" "apiserver" {
         dynamic "env" {
           for_each = merge(
             local.cache_config,
-            local.csrf_config,
             local.database_config,
             local.firebase_config,
             local.gcp_config,

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -85,7 +85,6 @@ resource "google_cloud_run_service" "appsync" {
           for_each = merge(
             local.appsync_config,
             local.cache_config,
-            local.csrf_config,
             local.database_config,
             local.firebase_config,
             local.gcp_config,

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -96,7 +96,6 @@ resource "google_cloud_run_service" "cleanup" {
         dynamic "env" {
           for_each = merge(
             local.cache_config,
-            local.csrf_config,
             local.database_config,
             local.firebase_config,
             local.gcp_config,

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -84,7 +84,6 @@ resource "google_cloud_run_service" "e2e-runner" {
         dynamic "env" {
           for_each = merge(
             local.cache_config,
-            local.csrf_config,
             local.database_config,
             local.firebase_config,
             local.gcp_config,

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -102,7 +102,6 @@ resource "google_cloud_run_service" "server" {
         dynamic "env" {
           for_each = merge(
             local.cache_config,
-            local.csrf_config,
             local.database_config,
             local.firebase_config,
             local.gcp_config,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -30,11 +30,6 @@ locals {
     BACKUP_DATABASE_NAME         = google_sql_database.db.name
   }
 
-  # TODO(sethvargo): Remove in 0.26+
-  csrf_config = {
-    CSRF_AUTH_KEY = "secret://${google_secret_manager_secret_version.csrf-token-version.id}"
-  }
-
   session_config = {
     COOKIE_KEYS = "secret://${google_secret_manager_secret_version.cookie-hmac-key-version.id},secret://${google_secret_manager_secret_version.cookie-encryption-key-version.id}"
   }

--- a/terraform/sessions.tf
+++ b/terraform/sessions.tf
@@ -14,32 +14,9 @@
 
 locals {
   session_secrets = [
-    google_secret_manager_secret.csrf-token.id, # TODO(sethvargo): Remove in 0.26+
     google_secret_manager_secret.cookie-hmac-key.id,
     google_secret_manager_secret.cookie-encryption-key.id,
   ]
-}
-
-# TODO(sethvargo): Remove in 0.26+
-resource "random_id" "csrf-token" {
-  byte_length = 32
-}
-
-resource "google_secret_manager_secret" "csrf-token" {
-  secret_id = "csrf-token"
-
-  replication {
-    automatic = true
-  }
-
-  depends_on = [
-    google_project_service.services["secretmanager.googleapis.com"],
-  ]
-}
-
-resource "google_secret_manager_secret_version" "csrf-token-version" {
-  secret      = google_secret_manager_secret.csrf-token.id
-  secret_data = random_id.csrf-token.b64_std
 }
 
 resource "random_id" "cookie-hmac-key" {


### PR DESCRIPTION
This needed to stay in for the 0.26 release, but it is safe to remove now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Remove unused csrf token from Terraform.
```
