### PR TITLE
make certificate NBF duration configurable

### DIFF
--- a/pkg/config/certificate_signing_config.go
+++ b/pkg/config/certificate_signing_config.go
@@ -26,6 +26,9 @@ type CertificateSigningConfig struct {
 	// Keys determines the key manager configuration for this certificate signing
 	// configuration.
 	Keys keys.Config `env:",prefix=CERTIFICATE_"`
+	
+	// AllowedClockSkew impacts the "not before" or NBF time for certificates
+	AllowedClockSkew time.Duration `env:"ALLOWED_CLOCK_SKEW,default=5s"`
 
 	PublicKeyCacheDuration  time.Duration `env:"PUBLIC_KEY_CACHE_DURATION, default=15m"`
 	SignerCacheDuration     time.Duration `env:"CERTIFICATE_SIGNER_CACHE_DURATION, default=1m"`

--- a/pkg/config/certificate_signing_config.go
+++ b/pkg/config/certificate_signing_config.go
@@ -26,7 +26,7 @@ type CertificateSigningConfig struct {
 	// Keys determines the key manager configuration for this certificate signing
 	// configuration.
 	Keys keys.Config `env:",prefix=CERTIFICATE_"`
-	
+
 	// AllowedClockSkew impacts the "not before" or NBF time for certificates
 	AllowedClockSkew time.Duration `env:"ALLOWED_CLOCK_SKEW,default=5s"`
 

--- a/pkg/controller/certapi/certificate.go
+++ b/pkg/controller/certapi/certificate.go
@@ -122,7 +122,7 @@ func (c *Controller) HandleCertificate() http.Handler {
 		claims.StandardClaims.Issuer = signerInfo.Issuer
 		claims.StandardClaims.IssuedAt = now.Unix()
 		claims.StandardClaims.ExpiresAt = now.Add(signerInfo.Duration).Unix()
-		claims.StandardClaims.NotBefore = now.Add(-1 * time.Second).Unix()
+		claims.StandardClaims.NotBefore = now.Add(-1 * c.config.CertificateSigning.AllowedClockSkew).Unix()
 
 		certToken := jwt.NewWithClaims(jwt.SigningMethodES256, claims)
 		certToken.Header[verifyapi.KeyIDHeader] = signerInfo.KeyID


### PR DESCRIPTION

## Proposed Changes

**Release Note**

```release-note
The not before (nbf) time on certificates is no configurable to account for clock skew between verification and key servers.
```
