### PR TITLE
add user report to default accept

### DIFF
--- a/pkg/api/util.go
+++ b/pkg/api/util.go
@@ -28,7 +28,7 @@ type AcceptTypes map[string]struct{}
 func (v *VerifyCodeRequest) GetAcceptedTestTypes() (AcceptTypes, error) {
 	accepted := AcceptTypes{}
 	if len(v.AcceptTestTypes) == 0 {
-		accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely, TestTypeNegative)
+		accepted.AddAcceptTypes(TestTypeConfirmed, TestTypeLikely, TestTypeNegative, TestTypeUserReport)
 		return accepted, nil
 	}
 


### PR DESCRIPTION

## Proposed Changes

* user-report is not part of the default (empty) accept list

**Release Note**

```release-note
User-report types are part of the default accept list on the verify API now.
```
