### PR TITLE
Add alert for user-report webhook errors

### DIFF
--- a/docs/playbooks/alerts/UserReportWebhookError.md
+++ b/docs/playbooks/alerts/UserReportWebhookError.md
@@ -1,0 +1,9 @@
+# UserReportWebhookError
+
+This alert fires when requests to the upstream user-report webhook endpoint
+returns a non-200 status.
+
+## Triage Steps
+
+Go to the metrics explorer and find the offending realm ID. Contact the realm
+administrator and invite them to repair their webhook.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
