### PR TITLE
Add support for returning generated SMS via the admin API

### DIFF
--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -46,10 +46,10 @@
           <h6 class="mb-3">Verification code settings</h6>
           <div class="form-label-group input-group">
             <input name="short_code_max_minutes" id="short-code-max-minutes" type="text" class="form-control" value="{{$realm.ShortCodeMaxMinutes}}"  />
+            <label for="short-code-max-minutes">Short code max duration</label>
             <span class="input-group-append">
               <span class="input-group-text bg-transparent border-left-0">minutes</span>
             </span>
-            <label for="short-code-max-minutes">Short code max duration</label>
           </div>
 
           <div class="form-check mb-3">
@@ -60,6 +60,17 @@
                 If EN Express is enabled, the short code expiration time is normally
                 fixed at 15 minutes. By enabling this setting, a realm admin can customize
                 their short code expiration time even with EN Express enabled.
+              </small>
+            </label>
+          </div>
+
+          <div class="form-check mb-3">
+            <input type="checkbox" name="allow_generated_sms" id="allow-generated-sms" class="form-check-input" value="true" {{checkedIf ($realm.AllowGeneratedSMS)}} />
+            <label for="allow-generated-sms" class="form-check-label">
+              Allow generated SMS
+              <small class="form-text text-muted mb-3">
+                Permit this realm to request full generated SMS messages be
+                returned via the API.
               </small>
             </label>
           </div>

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -220,13 +220,28 @@ type IssueCodeRequest struct {
 	// callers are using a single API key behind an ERP, or when callers are using
 	// the verification server as an API with a different authentication system.
 	// This field is optional.
-
+	//
 	// The information provided is stored exactly as-is. If the identifier is
 	// uniquely identifying PII (such as an email address, employee ID, SSN, etc),
 	// the caller should apply a cryptographic hash before sending that data. The
 	// system does not sanitize or encrypt these external IDs, it is the caller's
 	// responsibility to do so.
 	ExternalIssuerID string `json:"externalIssuerID"`
+
+	// OnlyGenerateSMS is a boolean field which indicates whether the response
+	// should generate and return the SMS message.
+	//
+	// If true, the system will not send the SMS message, but the message will be
+	// returned in the response.
+	//
+	// If true, the Phone field must also be provided.
+	//
+	// If true and the realm has Authenticated SMS enabled, the returned message
+	// will include the authentication signature as part of the body.
+	//
+	// This field can only be set to true if the realm is configured to allow
+	// generated SMS messages.
+	OnlyGenerateSMS bool `json:"onlyGenerateSMS"`
 }
 
 // IssueCodeResponse defines the response type for IssueCodeRequest.
