### PR TITLE
user report improvements

### DIFF
--- a/assets/enx-redirect/report/header.html
+++ b/assets/enx-redirect/report/header.html
@@ -21,7 +21,7 @@
   integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
 <script src="/static/js/application.js?{{.buildID}}" crossorigin="anonymous"></script>
 
-<title>{{if .title}}[{.title}}{{else}}Verification Code Request{{end}}</title>
+<title>{{if .title}}{{.title}}{{else}}Verification Code Request{{end}}</title>
 
 <header class="mb-3">
   <nav class="nav nav-tabs navbar-expand-md navbar-light bg-light">

--- a/assets/enx-redirect/report/index.html
+++ b/assets/enx-redirect/report/index.html
@@ -12,7 +12,7 @@
   <main role="main" class="container">
     {{if $currentRealm.AgencyImage}}
     <div id="logo" style="background-color: {{$currentRealm.AgencyBackgroundColor}};" >
-      <img src="{{$currentRealm.AgencyImage}}" style="width: 80vw;" />
+      <img src="{{$currentRealm.AgencyImage}}" style="width: 80vw; max-width: 720px;" />
     </div>
     {{end}}
 

--- a/assets/enx-redirect/report/index.html
+++ b/assets/enx-redirect/report/index.html
@@ -10,6 +10,12 @@
 
 <body class="tab-content">
   <main role="main" class="container">
+    {{if $currentRealm.AgencyImage}}
+    <div id="logo" style="background-color: {{$currentRealm.AgencyBackgroundColor}};" >
+      <img src="{{$currentRealm.AgencyImage}}" style="width: 80vw;" />
+    </div>
+    {{end}}
+
     <h1>Request Exposure Notifications verification code from {{.realm.Name}} ({{.realm.RegionCode}})</h1>
 
     <form method="POST" action="/report/issue" class="floating-form">
@@ -53,7 +59,9 @@
                  <label for="agreement" class="form-check-label">
                    I agree that I have received a positive test result for COVID-19, that the phone
                    number provided belongs to me, and that I would like to receive a verification code
-                   for Exposure Notifications to share my information anonymously with others. 
+                   for Exposure Notifications to share my information anonymously with others. I understand
+                   that my phone number may be saved temporarily for anti-abuse purposes and this phone number
+                   will not be shared or used in any other way.
                  </label>              
               </div>
             </div>

--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -89,14 +89,6 @@
     {{if .features.EnableUserReport}}
     <label>User report</label>
 
-    {{if and $realm.AllowsUserReport (not $realm.UseAuthenticatedSMS)}}
-    <div class="alert alert-warning" role="alert">
-      This realm has user report enabled, but authenticated SMS disabled. It is recommended
-      to enable authenticated SMS as an extra security measure when using
-      user report. Contact Apple and Google if you have questions about this feature.
-    </div>
-    {{end}}
-
     <div class="form-check mb-3">
       <input type="checkbox" name="allow_user_report" id="allow-user-report" class="form-check-input" value="true" {{checkedIf ($realm.AllowsUserReport)}} />
       <label for="allow-user-report" class="form-check-label">

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -163,6 +163,12 @@
           For the <strong>User Report</strong> template it is strongly recommended that you
           indicate that the user should not use the code if they did not request it.
         </div>
+
+        <div class="alert alert-info" role="alert">
+          The <strong>User Report</strong> template must have the <code>[code]</code>
+          expansion (short code) for auto fill in the operating system / application.
+          Other fields can be included.
+        </div>
       {{end}}
       {{if or (not $realm.AllowsUserReport) (ne "User Report" $v.Label)}}
       <button class="btn btn-danger mb-3 {{if eq $i 0}}d-none{{end}}" type="button" {{if ne $i 0}}onClick="removeTemplate('sms-template-{{$i}}');"{{end}}>Delete template</button>

