### PR TITLE
Timing

### DIFF
--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -43,10 +43,13 @@
             <label for="code">Region code</label>
           </div>
 
-          <h6 class="mb-3">Verification Code Settings</h6>
-          <div class="form-label-group">
+          <h6 class="mb-3">Verification code settings</h6>
+          <div class="form-label-group input-group">
             <input name="short_code_max_minutes" id="short-code-max-minutes" type="text" class="form-control" value="{{$realm.ShortCodeMaxMinutes}}"  />
-            <label for="short-code-max-minutes">Short Code Max Minutes</label>
+            <span class="input-group-append">
+              <span class="input-group-text bg-transparent border-left-0">minutes</span>
+            </span>
+            <label for="short-code-max-minutes">Short code max duration</label>
           </div>
 
           <div class="form-check mb-3">

--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -43,6 +43,24 @@
             <label for="code">Region code</label>
           </div>
 
+          <h6 class="mb-3">Verification Code Settings</h6>
+          <div class="form-label-group">
+            <input name="short_code_max_minutes" id="short-code-max-minutes" type="text" class="form-control" value="{{$realm.ShortCodeMaxMinutes}}"  />
+            <label for="short-code-max-minutes">Short Code Max Minutes</label>
+          </div>
+
+          <div class="form-check mb-3">
+            <input type="checkbox" name="enx_code_expiration_configurable" id="enx-code-expiration-configurable" class="form-check-input" value="true" {{checkedIf ($realm.ENXCodeExpirationConfigurable)}} />
+            <label for="enx-code-expiration-configurable" class="form-check-label">
+              Allow realm short code configuration
+              <small class="form-text text-muted mb-3">
+                If EN Express is enabled, the short code expiration time is normally
+                fixed at 15 minutes. By enabling this setting, a realm admin can customize
+                their short code expiration time even with EN Express enabled.
+              </small>
+            </label>
+          </div>
+
           {{if .supportsPerRealmSigning}}
           <hr>
           <h6 class="mb-3">Certificate</h6>

--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -179,7 +179,7 @@
 
   <div class="form-group">
     <label for="code-duration">Short code expiration</label>
-    {{if $realm.EnableENExpress}}
+    {{if and $realm.EnableENExpress (not $realm.ENXCodeExpirationConfigurable)}}
       <input type="text" id="code-duration" class="form-control{{if $realm.ErrorsFor "CodeDurationSeconds"}} is-invalid{{end}}" value="{{$realm.GetCodeDurationMinutes}} minutes" readonly />
       <small class="form-text text-muted">
         This value cannot be changed when ENExpress is enabled.
@@ -192,7 +192,7 @@
         {{end}}
       </select>
       <small class="form-text text-muted">
-        The short code can be valid from anywhere between <code>5</code> and <code>60</code>
+        The short code can be valid from anywhere between <code>5</code> and <code>{{.maxShortCodeMinutes}}</code>
         minutes. If you are using SMS deeplinks, it is recommended to keep this duration
         short and let the long code be valid for a longer period (up to <code>24</code> hours).
       </small>

