### PR TITLE
Always use HMAC os E164 format phone number

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -39,6 +39,7 @@ require (
 	github.com/lib/pq v1.10.1
 	github.com/microcosm-cc/bluemonday v1.0.9
 	github.com/mikehelmick/go-chaff v0.5.0
+	github.com/nyaruka/phonenumbers v1.0.68 // indirect
 	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/ory/dockertest v3.3.5+incompatible
 	github.com/prometheus/common v0.21.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -734,6 +734,8 @@ github.com/nats-io/nuid v1.0.1/go.mod h1:19wcPz3Ph3q0Jbyiqsd0kePYG7A95tJPxeL+1OS
 github.com/neo4j/neo4j-go-driver v1.8.1-0.20200803113522-b626aa943eba/go.mod h1:ncO5VaFWh0Nrt+4KT4mOZboaczBZcLuHrG+/sUeP8gI=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/nyaruka/phonenumbers v1.0.68 h1:HM+zMsS0iOwREnRKieB+RmK3Sgthwf1Kftgi3GxIp7U=
+github.com/nyaruka/phonenumbers v1.0.68/go.mod h1:sDaTZ/KPX5f8qyV9qN+hIm+4ZBARJrupC6LuhshJq1U=
 github.com/oklog/oklog v0.3.2/go.mod h1:FCV+B7mhrz4o+ueLpx+KqkyXRGMWOYEvfiXtdGtbWGs=
 github.com/oklog/run v1.0.0/go.mod h1:dlhp/R75TPv97u0XWUtDeV/lRKWPKSdTuV0TZvrmrQA=
 github.com/oklog/ulid v1.3.1/go.mod h1:CirwcVhetQ6Lv90oh/F+FBtV6XMibvdAFo93nm5qn4U=

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -74,6 +74,8 @@ const (
 	ErrQuotaExceeded = "quota_exceeded"
 	// ErrSMSQueueFull indicates that Twilio's SMS queue is full and may not accept more SMS messages to send.
 	ErrSMSQueueFull = "sms_queue_full"
+	// ErrPhoneNumberInvalid indicates the phone number could not be parsed, details in the error message.
+	ErrPhoneNumberInvalid = "phone_number_invalid"
 	// ErrSMSFailure indicates that Twilio's responded with a failure.
 	ErrSMSFailure = "sms_failure"
 	// ErrMissingNonce indicates a UserReport request is missing the nonce value.

--- a/pkg/controller/issueapi/gen_code.go
+++ b/pkg/controller/issueapi/gen_code.go
@@ -83,7 +83,7 @@ func (c *Controller) IssueCode(ctx context.Context, vCode *database.Verification
 			return &IssueResult{
 				obsResult:   enobs.ResultError("DUPLICATE_USER_REPORT"),
 				HTTPCode:    http.StatusConflict,
-				ErrorReturn: api.Errorf("phone number not current eligible for user report").WithCode(api.ErrUserReportTryLater),
+				ErrorReturn: api.Errorf("phone number not currently eligible for user report").WithCode(api.ErrUserReportTryLater),
 			}
 		}
 		if errors.Is(err, database.ErrRequiresPhoneNumber) {

--- a/pkg/controller/issueapi/phone.go
+++ b/pkg/controller/issueapi/phone.go
@@ -1,0 +1,32 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueapi
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/nyaruka/phonenumbers"
+)
+
+// CanonicalPhoneNumber returns the E164 formatted phone number.
+func CanonicalPhoneNumber(phone string, defaultRegion string) (string, error) {
+	cc := strings.ToUpper(defaultRegion)
+	pn, err := phonenumbers.Parse(phone, cc)
+	if err != nil {
+		return "", fmt.Errorf("phonenumbers.Parse: %w", err)
+	}
+	return phonenumbers.Format(pn, phonenumbers.E164), nil
+}

--- a/pkg/controller/issueapi/phone_test.go
+++ b/pkg/controller/issueapi/phone_test.go
@@ -1,0 +1,86 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package issueapi
+
+import "testing"
+
+func TestPhoneParseError(t *testing.T) {
+	t.Parallel()
+
+	_, err := CanonicalPhoneNumber("5135551234", "")
+	if err == nil {
+		t.Fatal("expect error, got nil")
+	}
+}
+
+func TestPhoneParse(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name   string
+		input  []string
+		want   string
+		region string
+	}{
+		{
+			name: "us_match",
+			input: []string{
+				"2068675309",
+				"+1 2068675309",
+				"(206) 8675309",
+				"(206) 867-5309",
+				"+1 (206) 867-5309",
+			},
+			want:   "+12068675309",
+			region: "us",
+		},
+		{
+			name: "gb_match",
+			input: []string{
+				"2071838750",
+				"2071 838750",
+				"+44 2071 838750",
+			},
+			want:   "+442071838750",
+			region: "gb",
+		},
+		{
+			name: "br_match",
+			input: []string{
+				"1155256325",
+			},
+			want:   "+551155256325",
+			region: "br",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			for _, in := range tc.input {
+				got, err := CanonicalPhoneNumber(in, tc.region)
+				if err != nil {
+					t.Errorf("error on input %q err: %v", in, err)
+					continue
+				}
+				if got != tc.want {
+					t.Errorf("wrong canonical version for %q got: %q want: %q", in, got, tc.want)
+				}
+			}
+		})
+	}
+}

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -94,6 +94,16 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, internalRequest 
 				ErrorReturn: api.Error(err),
 			}
 		}
