### PR TITLE
Add rotation handlers

### DIFF
--- a/pkg/config/rotation_config.go
+++ b/pkg/config/rotation_config.go
@@ -48,7 +48,51 @@ type RotationConfig struct {
 	// rotation events. This is used to control whether rotation is actually
 	// attempted at the controller layer, independent of the data layer. In
 	// effect, it rate limits the number of rotation requests.
-	MinTTL time.Duration `env:"MIN_TTL, default=5m"`
+	MinTTL time.Duration `env:"MIN_TTL, default=1m"`
+
+	// SecretsParent is the parent directory where secrets should be written. This
+	// is only used when creating new secret versions. On Google Cloud, this
+	// should be "projects/$PROJECT_ID/secrets".
+	SecretsParent string `env:"SECRETS_PARENT, default=projects/$PROJECT_ID/secrets"`
+
+	// SecretActivationTTL is the amount of time a secret should have been
+	// "created" before being moved to the "active" state. This is used to ensure
+	// a secret has fully propagated to all instances before being promoted to
+	// active.
+	//
+	// SecretDestroyTTL is the amount of time a secret should be soft-deleted
+	// before being purged in the upstream secret manager.
+	SecretActivationTTL time.Duration `env:"SECRET_ACTIVATION_TTL, default=30m"`
+	SecretDestroyTTL    time.Duration `env:"SECRET_DESTROY_TTL, default=24h"`
+
+	// CookieKeyMinAge is the TTL at which a new cookie key will be created.
+	// CookieKeyMaxAge is the TTL at which a cookie key is deleted.
+	CookieKeyMinAge time.Duration `env:"COOKIE_KEY_MIN_AGE, default=720h"`  // 30d
+	CookieKeyMaxAge time.Duration `env:"COOKIE_KEY_MAX_AGE, default=1440h"` // 60d
+
+	// APIKeyDatabaseHMACKeyMinAge is the age at which to generate a new HMAC
+	// key for HMACing API keys. Revoking an old HMAC key revokes all API keys
+	// HMACed with that key, so existing values are kept.
+	APIKeyDatabaseHMACKeyMinAge time.Duration `env:"API_KEY_DATABASE_HMAC_KEY_MIN_AGE, default=4320h"` // 180d
+
+	// APIKeySignatureHMACKeyMinAge is the age at which to generate a new HMAC
+	// key for signing API keys. Revoking an old signing key revokes all API keys
+	// signed with that key, so existing values are kept.
+	APIKeySignatureHMACKeyMinAge time.Duration `env:"API_KEY_SIGNATURE_HMAC_KEY_MIN_AGE, default=4320h"` // 180d
+
+	// PhoneNumberDatabaseHMACKeyMinAge is the age at which to generate a new HMAC
+	// key for HMACing phone numbers. PhoneNumberDatabaseHMACKeyMaxAge is the age
+	// at which an HMAC key is deleted (which is 90 days after the last time the
+	// key was used).
+	PhoneNumberDatabaseHMACKeyMinAge time.Duration `env:"PHONE_NUMBER_DATABASE_HMAC_MIN_AGE, default=720h"`  // 30d
+	PhoneNumberDatabaseHMACKeyMaxAge time.Duration `env:"PHONE_NUMBER_DATABASE_HMAC_MAX_AGE, default=2880h"` // 30d + 90d
+
+	// VerificationCodeDatabaseHMACKeyMinAge is the age at which to generate a new
+	// HMAC key for HMACing verification codes in the database.
+	// VerificationCodeDatabaseHMACKeyMaxAge is the age at which the HMAC key can
+	// be safely deleted.
+	VerificationCodeDatabaseHMACKeyMinAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE=4h"`
+	VerificationCodeDatabaseHMACKeyMaxAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE=48h"`
 
 	// TokenSigning is the token signing configuration. This defines the parent
 	// key and common data like issuer, but the individual versions are controlled

--- a/pkg/config/rotation_config.go
+++ b/pkg/config/rotation_config.go
@@ -68,7 +68,7 @@ type RotationConfig struct {
 	// CookieKeyMinAge is the TTL at which a new cookie key will be created.
 	// CookieKeyMaxAge is the TTL at which a cookie key is deleted.
 	CookieKeyMinAge time.Duration `env:"COOKIE_KEY_MIN_AGE, default=720h"`  // 30d
-	CookieKeyMaxAge time.Duration `env:"COOKIE_KEY_MAX_AGE, default=1440h"` // 60d
+	CookieKeyMaxAge time.Duration `env:"COOKIE_KEY_MAX_AGE, default=1488h"` // 60d + 2d
 
 	// APIKeyDatabaseHMACKeyMinAge is the age at which to generate a new HMAC
 	// key for HMACing API keys. Revoking an old HMAC key revokes all API keys
@@ -85,14 +85,14 @@ type RotationConfig struct {
 	// at which an HMAC key is deleted (which is 90 days after the last time the
 	// key was used).
 	PhoneNumberDatabaseHMACKeyMinAge time.Duration `env:"PHONE_NUMBER_DATABASE_HMAC_MIN_AGE, default=720h"`  // 30d
-	PhoneNumberDatabaseHMACKeyMaxAge time.Duration `env:"PHONE_NUMBER_DATABASE_HMAC_MAX_AGE, default=2880h"` // 30d + 90d
+	PhoneNumberDatabaseHMACKeyMaxAge time.Duration `env:"PHONE_NUMBER_DATABASE_HMAC_MAX_AGE, default=2928h"` // 30d + 90d + 2d
 
 	// VerificationCodeDatabaseHMACKeyMinAge is the age at which to generate a new
 	// HMAC key for HMACing verification codes in the database.
 	// VerificationCodeDatabaseHMACKeyMaxAge is the age at which the HMAC key can
 	// be safely deleted.
-	VerificationCodeDatabaseHMACKeyMinAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE=4h"`
-	VerificationCodeDatabaseHMACKeyMaxAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE=48h"`
+	VerificationCodeDatabaseHMACKeyMinAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE=24h"`
+	VerificationCodeDatabaseHMACKeyMaxAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE=72h"` // 2d + 1d
 
 	// TokenSigning is the token signing configuration. This defines the parent
 	// key and common data like issuer, but the individual versions are controlled
@@ -123,8 +123,22 @@ func (c *RotationConfig) Validate() error {
 	fields := []struct {
 		Var  time.Duration
 		Name string
+		Min  time.Duration
 	}{
-		{c.TokenSigningKeyMaxAge, "TOKEN_SIGNING_KEY_MAX_AGE"},
+		{c.MinTTL, "MIN_TTL", 0},
+		{c.SecretActivationTTL, "SECRET_ACTIVATION_TTL", 0},
+		{c.SecretDestroyTTL, "SECRET_DESTROY_TTL", 0},
+		{c.CookieKeyMinAge, "COOKIE_KEY_MIN_AGE", 0},
+		{c.CookieKeyMaxAge, "COOKIE_KEY_MAX_AGE", 0},
+		{c.APIKeyDatabaseHMACKeyMinAge, "API_KEY_DATABASE_HMAC_KEY_MIN_AGE", 0},
+		{c.APIKeySignatureHMACKeyMinAge, "API_KEY_SIGNATURE_HMAC_KEY_MIN_AGE", 0},
+		{c.PhoneNumberDatabaseHMACKeyMinAge, "PHONE_NUMBER_DATABASE_HMAC_MIN_AGE", 0},
+		{c.PhoneNumberDatabaseHMACKeyMaxAge, "PHONE_NUMBER_DATABASE_HMAC_MAX_AGE", 0},
+		{c.VerificationCodeDatabaseHMACKeyMinAge, "VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE", 0},
+		{c.VerificationCodeDatabaseHMACKeyMaxAge, "VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE", 0},
+		{c.VerificationSigningKeyMaxAge, "VERIFICATION_SIGNING_KEY_MAX_AGE", 0},
+		{c.VerificationActivationDelay, "VERIFICATION_ACTIVATION_DELAY", 0},
+		{c.TokenSigningKeyMaxAge, "TOKEN_SIGNING_KEY_MAX_AGE", 0},
 	}
 
 	for _, f := range fields {

--- a/pkg/controller/rotation/handle_secrets_rotate.go
+++ b/pkg/controller/rotation/handle_secrets_rotate.go
@@ -114,7 +114,7 @@ func (c *Controller) RotateSecrets(ctx context.Context) error {
 		minTTL := c.config.CookieKeyMinAge
 		maxTTL := c.config.CookieKeyMaxAge
 		env := "COOKIE_KEYS"
-		if err := c.rotateSecret(ctx, typ, parent, 64+32, minTTL, maxTTL, env); err != nil {
+		if err := c.rotateSecret(ctx, typ, parent, 32+64, minTTL, maxTTL, env); err != nil {
 			merr = multierror.Append(merr, fmt.Errorf("failed to rotate cookie key: %w", err))
 			return
 		}

--- a/pkg/controller/rotation/handle_secrets_rotate.go
+++ b/pkg/controller/rotation/handle_secrets_rotate.go
@@ -1,0 +1,417 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotation
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/base64util"
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/hashicorp/go-multierror"
+	"go.opencensus.io/stats"
+)
+
+// HandleRotateSecrets handles secrets rotation.
+func (c *Controller) HandleRotateSecrets() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("rotation.HandleRotateSecrets")
+		logger.Debugw("starting")
+		defer logger.Debugw("finishing")
+
+		ok, err := c.db.TryLock(ctx, secretsRotationLock, c.config.MinTTL)
+		if err != nil {
+			logger.Errorw("failed to acquire lock", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+		if !ok {
+			logger.Debugw("skipping (too early)")
+			c.h.RenderJSON(w, http.StatusOK, fmt.Errorf("too early"))
+			return
+		}
+
+		// If there are any errors, return them
+		if err := c.RotateSecrets(ctx); err != nil {
+			logger.Errorw("failed to rotate secrets", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		stats.Record(ctx, mSecretsSuccess.M(1))
+		c.h.RenderJSON(w, http.StatusOK, nil)
+	})
+}
+
+// RotateSecrets triggers a secret rotation. It does not take out a lock nor
+// does it return an HTTP response. This is primarily used so other functions
+// can perform initials ecrets bootstrapping.
+func (c *Controller) RotateSecrets(ctx context.Context) error {
+	logger := logging.FromContext(ctx).Named("rotation.RotateSecrets")
+
+	var merr *multierror.Error
+
+	// API key database HMAC keys
+	func() {
+		logger.Debugw("rotating API key database HMAC keys")
+		defer logger.Debugw("finished rotating API key database HMAC keys")
+
+		typ := database.SecretTypeAPIKeyDatabaseHMAC
+		parent := "db-apikey-db-hmac"
+		minTTL := c.config.APIKeyDatabaseHMACKeyMinAge
+		maxTTL := time.Duration(0)
+		env := "DB_APIKEY_DATABASE_KEY"
+		if err := c.rotateSecret(ctx, typ, parent, 128, minTTL, maxTTL, env); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to rotate api key database hmac key: %w", err))
+			return
+		}
+	}()
+
+	// API key signature HMAC keys
+	func() {
+		logger.Debugw("rotating API key signature HMAC keys")
+		defer logger.Debugw("finished rotating API key signature HMAC keys")
+
+		typ := database.SecretTypeAPIKeySignatureHMAC
+		parent := "db-apikey-sig-hmac"
+		minTTL := c.config.APIKeySignatureHMACKeyMinAge
+		maxTTL := time.Duration(0)
+		env := "DB_APIKEY_SIGNATURE_KEY"
+		if err := c.rotateSecret(ctx, typ, parent, 128, minTTL, maxTTL, env); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to rotate api key signature hmac key: %w", err))
+			return
+		}
+	}()
+
+	// Cookie key rotation
+	func() {
+		logger.Debugw("rotating cookie keys")
+		defer logger.Debugw("finished rotating cookie keys")
+
+		typ := database.SecretTypeCookieKeys
+		parent := "cookie-keys"
+		minTTL := c.config.CookieKeyMinAge
+		maxTTL := c.config.CookieKeyMaxAge
+		env := "COOKIE_KEYS"
+		if err := c.rotateSecret(ctx, typ, parent, 64+32, minTTL, maxTTL, env); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to rotate cookie key: %w", err))
+			return
+		}
+	}()
+
+	// Phone number database HMAC
+	func() {
+		logger.Debugw("rotating phone number database HMAC keys")
+		defer logger.Debugw("finished rotating phone number database HMAC keys")
+
+		typ := database.SecretTypePhoneNumberDatabaseHMAC
+		parent := "db-phone-number-hmac"
+		minTTL := c.config.PhoneNumberDatabaseHMACKeyMinAge
+		maxTTL := c.config.PhoneNumberDatabaseHMACKeyMaxAge
+		env := "DB_PHONE_HMAC_KEY"
+		if err := c.rotateSecret(ctx, typ, parent, 128, minTTL, maxTTL, env); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to rotate phone number database hmac key: %w", err))
+			return
+		}
+	}()
+
+	// Verification code database HMAC
+	func() {
+		logger.Debugw("rotating verification code database HMAC keys")
+		defer logger.Debugw("finished rotating verification code database HMAC keys")
+
+		typ := database.SecretTypeVerificationCodeDatabaseHMAC
+		parent := "db-verification-code-hmac"
+		minTTL := c.config.VerificationCodeDatabaseHMACKeyMinAge
+		maxTTL := c.config.VerificationCodeDatabaseHMACKeyMaxAge
+		env := "DB_VERIFICATION_CODE_DATABASE_KEY"
+		if err := c.rotateSecret(ctx, typ, parent, 128, minTTL, maxTTL, env); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to rotate verification code database hmac key: %w", err))
+			return
+		}
+	}()
+
+	return merr.ErrorOrNil()
+}
+
+// rotateAPIKeyHMAC rotates the key used to HMAC API keys stored in the
+// database.
+func (c *Controller) rotateSecret(ctx context.Context, typ database.SecretType, parent string, numBytes int, minTTL, maxTTL time.Duration, env string) error {
+	now := time.Now().UTC()
+
+	logger := logging.FromContext(ctx).Named("rotateSecret").
+		With("type", typ).
+		With("parent", parent).
+		With("num_bytes", numBytes).
+		With("min_ttl", minTTL).
+		With("max_ttl", maxTTL)
+
+	existing, err := c.db.ListSecretsForType(typ)
+	if err != nil {
+		return fmt.Errorf("failed to lookup existing secrets: %w", err)
+	}
+
+	// If the secret exist in the environment, import.
+	// TODO(sethvargo): remove after 0.28.0+
+	if val := strings.TrimSpace(os.Getenv(env)); len(existing) == 0 && val != "" {
+		var mutators []importMutatorFunc
+
+		if typ == database.SecretTypeCookieKeys {
+			// Hack, but cookie keys are special
+			mutators = append(mutators, mutateCookieKeysSecrets())
+		}
+
+		created, err := c.importExistingSecretFromEnv(ctx, typ, parent, env, val, mutators...)
+		if err != nil {
+			return fmt.Errorf("failed to import secrets from environment: %w", err)
+		}
+		existing = append(existing, created...)
+	}
+
+	// If there is no latest secret, or if the latest secret has existed for
+	// longer than the minimum age, create a new one.
+	if minTTL > 0 && (len(existing) == 0 || now.Sub(existing[0].CreatedAt) > minTTL) {
+		logger.Infow("latest secret does not exist or is older than min_ttl, creating new secret",
+			"secret", existing)
+
+		ref, err := c.createUpstreamSecretVersion(ctx, parent, numBytes)
+		if err != nil {
+			return fmt.Errorf("failed to create new secret version: %w", err)
+		}
+
+		secret := &database.Secret{
+			Type:      typ,
+			Reference: ref,
+			Active:    len(existing) == 0,
+		}
+		if err := c.db.SaveSecret(secret, RotationActor); err != nil {
+			return fmt.Errorf("failed to save new secret %s: %w", ref, err)
+		}
+		existing = append(existing, secret)
+	}
+
+	for _, secret := range existing {
+		// Activate any secrets that are ready to be activated. Please don't try to
+		// optimize this. Yes, this could be reduced into a single SQL statement,
+		// but we want to ensure the logging and AuditLog exist for debugging.
+		if !secret.Active && secret.CreatedAt == secret.UpdatedAt && now.Sub(secret.CreatedAt) > c.config.SecretActivationTTL {
+			logger.Infow("activating secret", "secret", secret)
+
+			secret.Active = true
+			if err := c.db.SaveSecret(secret, RotationActor); err != nil {
+				return fmt.Errorf("failed to activate secret %d: %w", secret.ID, err)
+			}
+		}
+
+		// If a maximum TTL was given, check for expirations.
+		if maxTTL > 0 {
+			// If the secret has existed for longer than the maximum TTL, deactivate
+			// it. This will move it to the end of the list. For HMAC-style secrets,
+			// this means it will still be available to validate values as the cache
+			// updates, but will not be used to HMAC new values.
+			if secret.Active && now.Sub(secret.CreatedAt) > maxTTL {
+				logger.Infow("deactivating expired secret", "secret", secret)
+
+				secret.Active = false
+				if err := c.db.SaveSecret(secret, RotationActor); err != nil {
+					return fmt.Errorf("failed to deactivate secret %d: %w", secret.ID, err)
+				}
+			}
+
+			// If the secret is inactive, experienced an update, and the time since
+			// that update has exceeded the activation TTL, mark the secret for
+			// deletion.
+			//
+			// The only mutable field is "Active", so if CreatedAt and UpdatedAt have
+			// diverged, it means the secret was previously activated and is now
+			// deactivated.
+			//
+			// Without this check, a secret with a low TTL could be marked for
+			// deletion before activation.
+			if !secret.Active && secret.CreatedAt != secret.UpdatedAt && now.Sub(secret.UpdatedAt) > c.config.SecretActivationTTL {
+				logger.Infow("marking secret for deletion", "secret", secret)
+
+				if err := c.db.DeleteSecret(secret, RotationActor); err != nil {
+					return fmt.Errorf("failed to mark secret %d for deletion: %w", secret.ID, err)
+				}
+			}
+		}
+	}
+
+	// Hard delete any secrets that are marked for deletion and have exceeded
+	// the destroy TTL.
+	toDelete, err := c.db.ListSecretsForType(typ, database.Unscoped())
+	if err != nil {
+		return fmt.Errorf("failed to list unscoped secrets for type %s: %w", typ, err)
+	}
+	for _, secret := range toDelete {
+		if secret.DeletedAt != nil && now.Sub(*secret.DeletedAt) > c.config.SecretDestroyTTL {
+			logger.Infow("purging expired secret", "secret", secret)
+
+			if err := c.destroyUpstreamSecretVresion(ctx, secret.Reference); err != nil {
+				return fmt.Errorf("failed to destroy %s: %w", secret.Reference, err)
+			}
+
+			if err := c.db.PurgeSecret(secret, RotationActor); err != nil {
+				return fmt.Errorf("failed to purge secret %d: %w", secret.ID, err)
+			}
+		}
+	}
+
+	return nil
+}
+
+// createUpstreamSecretVersion creates an upstream secret version in the secret
+// manager.
+func (c *Controller) createUpstreamSecretVersion(ctx context.Context, name string, numBytes int) (string, error) {
+	b, err := project.RandomBytes(numBytes)
+	if err != nil {
+		return "", fmt.Errorf("failed to generate %d, bytes for secret: %w", numBytes, err)
+	}
+
+	pth := path.Join(c.config.SecretsParent, name)
+	version, err := c.secretManager.CreateSecretVersion(ctx, pth, b)
+	if err != nil {
+		return "", fmt.Errorf("failed to add secret version: %w", err)
+	}
+	return version, nil
+}
+
+func (c *Controller) destroyUpstreamSecretVresion(ctx context.Context, name string) error {
+	if err := c.secretManager.DestroySecretVersion(ctx, name); err != nil {
+		return fmt.Errorf("failed to destroy upstream secret version: %w", err)
+	}
+	return nil
+}
+
+// importMutatorFunc mutates raw bytes resolved secrets.
+type importMutatorFunc func([][]byte) ([][]byte, error)
+
+// importExistingSecretFromEnv downloads and parses v1 secrets into v2 secrets.
+func (c *Controller) importExistingSecretFromEnv(ctx context.Context, typ database.SecretType, secretName, envvar, envval string, mutators ...importMutatorFunc) ([]*database.Secret, error) {
+	logger := logging.FromContext(ctx).Named("importExistingSecretFromEnv").
+		With("type", typ).
+		With("env", envvar).
+		With("secretName", secretName)
+
+	now := time.Now().UTC()
+
+	// allSecretsBytes is the ordered list of all secrets in bytes format.
+	allSecretsBytes := make([][]byte, 0, 4)
+
+	// Iterate over each secret in the envvar, separated by commas. This collects
+	// the raw secret values as bytes.
+	parts := strings.Split(envval, ",")
+	for _, part := range parts {
+		// These should be in the form secret://...?target=file. Transform them
+		// back into their normal form.
+		ref := strings.TrimSpace(part)
+		if !strings.HasPrefix(ref, "secret://") {
+			continue
+		}
+		ref = strings.TrimPrefix(ref, "secret://")
+		ref = strings.TrimSuffix(ref, "?target=file")
+
+		logger.Infow("importing secret value", "ref", ref)
+
+		// Get the initial secret value.
+		val, err := c.secretManager.GetSecretValue(ctx, ref)
+		if err != nil {
+			return nil, fmt.Errorf("failed to access initial secret %s: %w", ref, err)
+		}
+
+		// v1 secrets are base64-encoded separated by commas.
+		insideParts := strings.Split(val, ",")
+		for i, insidePart := range insideParts {
+			dec, err := base64util.DecodeString(insidePart)
+			if err != nil {
+				return nil, fmt.Errorf("failed to decode initial secret %s at %d: %w", ref, i, err)
+			}
+			allSecretsBytes = append(allSecretsBytes, dec)
+		}
+	}
+
+	// Apply any mutations.
+	for _, fn := range mutators {
+		var err error
+		allSecretsBytes, err = fn(allSecretsBytes)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	// Now that we have all bytes, iterate and create the secrets.
+	orderedRefs := make([]string, 0, len(allSecretsBytes))
+	for _, b := range allSecretsBytes {
+		parent := path.Join(c.config.SecretsParent, secretName)
+		version, err := c.secretManager.CreateSecretVersion(ctx, parent, b)
+		if err != nil {
+			return nil, fmt.Errorf("failed to add secret version to %s: %w", parent, err)
+		}
+		orderedRefs = append(orderedRefs, version)
+	}
+
+	// Now that all secrets are created upstream, create the database records.
+	created := make([]*database.Secret, 0, len(orderedRefs))
+	for i, ref := range orderedRefs {
+		logger.Infow("create secret reference in database", "ref", ref)
+
+		secret := &database.Secret{
+			Type:      typ,
+			Reference: ref,
+			Active:    true,
+
+			CreatedAt: now.Add(time.Duration(-i) * time.Hour),
+			UpdatedAt: now.Add(time.Duration(-i) * time.Hour),
+		}
+		if err := c.db.SaveSecret(secret, RotationActor); err != nil {
+			return nil, fmt.Errorf("failed to save secret ref %s in database: %w", ref, err)
+		}
+		created = append(created, secret)
+	}
+
+	return created, nil
+}
+
+// mutateCookieKeysSecrets handles the special case of importing cookie keys.
+func mutateCookieKeysSecrets() importMutatorFunc {
+	return func(in [][]byte) ([][]byte, error) {
+		// Sanity check even number of elements.
+		if l := len(in); l%2 != 0 {
+			return nil, fmt.Errorf("invalid number of cookie secret bytes (%d), expected even", l)
+		}
+
+		// Cookie keys are currently special as separate secrets, but v2 cookie keys
+		// are stored in the same secret. This concatenates each HMAC key with its
+		// encryption key to be stored in the same secret moving forward.
+		out := make([][]byte, 0, len(in)/2)
+		for i := 0; i < len(in); i += 2 {
+			b := make([]byte, 0, len(in[i])+len(in[i+1]))
+			b = append(b, in[i]...)
+			b = append(b, in[i+1]...)
+			out = append(out, b)
+		}
+		return out, nil
+	}
+}

--- a/pkg/controller/rotation/handle_secrets_rotate_test.go
+++ b/pkg/controller/rotation/handle_secrets_rotate_test.go
@@ -1,0 +1,451 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package rotation
+
+import (
+	"encoding/base64"
+	"fmt"
+	"net/http"
+	"reflect"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/secrets"
+	"github.com/google/exposure-notifications-verification-server/internal/envstest"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+func TestHandleRotateSecrets(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	secretManager, err := secrets.NewInMemory(ctx, &secrets.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretManagerTyp, ok := secretManager.(secrets.SecretVersionManager)
+	if !ok {
+		t.Fatal("secret manager cannot manage versions")
+	}
+
+	h, err := render.New(ctx, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("too_early", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		cfg := &config.RotationConfig{
+			MinTTL: 5 * time.Minute,
+		}
+
+		c := New(cfg, db, nil, secretManagerTyp, h)
+
+		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
+
+		c.HandleRotateSecrets().ServeHTTP(w, r)
+		if got, want := w.Code, http.StatusOK; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
+
+		// again
+		c.HandleRotateSecrets().ServeHTTP(w, r)
+		if got, want := w.Code, http.StatusOK; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
+	})
+
+	t.Run("database_error", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+		db.SetRawDB(envstest.NewFailingDatabase())
+
+		cfg := &config.RotationConfig{}
+
+		c := New(cfg, db, nil, secretManagerTyp, h)
+
+		w, r := envstest.BuildJSONRequest(ctx, t, http.MethodGet, "/", nil)
+		c.HandleRotateSecrets().ServeHTTP(w, r)
+
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
+	})
+}
+
+func TestRotateSecret(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	secretManager, err := secrets.NewInMemory(ctx, &secrets.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretManagerTyp, ok := secretManager.(secrets.SecretVersionManager)
+	if !ok {
+		t.Fatal("secret manager cannot manage versions")
+	}
+
+	h, err := render.New(ctx, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.RotationConfig{
+		SecretsParent:       "test/rotation",
+		SecretActivationTTL: 500 * time.Millisecond,
+		SecretDestroyTTL:    500 * time.Millisecond,
+	}
+
+	t.Run("rotates", func(t *testing.T) {
+		t.Parallel()
+
+		typ := database.SecretTypeCookieKeys
+		parent := "my-secret"
+		numBytes := 96
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		c := New(cfg, db, nil, secretManagerTyp, h)
+
+		// Clear secrets created by bootstrap
+		if err := db.RawDB().Unscoped().Delete(&database.Secret{}).Error; err != nil {
+			t.Fatal(err)
+		}
+
+		var initialSecret *database.Secret
+
+		// No secrets, so initial value should be created and active.
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 1*time.Nanosecond, 0, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 1; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			initialSecret = secrets[0]
+			if got, want := initialSecret.Active, true; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, initialSecret)
+			}
+		}
+
+		// Rotating again where minTTL has not elapsed does nothing.
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 5*time.Second, 0, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 1; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+			if got, want := secrets[0].Active, true; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[0])
+			}
+		}
+
+		// Rotate again where minTTL has elapsed generates a new secret.
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 1*time.Nanosecond, 0, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 2; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			// The activation TTL has not elapsed, so the first secret should still be
+			// active, but the newly-created secret should be inactive.
+			if got, want := secrets[0].Active, true; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[0])
+			}
+			if got, want := secrets[1].Active, false; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[1])
+			}
+		}
+
+		// Wait for activation delay, all secrets should be active.
+		time.Sleep(cfg.SecretActivationTTL + 100*time.Millisecond)
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 0, 0, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 2; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			// The activation TTL has elapsed, so both should be active.
+			if got, want := secrets[0].Active, true; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[0])
+			}
+			if got, want := secrets[1].Active, true; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[1])
+			}
+		}
+
+		// If the maxTTL has passed, secrets should be inactive.
+		{
+			// Use a no minTTL because we don't want to create a new version.
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 0, 1*time.Nanosecond, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 2; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			// The maxTTL has elapsed, so both should be inactive.
+			if got, want := secrets[0].Active, false; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[0])
+			}
+			if got, want := secrets[1].Active, false; got != want {
+				t.Errorf("expected %t to be %t: %#v", got, want, secrets[1])
+			}
+		}
+
+		// After a secret has been moved to inactive for more than the activation
+		// delay, it should be marked for deletion.
+		time.Sleep(cfg.SecretActivationTTL + 100*time.Millisecond)
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 0, 1*time.Nanosecond, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets()
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 0; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			// Secrets should still exist in secret manager though.
+			if _, err := secretManagerTyp.GetSecretValue(ctx, initialSecret.Reference); err != nil {
+				t.Fatal(err)
+			}
+		}
+
+		// After a secret has been deleted for more than the destroy TTL, purge it.
+		time.Sleep(cfg.SecretDestroyTTL + 100*time.Millisecond)
+		{
+			if err := c.rotateSecret(ctx, typ, parent, numBytes, 0, 0, ""); err != nil {
+				t.Fatal(err)
+			}
+			secrets, err := db.ListSecrets(database.Unscoped())
+			if err != nil {
+				t.Fatal(err)
+			}
+			if got, want := len(secrets), 0; got != want {
+				t.Errorf("expected %d secret, got %d: %#v", want, got, secrets)
+			}
+
+			// Secrets should still exist in secret manager though.
+			if _, err := secretManagerTyp.GetSecretValue(ctx, initialSecret.Reference); err == nil {
+				t.Errorf("expected error, got %#v", err)
+			}
+		}
+	})
+}
+
+func TestImportExistingSecretFromEnv(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	h, err := render.New(ctx, nil, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cfg := &config.RotationConfig{
+		SecretsParent: "test/rotation",
+	}
+
+	secretManager, err := secrets.NewInMemory(ctx, &secrets.Config{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	secretManagerTyp, ok := secretManager.(secrets.SecretVersionManager)
+	if !ok {
+		t.Fatal("secret manager cannot manage versions")
+	}
+	notBase64Ref, err := secretManagerTyp.CreateSecretVersion(ctx, "not-b64",
+		[]byte("%"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	singleValueRef, err := secretManagerTyp.CreateSecretVersion(ctx, "single-value",
+		[]byte(base64.StdEncoding.EncodeToString([]byte("hello"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+	multiValueRef, err := secretManagerTyp.CreateSecretVersion(ctx, "multi-value",
+		[]byte(base64.StdEncoding.EncodeToString([]byte("hello"))+","+base64.StdEncoding.EncodeToString([]byte("world"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	cases := []struct {
+		name     string
+		envval   string
+		mutators []importMutatorFunc
+		exp      int
+		err      string
+	}{
+		{
+			name:   "empty",
+			envval: "",
+		},
+		{
+			name:   "missing_secret",
+			envval: "secret://foo",
+			err:    "failed to access initial secret",
+		},
+		{
+			name:   "secret_not_base64",
+			envval: fmt.Sprintf("secret://%s", notBase64Ref),
+			err:    "failed to decode initial secret",
+		},
+		{
+			name:   "single_value",
+			envval: fmt.Sprintf("secret://%s", singleValueRef),
+			exp:    1,
+		},
+		{
+			name:   "multi_value",
+			envval: fmt.Sprintf("secret://%s", multiValueRef),
+			exp:    2,
+		},
+		{
+			name:   "multi_env_value",
+			envval: fmt.Sprintf("secret://%s,secret://%s?target=file", singleValueRef, multiValueRef),
+			exp:    3,
+		},
+		{
+			// The cookie mutator should combine 2 values into 1.
+			name:     "cookie_mutator",
+			envval:   fmt.Sprintf("secret://%s,secret://%s", multiValueRef, multiValueRef),
+			mutators: []importMutatorFunc{mutateCookieKeysSecrets()},
+			exp:      2,
+		},
+		{
+			name:     "cookie_mutator_odd",
+			envval:   fmt.Sprintf("secret://%s,secret://%s", singleValueRef, multiValueRef),
+			mutators: []importMutatorFunc{mutateCookieKeysSecrets()},
+			err:      "invalid number of cookie secret bytes (3)",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			db, _ := testDatabaseInstance.NewDatabase(t, nil)
+			c := New(cfg, db, nil, secretManagerTyp, h)
+
+			typ := database.SecretTypeCookieKeys
+			result, err := c.importExistingSecretFromEnv(ctx, typ, tc.name, "env", tc.envval, tc.mutators...)
+			if err != nil {
+				if tc.err == "" {
+					t.Fatal(err)
+				}
+
+				if got, want := err.Error(), tc.err; !strings.Contains(got, want) {
+					t.Errorf("expected %q to contain %q", got, want)
+				}
+			} else {
+				if tc.err != "" {
+					t.Fatalf("expected error %q, got nothing", tc.err)
+				}
+			}
+
+			if got, want := len(result), tc.exp; got != want {
+				t.Errorf("expected %d secrets, got %d: %#v", want, got, result)
+			}
+		})
+	}
+}
+
+func TestMutateCookieKeysSecrets(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name string
+		in   [][]byte
+		out  [][]byte
+		err  bool
+	}{
+		{
+			name: "empty",
+			in:   nil,
+			out:  [][]byte{},
+		},
+		{
+			name: "odd",
+			in:   [][]byte{[]byte("hi")},
+			err:  true,
+		},
+		{
+			name: "merges",
+			in:   [][]byte{[]byte("hello"), []byte("world")},
+			out:  [][]byte{[]byte("helloworld")},
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			got, err := mutateCookieKeysSecrets()(tc.in)
+			if (err != nil) != tc.err {
+				t.Fatal(err)
+			}
+
+			if got, want := got, tc.out; !reflect.DeepEqual(got, want) {
+				t.Errorf("expected %#v to be %#v", got, want)
+			}
+		})
+	}
+}

--- a/pkg/controller/rotation/rotation.go
+++ b/pkg/controller/rotation/rotation.go
@@ -24,6 +24,7 @@ import (
 )
 
 const (
+	secretsRotationLock      = "secretsRotationLock"
 	tokenRotationLock        = "tokenRotationLock"
 	verificationRotationLock = "verificationRotationLock"
 )

--- a/pkg/database/user_report_test.go
+++ b/pkg/database/user_report_test.go
@@ -106,10 +106,11 @@ func TestFindUserReport(t *testing.T) {
 			t.Parallel()
 
 			userReport, err := db.NewUserReport(tc.phone, []byte{0}, true)
-			userReport.Nonce = tc.nonce // override the encoding from NewUserReport for testing errors.
 			if err != nil {
 				t.Fatalf("error creating user report: %v", err)
 			}
+
+			userReport.Nonce = tc.nonce // override the encoding from NewUserReport for testing errors.
 			err = db.db.Save(userReport).Error
 			errcmp.MustMatch(t, err, tc.want)
 			if diff := cmp.Diff(tc.fieldErrors, userReport.ErrorMessages()); diff != "" {

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -57,11 +57,11 @@ locals {
     # modeler runs every 4h, alert after 2 failures
     "modeler" = { metric = "modeler/success", window = 8 * local.hour + 10 * local.minute },
 
-    # realm-key-rotation runs every 15m, alert after 2 failures
-    "realm-key-rotation" = { metric = "rotation/verification/success", window = 30 * local.minute + 5 * local.minute }
+    # rotation-token runs every 30m, alert after 2 failures
+    "rotation-token" = { metric = "rotation/token/success", window = 60 * local.minute + 10 * local.minute }
 
-    # rotation runs every 30m, alert after 2 failures
-    "rotation" = { metric = "rotation/token/success", window = 60 * local.minute + 10 * local.minute }
+    # rotation-realm-key runs every 15m, alert after 2 failures
+    "rotation-realm-key" = { metric = "rotation/verification/success", window = 30 * local.minute + 5 * local.minute }
 
     # stats-puller runs every 15m, alert after 2 failures
     "stats-puller" = { metric = "statspuller/success", window = 30 * local.minute + 5 * local.minute }

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -82,6 +82,10 @@ locals {
     RATE_LIMIT_REDIS_PASSWORD = var.redis_enable_auth ? "secret://${google_secret_manager_secret_version.redis-auth.id}" : ""
   }
 
+  rotation_config = {
+    SECRETS_PARENT = "projects/${var.project}/secrets"
+  }
+
   signing_config = {
     CERTIFICATE_KEY_MANAGER = "GOOGLE_CLOUD_KMS"
     CERTIFICATE_SIGNING_KEY = trimprefix(data.google_kms_crypto_key_version.certificate-signer-version.id, "//cloudkms.googleapis.com/v1/")

--- a/terraform/sessions.tf
+++ b/terraform/sessions.tf
@@ -14,8 +14,21 @@
 
 locals {
   session_secrets = [
+    google_secret_manager_secret.cookie-keys,
     google_secret_manager_secret.cookie-hmac-key.id,
     google_secret_manager_secret.cookie-encryption-key.id,
+  ]
+}
+
+resource "google_secret_manager_secret" "cookie-keys" {
+  secret_id = "cookie-keys"
+
+  replication {
+    automatic = true
+  }
+
+  depends_on = [
+    google_project_service.services["secretmanager.googleapis.com"],
   ]
 }
 

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -623,6 +623,10 @@ func createSecrets(ctx context.Context, db *database.Database, keyManager keys.S
 
 	rotationController := rotation.New(cfg, db, keyManager, secretManager, h)
 
+	if err := rotationController.RotateSecrets(ctx); err != nil {
+		return fmt.Errorf("failed to create initial secrets: %w", err)
+	}
+
 	if err := rotationController.RotateTokenSigningKey(ctx); err != nil {
 		return fmt.Errorf("failed to create initial token signing key: %w", err)
 	}


### PR DESCRIPTION
This adds the rotation handlers and required Terraform configuration. It does not actually mount the path to be invoked, nor does it set up the Cloud Scheduler job. This is the core rotation logic, so please review closely.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add rotation handling logic.
```
