### PR TITLE
add end to end runner for user-report test type

### DIFF
--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -218,19 +218,10 @@ func handleEndToEnd(cfg *config.E2ERunnerConfig, db *database.Database, h *rende
 		logger := logging.FromContext(ctx)
 
 		if cfg.DoUserReport {
-			userReport, err := db.FindUserReport(db.RawDB(), project.TestPhoneNumber)
-			if err != nil && !database.IsNotFound(err) {
-				logger.Errorw("error looking up user reports for test phone number", "error", err)
+			if err := db.DeleteUserReport(project.TestPhoneNumber); err != nil {
+				logger.Errorw("error deleting previous user report for test phone number", "error", err)
 				h.RenderJSON(w, http.StatusInternalServerError, err)
 				return
-			}
-
-			if userReport != nil {
-				if err := db.RawDB().Delete(userReport); err != nil {
-					logger.Errorw("error deleting previous user report for test phone number", "error", err)
-					h.RenderJSON(w, http.StatusInternalServerError, err)
-					return
-				}
 			}
 		}
 

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -192,7 +192,7 @@ func handleRevise(cfg *config.E2ERunnerConfig, db *database.Database, h *render.
 	return handleEndToEnd(&c, db, h, mRevisionSuccess)
 }
 
-//handleUserReport runs the end-to-end runner initiated by a user-report API request.
+// handleUserReport runs the end-to-end runner initiated by a user-report API request.
 func handleUserReport(cfg *config.E2ERunnerConfig, db *database.Database, h *render.Renderer) http.Handler {
 	if !cfg.Features.EnableUserReport {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/e2e-runner/metrics.go
+++ b/cmd/e2e-runner/metrics.go
@@ -25,9 +25,10 @@ import (
 const metricPrefix = observability.MetricRoot + "/e2e"
 
 var (
-	mDefaultSuccess  = stats.Int64(metricPrefix+"/default/success", "successful default execution", stats.UnitDimensionless)
-	mRevisionSuccess = stats.Int64(metricPrefix+"/revision/success", "successful revision execution", stats.UnitDimensionless)
-	mRedirectSuccess = stats.Int64(metricPrefix+"/redirect/success", "successful redirect execution", stats.UnitDimensionless)
+	mDefaultSuccess    = stats.Int64(metricPrefix+"/default/success", "successful default execution", stats.UnitDimensionless)
+	mRevisionSuccess   = stats.Int64(metricPrefix+"/revision/success", "successful revision execution", stats.UnitDimensionless)
+	mRedirectSuccess   = stats.Int64(metricPrefix+"/redirect/success", "successful redirect execution", stats.UnitDimensionless)
+	mUserReportSuccess = stats.Int64(metricPrefix+"/user-report/success", "successful user-report execution", stats.UnitDimensionless)
 )
 
 func init() {
@@ -48,6 +49,12 @@ func init() {
 			Name:        metricPrefix + "/redirect/success",
 			Description: "Number of redirect successes",
 			Measure:     mRedirectSuccess,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/user-report/success",
+			Description: "Number of user-report successes",
+			Measure:     mUserReportSuccess,
 			Aggregation: view.Count(),
 		},
 	}...)

--- a/internal/clients/e2e.go
+++ b/internal/clients/e2e.go
@@ -105,6 +105,9 @@ func RunEndToEnd(ctx context.Context, cfg *config.E2ERunnerConfig) error {
 		testType = "likely"
 		iterations++
 	}
+	if cfg.DoUserReport {
+		testType = "user-report"
+	}
 	symptomDate := time.Now().UTC().Add(-48 * time.Hour).Format(project.RFC3339Date)
 	adminID := ""
 	revisionToken := ""

--- a/internal/envstest/bootstrap.go
+++ b/internal/envstest/bootstrap.go
@@ -71,8 +71,10 @@ func Bootstrap(ctx context.Context, db *database.Database) (*BootstrapResponse, 
 	}
 
 	realm.AllowedTestTypes = database.TestTypeNegative | database.TestTypeConfirmed | database.TestTypeLikely
+	realm.AddUserReportToAllowedTestTypes()
 	realm.AllowBulkUpload = true
 	realm.UseAuthenticatedSMS = true
+	realm.AllowAdminUserReport = true
 	if err := db.SaveRealm(realm, database.SystemTest); err != nil {
 		return &resp, fmt.Errorf("failed to save realm: %w", err)
 	}

--- a/pkg/config/e2e_runner_server_config.go
+++ b/pkg/config/e2e_runner_server_config.go
@@ -40,7 +40,9 @@ type E2ERunnerConfig struct {
 	VerificationAPIServerKey   string `env:"VERIFICATION_SERVER_API_KEY"`
 	KeyServer                  string `env:"KEY_SERVER, default=http://localhost:8080"`
 	HealthAuthorityCode        string `env:"HEALTH_AUTHORITY_CODE,required"`
-	DoRevise                   bool   `env:"DO_REVISIONS"`
+	// Not environment vars, but set by each type of test run.
+	DoRevise     bool
+	DoUserReport bool
 
 	// ENXRedirectURL is the host to use for testing the ENX redirector service.
 	// This should be the value of the e2e realm's host, like

--- a/pkg/controller/issueapi/gen_code.go
+++ b/pkg/controller/issueapi/gen_code.go
@@ -86,6 +86,13 @@ func (c *Controller) IssueCode(ctx context.Context, vCode *database.Verification
 				ErrorReturn: api.Errorf("phone number not current eligible for user report").WithCode(api.ErrUserReportTryLater),
 			}
 		}
+		if errors.Is(err, database.ErrRequiresPhoneNumber) {
+			return &IssueResult{
+				obsResult:   enobs.ResultError("MISSING_PHONE_NUMBER"),
+				HTTPCode:    http.StatusBadRequest,
+				ErrorReturn: api.Errorf("phone number is required when initiating a user report").WithCode(api.ErrMissingPhone),
+			}
+		}
 		logger.Errorw("failed to issue code", "error", err)
 		return &IssueResult{
 			obsResult:   enobs.ResultError("FAILED_TO_ISSUE_CODE"),

--- a/pkg/controller/issueapi/handle_issue.go
+++ b/pkg/controller/issueapi/handle_issue.go
@@ -22,6 +22,7 @@ import (
 
 	"github.com/google/exposure-notifications-verification-server/pkg/api"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
 
 	enobs "github.com/google/exposure-notifications-server/pkg/observability"
@@ -103,9 +104,15 @@ func (c *Controller) decodeAndIssue(ctx context.Context, w http.ResponseWriter, 
 		return
 	}
 
+	// If the report type is user-report AND the SMS template is not being set, change it to the user report template.
+	if request.TestType == api.TestTypeUserReport && request.SMSTemplateLabel == "" {
+		request.SMSTemplateLabel = database.UserReportTemplateLabel
+	}
+
 	internalRequest := &IssueRequestInternal{
 		IssueRequest: &request,
 	}
+
 	res := c.IssueOne(ctx, internalRequest)
 	result.HTTPCode = res.HTTPCode
 

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -54,11 +54,12 @@ var (
 		"user-report": {},
 	}
 
-	ErrInvalidTestType    = errors.New("invalid test type, must be confirmed, likely, negative, or self_report")
-	ErrCodeAlreadyExpired = errors.New("code already expired")
-	ErrCodeAlreadyClaimed = errors.New("code already claimed")
-	ErrCodeTooShort       = errors.New("verification code is too short")
-	ErrAlreadyReported    = errors.New("phone number not eligible for user report, try again later")
+	ErrInvalidTestType     = errors.New("invalid test type, must be confirmed, likely, negative, or self_report")
+	ErrCodeAlreadyExpired  = errors.New("code already expired")
+	ErrCodeAlreadyClaimed  = errors.New("code already claimed")
+	ErrCodeTooShort        = errors.New("verification code is too short")
+	ErrAlreadyReported     = errors.New("phone number not eligible for user report, try again later")
+	ErrRequiresPhoneNumber = errors.New("phone number is required for user report requests")
 )
 
 // VerificationCode represents a verification code in the database.
@@ -276,7 +277,7 @@ func (db *Database) SaveVerificationCode(vc *VerificationCode, realm *Realm) err
 		var err error
 		if vc.TestType == verifyapi.ReportTypeSelfReport {
 			if len(vc.PhoneNumber) == 0 {
-				return fmt.Errorf("request has nonce but no phone number for SMS, invalid combination")
+				return ErrRequiresPhoneNumber
 			}
 			userReport, err = db.FindUserReport(tx, vc.PhoneNumber)
 			if err != nil && !IsNotFound(err) {

--- a/pkg/integration/enx_redirect_test.go
+++ b/pkg/integration/enx_redirect_test.go
@@ -49,7 +49,7 @@ func TestENXRedirect(t *testing.T) {
 	}
 
 	if err := server.Database.SaveRealm(realm, database.SystemTest); err != nil {
-		t.Fatalf("err: %v, errors: %+v", err, realm.ErrorMessages())
+		t.Fatal(err)
 	}
 
 	client, err := clients.NewENXRedirectClient("http://"+server.Server.Addr(),

--- a/pkg/integration/enx_redirect_test.go
+++ b/pkg/integration/enx_redirect_test.go
@@ -42,9 +42,15 @@ func TestENXRedirect(t *testing.T) {
 
 	realm := bs.Realm
 	realm.EnableENExpress = true
-	realm.SMSTextTemplate = "[enslink]"
+	template := "[enslink]"
+	realm.SMSTextTemplate = template
+
+	for k := range realm.SMSTextAlternateTemplates {
+		realm.SMSTextAlternateTemplates[k] = &template
+	}
+
 	if err := server.Database.SaveRealm(realm, database.SystemTest); err != nil {
-		t.Fatal(err)
+		t.Fatalf("err: %v, errors: %+v", err, realm.ErrorMessages())
 	}
 
 	client, err := clients.NewENXRedirectClient("http://"+server.Server.Addr(),

--- a/pkg/integration/enx_redirect_test.go
+++ b/pkg/integration/enx_redirect_test.go
@@ -44,7 +44,6 @@ func TestENXRedirect(t *testing.T) {
 	realm.EnableENExpress = true
 	template := "[enslink]"
 	realm.SMSTextTemplate = template
-
 	for k := range realm.SMSTextAlternateTemplates {
 		realm.SMSTextAlternateTemplates[k] = &template
 	}

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -51,6 +51,9 @@ locals {
     # e2e-revision runs every 5 minutes, alert after 2 failures
     "e2e-revision" = { metric = "e2e/revision/success", window = 10 * local.minute + 1 * local.minute },
 
+    # e2e-user-report runs every 5 minutes, alert after 2 failures
+    "e2e-user-report" = { metric = "e2e/user-report/success", window = 10 * local.minute + 1 * local.minute },
+
     # e2e-redirect runs every 5 minutes, alert after 2 failures
     "e2e-redirect" = { metric = "e2e/redirect/success", window = 10 * local.minute + 1 * local.minute },
 

--- a/tools/get-code/main.go
+++ b/tools/get-code/main.go
@@ -37,6 +37,7 @@ var (
 	apikeyFlag   = flag.String("apikey", "", "API Key to use")
 	adminIDFlag  = flag.String("adminID", "", "AdminID for statistics tracking")
 	addrFlag     = flag.String("addr", "http://localhost:8080", "protocol, address and port on which to make the API call")
+	phoneFlag    = flag.String("phone-number", "", "If provided, phone number to send SMS to")
 )
 
 func main() {
@@ -72,6 +73,7 @@ func realMain(ctx context.Context) error {
 		SymptomDate:      *onsetFlag,
 		TZOffset:         float32(*tzOffsetFlag),
 		ExternalIssuerID: *adminIDFlag,
+		Phone:            *phoneFlag,
 	})
 	if err != nil {
 		return err


### PR DESCRIPTION
Last non web UI thing for  #1928

## Proposed Changes

* add end to end test for user-report
* ensure that user report SMS template is used for admin API requests codes (as a default)

**Release Note**

```release-note
Adds end to end test runner for user-report if that feature is enabled.
```
