### PR TITLE
smsAuth always on

### DIFF
--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -146,11 +146,9 @@ aria-expanded="false" aria-label="Toggle navigation">
             <a class="dropdown-item {{if .currentPath.IsDir "/realm/keys"}}active{{end}}" href="/realm/keys">
               {{t $.locale "nav.signing-keys"}}
             </a>
-            {{if .features.EnableAuthenticatedSMS}}
-              <a class="dropdown-item {{if .currentPath.IsDir "/realm/sms-keys"}}active{{end}}" href="/realm/sms-keys">
-                {{t $.locale "nav.authenticated-sms"}}
-              </a>
-            {{end}}
+            <a class="dropdown-item {{if .currentPath.IsDir "/realm/sms-keys"}}active{{end}}" href="/realm/sms-keys">
+              {{t $.locale "nav.authenticated-sms"}}
+            </a>            
           {{end}}
           {{if $currentMembership.Can rbac.StatsRead}}
             {{$showRealmMenu = true}}

--- a/internal/envstest/adminapi.go
+++ b/internal/envstest/adminapi.go
@@ -82,9 +82,7 @@ func NewAdminAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestI
 			FailClosed: true,
 		},
 
-		Features: config.FeatureConfig{
-			EnableAuthenticatedSMS: true,
-		},
+		Features: config.FeatureConfig{},
 
 		APIKeyCacheDuration: 5 * time.Second,
 		Issue: config.IssueAPIVars{

--- a/internal/envstest/apiserver.go
+++ b/internal/envstest/apiserver.go
@@ -105,9 +105,7 @@ func NewAPIServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstan
 			TokenIssuer:     "test-iss",
 		},
 
-		Features: config.FeatureConfig{
-			EnableAuthenticatedSMS: true,
-		},
+		Features: config.FeatureConfig{},
 
 		RateLimit: *harness.RateLimiterConfig,
 		DevMode:   true,

--- a/internal/envstest/enx_redirect.go
+++ b/internal/envstest/enx_redirect.go
@@ -78,9 +78,8 @@ func NewENXRedirectServerConfig(tb testing.TB, testDatabaseInstance *database.Te
 		},
 
 		Features: config.FeatureConfig{
-			EnableAuthenticatedSMS: true,
-			EnableUserReport:       true,
-			EnableUserReportWeb:    true,
+			EnableUserReport:    true,
+			EnableUserReportWeb: true,
 		},
 
 		RateLimit: *harness.RateLimiterConfig,

--- a/internal/envstest/server.go
+++ b/internal/envstest/server.go
@@ -243,9 +243,7 @@ func NewServerConfig(tb testing.TB, testDatabaseInstance *database.TestInstance)
 			FailClosed: true,
 		},
 
-		Features: config.FeatureConfig{
-			EnableAuthenticatedSMS: true,
-		},
+		Features: config.FeatureConfig{},
 
 		CertificateSigning: config.CertificateSigningConfig{
 			Keys:                  *harness.KeyManagerConfig,

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -323,9 +323,7 @@ func Server(
 		realmkeysRoutes(sub, realmkeysController)
 
 		realmSMSKeysController := smskeys.New(cfg, db, publicKeyCache, h)
-		if cfg.Features.EnableAuthenticatedSMS {
-			realmSMSkeysRoutes(sub, realmSMSKeysController)
-		}
+		realmSMSkeysRoutes(sub, realmSMSKeysController)
 	}
 
 	// JWKs

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -19,11 +19,6 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 // FeatureConfig represents features that are introduced as off by default allowing
 // for server operators to control their release.
 type FeatureConfig struct {
-	// EnableAuthenticatedSMS allows for realms to managed SMS specific signing keys,
-	// and enable/disable this feature. There is no launch timeline for GA.
-	// This should not be used without prior coordination with Apple/Google.
-	EnableAuthenticatedSMS bool `env:"ENABLE_AUTHENTICATED_SMS, default=true"`
-
 	// EnableUserReport allows for realms to enable user initiated diagnosis reporting,
 	// via API + SMS.
 	EnableUserReport bool `env:"ENABLE_USER_REPORT, default=false"`

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -168,7 +168,7 @@ func (c *Controller) smsProviderFor(ctx context.Context, realm *database.Realm) 
 // from a local in-memory cache.
 func (c *Controller) smsSignerFor(ctx context.Context, realm *database.Realm) (crypto.Signer, string, error) {
 	// Do not create a signer if the realm does not sign SMS.
-	if !c.config.GetFeatureConfig().EnableAuthenticatedSMS || !realm.UseAuthenticatedSMS {
+	if !realm.UseAuthenticatedSMS {
 		return nil, "", nil
 	}
 

--- a/pkg/controller/userreport/index_test.go
+++ b/pkg/controller/userreport/index_test.go
@@ -44,9 +44,8 @@ func TestIndex(t *testing.T) {
 		HostnameConfig: map[string]string{},
 
 		Features: config.FeatureConfig{
-			EnableAuthenticatedSMS: true,
-			EnableUserReport:       true,
-			EnableUserReportWeb:    true,
+			EnableUserReport:    true,
+			EnableUserReportWeb: true,
 		},
 	}
 	cfg.Issue.ENExpressRedirectDomain = "127.0.0.1"


### PR DESCRIPTION
## Proposed Changes

* remove feature flag for auth sms

**Release Note**

```release-note
The feature flag control for authenticated SMS is being removed and that feature is now always available.
```
