### PR TITLE
Move ratelimit middleware after API key

### DIFF
--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -85,10 +85,6 @@ func AdminAPI(
 	processDebug := middleware.ProcessDebug()
 	r.Use(processDebug)
 
-	// Install the rate limiting first. In this case, we want to limit by key
-	// first to reduce the chance of a database lookup.
-	r.Use(rateLimit)
-
 	// Other common middlewares
 	requireAdminAPIKey := middleware.RequireAPIKey(cacher, db, h, []database.APIKeyType{
 		database.APIKeyTypeAdmin,
@@ -105,6 +101,7 @@ func AdminAPI(
 	{
 		sub := r.PathPrefix("/api").Subrouter()
 		sub.Use(requireAdminAPIKey)
+		sub.Use(rateLimit)
 		sub.Use(processFirewall)
 
 		issueapiController := issueapi.New(cfg, db, limiterStore, smsSigner, h)
@@ -120,6 +117,7 @@ func AdminAPI(
 	{
 		sub := r.PathPrefix("/api/stats").Subrouter()
 		sub.Use(requireStatsAPIKey)
+		sub.Use(rateLimit)
 		sub.Use(processFirewall)
 
 		statsController := stats.New(cacher, db, h)


### PR DESCRIPTION
This fixes an issue where metrics don't include the realm id. Originally the rate limiter existed before requiring an API key to limit database load, but we've since introduced multiple layers of caching that mitigate this.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue where adminapi metrics were not tagged with the realm ID.
```
