### PR TITLE
Add automated secrets rotation

### DIFF
--- a/cmd/rotation/main.go
+++ b/cmd/rotation/main.go
@@ -141,6 +141,7 @@ func realMain(ctx context.Context) error {
 	rotationController := rotation.New(cfg, db, tokenSignerTyp, secretManagerTyp, h)
 	r.Handle("/token-signing-key", rotationController.HandleRotateTokenSigningKey()).Methods(http.MethodGet)
 	r.Handle("/realm-verification-keys", rotationController.HandleRotateVerificationKeys()).Methods(http.MethodGet)
+	r.Handle("/secrets", rotationController.HandleRotateSecrets()).Methods(http.MethodGet)
 
 	srv, err := server.New(cfg.Port)
 	if err != nil {

--- a/docs/development.md
+++ b/docs/development.md
@@ -75,14 +75,6 @@ represent best practices.
     # Disable local observability.
     export OBSERVABILITY_EXPORTER="NOOP"
 
-    # Configure cookie encryption, the first is 64 bytes, the second is 32.
-    # Create your own values with:
-    #
-    #     openssl rand -base64 NUM
-    #
-    # where NUM is 32 or 64, respectively.
-    export COOKIE_KEYS="ARLaFwAqBGIkm5pLjAveJuahtCnX2NLoAUz2kCZKrScUaUkEaxHSvJLVYb5yAPCc441Cho5n5yp8jdEmy6hyig==,RLjcRZeqc07s6dh3OK4CM1POjHDZHC+usNU1w/XNTjM="
-
     # Configure cache and cache HMAC. Create your own values with:
     #
     #     openssl rand -base64 128
@@ -124,15 +116,6 @@ represent best practices.
     # your own encryption key with `openssl rand -base64 64`.
     export KEY_MANAGER="IN_MEMORY"
     export DB_ENCRYPTION_KEY="O04ZjG4WuoceRd0k2pTqDN0r8omr6sbFL0U3T5b12Lo="
-
-    # Database HMAC keys - these should be at least 64 bytes, preferably 128.
-    # Create your own with:
-    #
-    #     openssl rand -base64 128
-    #
-    export DB_APIKEY_DATABASE_KEY="RlV/RBEt0lDeK54r8U9Zi7EDFZid3fiKM2HFgjR9sZGMb+duuQomjGdNKYnzrNyKgeTBcc1V4qVs6fBrN6IFTLbgkp/u52MGhSooAQI4EuZ6JFuyxQBeu54Ia3mihF111BMcCWpHDg2MAh8k8f669plEQaqoQFg3GThP/Lx1OY0="
-    export DB_APIKEY_SIGNATURE_KEY="HFeglmupbtv/I2X04OQRl1V7mcvfAXuv8XtmIFYV6aYsPuwQVFtXDlfFrjouYT2Z6kYln7B90RcutHJNjpPDRkyBQ28HtWmid3dr0tpJ1KiiK5NGG7JS9mU8fCvEYklw5RV+1f8qN13nWzHpW8/RQw9rR/vQGy90yL5/aydBuVA="
-    export DB_VERIFICATION_CODE_DATABASE_KEY="YEN4+tnuf1DzQPryRzrPVilqT0Q2TO8IIg3C8prvXWGAaoABOWACl79hS40OneuaU8GsQHwhJ13wM2A5ooyOq+uqxCjrqVJZZXPU5xzl/6USEYAp4z2b0ZYrfkx2SRk1o9HfFi1RMqpaBf1TRIbsNOK9hNRG3nS2It49y6mR1ho="
 
     # Configure database pooling.
     export DB_POOL_MIN_CONNS="2"

--- a/docs/production.md
+++ b/docs/production.md
@@ -134,59 +134,18 @@ This section describes how to rotate secrets in the system.
 
 ### Cookie keys
 
-**Recommended frequency:** 30 days, on breach
+**Recommended frequency:** automatic
 
-The cookie keys are an array. The items at odd indicies are HMAC keys and the
-items at even indicies are encryption keys. The HMAC key should be 64 bytes and
-the encryption key should be 32. Even though the array is flat, each even/odd
-pairing is actually a tuple:
-
-```text
-[<hmac_key_1>, <encryption_key_1>, <hmac_key_2>, <encryption_key_2>]
-```
-
-Each key is supplied to this system as base64, for example:
-
-```sh
-# "<base64_hmac_key_1>,<base64_encryption_key_1>"
-export COOKIE_KEYS="ARLaFwAqBGIkm5pLjAveJuahtCnX2NLoAUz2kCZKrScUaUkEaxHSvJLVYb5yAPCc441Cho5n5yp8jdEmy6hyig==,RLjcRZeqc07s6dh3OK4CM1POjHDZHC+usNU1w/XNTjM="
-```
-
-To rotate the cookie keys, generate two new keys of the correct lengths as
-specificed above and insert them **into the front** of the array. **Do not
-remove the existing values from the array**, as doing so will invalidate all
-existing sessions.
-
-```text
-[<NEW_HMAC_KEY>, <NEW_ENCRYPTION_KEY>, <hmac_key_1>, <encryption_key_1>, <hmac_key_2>, <encryption_key_2>]
-```
-
-Just as before, the new values should be base64-encoded:
-
-```sh
-# "<base64_hmac_key_1>,<base64_encryption_key_1>,<base64_hmac_key_2>,<base64_encryption_key_2>"
-export COOKIE_KEYS="c8+OD0vpvT/FrtGAtHc1nYhtkYMhjEEHCLgzuIiKJbskAbMI7bJxSnlBMKmc2AQmo8QVAViJuKoopuSuXE7tYw==,KRN9OK/lcs/uBWKQ2/1I0g9KR/iL3/MHuCn6esI02fs=,ARLaFwAqBGIkm5pLjAveJuahtCnX2NLoAUz2kCZKrScUaUkEaxHSvJLVYb5yAPCc441Cho5n5yp8jdEmy6hyig==,RLjcRZeqc07s6dh3OK4CM1POjHDZHC+usNU1w/XNTjM="
-```
-
-Upon deploying, all _new_ sessions will use these new keys. Old sessions will be
-automatically upgraded on the next visit. After a period of time that you deem
-acceptable (e.g. 30d), you can remove the older keys from the end of the array.
-
-You can use `openssl` or similar tooling to generate the secret. Note that this
-is **not** preferred since it requires a human to see the plaintext secret.
-
-```sh
-openssl rand -base64 64 | tr -d "\n" # or 32
-```
-
-If you are using a secret manager, put this value in the secret manager and
-provide its _reference_ in the environment. If you are not using a secret
-manager, provide this value directly in the environment.
+Cookie keys are automatically rotated every 30 days. The rotation gracefully
+allows the old secret to phase out.
 
 
 ### Database encryption keys
 
 **Recommend frequency:** 90 days, on breach
+
+**If you are using Google Cloud KMS with the provided Terraform configurations,
+this rotation happens automatically!**
 
 These keys control application-layer encryption of secrets before they are
 stored in the database. For example, this key encrypts Twilio credentials so
@@ -202,94 +161,38 @@ manager.
 While unlikely, this may require you to update the `DB_ENCRYPTION_KEY`
 environment variable.
 
-**If you are using Google Cloud KMS with the provided Terraform configurations,
-this rotation happens automatically!**
-
 
 ### API Key signature HMAC keys
 
-**Recommended frequency:** 90 days
+**Recommended frequency:** automatic
 
 This key is used as the HMAC secret when signing API keys. API keys are signed
-and verified using this value. Like cookies, it accepts an array of values. The
-first item in the array is used to sign all new API keys, but all remaining
-values are still accepted as valid. These keys should be at least 64 bytes, but 128 is recommended.
+and verified using this value.
 
-To generate a new key:
-
-```sh
-openssl rand -base64 128 | tr -d "\n"
-```
-
-Insert this new value **into the front** of the `DB_APIKEY_SIGNATURE_KEY`
-environment variable:
-
-```sh
-DB_APIKEY_SIGNATURE_KEY="gSEGlr482MSTm0eGRm2VvS86iQin3+/+80ALBkKKBYgu2EJyhGkvi8BULeFQDW/qZp2y3IbKY0MUTqioG7InBZdCkisYjr8UNuA+PONxMSaw/x8m+CXF28qb2WF0OGYQIPgbOdQ7cChG3Ox5AQgWFmNwyr486lTxSM8TE7dfCfU=,oXrnYzt6MXKBB/+zZWTvkUABW8SSCAFv5Mc475sSVPGBqCf1hWvv/VmByFj/5457Ho0AVbDUiCpKnjW2Q8ZlxqRo5dJyRifwvmW2JYcpxe+Ff/d+tb2x+TwlzqEzrKVatEWX4cmMG7ZP6B1oTCw/uZPTDhgB3lerXVIBTxdAaQc="
-```
-
-Note: Removing any of the keys from this list will invalidate API keys signed by
-that version.
-
-If you are using Terraform, increment the `db_apikey_sig_hmac_count` by 1.
+Removing any of the keys from this list will invalidate API keys signed by that
+version.
 
 
 ### API Key database HMAC keys
 
-**Recommended frequency:** 90 days
+**Recommended frequency:** automatic
 
 This key is used as the HMAC secret when saving hashed API keys in the database.
-Like cookies, it accepts an array of values. The first item in the array is used
-to HMAC all new API keys, but all remaining values are still accepted as valid.
-These keys should be at least 64 bytes, but 128 is recommended.
 
-To generate a new key:
-
-```sh
-openssl rand -base64 128 | tr -d "\n"
-```
-
-Insert this new value **into the front** of the `DB_APIKEY_DATABASE_KEY`
-environment variable:
-
-```sh
-DB_APIKEY_SIGNATURE_KEY="1do5HM96Bk9WD15BQC3qbW9e3T2V6T0DHn2i1xGJRKX8tZubxuaezivMhO3uJFEye8SITH3UFB+mo9oE0VGPiP/4TOXejfsd1g2L518itJbrK4/qNh6QMk0I04mqNtR55uvyt7G/ObADn2hQDYMVOGg/C6nLiqO+nqQ/UoUcGkA=,tJiUPEi0xS5QbykypVlquWsxQ0DAgxY41w+PkNqpoqzWQyDnEUAWFwIFUUFllqT+m0f2Kqh8EB1zjYgFcGP16O52rHer5sr4x6nsnQ/AiOHDrztJnEqGvutetHhZHLGKY0HxlxkZxcFLCmbgs6pa0vNUodrzOsCYysD7MLCSL5M="
-```
-
-Note: Removing any of the keys from this list will invalidate API keys HMACed by
-that version.
-
-If you are using Terraform, increment the `db_apikey_db_hmac_count` by 1.
+Removing any of the keys from this list will invalidate API keys HMACed by that
+version.
 
 
 ### Verification Code database HMAC keys
 
-**Recommended frequency:** 30 days
+**Recommended frequency:** automatic
 
 This key is used as the HMAC secret when saving verification codes in the
-database. Like cookies, it accepts an array of values. The first item in the
-array is used to HMAC all new verification codes, but all remaining values are
-still accepted as valid. These keys should be at least 64 bytes, but 128 is
-recommended.
+database.
 
-To generate a new key:
-
-```sh
-openssl rand -base64 128 | tr -d "\n"
-```
-
-Insert this new value **into the front** of the `DB_VERIFICATION_CODE_DATABASE_KEY`
-environment variable:
-
-```sh
-DB_APIKEY_SIGNATURE_KEY="g7GdsjuN+eydQIUCena2gleSHsmu46Gs+62ENViXsaV123AoVEwZ94ywpCQ2hxJ6CSBc4wXOwrxhg+psiwfp9eyBcpOFC7i98mOTLu1gxznZe943PVKl9vKJx9SgFrSnI1prWoQj85xGJKMBlM/pj608LWpZ3aIxyk0t7Sk/iWE=,G1VCqQVqe+4GD60YsqOHVgYEXN6WMh8tuF9bAfRJyt9sVk9kBWbPdhFQVUdCqoE3cckSsxz7LMApiN1/2jbwG3qkTicx4YuwQMUDVg2Stdv0L2kvek/+MYcA0lVYaNZWBJCSgmaMzjzOGW/BsbR/ssX1WhGI9aVoGpFQMiEJaVE="
-```
-
-Note: Removing any of the keys from this list will invalidate verification codes
+Removing any of the keys from this list will invalidate verification codes
 HMACed by that version. However, given verification a verification code's
 lifetime is short, it is probably safe to remove the key beyond 30 days.
-
-If you are using Terraform, increment the `db_verification_code_hmac_count` by 1.
 
 
 ### Token signing keys

--- a/internal/envstest/enx_redirect.go
+++ b/internal/envstest/enx_redirect.go
@@ -83,8 +83,7 @@ func NewENXRedirectServerConfig(tb testing.TB, testDatabaseInstance *database.Te
 			EnableUserReportWeb:    true,
 		},
 
-		CookieKeys: config.Base64ByteSlice{randomBytes(tb, 64), randomBytes(tb, 32)},
-		RateLimit:  *harness.RateLimiterConfig,
+		RateLimit: *harness.RateLimiterConfig,
 
 		DevMode: true,
 	}

--- a/internal/envstest/harness.go
+++ b/internal/envstest/harness.go
@@ -149,6 +149,7 @@ func NewTestHarness(tb testing.TB, testDatabaseInstance *database.TestInstance) 
 	// Create the bad database.
 	badDB := *db //nolint:govet
 	badDB.SetRawDB(NewFailingDatabase())
+	badDB.SetSecretResolver(database.NewSecretResolver())
 
 	// Create the rate limiter.
 	limiterStore, err := memorystore.New(&memorystore.Config{

--- a/internal/project/context.go
+++ b/internal/project/context.go
@@ -36,5 +36,8 @@ func TestContext(tb testing.TB) context.Context {
 //     https://pkg.go.dev/go.uber.org/zap/zaptest
 //
 func TestLogger(tb testing.TB) *zap.SugaredLogger {
+	if testing.Verbose() {
+		return zaptest.NewLogger(tb, zaptest.Level(zap.DebugLevel)).Sugar()
+	}
 	return zaptest.NewLogger(tb, zaptest.Level(zap.WarnLevel)).Sugar()
 }

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -50,7 +50,7 @@ type RedirectConfig struct {
 
 	// CookieKeys is a slice of bytes. The first is 64 bytes, the second is 32.
 	// They should be base64-encoded.
-	CookieKeys Base64ByteSlice `env:"COOKIE_KEYS,required"`
+	CookieKeys []envconfig.Base64Bytes `env:"COOKIE_KEYS"`
 
 	// Issue config is pulled in for the ENX_REDIRECT_DOMAIN
 	Issue IssueAPIVars

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -82,7 +82,7 @@ type ServerConfig struct {
 
 	// CookieKeys is a slice of bytes. The first is 64 bytes, the second is 32.
 	// They should be base64-encoded.
-	CookieKeys Base64ByteSlice `env:"COOKIE_KEYS,required"`
+	CookieKeys []envconfig.Base64Bytes `env:"COOKIE_KEYS"`
 
 	// CookieDomain is the domain for which cookie should be valid.
 	CookieDomain string `env:"COOKIE_DOMAIN"`
@@ -205,17 +205,4 @@ func (c *ServerConfig) FirebaseConfig() *firebase.Config {
 		ProjectID:     c.Firebase.ProjectID,
 		StorageBucket: c.Firebase.StorageBucket,
 	}
-}
-
-// Base64ByteSlice is a slice of base64-encoded strings that we want to convert
-// to bytes.
-type Base64ByteSlice []envconfig.Base64Bytes
-
-// AsBytes returns the value as a slice of bytes instead of its main type.
-func (c Base64ByteSlice) AsBytes() [][]byte {
-	s := make([][]byte, len(c))
-	for i, v := range c {
-		s[i] = []byte(v)
-	}
-	return s
 }

--- a/pkg/controller/middleware/apikey_test.go
+++ b/pkg/controller/middleware/apikey_test.go
@@ -87,7 +87,7 @@ func TestRequireAPIKey(t *testing.T) {
 		{
 			name:   "bad_database_conn",
 			apiKey: apiKey,
-			code:   http.StatusInternalServerError,
+			code:   http.StatusUnauthorized,
 			db:     badDB,
 		},
 		{

--- a/pkg/controller/rotation/handle_secrets_rotate.go
+++ b/pkg/controller/rotation/handle_secrets_rotate.go
@@ -399,7 +399,7 @@ func mutateCookieKeysSecrets() importMutatorFunc {
 	return func(in [][]byte) ([][]byte, error) {
 		// Sanity check even number of elements.
 		if l := len(in); l%2 != 0 {
-			return nil, fmt.Errorf("invalid number of cookie secret bytes (%d), expected even", l)
+			return nil, fmt.Errorf("failed to mutate cookie keys: invalid number of cookie secret bytes (%d), expected even", l)
 		}
 
 		// Cookie keys are currently stored as separate secrets, but v2 cookie keys
@@ -409,7 +409,7 @@ func mutateCookieKeysSecrets() importMutatorFunc {
 		for i := 0; i < len(in); i += 2 {
 			encryptionKey := in[i+1]
 			if l := len(encryptionKey); l != 32 {
-				return nil, fmt.Errorf("invalid encryption key in import (got %d)", l)
+				return nil, fmt.Errorf("failed to mutate cookie keys: invalid encryption key length in import (got %d)", l)
 			}
 
 			hashKey := in[i]

--- a/pkg/controller/rotation/handle_secrets_rotate_test.go
+++ b/pkg/controller/rotation/handle_secrets_rotate_test.go
@@ -323,6 +323,12 @@ func TestImportExistingSecretFromEnv(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	cookieEncryptionKeyValueRef, err := secretManagerTyp.CreateSecretVersion(ctx, "cookie-encryption-key",
+		[]byte(base64.StdEncoding.EncodeToString([]byte("thisisroughly32charactersright??"))))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	cases := []struct {
 		name     string
 		envval   string
@@ -362,9 +368,9 @@ func TestImportExistingSecretFromEnv(t *testing.T) {
 		{
 			// The cookie mutator should combine 2 values into 1.
 			name:     "cookie_mutator",
-			envval:   fmt.Sprintf("secret://%s,secret://%s", multiValueRef, multiValueRef),
+			envval:   fmt.Sprintf("secret://%s,secret://%s", singleValueRef, cookieEncryptionKeyValueRef),
 			mutators: []importMutatorFunc{mutateCookieKeysSecrets()},
-			exp:      2,
+			exp:      1,
 		},
 		{
 			name:     "cookie_mutator_odd",
@@ -427,8 +433,8 @@ func TestMutateCookieKeysSecrets(t *testing.T) {
 		},
 		{
 			name: "merges",
-			in:   [][]byte{[]byte("hello"), []byte("world")},
-			out:  [][]byte{[]byte("helloworld")},
+			in:   [][]byte{[]byte("hello"), []byte("thisisroughly32charactersright??")},
+			out:  [][]byte{[]byte("thisisroughly32charactersright??hello")},
 		},
 	}
 

--- a/pkg/database/config.go
+++ b/pkg/database/config.go
@@ -65,19 +65,35 @@ type Config struct {
 
 	// APIKeyDatabaseHMAC is the HMAC key to use for API keys before storing them
 	// in the database.
-	APIKeyDatabaseHMAC []envconfig.Base64Bytes `env:"DB_APIKEY_DATABASE_KEY,required" json:"-"`
+	//
+	// TODO(sethvargo): remove in 0.28.0+
+	//
+	// Deprecated: Secrets management and rotation have moved into the database.
+	APIKeyDatabaseHMAC []envconfig.Base64Bytes `env:"DB_APIKEY_DATABASE_KEY" json:"-"`
 
 	// APIKeySignatureHMAC is the HMAC key to sign API keys before returning them
 	// to the requestor.
-	APIKeySignatureHMAC []envconfig.Base64Bytes `env:"DB_APIKEY_SIGNATURE_KEY,required" json:"-"`
+	//
+	// TODO(sethvargo): remove in 0.28.0+
+	//
+	// Deprecated: Secrets management and rotation have moved into the database.
+	APIKeySignatureHMAC []envconfig.Base64Bytes `env:"DB_APIKEY_SIGNATURE_KEY" json:"-"`
 
 	// VerificationCodeDatabaseHMAC is the HMAC key to hash codes before storing
 	// them in the database.
-	VerificationCodeDatabaseHMAC []envconfig.Base64Bytes `env:"DB_VERIFICATION_CODE_DATABASE_KEY,required" json:"-"`
+	//
+	// TODO(sethvargo): remove in 0.28.0+
+	//
+	// Deprecated: Secrets management and rotation have moved into the database.
+	VerificationCodeDatabaseHMAC []envconfig.Base64Bytes `env:"DB_VERIFICATION_CODE_DATABASE_KEY" json:"-"`
 
 	// PhoneNumberHMAC is the HMAC key to hash phone numbers before storing
 	// in the database. This is only used of user initiated reporting is enabled
 	// at the system and at the realm level.
+	//
+	// TODO(sethvargo): remove in 0.28.0+
+	//
+	// Deprecated: Secrets management and rotation have moved into the database.
 	PhoneNumberHMAC []envconfig.Base64Bytes `env:"DB_PHONE_HMAC_KEY" json:"-"`
 
 	// Secrets is the secret configuration. This is used to resolve values that

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -425,6 +425,14 @@ func (db *Database) SetRawDB(tx *gorm.DB) {
 	db.db = tx
 }
 
+// SetSecretResolver sets the underlying secret resolver. This is publicly exposed for
+// tests.
+func (db *Database) SetSecretResolver(r *SecretResolver) {
+	db.dbLock.Lock()
+	defer db.dbLock.Unlock()
+	db.secretResolver = r
+}
+
 // IsNotFound determines if an error is a record not found.
 func IsNotFound(err error) bool {
 	return errors.Is(err, gorm.ErrRecordNotFound) || gorm.IsRecordNotFoundError(err)

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -75,6 +75,9 @@ type Database struct {
 	// secretManager is used to resolve secrets.
 	secretManager secrets.SecretManager
 
+	// secretResolver is used for resolving secrets.
+	secretResolver *SecretResolver
+
 	statsCloser func()
 }
 
@@ -103,6 +106,132 @@ func (db *Database) KeyManager() keys.KeyManager {
 	return db.keyManager
 }
 
+// GetCookieHashAndEncryptionKeys gets the cookie hash and encryption keys. The
+// first 32 bytes are the encryption key and the remaining bytes are the HMAC
+// key.
+func (db *Database) GetCookieHashAndEncryptionKeys(fallback []envconfig.Base64Bytes) ([][]byte, error) {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	results, err := db.secretResolver.Resolve(ctx, db, db.secretManager, SecretTypeCookieKeys)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(sethvargo): remove in 0.28.0+
+	if len(results) == 0 {
+		existing := envconfigBytesToBytes(fallback)
+		if l := len(existing); l%2 != 0 {
+			return nil, fmt.Errorf("fallback bytes are not even (got %d)", l)
+		}
+
+		// In v1 cookies, the HMAC key is first, then the encryption key.
+		final := make([][]byte, len(existing)/2)
+		for i := 0; i < len(existing); i += 2 {
+			encryptionBytes := existing[i+1]
+			if l := len(encryptionBytes); l != 32 {
+				return nil, fmt.Errorf("fallback encryption bytes are not 32 (got %d)", l)
+			}
+
+			hmacBytes := existing[i]
+
+			final[i/2] = append(final[i/2], encryptionBytes...)
+			final[i/2] = append(final[i/2], hmacBytes...)
+		}
+		return final, nil
+	}
+
+	return results, nil
+}
+
+// GetAPIKeyDatabaseHMAC returns the HMAC keys for storing API keys in the
+// database.
+func (db *Database) GetAPIKeyDatabaseHMAC() ([][]byte, error) {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	results, err := db.secretResolver.Resolve(ctx, db, db.secretManager, SecretTypeAPIKeyDatabaseHMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(sethvargo): remove in 0.28.0+
+	if len(results) == 0 {
+		return envconfigBytesToBytes(db.config.APIKeyDatabaseHMAC), nil
+	}
+
+	return results, nil
+}
+
+// GetAPIKeySignatureHMAC returns the HMAC keys for signing API keys in the
+// database.
+func (db *Database) GetAPIKeySignatureHMAC() ([][]byte, error) {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	results, err := db.secretResolver.Resolve(ctx, db, db.secretManager, SecretTypeAPIKeySignatureHMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(sethvargo): remove in 0.28.0+
+	if len(results) == 0 {
+		return envconfigBytesToBytes(db.config.APIKeySignatureHMAC), nil
+	}
+
+	return results, nil
+}
+
+// GetPhoneNumberDatabaseHMAC returns the HMAC keys for storing phone numbers in
+// the database.
+func (db *Database) GetPhoneNumberDatabaseHMAC() ([][]byte, error) {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	results, err := db.secretResolver.Resolve(ctx, db, db.secretManager, SecretTypePhoneNumberDatabaseHMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(sethvargo): remove in 0.28.0+
+	if len(results) == 0 {
+		return envconfigBytesToBytes(db.config.PhoneNumberHMAC), nil
+	}
+
+	return results, nil
+}
+
+// GetVerificationCodeDatabaseHMAC returns the HMAC keys for storing verification
+// codes in the database.
+func (db *Database) GetVerificationCodeDatabaseHMAC() ([][]byte, error) {
+	ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+	defer done()
+
+	results, err := db.secretResolver.Resolve(ctx, db, db.secretManager, SecretTypeVerificationCodeDatabaseHMAC)
+	if err != nil {
+		return nil, err
+	}
+
+	// TODO(sethvargo): remove in 0.28.0+
+	if len(results) == 0 {
+		return envconfigBytesToBytes(db.config.VerificationCodeDatabaseHMAC), nil
+	}
+
+	return results, nil
+}
+
+// envconfigBytesToBytes is a helper that converts envconfig.Base64Bytes to
+// [][]byte.
+//
+// TODO(sethvargo): remove in 0.28.0+
+func envconfigBytesToBytes(in []envconfig.Base64Bytes) [][]byte {
+	result := make([][]byte, len(in))
+	for i, v := range in {
+		result[i] = v.Bytes()
+	}
+	return result
+}
+
 // Load loads the configuration and processes any dependencies like secret and
 // key managers. It does NOT connect to the database.
 func (c *Config) Load(ctx context.Context) (*Database, error) {
@@ -113,6 +242,7 @@ func (c *Config) Load(ctx context.Context) (*Database, error) {
 	if err != nil {
 		return nil, fmt.Errorf("failed to create secret manager: %w", err)
 	}
+	secretResolver := NewSecretResolver()
 
 	// Create the key manager.
 	keyManager, err := keys.KeyManagerFor(ctx, &c.Keys)
@@ -133,6 +263,7 @@ func (c *Config) Load(ctx context.Context) (*Database, error) {
 		signingKeyManager: signingKeyManager,
 		logger:            logger,
 		secretManager:     secretManager,
+		secretResolver:    secretResolver,
 	}, nil
 }
 
@@ -717,10 +848,8 @@ func uintDiff(then, now uint) string {
 	return stringDiff(strconv.FormatUint(uint64(then), 10), strconv.FormatUint(uint64(now), 10))
 }
 
-// initialHMAC uses the currently active HMAC key to seed a new record
-// This depends on envconfig.Base64Bytes since the callers are all using items
-// directly from config struct and this avoids unnecessary casing.
-func initialHMAC(keys []envconfig.Base64Bytes, data string) (string, error) {
+// initialHMAC uses the currently active HMAC key to seed a new record.
+func initialHMAC(keys [][]byte, data string) (string, error) {
 	if len(keys) < 1 {
 		return "", fmt.Errorf("expected at least 1 hmac key")
 	}
@@ -731,11 +860,9 @@ func initialHMAC(keys []envconfig.Base64Bytes, data string) (string, error) {
 	return base64.RawURLEncoding.EncodeToString(sig.Sum(nil)), nil
 }
 
-// allAllowedHMACs uses all passed in HMAC keys to return al valid
-// results for searching for a previously saved record.
-// This depends on envconfig.Base64Bytes since the callers are all using items
-// directly from config struct and this avoids unnecessary casing.
-func allAllowedHMACs(keys []envconfig.Base64Bytes, data string) ([]string, error) {
+// allAllowedHMACs uses all passed in HMAC keys to return all valid results for
+// searching for a previously saved record.
+func allAllowedHMACs(keys [][]byte, data string) ([]string, error) {
 	sigs := make([]string, 0, len(keys))
 	for _, key := range keys {
 		sig := hmac.New(sha512.New, key)

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -155,24 +155,6 @@ func NewTestInstance() (*TestInstance, error) {
 		return nil, fmt.Errorf("failed to expire database container: %w", err)
 	}
 
-	// Generate keys.
-	apiKeyDatabaseHMAC, err := generateKeys(2, 128)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate api key database hmac: %w", err)
-	}
-	apiKeySignatureHMAC, err := generateKeys(2, 128)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate api key signature hmac: %w", err)
-	}
-	verificationCodeDatabaseHMAC, err := generateKeys(2, 128)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate verification code database hmac: %w", err)
-	}
-	phoneHMAC, err := generateKeys(2, 128)
-	if err != nil {
-		return nil, fmt.Errorf("failed to generate phone number database hmac: %w", err)
-	}
-
 	// Create a temporary directory for the key manager,
 	tmpdir, err := os.MkdirTemp("", "")
 	if err != nil {
@@ -182,11 +164,6 @@ func NewTestInstance() (*TestInstance, error) {
 	// Build database configuration. This is required to connect to the database
 	// and to run the initial migrations.
 	config := &Config{
-		APIKeyDatabaseHMAC:           apiKeyDatabaseHMAC,
-		APIKeySignatureHMAC:          apiKeySignatureHMAC,
-		VerificationCodeDatabaseHMAC: verificationCodeDatabaseHMAC,
-		PhoneNumberHMAC:              phoneHMAC,
-
 		Host:     container.GetBoundIP("5432/tcp"),
 		Port:     container.GetPort("5432/tcp"),
 		User:     databaseUser,
@@ -341,12 +318,25 @@ func (i *TestInstance) NewDatabase(tb testing.TB, cacher cache.Cacher, opts ...U
 		db.config.EncryptionKey = keys.TestEncryptionKey(tb, db.keyManager)
 	}
 
+	if db.secretManager == nil {
+		secretManager, err := secrets.NewInMemory(context.Background(), &secrets.Config{})
+		if err != nil {
+			tb.Fatalf("failed to create secret manager: %s", err)
+		}
+		db.secretManager = secretManager
+	}
+
 	// Try to establish a connection to the database.
 	if err := db.OpenWithCacher(ctx, cacher); err != nil {
 		tb.Fatalf("failed to open database connection: %s", err)
 	}
 	db.db.SetLogger(gorm.Logger{LogWriter: log.New(io.Discard, "", 0)})
 	db.db.LogMode(false)
+
+	// Create secrets
+	if err := createSecrets(ctx, db); err != nil {
+		tb.Fatalf("failed to create initial secrets: %s", err)
+	}
 
 	// Close connection and delete database when done.
 	tb.Cleanup(func() {
@@ -400,6 +390,51 @@ func runMigrations(db *Database) error {
 	if err := db.MigrateTo(context.Background(), "", false); err != nil {
 		return fmt.Errorf("failed to migrate database: %w", err)
 	}
+	return nil
+}
+
+// createSecrets generates and inserts the initial secrets into the secret
+// manager and database entry.
+func createSecrets(ctx context.Context, db *Database) error {
+	secretManagerTyp, ok := db.secretManager.(secrets.SecretVersionManager)
+	if !ok {
+		return fmt.Errorf("secret manager cannot manage versions")
+	}
+
+	secrets := []struct {
+		typ    SecretType
+		length int
+	}{
+		{SecretTypeAPIKeyDatabaseHMAC, 128},
+		{SecretTypeAPIKeySignatureHMAC, 128},
+		{SecretTypeCookieKeys, 64 + 32},
+		{SecretTypePhoneNumberDatabaseHMAC, 128},
+		{SecretTypeVerificationCodeDatabaseHMAC, 128},
+	}
+
+	for _, v := range secrets {
+		b, err := generateKeys(1, v.length)
+		if err != nil {
+			return fmt.Errorf("failed to generate bytes for %s: %w", v.typ, err)
+		}
+
+		parent := fmt.Sprintf("seed/%s", v.typ)
+		ref, err := secretManagerTyp.CreateSecretVersion(ctx, parent, b[0])
+		if err != nil {
+			return fmt.Errorf("failed to create secret version for %s: %w", v.typ, err)
+		}
+
+		// Save, bypass audits because some tests count the number of audits.
+		secret := &Secret{
+			Type:      v.typ,
+			Reference: ref,
+			Active:    true,
+		}
+		if err := db.db.Save(secret).Error; err != nil {
+			return fmt.Errorf("failed to save secret reference for %s: %w", v.typ, err)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/database/database_util.go
+++ b/pkg/database/database_util.go
@@ -337,6 +337,7 @@ func (i *TestInstance) NewDatabase(tb testing.TB, cacher cache.Cacher, opts ...U
 	if err := createSecrets(ctx, db); err != nil {
 		tb.Fatalf("failed to create initial secrets: %s", err)
 	}
+	db.secretResolver.ClearCaches()
 
 	// Close connection and delete database when done.
 	tb.Cleanup(func() {

--- a/pkg/database/secret.go
+++ b/pkg/database/secret.go
@@ -131,10 +131,10 @@ func (db *Database) ListSecretsForType(typ SecretType, scopes ...Scope) ([]*Secr
 
 // ActivateSecrets activates all secrets that are not currently activate but
 // have been created for since the provided timestamp.
-func (db *Database) ActivateSecrets(since time.Time) error {
+func (db *Database) ActivateSecrets(typ SecretType, since time.Time) error {
 	if err := db.db.
 		Model(&Secret{}).
-		Where("active IS FALSE AND created_at < ?", since).
+		Where("active IS FALSE AND type = ? AND created_at < ?", typ, since).
 		UpdateColumn("active", true).
 		Error; err != nil && !IsNotFound(err) {
 		return fmt.Errorf("failed to activate secrets: %w", err)

--- a/pkg/database/secretresolver.go
+++ b/pkg/database/secretresolver.go
@@ -119,3 +119,11 @@ func (r *SecretResolver) ResolveValue(ctx context.Context, sm secrets.SecretMana
 	}
 	return typ, nil
 }
+
+// ClearCaches purges all cached data from the references and values cache.
+func (r *SecretResolver) ClearCaches() {
+	fmt.Printf("\n\nclearing caches\n\n")
+
+	r.referencesCache.Clear()
+	r.valuesCache.Clear()
+}

--- a/pkg/database/secretresolver.go
+++ b/pkg/database/secretresolver.go
@@ -122,8 +122,6 @@ func (r *SecretResolver) ResolveValue(ctx context.Context, sm secrets.SecretMana
 
 // ClearCaches purges all cached data from the references and values cache.
 func (r *SecretResolver) ClearCaches() {
-	fmt.Printf("\n\nclearing caches\n\n")
-
 	r.referencesCache.Clear()
 	r.valuesCache.Clear()
 }

--- a/pkg/database/user_report.go
+++ b/pkg/database/user_report.go
@@ -143,7 +143,12 @@ func (db *Database) PurgeClaimedUserReports(maxAge time.Duration) (int64, error)
 
 // GeneratePhoneNumberHMAC generates the HMAC of the phone number using the latest key.
 func (db *Database) GeneratePhoneNumberHMAC(phoneNumber string) (string, error) {
-	s, err := initialHMAC(db.config.PhoneNumberHMAC, phoneNumber)
+	keys, err := db.GetPhoneNumberDatabaseHMAC()
+	if err != nil {
+		return "", fmt.Errorf("failed to get keys to generate phone number database HMAC: %w", err)
+	}
+
+	s, err := initialHMAC(keys, phoneNumber)
 	if err != nil {
 		return "", fmt.Errorf("failed to generate phone number HMAC: %w", err)
 	}
@@ -152,5 +157,10 @@ func (db *Database) GeneratePhoneNumberHMAC(phoneNumber string) (string, error) 
 
 // generatePhoneNumberHMACs is a helper for generating all possible HMACs of a phone number.
 func (db *Database) generatePhoneNumberHMACs(phoneNumber string) ([]string, error) {
-	return allAllowedHMACs(db.config.PhoneNumberHMAC, phoneNumber)
+	keys, err := db.GetPhoneNumberDatabaseHMAC()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get keys to generate phone number database HMACs: %w", err)
+	}
+
+	return allAllowedHMACs(keys, phoneNumber)
 }

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -425,11 +425,21 @@ func (db *Database) PurgeVerificationCodes(maxAge time.Duration) (int64, error) 
 // GenerateVerificationCodeHMAC generates the HMAC of the code using the latest
 // key.
 func (db *Database) GenerateVerificationCodeHMAC(verCode string) (string, error) {
-	return initialHMAC(db.config.VerificationCodeDatabaseHMAC, verCode)
+	keys, err := db.GetVerificationCodeDatabaseHMAC()
+	if err != nil {
+		return "", fmt.Errorf("failed to get keys to generate verification code database HMAC: %w", err)
+	}
+
+	return initialHMAC(keys, verCode)
 }
 
 // generateVerificationCodeHMACs is a helper for generating all possible HMACs of a
 // token.
 func (db *Database) generateVerificationCodeHMACs(v string) ([]string, error) {
-	return allAllowedHMACs(db.config.VerificationCodeDatabaseHMAC, v)
+	keys, err := db.GetVerificationCodeDatabaseHMAC()
+	if err != nil {
+		return nil, fmt.Errorf("failed to get keys to generate verification code database HMACs: %w", err)
+	}
+
+	return allAllowedHMACs(keys, v)
 }

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -60,6 +60,9 @@ locals {
     # modeler runs every 4h, alert after 2 failures
     "modeler" = { metric = "modeler/success", window = 8 * local.hour + 10 * local.minute },
 
+    # rotation-secrets runs every 5m, alert after 2 failures
+    "rotation-secrets" = { metric = "rotation/secrets/success", window = 10 * local.minute + 1 * local.minute }
+
     # rotation-token runs every 30m, alert after 2 failures
     "rotation-token" = { metric = "rotation/token/success", window = 60 * local.minute + 10 * local.minute }
 

--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -188,6 +188,7 @@ resource "google_secret_manager_secret_version" "db-secret-version" {
 }
 
 # Create secret for the database HMAC for API keys
+# TODO(sethvargo): remove in v0.28.0+
 resource "random_id" "db-apikey-db-hmac" {
   count       = var.db_apikey_db_hmac_count
   byte_length = 128
@@ -205,12 +206,14 @@ resource "google_secret_manager_secret" "db-apikey-db-hmac" {
   ]
 }
 
+# TODO(sethvargo): remove in v0.28.0+
 resource "google_secret_manager_secret_version" "db-apikey-db-hmac" {
   secret      = google_secret_manager_secret.db-apikey-db-hmac.id
   secret_data = join(",", reverse(random_id.db-apikey-db-hmac.*.b64_std))
 }
 
 # Create secret for signature HMAC for api keys
+# TODO(sethvargo): remove in v0.28.0+
 resource "random_id" "db-apikey-sig-hmac" {
   count       = var.db_apikey_sig_hmac_count
   byte_length = 128
@@ -228,12 +231,14 @@ resource "google_secret_manager_secret" "db-apikey-sig-hmac" {
   ]
 }
 
+# TODO(sethvargo): remove in v0.28.0+
 resource "google_secret_manager_secret_version" "db-apikey-sig-hmac" {
   secret      = google_secret_manager_secret.db-apikey-sig-hmac.id
   secret_data = join(",", reverse(random_id.db-apikey-sig-hmac.*.b64_std))
 }
 
 # Create secret for the database HMAC for verification codes
+# TODO(sethvargo): remove in v0.28.0+
 resource "random_id" "db-verification-code-hmac" {
   count       = var.db_verification_code_hmac_count
   byte_length = 128
@@ -251,12 +256,14 @@ resource "google_secret_manager_secret" "db-verification-code-hmac" {
   ]
 }
 
+# TODO(sethvargo): remove in v0.28.0+
 resource "google_secret_manager_secret_version" "db-verification-code-hmac" {
   secret      = google_secret_manager_secret.db-verification-code-hmac.id
   secret_data = join(",", reverse(random_id.db-verification-code-hmac.*.b64_std))
 }
 
 # Create secret for the database HMAC for phone numbers
+# TODO(sethvargo): remove in v0.28.0+
 resource "random_id" "db-phone-number-hmac" {
   count       = var.db_phone_number_hmac_count
   byte_length = 128
@@ -274,6 +281,7 @@ resource "google_secret_manager_secret" "db-phone-number-hmac" {
   ]
 }
 
+# TODO(sethvargo): remove in v0.28.0+
 resource "google_secret_manager_secret_version" "db-phone-number-hmac" {
   secret      = google_secret_manager_secret.db-phone-number-hmac.id
   secret_data = join(",", reverse(random_id.db-phone-number-hmac.*.b64_std))

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -26,8 +26,6 @@ provider "google-beta" {
   user_project_override = true
 }
 
-provider "random" {}
-
 data "google_project" "project" {
   project_id = var.project
 }

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -244,3 +244,31 @@ resource "google_cloud_scheduler_job" "rotation-worker-realm-verification-keys" 
     google_project_service.services["cloudscheduler.googleapis.com"],
   ]
 }
+
+resource "google_cloud_scheduler_job" "rotation-worker-secrets" {
+  name   = "rotation-worker-secrets"
+  region = var.cloudscheduler_location
+
+  schedule         = "*/5 * * * *"
+  time_zone        = "America/Los_Angeles"
+  attempt_deadline = "${google_cloud_run_service.rotation.template[0].spec[0].timeout_seconds + 60}s"
+
+  retry_config {
+    retry_count = 3
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.rotation.status.0.url}/secrets"
+    oidc_token {
+      audience              = google_cloud_run_service.rotation.status.0.url
+      service_account_email = google_service_account.rotation-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.rotation-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}

--- a/terraform/sessions.tf
+++ b/terraform/sessions.tf
@@ -15,6 +15,8 @@
 locals {
   session_secrets = [
     google_secret_manager_secret.cookie-keys.id,
+
+    # TODO(sethvargo): remove after 0.28.0+
     google_secret_manager_secret.cookie-hmac-key.id,
     google_secret_manager_secret.cookie-encryption-key.id,
   ]
@@ -32,10 +34,12 @@ resource "google_secret_manager_secret" "cookie-keys" {
   ]
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "random_id" "cookie-hmac-key" {
   byte_length = 32
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "google_secret_manager_secret" "cookie-hmac-key" {
   secret_id = "cookie-hmac-key"
 
@@ -48,15 +52,18 @@ resource "google_secret_manager_secret" "cookie-hmac-key" {
   ]
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "google_secret_manager_secret_version" "cookie-hmac-key-version" {
   secret      = google_secret_manager_secret.cookie-hmac-key.id
   secret_data = random_id.cookie-hmac-key.b64_std
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "random_id" "cookie-encryption-key" {
   byte_length = 32
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "google_secret_manager_secret" "cookie-encryption-key" {
   secret_id = "cookie-encryption-key"
 
@@ -69,6 +76,7 @@ resource "google_secret_manager_secret" "cookie-encryption-key" {
   ]
 }
 
+# TODO(sethvargo): remove after 0.28.0+
 resource "google_secret_manager_secret_version" "cookie-encryption-key-version" {
   secret      = google_secret_manager_secret.cookie-encryption-key.id
   secret_data = random_id.cookie-encryption-key.b64_std


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
**Add automated secrets rotation.** This introduces automated rotation for most application-level secrets. Whereas previously it was the responsibility of server administrators to rotate secrets, the application will now rotate a variety of secrets on regular intervals for improved security.
```