+
+		canonicalPhone, err := CanonicalPhoneNumber(request.Phone, realm.SMSCountry)
+		if err != nil {
+			return nil, &IssueResult{
+				obsResult:   enobs.ResultError("INVALID_PHONE"),
+				HTTPCode:    http.StatusBadRequest,
+				ErrorReturn: api.Error(err).WithCode(api.ErrPhoneNumberInvalid),
+			}
+		}
+		request.Phone = canonicalPhone
 	}
 
 	if request.Phone == "" || smsProvider == nil {

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -132,7 +132,14 @@ func (c *Controller) HandleSend() http.Handler {
 				c.renderIndex(w, realm, m)
 				return
 			}
+			if result.ErrorReturn.ErrorCode == api.ErrUserReportTryLater {
+				m["error"] = []string{result.ErrorReturn.Error}
+				m["skipForm"] = true
+				c.renderIndex(w, realm, m)
+				return
+			}
 
+			logger.Errorw("unable to issue user-report code", "status", result.HTTPCode, "error", result.ErrorReturn.Error)
 			// The error returned isn't something the user can easily fix, show internal error, but hide form.
 			m["error"] = []string{"There was an internal error. A verification code cannot be requested at this time."}
 			m["skipForm"] = true

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -322,6 +322,7 @@ func NewRealmWithDefaults(name string) *Realm {
 		LongCodeDuration:    FromDuration(DefaultLongCodeExpirationHours * time.Hour),
 		ShortCodeMaxMinutes: DefaultMaxShortCodeMinutes,
 		SMSTextTemplate:     DefaultSMSTextTemplate,
+		SMSCountry:          "us",
 		AllowedTestTypes:    TestTypeConfirmed | TestTypeLikely | TestTypeNegative,
 		CertificateDuration: FromDuration(15 * time.Minute),
 		RequireDate:         true, // Having dates is really important to risk scoring, encourage this by default true.
@@ -470,6 +471,12 @@ func (r *Realm) BeforeSave(tx *gorm.DB) error {
 				continue
 			}
 			r.validateSMSTemplate(l, *t)
+		}
+	}
+
+	if r.AllowsUserReport() {
+		if r.SMSCountry == "" {
+			r.AddError("smsCountry", "A default SMS Country must be set when user report is enabled")
 		}
 	}
 

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -145,6 +145,7 @@ func TestIssueToken(t *testing.T) {
 		t.Fatal(err)
 	}
 	realm.AddUserReportToAllowedTestTypes()
+	realm.SMSCountry = "us"
 	if err := db.SaveRealm(realm, SystemTest); err != nil {
 		t.Fatalf("unable to enable user-report on test realm: %v errors: %+v", err, realm.ErrorMessages())
 	}

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -271,6 +271,7 @@ func TestSaveUserReport(t *testing.T) {
 	db, _ := testDatabaseInstance.NewDatabase(t, nil)
 	realm := NewRealmWithDefaults("The Grid")
 	realm.AddUserReportToAllowedTestTypes()
+	realm.SMSCountry = "us"
 	if err := db.SaveRealm(realm, SystemTest); err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Towards #1928 

## Proposed Changes

* Add phonenumber lib
* Canonicalize phone numbers (E164) before calculation of HMAC for user-report
* Require realm to have default SMS country when user report enabled

**Release Note**

```release-note
Always store HMAC of E164 version of a phone number so that different formats and presence/absence of country code are treated the same.
```
