### PR TITLE
Add secret models and structure to info page

### DIFF
--- a/assets/server/admin/info.html
+++ b/assets/server/admin/info.html
@@ -13,53 +13,104 @@
     {{template "flash" .}}
 
     <div class="card shadow-sm mb-3">
-      <div class="card-header">Info</div>
-      <div class="card-body mb-n3">
-        <dl>
-          <dt>Build ID</dt>
-          <dd>{{.buildID}}</dd>
+      <div class="card-header">
+        <span id="icon" class="oi oi-cog mr-2 ml-n1" aria-hidden="true"></span>
+        System information
+      </div>
+      <div class="card-body">
+        <div>
+          <strong>Build ID</strong>
+          <div>{{.buildID}}</div>
+        </div>
 
-          <dt>Build tag</dt>
-          <dd>{{.buildTag}}</dd>
+        <div class="mt-3">
+          <strong>Build tag</strong>
+          <div>{{.buildTag}}</div>
+        </div>
+      </div>
+    </div>
 
-          <dt>Token signing keys</dt>
-          {{if $keys := .tokenSigningKeys}}
-            <dd>
-              <table class="small table table-bordered table-striped table-fixed mt-2">
-                <thead>
-                  <tr>
-                    <th width="40"></th>
-                    <th width="305">Key ID (kid)</th>
-                    <th>Key version</th>
-                    <th width="165">Created at</th>
-                  </tr>
-                </thead>
-                <tbody>
-                  {{range $key := $keys}}
-                    <tr>
-                      <td class="text-center">
-                        {{if $key.IsActive}}
-                          <span class="oi oi-check" aria-hidden="true" data-toggle="tooltip" title="Active key"></span>
-                        {{end}}
-                      </td>
-                      <td class="text-monospace user-select-all">
-                        {{$key.UUID}}
-                      </td>
-                      <td class="text-monospace user-select-all">
-                        {{$key.KeyVersionID}}
-                      </td>
-                      <td>
-                        <span data-timestamp="{{$key.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$key.CreatedAt.Format "2006-02-01 15:04"}}</span>
-                      </td>
-                    </tr>
-                  {{end}}
-                </tbody>
-              </table>
-            </dd>
-          {{else}}
-            <dd>not configured</dd>
-          {{end}}
-        </dl>
+    <div class="card shadow-sm mb-3">
+      <div class="card-header">
+        <span id="icon" class="oi oi-key mr-2 ml-n1" aria-hidden="true"></span>
+        Keys
+      </div>
+      <div class="card-body mb-n5">
+        {{if $keys := .tokenSigningKeys}}
+          <strong>Token signing keys</strong>
+          <table class="small table table-bordered table-striped table-fixed mt-3 mb-5">
+            <thead>
+              <tr>
+                <th width="40"></th>
+                <th width="305">Key ID (kid)</th>
+                <th>Key version</th>
+                <th width="175">Created at</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{range $key := $keys}}
+                <tr>
+                  <td class="text-center">
+                    {{if $key.IsActive}}
+                      <span class="oi oi-check" aria-hidden="true" data-toggle="tooltip" title="Active key"></span>
+                    {{end}}
+                  </td>
+                  <td class="text-monospace user-select-all">
+                    {{$key.UUID}}
+                  </td>
+                  <td class="text-monospace user-select-all">
+                    {{$key.KeyVersionID}}
+                  </td>
+                  <td>
+                    <span data-timestamp="{{$key.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$key.CreatedAt.Format "2006-02-01 15:04"}}</span>
+                  </td>
+                </tr>
+              {{end}}
+            </tbody>
+          </table>
+        {{else}}
+          <p class="text-center p-3">not configured</p>
+        {{end}}
+      </div>
+    </div>
+
+    <div class="card shadow-sm mb-3">
+      <div class="card-header">
+        <span id="icon" class="oi oi-lock-locked mr-2 ml-n1" aria-hidden="true"></span>
+        Secrets
+      </div>
+      <div class="card-body mb-n5">
+        {{range $type, $secretsList := .secrets}}
+          <strong>{{$type}}</strong>
+          <table class="small table table-bordered table-striped table-fixed mt-3 mb-5">
+            <thead>
+              <tr>
+                <th width="40"></th>
+                <th>Reference</th>
+                <th width="175">Created at</th>
+              </tr>
+            </thead>
+            <tbody>
+              {{range $secret := $secretsList}}
+                <tr>
+                  <td class="text-center">
+                    {{if $secret.Active}}
+                      <span class="oi oi-check" aria-hidden="true" data-toggle="tooltip" title="Active secret"></span>
+                    {{end}}
+                  </td>
+                  <td class="text-monospace user-select-all">
+                    {{$secret.Reference}}
+                  </td>
+                  <td>
+                    <span data-timestamp="{{$secret.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">{{$secret.CreatedAt.Format "2006-02-01 15:04"}}</span>
+                  </td>
+                </tr>
+              {{end}}
+            </tbody>
+          </table>
+        {{else}}
+          <p class="text-center p-3">not configured</p>
+        {{end}}
       </div>
     </div>
   </main>

