### PR TITLE
decreasing threshold for hostdown alert to improve alert times for DN…

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -86,7 +86,7 @@ resource "google_monitoring_alert_policy" "probers" {
       | align next_older(1m)
       | every 1m
       | group_by [resource.host], [val: fraction_true(value.check_passed)]
-      | condition val < 20 '%'
+      | condition val < 60 '%'
       EOT
       trigger {
         count = 1


### PR DESCRIPTION
decreasing threshold for hostdown alert to improve alert times for DNS related service degradation

## Proposed Changes

* Set hostdown to alert when service degrades to under 60% availability over 5m instead of 20%

**Release Note**

```release-note
lowering threshold for hostdown alert
```
