### PR TITLE
Enable viewing API key usage by default

### DIFF
--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -34,9 +34,7 @@ type FeatureConfig struct {
 
 	// EnableAPIKeyLastUsedAt controls whether the UI will show the last_used_at
 	// value for an API key.
-	//
-	// TODO(sethvargo): Move to true in 0.28.0+.
-	EnableAPIKeyLastUsedAt bool `env:"ENABLE_API_KEY_LAST_USED_AT, default=false"`
+	EnableAPIKeyLastUsedAt bool `env:"ENABLE_API_KEY_LAST_USED_AT, default=true"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
The UI elements for displaying when an API key was last used is now **ON** by default. To disable this, set `ENABLE_API_KEY_LAST_USED_AT` to false.
```
