### PR TITLE
Note that last_used_time has 15m granularity

### DIFF
--- a/assets/server/apikeys/index.html
+++ b/assets/server/apikeys/index.html
@@ -52,7 +52,11 @@
               <th scope="col" width="90" class="d-none d-md-table-cell">Key</th>
               <th scope="col" width="90" class="d-none d-md-table-cell">Type</th>
               {{if $.features.EnableAPIKeyLastUsedAt}}
-                <th scope="col" width="150" class="d-none d-md-table-cell">Last used</th>
+                <th scope="col" width="150" class="d-none d-md-table-cell">
+                  Last used
+                  <span class="oi oi-bell small pl-1 mt-n3" aria-hidden="true"
+                    data-toggle="tooltip" data-placement="top" title="15 minute accuracy"></span>
+                </th>
               {{end}}
               {{if $canWrite}}
                 <th scope="col" width="40"></th>

--- a/assets/server/apikeys/show.html
+++ b/assets/server/apikeys/show.html
@@ -75,7 +75,11 @@
 
         {{if $.features.EnableAPIKeyLastUsedAt}}
           <div class="mt-3">
-            <strong>Last used</strong>
+            <strong>
+              Last used
+              <span class="oi oi-bell small pl-1 mt-n3" aria-hidden="true"
+                data-toggle="tooltip" data-placement="top" title="15 minute accuracy"></span>
+            </strong>
             <div>
               {{$authApp.LastUsedAt | humanizeTime}}
             </div>


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Note that last_used_time has 15m granularity in the UI.
```
