### PR TITLE
Extract key/secret bootstrapping into functions for seeding

### DIFF
--- a/pkg/config/rotation_config.go
+++ b/pkg/config/rotation_config.go
@@ -21,6 +21,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-server/pkg/secrets"
 
 	"github.com/sethvargo/go-envconfig"
 )
@@ -31,6 +32,10 @@ type RotationConfig struct {
 	Database      database.Config
 	Observability observability.Config
 	Features      FeatureConfig
+	Secrets       secrets.Config
+
+	// ProjectID is the Google Cloud project ID.
+	ProjectID string `env:"PROJECT_ID, required"`
 
 	// Port is the port upon which to bind.
 	Port string `env:"PORT, default=8080"`

--- a/pkg/controller/rotation/handle_token_rotate_test.go
+++ b/pkg/controller/rotation/handle_token_rotate_test.go
@@ -27,7 +27,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
-func TestHandleRotate(t *testing.T) {
+func TestHandleRotateTokenSigningKey(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -56,12 +56,12 @@ func TestHandleRotate(t *testing.T) {
 
 		db, _ := testDatabaseInstance.NewDatabase(t, nil)
 
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		// Rotating should create a new key since none exists.
 		{
 			w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
-			c.HandleRotate().ServeHTTP(w, r)
+			c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 
 			keys, err := db.ListTokenSigningKeys()
 			if err != nil {
@@ -85,7 +85,7 @@ func TestHandleRotate(t *testing.T) {
 			}
 
 			w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
-			c.HandleRotate().ServeHTTP(w, r)
+			c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 
 			keys, err := db.ListTokenSigningKeys()
 			if err != nil {
@@ -100,7 +100,7 @@ func TestHandleRotate(t *testing.T) {
 		// since TokenSigningKeyMaxAge).
 		{
 			w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
-			c.HandleRotate().ServeHTTP(w, r)
+			c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 
 			keys, err := db.ListTokenSigningKeys()
 			if err != nil {
@@ -125,17 +125,17 @@ func TestHandleRotate(t *testing.T) {
 			MinTTL:                5 * time.Minute,
 		}
 
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
 
-		c.HandleRotate().ServeHTTP(w, r)
+		c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// again
-		c.HandleRotate().ServeHTTP(w, r)
+		c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
@@ -147,10 +147,10 @@ func TestHandleRotate(t *testing.T) {
 		db, _ := testDatabaseInstance.NewDatabase(t, nil)
 		db.SetRawDB(envstest.NewFailingDatabase())
 
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
-		c.HandleRotate().ServeHTTP(w, r)
+		c.HandleRotateTokenSigningKey().ServeHTTP(w, r)
 
 		if got, want := w.Code, http.StatusInternalServerError; got != want {
 			t.Errorf("Expected %d to be %d", got, want)

--- a/pkg/controller/rotation/handle_verification_rotate_test.go
+++ b/pkg/controller/rotation/handle_verification_rotate_test.go
@@ -29,7 +29,7 @@ import (
 	"github.com/jinzhu/gorm"
 )
 
-func TestHandleVerificationRotation(t *testing.T) {
+func TestHandleRotateVerificationKeys(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -65,7 +65,7 @@ func TestHandleVerificationRotation(t *testing.T) {
 			VerificationActivationDelay:  2 * time.Second,
 			MinTTL:                       time.Microsecond,
 		}
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		// create the initial signing key version, which will make it active.
 		if _, err := realm.CreateSigningKeyVersion(ctx, db, database.SystemTest); err != nil {
@@ -104,17 +104,17 @@ func TestHandleVerificationRotation(t *testing.T) {
 			MinTTL:                       5 * time.Minute,
 		}
 
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
 
-		c.HandleVerificationRotate().ServeHTTP(w, r)
+		c.HandleRotateVerificationKeys().ServeHTTP(w, r)
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 
 		// again
-		c.HandleVerificationRotate().ServeHTTP(w, r)
+		c.HandleRotateVerificationKeys().ServeHTTP(w, r)
 		if got, want := w.Code, http.StatusOK; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
@@ -131,10 +131,10 @@ func TestHandleVerificationRotation(t *testing.T) {
 			VerificationActivationDelay:  1 * time.Second,
 			MinTTL:                       time.Microsecond,
 		}
-		c := New(cfg, db, keyManagerSigner, h)
+		c := New(cfg, db, keyManagerSigner, nil, h)
 
 		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
-		c.HandleVerificationRotate().ServeHTTP(w, r)
+		c.HandleRotateVerificationKeys().ServeHTTP(w, r)
 
 		if got, want := w.Code, http.StatusInternalServerError; got != want {
 			t.Errorf("Expected %d to be %d", got, want)
@@ -177,7 +177,7 @@ func invokeRotate(ctx context.Context, tb testing.TB, c *Controller) {
 	tb.Helper()
 
 	w, r := envstest.BuildJSONRequest(ctx, tb, http.MethodGet, "/", nil)
-	c.HandleVerificationRotate().ServeHTTP(w, r)
+	c.HandleRotateVerificationKeys().ServeHTTP(w, r)
 
 	if w.Code != http.StatusOK {
 		tb.Fatalf("invoke didn't return success, status: %v", w.Code)

--- a/pkg/controller/rotation/metrics.go
+++ b/pkg/controller/rotation/metrics.go
@@ -29,6 +29,7 @@ const metricPrefix = observability.MetricRoot + "/rotation"
 var (
 	mClaimRequests       = stats.Int64(metricPrefix+"/claim_requests", "The number of rotation claim requests.", stats.UnitDimensionless)
 	mLatencyMs           = stats.Float64(metricPrefix+"/requests", "The number of rotation requests.", stats.UnitMilliseconds)
+	mSecretsSuccess      = stats.Int64(metricPrefix+"/secrets_success", "successful secrets rotation", stats.UnitDimensionless)
 	mTokenSuccess        = stats.Int64(metricPrefix+"/token_success", "successful token rotation", stats.UnitDimensionless)
 	mVerificationSuccess = stats.Int64(metricPrefix+"/verification_success", "successful verification rotation", stats.UnitDimensionless)
 
@@ -56,6 +57,13 @@ func init() {
 			Measure:     mClaimRequests,
 			Description: "The count of the rotation claim requests",
 			TagKeys:     append(observability.CommonTagKeys(), enobs.ResultTagKey),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/secrets/success",
+			Description: "Number of secrets rotation successes",
+			TagKeys:     observability.CommonTagKeys(),
+			Measure:     mSecretsSuccess,
 			Aggregation: view.Count(),
 		},
 		{

--- a/pkg/controller/rotation/rotation.go
+++ b/pkg/controller/rotation/rotation.go
@@ -17,29 +17,33 @@ package rotation
 
 import (
 	"github.com/google/exposure-notifications-server/pkg/keys"
+	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
 )
 
 const (
+	secretsRotationLock      = "secretsRotationLock"
 	tokenRotationLock        = "tokenRotationLock"
 	verificationRotationLock = "verificationRotationLock"
 )
 
 type Controller struct {
-	config     *config.RotationConfig
-	db         *database.Database
-	keyManager keys.SigningKeyManager
-	h          *render.Renderer
+	config        *config.RotationConfig
+	db            *database.Database
+	keyManager    keys.SigningKeyManager
+	secretManager secrets.SecretVersionManager
+	h             *render.Renderer
 }
 
-func New(cfg *config.RotationConfig, db *database.Database, keyManager keys.SigningKeyManager, h *render.Renderer) *Controller {
+func New(cfg *config.RotationConfig, db *database.Database, keyManager keys.SigningKeyManager, secretManager secrets.SecretVersionManager, h *render.Renderer) *Controller {
 	return &Controller{
-		config:     cfg,
-		db:         db,
-		keyManager: keyManager,
-		h:          h,
+		config:        cfg,
+		db:            db,
+		keyManager:    keyManager,
+		secretManager: secretManager,
+		h:             h,
 	}
 }
 

--- a/pkg/controller/rotation/rotation.go
+++ b/pkg/controller/rotation/rotation.go
@@ -24,7 +24,6 @@ import (
 )
 
 const (
-	secretsRotationLock      = "secretsRotationLock"
 	tokenRotationLock        = "tokenRotationLock"
 	verificationRotationLock = "verificationRotationLock"
 )

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -176,8 +176,8 @@ resource "google_cloud_run_service_iam_member" "rotation-invoker" {
   member   = "serviceAccount:${google_service_account.rotation-invoker.email}"
 }
 
-resource "google_cloud_scheduler_job" "rotation-worker" {
-  name             = "rotation-worker"
+resource "google_cloud_scheduler_job" "rotation-worker-token-signing-key" {
+  name             = "rotation-worker-token-signing-key"
   region           = var.cloudscheduler_location
   schedule         = "2,32 * * * *"
   time_zone        = "America/Los_Angeles"
@@ -189,7 +189,7 @@ resource "google_cloud_scheduler_job" "rotation-worker" {
 
   http_target {
     http_method = "GET"
-    uri         = "${google_cloud_run_service.rotation.status.0.url}/"
+    uri         = "${google_cloud_run_service.rotation.status.0.url}/token-signing-key"
     oidc_token {
       audience              = google_cloud_run_service.rotation.status.0.url
       service_account_email = google_service_account.rotation-invoker.email
@@ -203,8 +203,8 @@ resource "google_cloud_scheduler_job" "rotation-worker" {
   ]
 }
 
-resource "google_cloud_scheduler_job" "realm-key-rotation-worker" {
-  name   = "realm-key-rotation-worker"
+resource "google_cloud_scheduler_job" "rotation-worker-realm-verification-keys" {
+  name   = "rotation-worker-realm-verification-keys"
   region = var.cloudscheduler_location
 
   // This schedule is offset from the token rotation schedule.
@@ -218,7 +218,7 @@ resource "google_cloud_scheduler_job" "realm-key-rotation-worker" {
 
   http_target {
     http_method = "GET"
-    uri         = "${google_cloud_run_service.rotation.status.0.url}/realms"
+    uri         = "${google_cloud_run_service.rotation.status.0.url}/realm-verification-keys"
     oidc_token {
       audience              = google_cloud_run_service.rotation.status.0.url
       service_account_email = google_service_account.rotation-invoker.email


### PR DESCRIPTION
This also adds the secrets.SecretVersionManager on the rotation controller but does not use it yet.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Extract key/secret bootstrapping from rotation controller into functions for seeding.
```