--- a/internal/clients/app_sync.go
+++ b/internal/clients/app_sync.go
@@ -60,6 +60,8 @@ type App struct {
 	Region        string `json:"region"`
 	IsEnx         bool   `json:"is_enx,omitempty"`
 	AndroidTarget `json:"android_target"`
+	AgencyColor   string `json:"agencyColor"`
+	AgencyImage   string `json:"agencyImage"`
 }
 
 // AndroidTarget holds the android metadata for an App of AppResponse.

--- a/internal/clients/app_sync.go
+++ b/internal/clients/app_sync.go
@@ -60,8 +60,8 @@ type App struct {
 	Region        string `json:"region"`
 	IsEnx         bool   `json:"is_enx,omitempty"`
 	AndroidTarget `json:"android_target"`
-	AgencyColor   string `json:"agencyColor"`
-	AgencyImage   string `json:"agencyImage"`
+	AgencyColor   string `json:"agency_color"`
+	AgencyImage   string `json:"agency_image"`
 }
 
 // AndroidTarget holds the android metadata for an App of AppResponse.

--- a/pkg/controller/appsync/handle_sync_test.go
+++ b/pkg/controller/appsync/handle_sync_test.go
@@ -132,8 +132,6 @@ func testAppSyncServer(tb testing.TB) *httptest.Server {
 						PackageName:            "testAppID-butDifferent",
 						SHA256CertFingerprints: "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
-					AgencyColor: "#AABBCC",
-					AgencyImage: "https://example.com/logo.png",
 				}, {
 					Region: "US-WA",
 					IsEnx:  true,
@@ -142,6 +140,8 @@ func testAppSyncServer(tb testing.TB) *httptest.Server {
 						PackageName:            "testAppId2",
 						SHA256CertFingerprints: "BB:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
+					AgencyColor: "#AABBCC",
+					AgencyImage: "https://example.com/logo.png",
 				},
 			},
 		}

--- a/pkg/controller/appsync/handle_sync_test.go
+++ b/pkg/controller/appsync/handle_sync_test.go
@@ -132,6 +132,8 @@ func testAppSyncServer(tb testing.TB) *httptest.Server {
 						PackageName:            "testAppID-butDifferent",
 						SHA256CertFingerprints: "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
+					AgencyColor: "#AABBCC",
+					AgencyImage: "https://example.com/logo.png",
 				}, {
 					Region: "US-WA",
 					IsEnx:  true,

--- a/pkg/controller/appsync/helpers.go
+++ b/pkg/controller/appsync/helpers.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"fmt"
 	"net/url"
+	"strings"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 
@@ -58,7 +59,7 @@ func (c *Controller) syncApps(ctx context.Context, apps *clients.AppsResponse) *
 
 		if _, found := agencyUpdatedAlready[realm.RegionCode]; !found {
 			// Sync the realm level items.
-			realm.AgencyBackgroundColor = app.AgencyColor
+			realm.AgencyBackgroundColor = strings.ToLower(app.AgencyColor)
 			realm.AgencyImage = app.AgencyImage
 			if err := c.db.SaveRealm(realm, database.System); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("unable to update agency information: %w", err))

--- a/pkg/controller/appsync/helpers.go
+++ b/pkg/controller/appsync/helpers.go
@@ -39,11 +39,6 @@ func (c *Controller) syncApps(ctx context.Context, apps *clients.AppsResponse) *
 	realms := map[string]*database.Realm{}
 	appsByRealm := map[uint][]*database.MobileApp{}
 
-	// agencyUpdatedAlready is used to ensure that if a realm has multiple apps synced we only update
-	// this to a non-empty value once and that we don't let a later element in the list without agency
-	// images clear something saved earlier.
-	agencyUpdatedAlready := make(map[string]struct{})
-
 	for _, app := range apps.Apps {
 		realm, err := c.findRealmForApp(app, realms)
 		if err != nil {
@@ -57,18 +52,11 @@ func (c *Controller) syncApps(ctx context.Context, apps *clients.AppsResponse) *
 			continue
 		}
 
-		if _, found := agencyUpdatedAlready[realm.RegionCode]; !found {
-			// Sync the realm level items.
-			realm.AgencyBackgroundColor = strings.ToLower(app.AgencyColor)
-			realm.AgencyImage = app.AgencyImage
-			if err := c.db.SaveRealm(realm, database.System); err != nil {
-				merr = multierror.Append(merr, fmt.Errorf("unable to update agency information: %w", err))
-				continue
-			}
-
-			if app.AgencyImage != "" {
-				agencyUpdatedAlready[realm.RegionCode] = struct{}{}
-			}
+		realm.AgencyBackgroundColor = strings.ToLower(app.AgencyColor)
+		realm.AgencyImage = app.AgencyImage
+		if err := c.db.SaveRealm(realm, database.System); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("unable to update agency information: %w", err))
+			continue
 		}
 
 		realmApps, err := c.findAppsForRealm(realm.ID, appsByRealm)

--- a/pkg/controller/appsync/helpers_test.go
+++ b/pkg/controller/appsync/helpers_test.go
@@ -103,6 +103,5 @@ func Test_syncApps(t *testing.T) {
 		if gotRealm.AgencyImage != agencyImage {
 			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyImage, agencyImage)
 		}
-
 	})
 }