--- a/go.mod
+++ b/go.mod
@@ -7,9 +7,10 @@ require (
 	cloud.google.com/go/firestore v1.5.0 // indirect
 	contrib.go.opencensus.io/integrations/ocsql v0.1.7
 	firebase.google.com/go v3.13.0+incompatible
-	github.com/Azure/azure-sdk-for-go v53.1.0+incompatible // indirect
+	github.com/Azure/azure-sdk-for-go v53.2.0+incompatible // indirect
+	github.com/Microsoft/go-winio v0.4.17 // indirect
 	github.com/NYTimes/gziphandler v1.1.1
-	github.com/aws/aws-sdk-go v1.38.17 // indirect
+	github.com/aws/aws-sdk-go v1.38.20 // indirect
 	github.com/chromedp/cdproto v0.0.0-20210323015217-0942afbea50e
 	github.com/chromedp/chromedp v0.6.10
 	github.com/dgrijalva/jwt-go v3.2.0+incompatible
@@ -20,7 +21,7 @@ require (
 	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
-	github.com/google/exposure-notifications-server v0.26.0
+	github.com/google/exposure-notifications-server v0.26.1-0.20210414205754-36dbf20153e8
 	github.com/google/go-cmp v0.5.5
 	github.com/google/uuid v1.2.0
 	github.com/gorilla/handlers v1.5.1
@@ -48,12 +49,14 @@ require (
 	github.com/unrolled/secure v1.0.8
 	go.opencensus.io v0.23.0
 	go.uber.org/zap v1.16.0
-	golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1
+	golang.org/x/net v0.0.0-20210414194228-064579744ee0
+	golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 // indirect
 	golang.org/x/sync v0.0.0-20210220032951-036812b2e83c
+	golang.org/x/sys v0.0.0-20210415045647-66c3f260301c // indirect
 	golang.org/x/text v0.3.6
 	golang.org/x/tools v0.1.1-0.20210302220138-2ac05c832e1a
 	google.golang.org/api v0.44.0
-	google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46
+	google.golang.org/genproto v0.0.0-20210415145412-64678f1ae2d5
 	google.golang.org/grpc v1.37.0 // indirect
 	gopkg.in/gormigrate.v1 v1.6.0
 	honnef.co/go/tools v0.1.3 // indirect

--- a/go.sum
+++ b/go.sum
@@ -61,8 +61,8 @@ firebase.google.com/go v3.13.0+incompatible/go.mod h1:xlah6XbEyW6tbfSklcfe5FHJIw
 github.com/Azure/azure-pipeline-go v0.2.3 h1:7U9HBg1JFK3jHl5qmo4CTZKFTVgMwdFHMVtCdfBE21U=
 github.com/Azure/azure-pipeline-go v0.2.3/go.mod h1:x841ezTBIMG6O3lAcl8ATHnsOPVl2bqk7S3ta6S6u4k=
 github.com/Azure/azure-sdk-for-go v53.0.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
-github.com/Azure/azure-sdk-for-go v53.1.0+incompatible h1:f2h0KLVGa3zIaMDMHBe5Lazc0FT5+L78z0B8K9PmDyg=
-github.com/Azure/azure-sdk-for-go v53.1.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
+github.com/Azure/azure-sdk-for-go v53.2.0+incompatible h1:XaOWAbkI9QeaO/YTtmz8Pt+9rLCrLyYdR9AsvP2irSQ=
+github.com/Azure/azure-sdk-for-go v53.2.0+incompatible/go.mod h1:9XXNKU+eRnpl9moKnB4QOLf1HestfXbmab5FXxiDBjc=
 github.com/Azure/azure-storage-blob-go v0.13.0 h1:lgWHvFh+UYBNVQLFHXkvul2f6yOPA9PIH82RTG2cSwc=
 github.com/Azure/azure-storage-blob-go v0.13.0/go.mod h1:pA9kNqtjUeQF2zOSu4s//nUdBD+e64lEuc4sVnuOfNs=
 github.com/Azure/go-ansiterm v0.0.0-20170929234023-d6e3b3328b78 h1:w+iIsaOQNcT7OZ575w+acHgRric5iCyQh+xv+KJ4HB8=
@@ -102,8 +102,9 @@ github.com/DataDog/datadog-go v3.2.0+incompatible/go.mod h1:LButxg5PwREeZtORoXG3
 github.com/Knetic/govaluate v3.0.1-0.20171022003610-9aa49832a739+incompatible/go.mod h1:r7JcOSlj0wfOMncg0iLm8Leh48TZaKVeNIfJntJ2wa0=
 github.com/Masterminds/semver/v3 v3.1.1/go.mod h1:VPu/7SZ7ePZ3QOrcuXROw5FAcLl4a0cBrbBpGY/8hQs=
 github.com/Microsoft/go-winio v0.4.15-0.20190919025122-fc70bd9a86b5/go.mod h1:tTuCMEN+UleMWgg9dVx4Hu52b1bJo+59jBh3ajtinzw=
-github.com/Microsoft/go-winio v0.4.16 h1:FtSW/jqD+l4ba5iPBj9CODVtgfYAD8w2wS923g/cFDk=
 github.com/Microsoft/go-winio v0.4.16/go.mod h1:XB6nPKklQyQ7GC9LdcBEcBl8PF76WugXOPRXwdLnMv0=
+github.com/Microsoft/go-winio v0.4.17 h1:iT12IBVClFevaf8PuVyi3UmZOVh4OqnaLxDTW2O6j3w=
+github.com/Microsoft/go-winio v0.4.17/go.mod h1:JPGBdM1cNvN/6ISo+n8V5iA4v8pBzdOpzfwIujj1a84=
 github.com/Microsoft/hcsshim v0.8.9/go.mod h1:5692vkUqntj1idxauYlpoINNKeqCiG6Sg38RRsjT5y8=
 github.com/NYTimes/gziphandler v1.1.1 h1:ZUDjpQae29j0ryrS0u/B8HZfJBtBQHjqw2rQ2cqUQ3I=
 github.com/NYTimes/gziphandler v1.1.1/go.mod h1:n/CVRwUEOgIxrgPvAQhUUr9oeUtvrhMomdKFjzJNB0c=
@@ -144,8 +145,8 @@ github.com/aws/aws-sdk-go v1.25.44/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpi
 github.com/aws/aws-sdk-go v1.27.0/go.mod h1:KmX6BPdI08NWTb3/sm4ZGu5ShLoqVDhKgpiN924inxo=
 github.com/aws/aws-sdk-go v1.30.27/go.mod h1:5zCpMtNQVjRREroY7sYe8lOMRSxkhG6MZveU8YkpAk0=
 github.com/aws/aws-sdk-go v1.38.13/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
-github.com/aws/aws-sdk-go v1.38.17 h1:1OfcfEtNrphUZYa+J0U35/1hxePbb3ASSQWdFS7L0Hs=
-github.com/aws/aws-sdk-go v1.38.17/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
+github.com/aws/aws-sdk-go v1.38.20 h1:QbzNx/tdfATbdKfubBpkt84OM6oBkxQZRw6+bW2GyeA=
+github.com/aws/aws-sdk-go v1.38.20/go.mod h1:hcU610XS61/+aQV88ixoOzUoG7v3b31pl2zKMmprdro=
 github.com/aws/aws-sdk-go-v2 v0.18.0/go.mod h1:JWVYvqSMppoMJC0x5wdwiImzgXTI9FuZwxzkQq9wy+g=
 github.com/aymerick/douceur v0.2.0 h1:Mv+mAeH1Q+n9Fr+oyamOlAkUNPWPlA8PPGR0QAaYuPk=
 github.com/aymerick/douceur v0.2.0/go.mod h1:wlT5vV2O3h55X9m7iVYN0TBM0NH/MmbLnd30/FjWUq4=
@@ -383,8 +384,8 @@ github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 h1:V2IgdyerlBa/MxaEFR
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/exposure-notifications-server v0.26.0 h1:4OtHAIqeYCzPHGwGoa/8BUp1jMaNyH9fdjiKM1YCLQw=
-github.com/google/exposure-notifications-server v0.26.0/go.mod h1:byZ3tVbASahXIlDT03pTt8CJ0jWuIo+6pcGxlyYLvPs=
+github.com/google/exposure-notifications-server v0.26.1-0.20210414205754-36dbf20153e8 h1:LmvYMuBEhYHfwcQpAOf4pIbF4QjLYO55hoIpOiqDKXs=
+github.com/google/exposure-notifications-server v0.26.1-0.20210414205754-36dbf20153e8/go.mod h1:byZ3tVbASahXIlDT03pTt8CJ0jWuIo+6pcGxlyYLvPs=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
@@ -1094,8 +1095,8 @@ golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v
 golang.org/x/net v0.0.0-20210316092652-d523dce5a7f4/go.mod h1:RBQZq4jEuRlivfhVLdyRGr576XBO4/greRjx4P4O3yc=
 golang.org/x/net v0.0.0-20210331212208-0fccb6fa2b5c/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
 golang.org/x/net v0.0.0-20210405180319-a5a99cb37ef4/go.mod h1:p54w0d4576C0XHj96bSt6lcn1PtDYWL6XObtHCRCNQM=
-golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1 h1:4qWs8cYYH6PoEFy4dfhDFgoMGkwAcETd+MmPdCPMzUc=
-golang.org/x/net v0.0.0-20210410081132-afb366fc7cd1/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
+golang.org/x/net v0.0.0-20210414194228-064579744ee0 h1:iqW3Mjl/6IP9cHJC/wdiIu3lyBDMUfDElRMyFlqbtiQ=
+golang.org/x/net v0.0.0-20210414194228-064579744ee0/go.mod h1:9tjilg8BloeKEkVJvy7fQ90B1CfIiPueXVOjqfkSzI8=
 golang.org/x/oauth2 v0.0.0-20180227000427-d7d64896b5ff/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/oauth2 v0.0.0-20181106182150-f42d05182288/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
@@ -1109,8 +1110,9 @@ golang.org/x/oauth2 v0.0.0-20201208152858-08078c50e5b5/go.mod h1:KelEdhl1UZF7XfJ
 golang.org/x/oauth2 v0.0.0-20210218202405-ba52d332ba99/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210220000619-9bb904979d93/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/oauth2 v0.0.0-20210313182246-cd4f82c27b84/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
-golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602 h1:0Ja1LBD+yisY6RWM/BH7TJVXWsSjs2VwBSmvSX4HdBc=
 golang.org/x/oauth2 v0.0.0-20210402161424-2e8d93401602/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
+golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78 h1:rPRtHfUb0UKZeZ6GH4K4Nt4YRbE9V1u+QZX5upZXqJQ=
+golang.org/x/oauth2 v0.0.0-20210413134643-5e61552d6c78/go.mod h1:KelEdhl1UZF7XfJ4dDtk6s++YSgaE7mD/BuKKDLBl4A=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181221193216-37e7f081c4d4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -1199,8 +1201,9 @@ golang.org/x/sys v0.0.0-20210309074719-68d13333faf2/go.mod h1:h1NjWce9XRLGQEsW7w
 golang.org/x/sys v0.0.0-20210315160823-c6e025ad8005/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210320140829-1e4c9ba3b0c4/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210330210617-4fbd30eecc44/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
-golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57 h1:F5Gozwx4I1xtr/sr/8CFbb57iKi3297KFs0QDbGN60A=
 golang.org/x/sys v0.0.0-20210403161142-5e06dd20ab57/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
+golang.org/x/sys v0.0.0-20210415045647-66c3f260301c h1:6L+uOeS3OQt/f4eFHXZcTxeZrGCuz+CLElgEBjbcTA4=
+golang.org/x/sys v0.0.0-20210415045647-66c3f260301c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/term v0.0.0-20201117132131-f5c789dd3221/go.mod h1:Nr5EML6q2oocZ2LXRh80K7BxOlk5/8JxuGnuhpl+muw=
 golang.org/x/term v0.0.0-20201126162022-7de9c90e9dd1/go.mod h1:bj7SfCRtBDWHUb9snDiAeCFNEtKQo2Wmx5Cou7ajbmo=
 golang.org/x/text v0.0.0-20170915032832-14c0d48ead0c/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
@@ -1384,8 +1387,8 @@ google.golang.org/genproto v0.0.0-20210310155132-4ce2db91004e/go.mod h1:FWY/as6D
 google.golang.org/genproto v0.0.0-20210319143718-93e7006c17a6/go.mod h1:FWY/as6DDZQgahTzZj3fqbO1CbirC29ZNUFHwi0/+no=
 google.golang.org/genproto v0.0.0-20210402141018-6c239bbf2bb1/go.mod h1:9lPAdzaEmUacj36I+k7YKbEc5CXzPIeORRgDAUOu28A=
 google.golang.org/genproto v0.0.0-20210405174219-a39eb2f71cb9/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
-google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46 h1:f4STrQZf8jaowsiUitigvrqMCCM4QJH1A2JCSI7U1ow=
-google.golang.org/genproto v0.0.0-20210406143921-e86de6bf7a46/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
+google.golang.org/genproto v0.0.0-20210415145412-64678f1ae2d5 h1:MSDsGZzppeaFIEzKO8W4ONBHajeQ0fMfwcQev1Z3T0o=
+google.golang.org/genproto v0.0.0-20210415145412-64678f1ae2d5/go.mod h1:P3QM42oQyzQSnHPnZ/vqoCdDmzH28fzWByN9asMeM8A=
 google.golang.org/grpc v1.14.0/go.mod h1:yo6s7OP7yaDglbqo1J04qKzAhqBH6lvTonzMVmEdcZw=
 google.golang.org/grpc v1.17.0/go.mod h1:6QZJwpn2B+Zp71q/5VxRsJ6NXXVCE5NRUHRo+f3cWCs=
 google.golang.org/grpc v1.19.0/go.mod h1:mqu4LbDTu4XGKhr4mRzUsmM4RtVoemTSY81AxZiDr8c=

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -35,7 +35,7 @@ type FeatureConfig struct {
 	// EnableAPIKeyLastUsedAt controls whether the UI will show the last_used_at
 	// value for an API key.
 	//
-	// TODO(sethvargo): Move to true in 0.27.0+.
+	// TODO(sethvargo): Move to true in 0.28.0+.
 	EnableAPIKeyLastUsedAt bool `env:"ENABLE_API_KEY_LAST_USED_AT, default=false"`
 }
 

--- a/pkg/controller/middleware/apikey_test.go
+++ b/pkg/controller/middleware/apikey_test.go
@@ -62,8 +62,7 @@ func TestRequireAPIKey(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	badDB, _ := testDatabaseInstance.NewDatabase(t, nil)
-	badDB.SetRawDB(envstest.NewFailingDatabase())
+	badDB := harness.BadDatabase
 
 	cases := []struct {
 		name   string

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2245,6 +2245,30 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`DROP INDEX IF EXISTS idx_authorized_apps_last_used_at`)
 			},
 		},
+		{
+			ID: "00103-AddSecrets",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`CREATE TABLE secrets (
+  					id BIGSERIAL PRIMARY KEY,
+  					type TEXT NOT NULL,
+  					reference TEXT NOT NULL,
+  					active BOOL DEFAULT FALSE NOT NULL,
+  					created_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  					updated_at TIMESTAMP WITH TIME ZONE NOT NULL,
+  					deleted_at TIMESTAMP WITH TIME ZONE
+					);
+					CREATE UNIQUE INDEX uix_secrets_type_reference ON secrets(type, reference);
+					CREATE INDEX idx_secrets_active_created_at ON secrets(active, created_at);
+					CREATE INDEX idx_secrets_created_at ON secrets(created_at);
+					CREATE INDEX idx_secrets_deleted_at ON secrets(deleted_at);
+				`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`DROP TABLE secrets`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -27,11 +27,27 @@ import (
 // function length. Note this is an ALIAS. It is NOT a new type.
 type Scope = func(db *gorm.DB) *gorm.DB
 
+// Unscoped returns an unscoped database (for finding soft-deleted records and
+// clearing other scopes).
+func Unscoped() Scope {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Unscoped()
+	}
+}
+
 // OnlySystemAdmins returns a scope that restricts the query to system admins.
 // It's only applicable to functions that query User.
 func OnlySystemAdmins() Scope {
 	return func(db *gorm.DB) *gorm.DB {
 		return db.Where(&User{SystemAdmin: true})
+	}
+}
+
+// InConsumableSecretOrder is a scope that orders secrets in the order in which
+// they should be consumed.
+func InConsumableSecretOrder() Scope {
+	return func(db *gorm.DB) *gorm.DB {
+		return db.Order("secrets.active DESC, secrets.created_at DESC")
 	}
 }
 

--- a/pkg/database/secret.go
+++ b/pkg/database/secret.go
@@ -1,0 +1,238 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/jinzhu/gorm"
+)
+
+// SecretType represents a secret type.
+type SecretType string
+
+const (
+	SecretTypeAPIKeyDatabaseHMAC           = SecretType("api_key_database_hmac")
+	SecretTypeAPIKeySignatureHMAC          = SecretType("api_key_signature_hmac")
+	SecretTypeCookieKeys                   = SecretType("cookie_keys")
+	SecretTypePhoneNumberDatabaseHMAC      = SecretType("phone_number_database_hmac")
+	SecretTypeVerificationCodeDatabaseHMAC = SecretType("verification_code_database_hmac")
+)
+
+var _ Auditable = (*Secret)(nil)
+
+// Secret represents the reference to a secret in an upstream secret manager. It
+// exists to facilitate rotation and auditing.
+type Secret struct {
+	Errorable
+
+	// ID is the primary key of the secret.
+	ID uint
+
+	// Type is the type of secret.
+	Type SecretType
+
+	// Reference is the pointer to the secret in the secret manager.
+	Reference string
+
+	// Active is a boolean indicating whether this secret is active.
+	Active bool
+
+	// CreatedAt, UpdatedAt, and DeletedAt are the timestamps.
+	CreatedAt time.Time
+	UpdatedAt time.Time
+	DeletedAt *time.Time
+}
+
+func (s *Secret) AuditID() string {
+	return fmt.Sprintf("secret:%d", s.ID)
+}
+
+func (s *Secret) AuditDisplay() string {
+	return fmt.Sprintf("%s (%s)", s.Type, s.Reference)
+}
+
+// BeforeSave runs validations. If there are errors, the save fails.
+func (s *Secret) BeforeSave(tx *gorm.DB) error {
+	s.Reference = project.TrimSpace(s.Reference)
+
+	if s.Reference == "" {
+		s.AddError("reference", "cannot be blank")
+	}
+
+	if err := s.ErrorOrNil(); err != nil {
+		return fmt.Errorf("%w: %s", err, strings.Join(s.ErrorMessages(), ", "))
+	}
+	return nil
+}
+
+// FindSecret gets a specific secret by its database ID.
+func (db *Database) FindSecret(id interface{}) (*Secret, error) {
+	var secret Secret
+	if err := db.db.
+		Model(&Secret{}).
+		Where("id = ?", id).
+		First(&secret).
+		Error; err != nil {
+		return nil, fmt.Errorf("failed to find secret %v: %w", id, err)
+	}
+	return &secret, nil
+}
+
+// ListSecrets lists all secrets in the database.
+func (db *Database) ListSecrets(scopes ...Scope) ([]*Secret, error) {
+	var secrets []*Secret
+	if err := db.db.
+		Scopes(scopes...).
+		Model(&Secret{}).
+		Find(&secrets).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return secrets, nil
+		}
+	}
+	return secrets, nil
+}
+
+// ListSecretsForType lists all secrets for the given type, ordered by their
+// creation date, but with inactive secrets (ones not ready to be used as
+// primary) at the end of the list, allowing for propagation over time.
+func (db *Database) ListSecretsForType(typ SecretType, scopes ...Scope) ([]*Secret, error) {
+	scopes = append(scopes, InConsumableSecretOrder())
+
+	var secrets []*Secret
+	if err := db.db.
+		Scopes(scopes...).
+		Model(&Secret{}).
+		Where("secrets.type = ?", typ).
+		Find(&secrets).
+		Error; err != nil {
+		if IsNotFound(err) {
+			return secrets, nil
+		}
+	}
+	return secrets, nil
+}
+
+// ActivateSecrets activates all secrets that are not currently activate but
+// have been created for since the provided timestamp.
+func (db *Database) ActivateSecrets(since time.Time) error {
+	if err := db.db.
+		Model(&Secret{}).
+		Where("active IS FALSE AND created_at < ?", since).
+		UpdateColumn("active", true).
+		Error; err != nil && !IsNotFound(err) {
+		return fmt.Errorf("failed to activate secrets: %w", err)
+	}
+	return nil
+}
+
+// SaveSecret creates or updates the secret.
+func (db *Database) SaveSecret(s *Secret, actor Auditable) error {
+	if s == nil {
+		return fmt.Errorf("provided secret is nil")
+	}
+
+	if actor == nil {
+		return fmt.Errorf("auditing actor is nil")
+	}
+
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		var audits []*AuditEntry
+
+		var existing Secret
+		if err := tx.
+			Unscoped().
+			Model(&Secret{}).
+			Where("id = ?", s.ID).
+			First(&existing).
+			Error; err != nil && !IsNotFound(err) {
+			return fmt.Errorf("failed to get existing secret: %w", err)
+		}
+
+		// Save the record
+		if err := tx.Unscoped().Save(s).Error; err != nil {
+			return err
+		}
+
+		// New record?
+		if existing.ID == 0 {
+			audit := BuildAuditEntry(actor, "created secret", s, 0)
+			audits = append(audits, audit)
+		} else {
+			if existing.Type != s.Type {
+				audit := BuildAuditEntry(actor, "updated secret type", s, 0)
+				audit.Diff = stringDiff(string(existing.Type), string(s.Type))
+				audits = append(audits, audit)
+			}
+
+			if existing.Reference != s.Reference {
+				audit := BuildAuditEntry(actor, "updated secret reference", s, 0)
+				audit.Diff = stringDiff(existing.Reference, s.Reference)
+				audits = append(audits, audit)
+			}
+
+			if existing.Active != s.Active {
+				audit := BuildAuditEntry(actor, "updated secret active status", s, 0)
+				audit.Diff = boolDiff(existing.Active, s.Active)
+				audits = append(audits, audit)
+			}
+		}
+
+		// Save all audits
+		for _, audit := range audits {
+			if err := tx.Save(audit).Error; err != nil {
+				return fmt.Errorf("failed to save audits: %w", err)
+			}
+		}
+
+		return nil
+	})
+}
+
+// DeleteSecret performs a soft delete on the provided secret.
+func (db *Database) DeleteSecret(s *Secret, actor Auditable) error {
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Delete(s).Error; err != nil && !IsNotFound(err) {
+			return fmt.Errorf("failed to delete secret: %w", err)
+		}
+
+		audit := BuildAuditEntry(actor, "marked secret for deletion", s, 0)
+		if err := tx.Save(audit).Error; err != nil {
+			return fmt.Errorf("failed to save audits: %w", err)
+		}
+
+		return nil
+	})
+}
+
+// PurgeSecret deletes the secret for real.
+func (db *Database) PurgeSecret(s *Secret, actor Auditable) error {
+	return db.db.Transaction(func(tx *gorm.DB) error {
+		if err := tx.Unscoped().Delete(s).Error; err != nil && !IsNotFound(err) {
+			return fmt.Errorf("failed to purge secret: %w", err)
+		}
+
+		audit := BuildAuditEntry(actor, "purged secret", s, 0)
+		if err := tx.Save(audit).Error; err != nil {
+			return fmt.Errorf("failed to save audits: %w", err)
+		}
+
+		return nil
+	})
+}