@@ -251,6 +266,11 @@ type IssueCodeResponse struct {
 	// code expires, in UTC seconds since epoch.
 	LongExpiresAt          string `json:"longExpiresAt,omitempty"`
 	LongExpiresAtTimestamp int64  `json:"longExpiresAtTimestamp,omitempty"`
+
+	// GenerateSMS is the compiled SMS message. This field will only be present if
+	// a phone number was provided and onlyGenerateSMS was specified on the
+	// request.
+	GeneratedSMS string `json:"generatedSMS,omitempty"`
 
 	Error     string `json:"error,omitempty"`
 	ErrorCode string `json:"errorCode,omitempty"`

--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -189,6 +189,7 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 		CanUseSystemEmailConfig       bool `form:"can_use_system_email_config"`
 		ShortCodeMaxMinutes           uint `form:"short_code_max_minutes"`
 		ENXCodeExpirationConfigurable bool `form:"enx_code_expiration_configurable"`
+		AllowGeneratedSMS             bool `form:"allow_generated_sms"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -270,6 +271,7 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 		realm.CanUseSystemEmailConfig = form.CanUseSystemEmailConfig
 		realm.ShortCodeMaxMinutes = form.ShortCodeMaxMinutes
 		realm.ENXCodeExpirationConfigurable = form.ENXCodeExpirationConfigurable
+		realm.AllowGeneratedSMS = form.AllowGeneratedSMS
 		if err := c.db.SaveRealm(realm, currentUser); err != nil {
 			if database.IsValidationError(err) {
 				w.WriteHeader(http.StatusUnprocessableEntity)

--- a/pkg/controller/issueapi/handle_issue_test.go
+++ b/pkg/controller/issueapi/handle_issue_test.go
@@ -28,7 +28,7 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
 
-func TestIssue(t *testing.T) {
+func TestHandleIssue(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -39,6 +39,7 @@ func TestIssue(t *testing.T) {
 		t.Fatal(err)
 	}
 	realm.AllowBulkUpload = true
+	realm.AllowGeneratedSMS = true
 	realm.AllowedTestTypes = database.TestTypeConfirmed
 	if err := harness.Database.SaveRealm(realm, database.SystemTest); err != nil {
 		t.Fatal(err)
@@ -70,6 +71,16 @@ func TestIssue(t *testing.T) {
 			request: &api.IssueCodeRequest{
 				TestType:    "confirmed",
 				SymptomDate: symptomDate,
+			},
+			httpStatusCode: http.StatusOK,
+		},
+		{
+			name: "only_generate_sms",
+			request: &api.IssueCodeRequest{
+				TestType:        "confirmed",
+				SymptomDate:     symptomDate,
+				Phone:           "something",
+				OnlyGenerateSMS: true,
 			},
 			httpStatusCode: http.StatusOK,
 		},

--- a/pkg/controller/issueapi/issueapi_test.go
+++ b/pkg/controller/issueapi/issueapi_test.go
@@ -17,6 +17,7 @@ package issueapi_test
 import (
 	"net/http"
 	"testing"
+	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
@@ -35,7 +36,7 @@ func TestMain(m *testing.M) {
 	m.Run()
 }
 
-func TestIssueMalformed(t *testing.T) {
+func TestIssue(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
@@ -45,6 +46,7 @@ func TestIssueMalformed(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	realm.AllowedTestTypes = database.TestTypeConfirmed | database.TestTypeLikely | database.TestTypeNegative | database.TestTypeUserReport
 	realm.AllowBulkUpload = true
 
 	c := issueapi.New(harness.Config, harness.Database, harness.RateLimiter, harness.KeyManager, harness.Renderer)
@@ -122,7 +124,6 @@ func TestIssueMalformed(t *testing.T) {
 		},
 		{
 			name: "issue batch, realm not allowed",
-
 			membership: &database.Membership{
 				Realm: &database.Realm{
 					AllowBulkUpload: false,
@@ -132,6 +133,43 @@ func TestIssueMalformed(t *testing.T) {
 			fn:   c.BatchIssueWithUIAuth,
 			req:  api.BatchIssueCodeRequest{},
 			code: http.StatusBadRequest,
+		},
+		{
+			name: "generated_sms_realm_not_allowed",
+			membership: &database.Membership{
+				Realm: &database.Realm{
+					AllowGeneratedSMS: false,
+				},
+				Permissions: rbac.CodeIssue,
+			},
+			fn: c.IssueWithUIAuth,
+			req: api.IssueCodeRequest{
+				Phone:           "something",
+				OnlyGenerateSMS: true,
+			},
+			code: http.StatusBadRequest,
+		},
+		{
+			name: "generated_sms_realm_allowed",
+			membership: &database.Membership{
+				Realm: &database.Realm{
+					CodeDuration:      database.FromDuration(5 * time.Minute),
+					CodeLength:        8,
+					LongCodeDuration:  database.FromDuration(15 * time.Minute),
+					LongCodeLength:    16,
+					AllowedTestTypes:  database.TestTypeConfirmed,
+					AllowGeneratedSMS: true,
+				},
+				Permissions: rbac.CodeIssue,
+			},
+			fn: c.IssueWithUIAuth,
+			req: api.IssueCodeRequest{
+				Phone:           "something",
+				SymptomDate:     time.Now().UTC().Format(project.RFC3339Date),
+				TestType:        "confirmed",
+				OnlyGenerateSMS: true,
+			},
+			code: http.StatusOK,
 		},
 	}
 
@@ -148,7 +186,7 @@ func TestIssueMalformed(t *testing.T) {
 			tc.fn(w, r)
 
 			if got, want := w.Code, tc.code; got != want {
-				t.Errorf("incorrect error code. got %d, want %d", got, want)
+				t.Errorf("expected %d to be %d: %s", got, want, w.Body.String())
 			}
 		})
 	}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2304,6 +2304,20 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 						DROP COLUMN IF EXISTS agency_image`)
 			},
 		},
+		{
+			ID: "00165-AddAllowGeneratedSMS",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						ADD COLUMN IF NOT EXISTS allow_generated_sms BOOL NOT NULL DEFAULT FALSE`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						DROP COLUMN IF EXISTS allow_generated_sms`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -221,6 +221,12 @@ type Realm struct {
 	// containing verification codes.
 	UseAuthenticatedSMS bool `gorm:"column:use_authenticated_sms; type:bool; not null; default:false;"`
 
+	// AllowGeneratedSMS indicates if this realm can request generated SMS
+	// messages via the API. If enabled, callers can request a fully-compiled and
+	// signed (if Authenticated SMS is enabled) SMS message to be returned when
+	// calling the issue API.
+	AllowGeneratedSMS bool `gorm:"column:allow_generated_sms; type:bool; not null; default:false;"`
+
 	// EmailInviteTemplate is the template for inviting new users.
 	EmailInviteTemplate string `gorm:"type:text;"`
 


### PR DESCRIPTION
This introduces new optional fields to the issue API request and response fields. If `onlyGenerateSMS` is specified in the request, the response will returned the compiled (and signed) SMS message. This feature must be enabled by a system admin on a per-realm basis.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Introduce new optional fields to the `/issue` API for requesting the generated SMS message. This feature must be enabled on a per-realm basis.
```