--- a/pkg/controller/appsync/helpers_test.go
+++ b/pkg/controller/appsync/helpers_test.go
@@ -65,8 +65,6 @@ func Test_syncApps(t *testing.T) {
 						PackageName:            "testAppID-butDifferent",
 						SHA256CertFingerprints: "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
-					AgencyColor: agencyColor,
-					AgencyImage: agencyImage,
 				}, {
 					Region: "US-WA",
 					IsEnx:  true,
@@ -75,6 +73,8 @@ func Test_syncApps(t *testing.T) {
 						PackageName:            "testAppId2",
 						SHA256CertFingerprints: "BB:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
+					AgencyColor: agencyColor,
+					AgencyImage: agencyImage,
 				},
 			},
 		}

--- a/pkg/controller/appsync/helpers_test.go
+++ b/pkg/controller/appsync/helpers_test.go
@@ -52,6 +52,9 @@ func Test_syncApps(t *testing.T) {
 			t.Fatalf("error saving realm: %v", err)
 		}
 
+		agencyColor := "#000000"
+		agencyImage := "https://example.com/logo.png"
+
 		resp := &clients.AppsResponse{
 			Apps: []clients.App{
 				{
@@ -62,6 +65,8 @@ func Test_syncApps(t *testing.T) {
 						PackageName:            "testAppID-butDifferent",
 						SHA256CertFingerprints: "AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
+					AgencyColor: agencyColor,
+					AgencyImage: agencyImage,
 				}, {
 					Region: "US-WA",
 					IsEnx:  true,
@@ -87,5 +92,17 @@ func Test_syncApps(t *testing.T) {
 		if got, want := len(apps), 2; got != want {
 			t.Errorf("got %d apps, expected %d", got, want)
 		}
+
+		gotRealm, err := db.FindRealmByRegion(realm.RegionCode)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if gotRealm.AgencyBackgroundColor != agencyColor {
+			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyBackgroundColor, agencyColor)
+		}
+		if gotRealm.AgencyImage != agencyImage {
+			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyImage, agencyImage)
+		}
+
 	})
 }

--- a/pkg/controller/userreport/index.go
+++ b/pkg/controller/userreport/index.go
@@ -32,7 +32,7 @@ func (c *Controller) HandleIndex() http.Handler {
 		}
 
 		realm := controller.RealmFromContext(ctx)