--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -185,8 +185,10 @@ func (c *Controller) renderNewRealm(ctx context.Context, w http.ResponseWriter,
 
 func (c *Controller) HandleRealmsUpdate() http.Handler {
 	type FormData struct {
-		CanUseSystemSMSConfig   bool `form:"can_use_system_sms_config"`
-		CanUseSystemEmailConfig bool `form:"can_use_system_email_config"`
+		CanUseSystemSMSConfig         bool `form:"can_use_system_sms_config"`
+		CanUseSystemEmailConfig       bool `form:"can_use_system_email_config"`
+		ShortCodeMaxMinutes           uint `form:"short_code_max_minutes"`
+		ENXCodeExpirationConfigurable bool `form:"enx_code_expiration_configurable"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -266,6 +268,8 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 
 		realm.CanUseSystemSMSConfig = form.CanUseSystemSMSConfig
 		realm.CanUseSystemEmailConfig = form.CanUseSystemEmailConfig
+		realm.ShortCodeMaxMinutes = form.ShortCodeMaxMinutes
+		realm.ENXCodeExpirationConfigurable = form.ENXCodeExpirationConfigurable
 		if err := c.db.SaveRealm(realm, currentUser); err != nil {
 			if database.IsValidationError(err) {
 				w.WriteHeader(http.StatusUnprocessableEntity)

--- a/pkg/controller/admin/realms_test.go
+++ b/pkg/controller/admin/realms_test.go
@@ -244,6 +244,7 @@ func TestHandleRealmsUpdate(t *testing.T) {
 		w, r := envstest.BuildFormRequest(ctx, t, http.MethodPost, "/", &url.Values{
 			"can_use_system_sms_config":   []string{"1"},
 			"can_use_system_email_config": []string{"1"},
+			"short_code_max_minutes":      []string{"60"},
 		})
 		r = mux.SetURLVars(r, map[string]string{"id": "1"})
 		handler.ServeHTTP(w, r)

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -55,7 +55,8 @@ func TestHandleDisableExpress(t *testing.T) {
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
-				EnableENExpress: true,
+				EnableENExpress:     true,
+				ShortCodeMaxMinutes: 60,
 			},
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,
@@ -76,7 +77,8 @@ func TestHandleDisableExpress(t *testing.T) {
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
-				EnableENExpress: false,
+				EnableENExpress:     false,
+				ShortCodeMaxMinutes: 60,
 			},
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,
@@ -100,7 +102,8 @@ func TestHandleDisableExpress(t *testing.T) {
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
-				EnableENExpress: true,
+				EnableENExpress:     true,
+				ShortCodeMaxMinutes: 60,
 			},
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,
@@ -123,6 +126,7 @@ func TestHandleDisableExpress(t *testing.T) {
 		realm := database.NewRealmWithDefaults("realmy2")
 		realm.RegionCode = "TT"
 		realm.EnableENExpress = true
+		realm.ShortCodeMaxMinutes = 60
 		realm.SMSTextTemplate = "[enslink]"
 		if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
 			t.Errorf("%#v", realm.ErrorMessages())

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -72,12 +72,13 @@ func TestHandleEnableExpress(t *testing.T) {
 	t.Run("already_enabled", func(t *testing.T) {
 		t.Parallel()
 
+		realm := database.NewRealmWithDefaults("already_enabled")
+		realm.EnableENExpress = true
+
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
-			Realm: &database.Realm{
-				EnableENExpress: true,
-			},
+			Realm:       realm,
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,
 		})
@@ -100,7 +101,8 @@ func TestHandleEnableExpress(t *testing.T) {
 		ctx = controller.WithSession(ctx, &sessions.Session{})
 		ctx = controller.WithMembership(ctx, &database.Membership{
 			Realm: &database.Realm{
-				EnableENExpress: false,
+				EnableENExpress:     false,
+				ShortCodeMaxMinutes: 60,
 			},
 			User:        &database.User{},
 			Permissions: rbac.SettingsWrite,

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -31,7 +31,6 @@ import (
 
 var (
 	shortCodeLengths            = []int{6, 7, 8}
-	shortCodeMinutes            = []int{}
 	longCodeLengths             = []int{12, 13, 14, 15, 16}
 	longCodeHours               = []int{}
 	mfaGracePeriod              = []int64{0, 1, 7, 30}
@@ -47,9 +46,6 @@ const (
 )
 
 func init() {
-	for i := 5; i <= maxShortCodeMinutes; i++ {
-		shortCodeMinutes = append(shortCodeMinutes, i)
-	}
 	for i := 1; i <= 24; i++ {
 		longCodeHours = append(longCodeHours, i)
 	}

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -40,12 +40,14 @@ var (
 )
 
 const (
+	maxShortCodeMinutes = 60
+
 	labelPrefix    = "sms_text_label_"
 	templatePrefix = "sms_text_template_"
 )
 
 func init() {
-	for i := 5; i <= 60; i++ {
+	for i := 5; i <= maxShortCodeMinutes; i++ {
 		shortCodeMinutes = append(shortCodeMinutes, i)
 	}
 	for i := 1; i <= 24; i++ {
@@ -245,6 +247,11 @@ func (c *Controller) HandleSettings() http.Handler {
 				currentRealm.CodeDuration.Duration = time.Duration(form.CodeDurationMinutes) * time.Minute
 				currentRealm.LongCodeLength = form.LongCodeLength
 				currentRealm.LongCodeDuration.Duration = time.Duration(form.LongCodeDurationHours) * time.Hour
+			} else {
+				// A system admin can allow an ENX realm to edit their code expiration.
+				if currentRealm.ENXCodeExpirationConfigurable {
+					currentRealm.CodeDuration.Duration = time.Duration(form.CodeDurationMinutes) * time.Minute
+				}
 			}
 		}
 

--- a/pkg/controller/realmadmin/settings_show.go
+++ b/pkg/controller/realmadmin/settings_show.go
@@ -145,7 +145,17 @@ func (c *Controller) renderSettings(
 	m["passwordWarnDays"] = passwordRotationWarningDays
 	// Valid settings for code parameters.
 	m["shortCodeLengths"] = shortCodeLengths
-	m["shortCodeMinutes"] = shortCodeMinutes
+	m["maxShortCodeMinutes"] = maxShortCodeMinutes
+	if realm.ShortCodeMaxMinutes > maxShortCodeMinutes {
+		m["maxShortCodeMinutes"] = realm.ShortCodeMaxMinutes
+		realmShortCodeMinutes := make([]int, 0, realm.ShortCodeMaxMinutes-5)
+		for i := 5; i <= int(realm.ShortCodeMaxMinutes); i++ {
+			realmShortCodeMinutes = append(realmShortCodeMinutes, i)
+		}
+		m["shortCodeMinutes"] = realmShortCodeMinutes
+	} else {
+		m["shortCodeMinutes"] = shortCodeMinutes
+	}
 	m["longCodeLengths"] = longCodeLengths
 	m["longCodeHours"] = longCodeHours
 	m["enxRedirectDomain"] = c.config.IssueConfig().ENExpressRedirectDomain

--- a/pkg/controller/realmadmin/settings_show.go
+++ b/pkg/controller/realmadmin/settings_show.go
@@ -146,16 +146,12 @@ func (c *Controller) renderSettings(
 	// Valid settings for code parameters.
 	m["shortCodeLengths"] = shortCodeLengths
 	m["maxShortCodeMinutes"] = maxShortCodeMinutes
-	if realm.ShortCodeMaxMinutes > maxShortCodeMinutes {
-		m["maxShortCodeMinutes"] = realm.ShortCodeMaxMinutes
-		realmShortCodeMinutes := make([]int, 0, realm.ShortCodeMaxMinutes-5)
-		for i := 5; i <= int(realm.ShortCodeMaxMinutes); i++ {
-			realmShortCodeMinutes = append(realmShortCodeMinutes, i)
-		}
-		m["shortCodeMinutes"] = realmShortCodeMinutes
-	} else {
-		m["shortCodeMinutes"] = shortCodeMinutes
+	// Generate possible values for short code expiration minutes.
+	realmShortCodeMinutes := make([]int, 0, realm.ShortCodeMaxMinutes-5)
+	for i := 5; i <= int(realm.ShortCodeMaxMinutes); i++ {
+		realmShortCodeMinutes = append(realmShortCodeMinutes, i)
 	}
+	m["shortCodeMinutes"] = realmShortCodeMinutes
 	m["longCodeLengths"] = longCodeLengths
 	m["longCodeHours"] = longCodeHours
 	m["enxRedirectDomain"] = c.config.IssueConfig().ENExpressRedirectDomain

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2284,8 +2284,8 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,
 					`ALTER TABLE realms
-						DROP COLUMN short_code_max_minutes,
-						DROP COLUMN enx_code_expiration_configurable`)
+						DROP COLUMN IF EXISTS short_code_max_minutes,
+						DROP COLUMN IF EXISTS enx_code_expiration_configurable`)
 			},
 		},
 	}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2269,6 +2269,25 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`DROP TABLE secrets`)
 			},
 		},
