### PR TITLE
Add webhook functionality for user report

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,9 +4,11 @@ on:
   push:
     branches:
     - main
+    - experimental
   pull_request:
     branches:
     - main
+    - experimental
   schedule:
     - cron: '0 0 */1 * *'
 

--- a/.golangci.yaml
+++ b/.golangci.yaml
@@ -48,7 +48,6 @@ linters:
   - 'gosimple'
   - 'govet'
   - 'ineffassign'
-  - 'interfacer'
   - 'makezero'
   - 'misspell'
   - 'nakedret'

--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -70,7 +70,8 @@
               Allow generated SMS
               <small class="form-text text-muted mb-3">
                 Permit this realm to request full generated SMS messages be
-                returned via the API.
+                returned via the API. This must be enabled for realms to use
+                their own SMS gateway for sending messages.
               </small>
             </label>
           </div>

--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -2,6 +2,7 @@
 
 {{$realm := .realm}}
 {{$testTypes := .testTypes}}
+{{$userReportDocs := "https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md#user-report-webhooks"}}
 
 <p class="mb-4">
   These are the settings for verification codes. These values determine how and
@@ -40,6 +41,7 @@
   </div>
 
   <hr>
+
   <div class="form-group">
     <label>Allowed test types</label>
     {{if not $realm.EnableENExpress}}
@@ -85,8 +87,11 @@
         </small>
       </label>
     </div>
+  </div>
 
-    
+  <hr>
+
+  <div class="form-group">
     <label>User report</label>
 
     <div class="form-check mb-3">
@@ -119,9 +124,41 @@
         </small>
       </label>
     </div>
+
+    {{if $realm.AllowGeneratedSMS}}
+      <div class="form-label-group">
+        <input type="text" name="user_report_webhook_url" id="user-report-webhook-url" class="form-control text-monospace{{if $realm.ErrorsFor "userReportWebhookURL"}} is-invalid{{end}}"
+          placeholder="Webhook URL" value="{{$realm.UserReportWebhookURL}}" />
+        <label for="user-report-webhook-url">Webhook URL</label>
+        {{template "errorable" $realm.ErrorsFor "userReportWebhookURL"}}
+        <small class="form-text text-muted">
+          To use your own gateway to dispatch SMS messages for user reports, you
+          must provide a publicly-accessible endpoint secured with TLS. When a
+          user completes a diagnosis, this server will send a request with the
+          compiled SMS message and destination phone number to your server. For
+          more information, see the
+          <a href="{{$userReportDocs}}">user report webhook documentation</a>.
+        </small>
+      </div>
+
+      <div class="form-label-group">
+        <input type="password" name="user_report_webhook_secret" id="user-report-webhook-secret" class="form-control text-monospace user-select-all{{if $realm.ErrorsFor "userReportWebhookSecret"}} is-invalid{{end}}"
+          placeholder="Webhook secret" {{if $realm.UserReportWebhookSecret}}value="{{passwordSentinel}}"{{end}} />
+        <label for="user-report-webhook-secret">Webhook secret</label>
+        {{template "errorable" $realm.ErrorsFor "userReportWebhookSecret"}}
+        <small class="form-text text-muted">
+          This shared secret is used to calculate the HMAC of the payload. Your
+          server can use this secret to verify the request came from this
+          server. This value is required if you specify a webhook URL, and it
+          must be at least 12 characters. For more information, see the <a
+          href="{{$userReportDocs}}">user report webhook documentation</a>.
+        </small>
+      </div>
+    {{end}}
   </div>
 
   <hr>
+
   <div class="form-group">
     <label>Date configuration</label>
     <div class="form-group">

--- a/docs/api.md
+++ b/docs/api.md
@@ -623,6 +623,7 @@ the compiled SMS message and destination phone number to your server.
 - Must be **secured via TLS** (https)
 - Must accept a **POST** request
 - Must parse the response as JSON
