### PR TITLE
Add custom cookiestore codec

### DIFF
--- a/pkg/cookiestore/codec.go
+++ b/pkg/cookiestore/codec.go
@@ -1,0 +1,76 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package cookiestore
+
+import (
+	"fmt"
+
+	"github.com/gorilla/securecookie"
+)
+
+// EntropyFunc is a function that returns the hash and encryption keys. Values
+// at the odd position are the 64-byte hash key. Values at the even position are
+// 32-byte encryption keys.
+type EntropyFunc func() ([][]byte, error)
+
+var _ securecookie.Codec = (*HotCodec)(nil)
+
+// HotCodec is a securecookie Codec that supports hot-loading its hash and
+// encryption keys.
+type HotCodec struct {
+	maxAge      int
+	entropyFunc EntropyFunc
+}
+
+// Encode implements securecookie Codec.
+func (c *HotCodec) Encode(name string, value interface{}) (string, error) {
+	cs, err := c.newSecureCookies()
+	if err != nil {
+		return "", fmt.Errorf("failed to make secure cookie: %w", err)
+	}
+
+	return securecookie.EncodeMulti(name, value, cs...)
+}
+
+// Decode implements securecookie Codec.
+func (c *HotCodec) Decode(name, value string, dst interface{}) error {
+	cs, err := c.newSecureCookies()
+	if err != nil {
+		return fmt.Errorf("failed to make secure cookie: %w", err)
+	}
+	return securecookie.DecodeMulti(name, value, dst, cs...)
+}
+
+// newSecureCookies creates a new collection of secure cookies from the data
+// from the entropy function.
+func (c *HotCodec) newSecureCookies() ([]securecookie.Codec, error) {
+	bs, err := c.entropyFunc()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get cookie hash/encryption keys: %w", err)
+	}
+
+	codecs := make([]securecookie.Codec, len(bs))
+	for i, b := range bs {
+		if got, want := len(b), 64+32; got != want {
+			return nil, fmt.Errorf("expected byte length %d to be %d", got, want)
+		}
+
+		// The first 64 bytes are the HMAC key, the rest are the encryption key.
+		cookie := securecookie.New(b[:64], b[64:])
+		cookie.MaxAge(c.maxAge)
+		codecs[i] = cookie
+	}
+	return codecs, nil
+}

--- a/pkg/cookiestore/cookiestore.go
+++ b/pkg/cookiestore/cookiestore.go
@@ -1,0 +1,46 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package cookiestore provies an abstraction on top of the existing cookie
+// store to handle hot-reloading of cookie HMAC and encryption keys.
+package cookiestore
+
+import (
+	"github.com/gorilla/securecookie"
+	"github.com/gorilla/sessions"
+)
+
+// New returns a new session store
+func New(fn EntropyFunc, opts *sessions.Options) sessions.Store {
+	if opts == nil {
+		opts = new(sessions.Options)
+	}
+	if opts.Path == "" {
+		opts.Path = "/"
+	}
+	if opts.MaxAge <= 0 {
+		opts.MaxAge = 30 * 86400 // 30d
+	}
+
+	codec := &HotCodec{
+		entropyFunc: fn,
+		maxAge:      opts.MaxAge,
+	}
+
+	cs := &sessions.CookieStore{
+		Codecs:  []securecookie.Codec{codec},
+		Options: opts,
+	}
+	return cs
+}


### PR DESCRIPTION
This leverages the same securecookie implementation we already have, but allows for a dynamic codec that sources entropy on _each_ invocation. This will be required for when cookie keys are automatically rotated so apps pick up the new cookie keys without needing a restart.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add custom cookiestore codec for dynamically resolving secrets.
```