+		{
+			ID: "00104-AddCodeOverrides",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						ADD COLUMN IF NOT EXISTS short_code_max_minutes SMALLINT DEFAULT 60,
+						ADD COLUMN IF NOT EXISTS enx_code_expiration_configurable BOOL DEFAULT false`,
+					`ALTER TABLE realms
+						ALTER COLUMN short_code_max_minutes SET NOT NULL,
+						ALTER COLUMN enx_code_expiration_configurable SET NOT NULL`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						DROP COLUMN short_code_max_minutes,
+						DROP COLUMN enx_code_expiration_configurable`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -109,7 +109,6 @@ var (
 var ENXRedirectDomain = os.Getenv("ENX_REDIRECT_DOMAIN")
 
 const (
-	maxCodeDuration     = time.Hour
 	maxLongCodeDuration = 24 * time.Hour
 
 	SMSRegion        = "[region]"
@@ -401,15 +400,9 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 	}
 
 	// Validation of the max code duration is dependent on overrides.
-	overrideDuration := time.Minute * time.Duration(r.ShortCodeMaxMinutes)
-	if overrideDuration != maxCodeDuration {
-		if r.CodeDuration.Duration > overrideDuration {
-			r.AddError("codeDuration", fmt.Sprintf("must be no more than %v minutes", r.ShortCodeMaxMinutes))
-		}
-	} else {
-		if r.CodeDuration.Duration > maxCodeDuration {
-			r.AddError("codeDuration", "must be no more than 1 hour")
-		}
+	realmMaxCodeDuration := time.Minute * time.Duration(r.ShortCodeMaxMinutes)
+	if r.CodeDuration.Duration > realmMaxCodeDuration {
+		r.AddError("codeDuration", fmt.Sprintf("must be no more than %v minutes", r.ShortCodeMaxMinutes))
 	}
 
 	if r.LongCodeLength < 12 {

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -109,7 +109,12 @@ var (
 var ENXRedirectDomain = os.Getenv("ENX_REDIRECT_DOMAIN")
 
 const (
-	maxLongCodeDuration = 24 * time.Hour
+	DefaultShortCodeLength            = 8
+	DefaultShortCodeExpirationMinutes = 15
+	DefaultLongCodeLength             = 16
+	DefaultLongCodeExpirationHours    = 24
+	DefaultMaxShortCodeMinutes        = 60
+	maxLongCodeDuration               = 24 * time.Hour
 
 	SMSRegion        = "[region]"
 	SMSCode          = "[code]"
@@ -171,10 +176,10 @@ type Realm struct {
 
 	// ShortCodeMaxMinutes can only be set by system admins and allows for a
 	// realm to have a higher max short code duration
-	ShortCodeMaxMinutes uint
+	ShortCodeMaxMinutes uint `gorm:"column: short_code_max_minutes; type:smallint; not null; default: 60;"`
 	// ENXCodeExpirationConfigurable can only be set by system admins and allows
 	// for an ENX realm to change the short code expiration time (normally fixed)
-	ENXCodeExpirationConfigurable bool
+	ENXCodeExpirationConfigurable bool `gorm:"column: enx_code_expiration_configurable; type:bool; not null; default: false;"`
 
 	// SMS configuration
 	SMSTextTemplate           string          `gorm:"type:text; not null; default: 'This is your Exposure Notifications Verification code: [longcode] Expires in [longexpires] hours';"`
@@ -301,11 +306,11 @@ type Realm struct {
 func NewRealmWithDefaults(name string) *Realm {
 	return &Realm{
 		Name:                name,
-		CodeLength:          8,
-		CodeDuration:        FromDuration(15 * time.Minute),
-		LongCodeLength:      16,
-		LongCodeDuration:    FromDuration(24 * time.Hour),
-		ShortCodeMaxMinutes: 60,
+		CodeLength:          DefaultShortCodeLength,
+		CodeDuration:        FromDuration(DefaultShortCodeExpirationMinutes * time.Minute),
+		LongCodeLength:      DefaultLongCodeLength,
+		LongCodeDuration:    FromDuration(DefaultLongCodeExpirationHours * time.Hour),
+		ShortCodeMaxMinutes: DefaultMaxShortCodeMinutes,
 		SMSTextTemplate:     DefaultSMSTextTemplate,
 		AllowedTestTypes:    TestTypeConfirmed | TestTypeLikely | TestTypeNegative,
 		CertificateDuration: FromDuration(15 * time.Minute),
@@ -391,6 +396,8 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 		r.AddError("passwordWarn", "may not be longer than password rotation period")
 	}
 
+	// TODO(mikehelmick) - make these configurable. There isn't currently a good way
+	// to thread config to this point though.
 	if r.ShortCodeMaxMinutes < 60 || r.ShortCodeMaxMinutes > 120 {
 		r.AddError("shortCodeMaxMinutes", "must be >= 60 and <= 120")
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -297,11 +297,12 @@ func TestRealm_BeforeSave(t *testing.T) {
 		{
 			Name: "valid",
 			Input: &Realm{
-				Name:            "a",
-				CodeLength:      6,
-				LongCodeLength:  12,
-				EnableENExpress: false,
-				SMSTextTemplate: valid,
+				Name:                "a",
+				CodeLength:          6,
+				LongCodeLength:      12,
+				EnableENExpress:     false,
+				SMSTextTemplate:     valid,
+				ShortCodeMaxMinutes: 60,
 			},
 		},
 		{
@@ -311,6 +312,7 @@ func TestRealm_BeforeSave(t *testing.T) {
 				EnableENExpress:           false,
 				SMSTextTemplate:           valid,
 				SMSTextAlternateTemplates: map[string]*string{"alternate1": nil},
+				ShortCodeMaxMinutes:       60,
 			},
 			Error: "no template for label alternate1",
 		},
@@ -320,6 +322,7 @@ func TestRealm_BeforeSave(t *testing.T) {
 				Name:                      "b",
 				CodeLength:                6,
 				LongCodeLength:            12,
+				ShortCodeMaxMinutes:       60,
 				EnableENExpress:           false,
 				SMSTextTemplate:           valid,
 				SMSTextAlternateTemplates: map[string]*string{"alternate1": &valid},

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -204,11 +204,12 @@ func TestRealm_BeforeSave(t *testing.T) {
 		{
 			Name: "code_duration_too_long",
 			Input: &Realm{
-				Name:         "a",
-				CodeLength:   6,
-				CodeDuration: FromDuration(time.Hour + time.Minute),
+				Name:                "a",
+				CodeLength:          6,
+				CodeDuration:        FromDuration(time.Hour + time.Minute),
+				ShortCodeMaxMinutes: 60, // the default.
 			},
-			Error: "codeDuration must be no more than 1 hour",
+			Error: "codeDuration must be no more than 60 minutes",
 		},
 		{
 			Name: "long_code_length_too_short",


### PR DESCRIPTION
## Proposed Changes

* System admin can change a short code max expiration to between 60 and 120 minute s
* System admin can allow an ENX realm to change their short code expiration

Admin screen

![image](https://user-images.githubusercontent.com/92319/115591059-8ecc4080-a286-11eb-99b3-d54f1dda6771.png)

ENX realm w/ editable code duration

![image](https://user-images.githubusercontent.com/92319/115591126-a3103d80-a286-11eb-81d1-ff48857995f2.png)


**Release Note**


```release-note
System admins can allow for a domain to have longer short code expiration times (up to 2 hours) and for that realm to edit their short code expiration time even if ENX is enabled
```