+- Must send a 200 OK response **within 10 seconds**
 
 The request body will be identical to the [API /issue response](#apiissue). Your
 server should parse the JSON body and extract the `generatedSMS` field.
@@ -649,7 +650,8 @@ func acceptPayload(w http.ResponseWriter, r *http.Request) {
     return
   }
 
-  body, err := ioutil.ReadAll(r.Body)
+  lr := io.LimitReader(r.Body, 2_097_152) // 2 MB
+  body, err := ioutil.ReadAll(lr)
   if err != nil {
     w.WriteHeader(500)
     return

--- a/docs/api.md
+++ b/docs/api.md
@@ -16,6 +16,7 @@
   - [`/api/checkcodestatus`](#apicheckcodestatus)
   - [`/api/expirecode`](#apiexpirecode)
   - [`/api/stats/*`](#apistats)
+- [User report webhooks](#user-report-webhooks)
 - [Chaffing requests](#chaffing-requests)
 - [Response codes overview](#response-codes-overview)
 
@@ -610,6 +611,93 @@ endpoints without notice.
 -   `/api/stats/realm/external-issuers.{csv,json}` - Daily statistics for codes
     issued by external issuers. These statistics only include codes issued by
     the API where an `externalIssuer` field was provided.
+
+# User report webhooks
+
+You can use your own gateway to dispatch SMS messages for user reports. When a
+user completes a self report, the verification server will send a request with
+the compiled SMS message and destination phone number to your server.
+
+- Must be a **publicly-accessible** endpoint
+- Must be **unauthenticated**
+- Must be **secured via TLS** (https)
+- Must accept a **POST** request
+- Must parse the response as JSON
+
+The request body will be identical to the [API /issue response](#apiissue). Your
+server should parse the JSON body and extract the `generatedSMS` field.
+
+Before accepting the request, your server **MUST** validate the integrity of the
+request. All messages from the verification server will include an `X-Signature`
+header. The value of this header will be the hex-encoded SHA-512 HMAC using the
+configured webhook secret as the HMAC secret.
+
+It is critical that your server validate the authenticity of the message. Here
+are some examples of validating the request payload:
+
+```go
+// secret is the webhook secret. It must be the same value as configured in the
+// verification server.
+const secret = "my-super-secret-value"
+
+func acceptPayload(w http.ResponseWriter, r *http.Request) {
+  defer r.Body.Close()
+
+  sig := w.Header.Get("X-Signature")
+  if sig == "" {
+    w.WriteHeader(400)
+    return
+  }
+
+  body, err := ioutil.ReadAll(r.Body)
+  if err != nil {
+    w.WriteHeader(500)
+    return
+  }
+
+  mac := hmac.New(sha512.New, []byte(secret))
+  mac.Write(body)
+  expected := hex.EncodeToString(mac.Sum(nil))
+
+  if subtle.ConstantTimeCompare([]byte(expected), []byte(sig)) != 1 {
+    w.WriteHeader(400)
+    return
+  }
+
+  // Success, process request as JSON and send SMS...
+  s := struct {
+    Phone        string `json:"phone"`
+    GeneratedSMS string `json:"generatedSMS"`
+  }{}
+  if err := json.NewDecoder(bytes.NewReader(body)).Decode(&s); err != nil {
+    w.WriteHeader(500)
+    return
+  }
+  sendSMS(s.Phone, s.GeneratedSMS)
+}
+```
+
+```ruby
+SECRET = "my-super-secret-value".freeze
+
+post '/' do
+  sig = headers['X-Signature']
+  return halt 400 if sig.empty?
+
+  request.body.rewind
+  body = request.body.read
+
+  expected = OpenSSL::HMAC.hexdigest(OpenSSL::Digest.new('sha512'), SECRET, body)
+
+  return halt 400 unless Rack::Utils.secure_compare(expected, sig)
+
+  # Success, process request as JSON and send SMS...
+  parsed = JSON.parse(body)
+  phone = parsed['phone']
+  message = parsed['generatedSMS']
+  send_sms(phone, message)
+end
+```
 
 
 # Chaffing requests

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -272,8 +272,8 @@ type IssueCodeResponse struct {
 	// request.
 	GeneratedSMS string `json:"generatedSMS,omitempty"`
 
-	// Phone is the phone number in which to send the compiled SMS message. This
-	// field will only be present if a phone number was provided and
+	// Phone is the E.164-formatted phone number in which to send the compiled SMS
+	// message. This field will only be present if a phone number was provided and
 	// onlyGenerateSMS was specified on the request.
 	Phone string `json:"phone,omitempty"`
 

--- a/pkg/api/api.go
+++ b/pkg/api/api.go
@@ -272,6 +272,11 @@ type IssueCodeResponse struct {
 	// request.
 	GeneratedSMS string `json:"generatedSMS,omitempty"`
 
+	// Phone is the phone number in which to send the compiled SMS message. This
+	// field will only be present if a phone number was provided and
+	// onlyGenerateSMS was specified on the request.
+	Phone string `json:"phone,omitempty"`
+
 	Error     string `json:"error,omitempty"`
 	ErrorCode string `json:"errorCode,omitempty"`
 }

--- a/pkg/controller/issueapi/handle_issue_test.go
+++ b/pkg/controller/issueapi/handle_issue_test.go
@@ -79,7 +79,7 @@ func TestHandleIssue(t *testing.T) {
 			request: &api.IssueCodeRequest{
 				TestType:        "confirmed",
 				SymptomDate:     symptomDate,
-				Phone:           "something",
+				Phone:           "5005550000",
 				OnlyGenerateSMS: true,
 			},
 			httpStatusCode: http.StatusOK,

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -60,15 +60,20 @@ func (result *IssueResult) IssueCodeResponse() *api.IssueCodeResponse {
 	}
 
 	v := result.VerCode
-	return &api.IssueCodeResponse{
+	resp := &api.IssueCodeResponse{
 		UUID:                   v.UUID,
 		VerificationCode:       v.Code,
 		ExpiresAt:              v.ExpiresAt.Format(time.RFC1123),
 		ExpiresAtTimestamp:     v.ExpiresAt.UTC().Unix(),
 		LongExpiresAt:          v.LongExpiresAt.Format(time.RFC1123),
 		LongExpiresAtTimestamp: v.LongExpiresAt.UTC().Unix(),
-		GeneratedSMS:           result.GeneratedSMS,
 	}
+
+	if result.GeneratedSMS != "" {
+		resp.GeneratedSMS = result.GeneratedSMS
+		resp.Phone = v.PhoneNumber
+	}
+	return resp
 }
 
 // IssueOne handles validating a single IssueCodeRequest, issuing a new code, and sending an SMS message.

--- a/pkg/controller/issueapi/issueapi_test.go
+++ b/pkg/controller/issueapi/issueapi_test.go
@@ -86,7 +86,7 @@ func TestIssue(t *testing.T) {
 			},
 			fn: c.IssueWithAPIAuth,
 			req: api.IssueCodeRequest{
-				Phone: "something",
+				Phone: "5005550000",
 			},
 			code: http.StatusInternalServerError, // unauthorized at middleware
 		},
@@ -108,7 +108,7 @@ func TestIssue(t *testing.T) {
 			},
 			fn: c.IssueWithUIAuth,
 			req: api.IssueCodeRequest{
-				Phone: "something",
+				Phone: "5005550000",
 			},
 			code: http.StatusUnauthorized,
 		},
@@ -144,7 +144,7 @@ func TestIssue(t *testing.T) {
 			},
 			fn: c.IssueWithUIAuth,
 			req: api.IssueCodeRequest{
-				Phone:           "something",
+				Phone:           "5005550000",
 				OnlyGenerateSMS: true,
 			},
 			code: http.StatusBadRequest,
@@ -159,12 +159,13 @@ func TestIssue(t *testing.T) {
 					LongCodeLength:    16,
 					AllowedTestTypes:  database.TestTypeConfirmed,
 					AllowGeneratedSMS: true,
+					SMSCountry:        "US",
 				},
 				Permissions: rbac.CodeIssue,
 			},
 			fn: c.IssueWithUIAuth,
 			req: api.IssueCodeRequest{
-				Phone:           "something",
+				Phone:           "5005550000",
 				SymptomDate:     time.Now().UTC().Format(project.RFC3339Date),
 				TestType:        "confirmed",
 				OnlyGenerateSMS: true,

--- a/pkg/controller/issueapi/phone.go
+++ b/pkg/controller/issueapi/phone.go
@@ -21,7 +21,7 @@ import (
 	"github.com/nyaruka/phonenumbers"
 )
 
-// CanonicalPhoneNumber returns the E164 formatted phone number.
+// CanonicalPhoneNumber returns the E.164 formatted phone number.
 func CanonicalPhoneNumber(phone string, defaultRegion string) (string, error) {
 	cc := strings.ToUpper(defaultRegion)
 	pn, err := phonenumbers.Parse(phone, cc)

--- a/pkg/controller/issueapi/validate_code_test.go
+++ b/pkg/controller/issueapi/validate_code_test.go
@@ -81,16 +81,16 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusOK,
 		},
 		{
-			name: "no phone provider",
+			name: "no_phone_provider",
 			request: api.IssueCodeRequest{
 				TestType:    "confirmed",
 				SymptomDate: symptomDate,
-				Phone:       "+somephone",
+				Phone:       "5005550000",
 			},
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "unsupported test type",
+			name: "unsupported_test_type",
 			request: api.IssueCodeRequest{
 				TestType:    "negative", // this realm only supports confirmed
 				SymptomDate: symptomDate,
@@ -99,7 +99,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "invalid test type",
+			name: "invalid_test_type",
 			request: api.IssueCodeRequest{
 				TestType:    "invalid",
 				SymptomDate: symptomDate,
@@ -108,7 +108,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "no test date",
+			name: "no_test_date",
 			request: api.IssueCodeRequest{
 				TestType: "confirmed",
 			},
@@ -116,7 +116,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "unparsable test date",
+			name: "unparsable_test_date",
 			request: api.IssueCodeRequest{
 				TestType: "confirmed",
 				TestDate: "invalid date",
@@ -125,7 +125,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "really old test date",
+			name: "really_old_test_date",
 			request: api.IssueCodeRequest{
 				TestType:    "confirmed",
 				SymptomDate: "1988-09-14",
@@ -134,7 +134,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "future date",
+			name: "future_date",
 			request: api.IssueCodeRequest{
 				TestType:    "confirmed",
 				SymptomDate: "3020-01-01",
@@ -143,7 +143,7 @@ func TestValidate(t *testing.T) {
 			httpStatusCode: http.StatusBadRequest,
 		},
 		{
-			name: "test older than minDate",
+			name: "test_older_than_minDate",
 			request: api.IssueCodeRequest{
 				TestType: "confirmed",
 				TestDate: minDate.Add(-12 * time.Hour).Format(project.RFC3339Date),

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -61,16 +61,18 @@ type formData struct {
 	KeyServerURLOverride      string `form:"key_server_url"`
 	KeyServerAudienceOverride string `form:"key_server_audience"`
 
-	Codes                 bool              `form:"codes"`
-	AllowedTestTypes      database.TestType `form:"allowed_test_types"`
-	AllowUserReport       bool              `form:"allow_user_report"`
-	AllowAdminUserReport  bool              `form:"allow_admin_user_report"`
-	AllowBulkUpload       bool              `form:"allow_bulk"`
-	RequireDate           bool              `form:"require_date"`
-	CodeLength            uint              `form:"code_length"`
-	CodeDurationMinutes   int64             `form:"code_duration"`
-	LongCodeLength        uint              `form:"long_code_length"`
-	LongCodeDurationHours int64             `form:"long_code_duration"`
+	Codes                   bool              `form:"codes"`
+	AllowedTestTypes        database.TestType `form:"allowed_test_types"`
+	AllowUserReport         bool              `form:"allow_user_report"`
+	AllowAdminUserReport    bool              `form:"allow_admin_user_report"`
+	UserReportWebhookURL    string            `form:"user_report_webhook_url"`
+	UserReportWebhookSecret string            `form:"user_report_webhook_secret"`
+	AllowBulkUpload         bool              `form:"allow_bulk"`
+	RequireDate             bool              `form:"require_date"`
+	CodeLength              uint              `form:"code_length"`
+	CodeDurationMinutes     int64             `form:"code_duration"`
+	LongCodeLength          uint              `form:"long_code_length"`
+	LongCodeDurationHours   int64             `form:"long_code_duration"`
 
 	SMS                       bool               `form:"sms"`
 	UseSystemSMSConfig        bool               `form:"use_system_sms_config"`
@@ -228,6 +230,12 @@ func (c *Controller) HandleSettings() http.Handler {
 			currentRealm.AllowedTestTypes = form.AllowedTestTypes
 			currentRealm.RequireDate = form.RequireDate
 			currentRealm.AllowBulkUpload = form.AllowBulkUpload
+
+			currentRealm.UserReportWebhookURL = form.UserReportWebhookURL
+			if form.UserReportWebhookSecret != project.PasswordSentinel {
+				currentRealm.UserReportWebhookSecret = form.UserReportWebhookSecret
+			}
+
 			if form.AllowUserReport {
 				currentRealm.AddUserReportToAllowedTestTypes()
 				currentRealm.AllowAdminUserReport = form.AllowAdminUserReport

--- a/pkg/controller/userreport/controller.go
+++ b/pkg/controller/userreport/controller.go
@@ -17,6 +17,7 @@ package userreport
 
 import (
 	"fmt"
+	"net/http"
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
@@ -36,6 +37,7 @@ type Controller struct {
 	config           *config.RedirectConfig
 	db               *database.Database
 	localCache       *memcache.Cache
+	httpClient       *http.Client
 	limiter          limiter.Store
 	smsSigner        keys.KeyManager
 	h                *render.Renderer
@@ -55,11 +57,16 @@ func New(cacher cache.Cacher, cfg *config.RedirectConfig, db *database.Database,
 
 	localCache, _ := memcache.New(30 * time.Second)
 
+	httpClient := &http.Client{
+		Timeout: 10 * time.Second,
+	}
+
 	return &Controller{
 		cacher:           cacher,
 		config:           cfg,
 		db:               db,
 		localCache:       localCache,
+		httpClient:       httpClient,
 		limiter:          limiter,
 		smsSigner:        smsSigner,
 		h:                h,

--- a/pkg/controller/userreport/metrics.go
+++ b/pkg/controller/userreport/metrics.go
@@ -1,0 +1,73 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userreport
+
+import (
+	enobs "github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+const metricPrefix = observability.MetricRoot + "/user-report"
+
+var (
+	mUserReportNotAllowed = stats.Float64(metricPrefix+"/user_report_not_allowed", "requests where realm doesnt allow user report", stats.UnitDimensionless)
+	mMissingNonce         = stats.Float64(metricPrefix+"/missing_nonce", "requests missing a nonce value", stats.UnitDimensionless)
+	mInvalidNonce         = stats.Float64(metricPrefix+"/invalid_nonce", "requests with an invalid nonce", stats.UnitDimensionless)
+	mMissingAgreement     = stats.Float64(metricPrefix+"/missing_agreement", "requests missing agreement acceptance", stats.UnitDimensionless)
+	mWebhookError         = stats.Float64(metricPrefix+"/webhook_error", "failed to make upstream webhook request", stats.UnitDimensionless)
+)
+
+func init() {
+	enobs.CollectViews([]*view.View{
+		{
+			Name:        metricPrefix + "/user_report_not_allowed",
+			Measure:     mUserReportNotAllowed,
+			Description: "Count of number of requests where a realm hasnt enabled user report",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/missing_nonce",
+			Measure:     mMissingNonce,
+			Description: "Count of number of requests missing a nonce",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/invalid_nonce",
+			Measure:     mInvalidNonce,
+			Description: "Count of number of requests with an invalid nonce",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/missing_agreement",
+			Measure:     mMissingAgreement,
+			Description: "Count of number of requests missing acceptance of the agreement",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/webhook_error",
+			Measure:     mWebhookError,
+			Description: "Count of number of requests with a non-200 response",
+			TagKeys:     observability.APITagKeys(),
+			Aggregation: view.Count(),
+		},
+	}...)
+}

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -15,7 +15,14 @@
 package userreport
 
 import (
+	"bytes"
+	"context"
+	"crypto/hmac"
+	"crypto/sha512"
+	"encoding/hex"
+	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
 
 	"github.com/google/exposure-notifications-server/pkg/base64util"
@@ -115,6 +122,13 @@ func (c *Controller) HandleSend() http.Handler {
 			Nonce:         nonce,
 		}
 
+		// If the realm has configured a custom webhook URL, do not send the message
+		// even if an SMS provider was given. Instead, generate the SMS message and
+		// post the payload to their endpoint.
+		if realm.UserReportWebhookURL != "" {
+			issueRequest.IssueRequest.OnlyGenerateSMS = true
+		}
+
 		result := c.issueController.IssueOne(ctx, issueRequest)
 		suppressError := false
 		if result.HTTPCode != http.StatusOK {
@@ -142,9 +156,8 @@ func (c *Controller) HandleSend() http.Handler {
 				return
 			}
 			if result.ErrorReturn.ErrorCode == api.ErrUserReportTryLater {
-				// This error counts as success. It prevents a user
-				// from probing for phone numbers that have already been used to
-				// self report.
+				// This error counts as success. It prevents a user from probing for
+				// phone numbers that have already been used to self report.
 				suppressError = true
 			}
 
@@ -153,6 +166,16 @@ func (c *Controller) HandleSend() http.Handler {
 				// The error returned isn't something the user can easily fix, show internal error, but hide form.
 				m["error"] = []string{locale.Get("user-report.internal-error")}
 				m["skipForm"] = true
+				c.renderIndex(w, realm, m)
+				return
+			}
+		}
+
+		// Compile and send the payload to the webhook URL.
+		if realm.UserReportWebhookURL != "" {
+			if err := sendWebhookRequest(ctx, c.httpClient, realm, result); err != nil {
+				logger.Errorw("failed to send webhook request", "error", err)
+				m["error"] = []string{locale.Get("user-report.internal-error")}
 				c.renderIndex(w, realm, m)
 				return
 			}
@@ -168,4 +191,59 @@ func (c *Controller) HandleSend() http.Handler {
 		m["realm"] = realm
 		c.h.RenderHTML(w, "report/issue", m)
 	})
+}
+
+// sendWebhookRequest builds and sends the webhook request to the realm's
+// webhook URL.
+func sendWebhookRequest(ctx context.Context, client *http.Client, realm *database.Realm, result *issueapi.IssueResult) error {
+	logger := logging.FromContext(ctx).Named("userreport.sendWebhookRequest").
+		With("realm", realm.ID).
+		With("webhook_url", realm.UserReportWebhookURL)
+
+	b, mac, err := buildAndSignPayloadForWebhook(realm.UserReportWebhookSecret, result)
+	if err != nil {
+		return fmt.Errorf("failed to build and sign payload for webhook: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, realm.UserReportWebhookURL, bytes.NewReader(b))
+	if err != nil {
+		return fmt.Errorf("failed to build webhook request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Signature", mac)
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("failed to issue payload request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if code := resp.StatusCode; code != 200 {
+		body, _ := ioutil.ReadAll(resp.Body)
+		logger.Errorw("unsuccessful response from webhook",
+			"code", code,
+			"headers", resp.Header,
+			"body", body)
+		return fmt.Errorf("unsuccessful response from webhook (%d)", code)
+	}
+
+	return nil
+}
+
+// buildAndSignPayloaForWebhook encodes the response as JSON, generates an HMAC
+// of the generated JSON, and returns the generated JSON and computed HMAC to
+// the caller.
+func buildAndSignPayloadForWebhook(secret string, body interface{}) ([]byte, string, error) {
+	b, err := json.Marshal(body)
+	if err != nil {
+		return nil, "", fmt.Errorf("failed to marshal json for webhook: %w", err)
+	}
+
+	mac := hmac.New(sha512.New, []byte(secret))
+	if _, err := mac.Write(b); err != nil {
+		return nil, "", fmt.Errorf("failed to write hmac for webhook: %w", err)
+	}
+	result := hex.EncodeToString(mac.Sum(nil))
+
+	return b, result, nil
 }

--- a/pkg/controller/userreport/send_test.go
+++ b/pkg/controller/userreport/send_test.go
@@ -1,0 +1,108 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package userreport
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+func TestBuildAndSignPayloadForWebhook(t *testing.T) {
+	t.Parallel()
+
+	cases := []struct {
+		name    string
+		secret  string
+		body    interface{}
+		expBody string
+		expMac  string
+	}{
+		{
+			name:    "empty",
+			secret:  "",
+			body:    struct{}{},
+			expBody: "{}",
+			expMac:  "bc7b0c6253e31736a26b597695004434377f48ccf1c5b97a44870c8c929495465b6693b4a7097a8ac6b8ee2f744f4ba6f6b52fcdb74cd5a4ec5611a89024b1f9",
+		},
+		{
+			name:    "with_secret",
+			secret:  "foobarbaz",
+			body:    struct{}{},
+			expBody: "{}",
+			expMac:  "e0baf34f99c5eadd808ff0d34326a634a8d8277f1f8839876d6fe7908c6849d559ca3593e16ca68106f93a7f791fec7bcf2d702a6036d84959df32de33f6a1b6",
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+
+			b, mac, err := buildAndSignPayloadForWebhook(tc.secret, tc.body)
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := string(b), tc.expBody; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+
+			if got, want := mac, tc.expMac; got != want {
+				t.Errorf("expected %q to be %q", got, want)
+			}
+		})
+	}
+}
+
+func TestSendWebhookRequest(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	client := &http.Client{
+		Timeout: 2 * time.Second,
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if v := r.Header.Get("Content-Type"); v != "application/json" {
+			t.Errorf("expected content-type to be application/json: %q", w.Header())
+		}
+
+		if r.Header.Get("X-Signature") == "" {
+			t.Errorf("expected signature to be present")
+		}
+
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(func() {
+		srv.Close()
+	})
+
+	realm := &database.Realm{
+		UserReportWebhookURL:    srv.URL,
+		UserReportWebhookSecret: "super-secret",
+	}
+
+	if err := sendWebhookRequest(ctx, client, realm, &issueapi.IssueResult{}); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2305,7 +2305,7 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			},
 		},
 		{
-			ID: "00165-AddAllowGeneratedSMS",
+			ID: "00106-AddAllowGeneratedSMS",
 			Migrate: func(tx *gorm.DB) error {
 				return multiExec(tx,
 					`ALTER TABLE realms
@@ -2314,8 +2314,23 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,
+					`DROP COLUMN IF EXISTS allow_generated_sms`)
+			},
+		},
+		{
+			ID: "00107-AddUserReportWebhook",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
 					`ALTER TABLE realms
-						DROP COLUMN IF EXISTS allow_generated_sms`)
+						ADD COLUMN IF NOT EXISTS user_report_webhook_url TEXT,
+						ADD COLUMN IF NOT EXISTS user_report_webhook_secret TEXT`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms
+						DROP COLUMN IF EXISTS user_report_webhook_url,
+						DROP COLUMN IF EXISTS user_report_webhook_secret`)
 			},
 		},
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -382,6 +382,28 @@ func TestRealm_BeforeSave(t *testing.T) {
 			},
 			Error: "certificateAudience cannot be blank",
 		},
+		{
+			Name: "user_report_webhook_url_no_protocol",
+			Input: &Realm{
+				UserReportWebhookURL: "foo.bar",
+			},
+			Error: "userReportWebhookURL must begin with https://",
+		},
+		{
+			Name: "user_report_webhook_url_http",
+			Input: &Realm{
+				UserReportWebhookURL: "http://foo.bar",
+			},
+			Error: "userReportWebhookURL must begin with https://",
+		},
+		{
+			Name: "user_report_webhook_secret_short",
+			Input: &Realm{
+				UserReportWebhookURL:    "http://foo.bar",
+				UserReportWebhookSecret: "abcd",
+			},
+			Error: "userReportWebhookSecret must be at least 12 characters",
+		},
 	}
 
 	for _, tc := range cases {

--- a/tools/seed/main.go
+++ b/tools/seed/main.go
@@ -138,6 +138,7 @@ func realMain(ctx context.Context) error {
 			realm1 = database.NewRealmWithDefaults("Narnia")
 			realm1.RegionCode = "US-PA"
 			realm1.AbusePreventionEnabled = true
+			realm1.AllowGeneratedSMS = true
 			realm1.AddUserReportToAllowedTestTypes() // Enable user reporting on Narnia
 			if err := db.SaveRealm(realm1, database.System); err != nil {
 				return fmt.Errorf("failed to create realm: %w: %v", err, realm1.ErrorMessages())
@@ -157,6 +158,7 @@ func realMain(ctx context.Context) error {
 			realm2.AllowedTestTypes = database.TestTypeLikely | database.TestTypeConfirmed
 			realm2.RegionCode = "US-WA"
 			realm2.AbusePreventionEnabled = true
+			realm1.AllowGeneratedSMS = true
 			if err := db.SaveRealm(realm2, database.System); err != nil {
 				return fmt.Errorf("failed to create realm: %w: %v", err, realm2.ErrorMessages())
 			}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add functionality for PHAs to use custom SMS gateways for user report via webhooks. This feature requires a system admin to enable generated SMS on the realm first. If enabled, PHAs will be able to configure a Webhook URL for user report. When a user submits their diagnoses, the verification server will send a request to the PHAs server, and the PHA can issue the SMS. For more information, please see the [documentation](https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md#user-report-webhooks).
```
