### PR TITLE
Fix syntax on envconfig

### DIFF
--- a/pkg/config/rotation_config.go
+++ b/pkg/config/rotation_config.go
@@ -91,8 +91,8 @@ type RotationConfig struct {
 	// HMAC key for HMACing verification codes in the database.
 	// VerificationCodeDatabaseHMACKeyMaxAge is the age at which the HMAC key can
 	// be safely deleted.
-	VerificationCodeDatabaseHMACKeyMinAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE=24h"`
-	VerificationCodeDatabaseHMACKeyMaxAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE=72h"` // 2d + 1d
+	VerificationCodeDatabaseHMACKeyMinAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MIN_AGE, default=24h"`
+	VerificationCodeDatabaseHMACKeyMaxAge time.Duration `env:"VERIFICATION_CODE_DATABASE_HMAC_KEY_MAX_AGE, default=72h"` // 2d + 1d
 
 	// TokenSigning is the token signing configuration. This defines the parent
 	// key and common data like issuer, but the individual versions are controlled


### PR DESCRIPTION
This explains why verification codes weren't rotating. I'll look at making this an error in envconfig.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
