### PR TITLE
modify error response if phone number already known

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -165,8 +165,11 @@
         </div>
 
         <div class="alert alert-info" role="alert">
-          The <strong>User Report</strong> template must have the <code>[code]</code>
-          expansion (short code) for auto fill in the operating system / application.
+          The <strong>User Report</strong> template:
+          <ul>
+            <li>MUST have the <code>[code]</code> expansion (short code) for auto fill in the operating system / application.</li>
+            <li>SHOULD also contain [enxlink] if you are using Exposure Notifications Express</li>
+          </ul>
           Other fields can be included.
         </div>
       {{end}}

--- a/docs/api.md
+++ b/docs/api.md
@@ -230,6 +230,10 @@ corresponds to the export report type of `SELF_REPORT`.
 
 **UserReportResponse**
 
+For successful responses, it could be that the phone number is not currently eligible
+for user report due to reporting too close together. In this case, success is returned
+and no SMS is send to the phone number.
+
 ```json
 http 200
 {
@@ -261,7 +265,6 @@ Possible error code responses. New error codes may be added in future releases.
 | `invalid_date`          | 400         | No    | The provided test or symptom date, was older or newer than the realm allows.                                    |
 | `missing_nonce`         | 400         | No    | The request is missing the required `nonce` field |
 | `missing_phone`         | 400         | No    | The request is missing the required `phone` field |
-| `user_report_try_later` | 409         | No    | The provided phone number is not allowed to make requests right now. It could be for as little as 30 minutes, or as much as 90 days. A cool down time is not provided. |
 | `maintenance_mode   `   | 429         | Yes   | The server is temporarily down for maintenance. Wait and retry later.                                           |
 | `quota_exceeded`        | 429         | Yes   | The realm has run out of its daily quota allocation for issuing codes. Wait and retry later.                    |
 |                         | 500         | Yes   | Internal processing error, may be successful on retry.                           |

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -73,7 +73,7 @@ type CleanupConfig struct {
 	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
 
 	// UserReportUnclaimedMaxAge is how long a user report phone hash will be kept if the record goes unclaimed.
-	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=60m"`
+	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=30m"`
 	// UserReportMaxAge is how long a claimed user report phone hash will be kept.
 	UserReportMaxAge time.Duration `env:"USER_REPORT_MAX_AGE, default=2160h"` // 2160h = 90 days
 }

--- a/pkg/controller/issueapi/gen_code.go
+++ b/pkg/controller/issueapi/gen_code.go
@@ -81,6 +81,7 @@ func (c *Controller) IssueCode(ctx context.Context, vCode *database.Verification
 		if errors.Is(err, database.ErrAlreadyReported) {
 			stats.Record(ctx, mUserReportColission.M(1))
 			return &IssueResult{
+				VerCode:     vCode,
 				obsResult:   enobs.ResultError("DUPLICATE_USER_REPORT"),
 				HTTPCode:    http.StatusConflict,
 				ErrorReturn: api.Errorf("phone number not currently eligible for user report").WithCode(api.ErrUserReportTryLater),

--- a/pkg/controller/issueapi/handle_user_report.go
+++ b/pkg/controller/issueapi/handle_user_report.go
@@ -119,6 +119,12 @@ func (c *Controller) HandleUserReport() http.Handler {
 		case http.StatusInternalServerError:
 			controller.InternalError(w, r, c.h, errors.New(res.ErrorReturn.Error))
 			return
+		case http.StatusConflict:
+			c.h.RenderJSON(w, http.StatusOK, &api.UserReportResponse{
+				ExpiresAt:          res.IssueCodeResponse().ExpiresAt,
+				ExpiresAtTimestamp: res.IssueCodeResponse().ExpiresAtTimestamp,
+			})
+			return
 		case http.StatusOK:
 			c.h.RenderJSON(w, http.StatusOK, &api.UserReportResponse{
 				ExpiresAt:          res.IssueCodeResponse().ExpiresAt,

--- a/pkg/controller/issueapi/handle_user_report_test.go
+++ b/pkg/controller/issueapi/handle_user_report_test.go
@@ -94,14 +94,16 @@ func TestUserReport(t *testing.T) {
 			httpStatusCode: http.StatusOK,
 		},
 		{
+			// Same phone number as previous case.
+			// The API still returns "success" to prevent
+			// probing for phone numbers that have reported positive.
 			name: "too_soon",
 			request: &api.UserReportRequest{
 				SymptomDate: symptomDate,
 				Phone:       "+12068675309",
 				Nonce:       nonce,
 			},
-			httpStatusCode: http.StatusConflict,
-			responseErr:    "user_report_try_later",
+			httpStatusCode: http.StatusOK,
 		},
 		{
 			name: "missing_phone",

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -181,7 +181,7 @@ resource "google_cloud_run_service_iam_member" "cleanup-invoker" {
 resource "google_cloud_scheduler_job" "cleanup-worker" {
   name             = "cleanup-worker"
   region           = var.cloudscheduler_location
-  schedule         = "*/15 * * * *"
+  schedule         = "*/5 * * * *"
   time_zone        = "America/Los_Angeles"
   attempt_deadline = "${google_cloud_run_service.cleanup.template[0].spec[0].timeout_seconds + 60}s"
 


### PR DESCRIPTION

## Proposed Changes

* prevent users from probing for phone numbers that have been used for self report

**Release Note**


```release-note
If a phone number was previously used for self report, success is return now instead of 409.
```