-		if !(realm.AllowsUserReport() && realm.AllowAdminUserReport) {
+		if !realm.AllowsUserReport() {
 			controller.NotFound(w, r, c.h)
 			return
 		}

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -57,7 +57,7 @@ func (c *Controller) HandleSend() http.Handler {
 		}
 		ctx = controller.WithRealm(ctx, realm)
 
-		if !(realm.AllowsUserReport() && realm.AllowAdminUserReport) {
+		if !realm.AllowsUserReport() {
 			controller.NotFound(w, r, c.h)
 			return
 		}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2288,6 +2288,25 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 						DROP COLUMN IF EXISTS enx_code_expiration_configurable`)
 			},
 		},
+		{
+			ID: "00105-AddAgencyData",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						ADD COLUMN IF NOT EXISTS agency_background_color TEXT DEFAULT '#ffffff',
+						ADD COLUMN IF NOT EXISTS agency_image TEXT DEFAULT ''`,
+					`ALTER TABLE realms
+						ALTER COLUMN agency_background_color SET NOT NULL,
+						ALTER COLUMN agency_image SET NOT NULL`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						DROP COLUMN IF EXISTS agency_background_color,
+						DROP COLUMN IF EXISTS agency_image`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2293,11 +2293,8 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			Migrate: func(tx *gorm.DB) error {
 				return multiExec(tx,
 					`ALTER TABLE realms
-						ADD COLUMN IF NOT EXISTS agency_background_color TEXT DEFAULT '#ffffff',
-						ADD COLUMN IF NOT EXISTS agency_image TEXT DEFAULT ''`,
-					`ALTER TABLE realms
-						ALTER COLUMN agency_background_color SET NOT NULL,
-						ALTER COLUMN agency_image SET NOT NULL`,
+						ADD COLUMN IF NOT EXISTS agency_background_color TEXT,
+						ADD COLUMN IF NOT EXISTS agency_image TEXT`,
 				)
 			},
 			Rollback: func(tx *gorm.DB) error {

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -504,7 +504,6 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 // validateSMSTemplate is a helper method to validate a single SMSTemplate.
 // Errors are returned by appending them to the realm's Errorable fields.
 func (r *Realm) validateSMSTemplate(label, t string) {
-
 	if label == UserReportTemplateLabel {
 		// For self report - the short code must be included. Including the long code or EN Express link is OK, but is optional.
 		if !strings.Contains(t, SMSCode) {

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -168,6 +168,14 @@ func TestRealm_BeforeSave(t *testing.T) {
 			Error: "regionCode cannot be blank when using EN Express",
 		},
 		{
+			Name: "bad_color",
+			Input: &Realm{
+				RegionCode:            "USA",
+				AgencyBackgroundColor: "green",
+			},
+			Error: "agencyBackgroundColor is not a valid hex color string",
+		},
+		{
 			Name: "system_sms_forbidden",
 			Input: &Realm{
 				UseSystemSMSConfig:    true,

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -146,7 +146,7 @@ func TestIssueToken(t *testing.T) {
 	}
 	realm.AddUserReportToAllowedTestTypes()
 	if err := db.SaveRealm(realm, SystemTest); err != nil {
-		t.Fatalf("unable to enable user-report on test realm: %v", err)
+		t.Fatalf("unable to enable user-report on test realm: %v errors: %+v", err, realm.ErrorMessages())
 	}
 
 	authApp := &AuthorizedApp{

--- a/pkg/integration/enx_redirect_test.go
+++ b/pkg/integration/enx_redirect_test.go
@@ -43,8 +43,13 @@ func TestENXRedirect(t *testing.T) {
 	realm := bs.Realm
 	realm.EnableENExpress = true
 	template := "[enslink]"
+	urTemplate := "[code]"
 	realm.SMSTextTemplate = template
 	for k := range realm.SMSTextAlternateTemplates {
+		if k == database.UserReportTemplateLabel {
+			realm.SMSTextAlternateTemplates[k] = &urTemplate
+			continue
+		}
 		realm.SMSTextAlternateTemplates[k] = &template
 	}
 


### PR DESCRIPTION
Fixes #2061
Towards #1928

## Proposed Changes

* Sync agency image from appsync feed
* Display agency image on appropriate background color for user report
* Change `User Report` templates and guidance/restriction to require short codes `[code]`

![image](https://user-images.githubusercontent.com/92319/116745322-c2f2e000-a9af-11eb-8f8a-6b7dfccafe64.png)

**Release Note**

```release-note
Appsync service will pull agency images if available.
Agency images will show up on the user-report webview
Changed rules on user-report SMS text template
```