--- a/pkg/database/secret_test.go
+++ b/pkg/database/secret_test.go
@@ -1,0 +1,220 @@
+// Copyright 20201Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package database
+
+import (
+	"fmt"
+	"reflect"
+	"testing"
+	"time"
+)
+
+func TestSecret_BeforeSave(t *testing.T) {
+	t.Parallel()
+
+	t.Run("reference", func(t *testing.T) {
+		t.Parallel()
+		exerciseValidation(t, &Secret{}, "Reference", "reference")
+	})
+}
+
+func TestDatabase_FindSecret(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	t.Run("not_found", func(t *testing.T) {
+		t.Parallel()
+		if _, err := db.FindSecret(60221023); !IsNotFound(err) {
+			t.Fatalf("expected %v to be NotFound", err)
+		}
+	})
+
+	t.Run("finds", func(t *testing.T) {
+		t.Parallel()
+
+		secret := &Secret{
+			Type:      SecretTypeCookieKeys,
+			Reference: "a/b/c",
+		}
+		if err := db.SaveSecret(secret, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		record, err := db.FindSecret(secret.ID)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := record.ID, secret.ID; got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+	})
+}
+
+func TestDatabase_ListSecrets(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		// Clear secrets created by bootstrap
+		if err := db.db.Unscoped().Delete(&Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		list, err := db.ListSecrets()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(list), 0; got != want {
+			t.Errorf("expected list to have %d elements: %v", want, list)
+		}
+	})
+
+	t.Run("lists", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		// Clear secrets created by bootstrap
+		if err := db.db.Unscoped().Delete(&Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		for i := 0; i < 3; i++ {
+			secret := &Secret{
+				Type:      SecretTypeCookieKeys,
+				Reference: fmt.Sprintf("a/b/c/%d", i),
+			}
+			if err := db.SaveSecret(secret, SystemTest); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		list, err := db.ListSecrets()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(list), 3; got != want {
+			t.Errorf("expected list to have %d elements: %v", want, list)
+		}
+	})
+}
+
+func TestDatabase_ListSecretsForType(t *testing.T) {
+	t.Parallel()
+
+	t.Run("empty", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		// Clear secrets created by bootstrap
+		if err := db.db.Unscoped().Delete(&Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		list, err := db.ListSecretsForType(SecretTypeCookieKeys)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(list), 0; got != want {
+			t.Errorf("expected list to have %d elements: %v", want, list)
+		}
+	})
+
+	t.Run("none_for_type", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		// Clear secrets created by bootstrap
+		if err := db.db.Unscoped().Delete(&Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		secret := &Secret{
+			Type:      SecretTypeAPIKeyDatabaseHMAC,
+			Reference: "a/b/c",
+		}
+		if err := db.SaveSecret(secret, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		list, err := db.ListSecretsForType(SecretTypeCookieKeys)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := len(list), 0; got != want {
+			t.Errorf("expected list to have %d elements: %v", want, list)
+		}
+	})
+
+	t.Run("lists", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		// Clear secrets created by bootstrap
+		if err := db.db.Unscoped().Delete(&Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		now := time.Now().UTC()
+
+		if err := db.SaveSecret(&Secret{
+			Type:      SecretTypeCookieKeys,
+			Reference: "active_1",
+			Active:    true,
+			CreatedAt: now.Add(-30 * time.Minute),
+		}, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.SaveSecret(&Secret{
+			Type:      SecretTypeCookieKeys,
+			Reference: "active_2",
+			Active:    true,
+			CreatedAt: now.Add(-25 * time.Minute),
+		}, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		if err := db.SaveSecret(&Secret{
+			Type:      SecretTypeCookieKeys,
+			Reference: "inactive",
+			Active:    false,
+			CreatedAt: now,
+		}, SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		list, err := db.ListSecretsForType(SecretTypeCookieKeys)
+		if err != nil {
+			t.Fatal(err)
+		}
+		got := make([]string, len(list))
+		for i, v := range list {
+			got[i] = v.Reference
+		}
+
+		want := []string{"active_2", "active_1", "inactive"}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})
+}

--- a/pkg/database/secret_test.go
+++ b/pkg/database/secret_test.go
@@ -1,4 +1,4 @@
-// Copyright 20201Google LLC
+// Copyright 2021 Google LLC
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
This is just the models; trying to split this up to make it easier to review.

<img width="1149" alt="screenshot-20210415-171255@2x" src="https://user-images.githubusercontent.com/408570/114939015-d62d7980-9e0d-11eb-8c9a-4a85c18e4e24.png">

Note that there won't be any secrets in the info page for now, since nothing is actually connected.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add secret models and structure to info page.
```
