### PR TITLE
Add missing 401 page + translations

### DIFF
--- a/assets/enx-redirect/401.html
+++ b/assets/enx-redirect/401.html
@@ -12,7 +12,7 @@
       {{t $.locale "static.unauthorized-message"}}
     </p>
     <div class="d-flex justify-content-center">
-      <a href="https://g.co/ens" class="small text-muted">{{t $.locale "login.about-exposure-notifications"}}</a>
+      <a href="https://g.co/ens" class="small text-decoration-none text-muted">{{t $.locale "login.about-exposure-notifications"}}</a>
     </div>
   </main>
 </body>

--- a/assets/enx-redirect/header.html
+++ b/assets/enx-redirect/header.html
@@ -34,6 +34,5 @@
     cursor: pointer;
     text-decoration: none;
   }
-
 </style>
 {{end}}

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -387,6 +387,12 @@ msgstr "هذا المورد غير موجود."
 msgid "static.redirect-not-found"
 msgstr "لاسترداد رمز Exposure Notifications ، قم بزيارة الرابط الموجود على جهازك المحمول."
 
+msgid "static.unauthorized"
+msgstr "غير مصرح"
+
+msgid "static.unauthorized-message"
+msgstr "أنت غير مخول للقيام بهذا الإجراء."
+
 
 #
 # User report webview
@@ -429,7 +435,7 @@ msgid "user-report.check-mobile-device"
 msgstr "يرجى التحقق من رسائلك النصية على جهازك المحمول."
 
 msgid "user-report.invalid-request"
-msgstr "طلب غير صالح ، يرجى بدء التشغيل من تطبيق Exposure Notifications على جهازك المحمول." 
+msgstr "طلب غير صالح ، يرجى بدء التشغيل من تطبيق Exposure Notifications على جهازك المحمول."
 
 msgid "user-report.not-available"
 msgstr "لا تقبل هيئة الصحة المحلية الخاصة بك التقارير التي بدأها المستخدم في الوقت الحالي."

--- a/internal/i18n/locales/bn/default.po
+++ b/internal/i18n/locales/bn/default.po
@@ -388,6 +388,12 @@ msgstr "সেই সংস্থান নেই"
 msgid "static.redirect-not-found"
 msgstr "একটি এক্সপোজার বিজ্ঞপ্তি কোড রিডিম করতে, আপনার মোবাইল ডিভাইসের লিঙ্কটি দেখুন।"
 
+msgid "static.unauthorized"
+msgstr "অননুমোদিত"
+
+msgid "static.unauthorized-message"
+msgstr "আপনি এই ক্রিয়াটি সম্পাদনের জন্য অনুমোদিত নন।"
+
 
 #
 # User report webview
@@ -430,7 +436,7 @@ msgid "user-report.check-mobile-device"
 msgstr "আপনার মোবাইল ডিভাইসে আপনার পাঠ্য বার্তাগুলি পরীক্ষা করুন।"
 
 msgid "user-report.invalid-request"
-msgstr "অবৈধ অনুরোধ, আপনার মোবাইল ডিভাইসে আপনার এক্সপোজার বিজ্ঞপ্তি অ্যাপ্লিকেশন থেকে লঞ্চ করুন।" 
+msgstr "অবৈধ অনুরোধ, আপনার মোবাইল ডিভাইসে আপনার এক্সপোজার বিজ্ঞপ্তি অ্যাপ্লিকেশন থেকে লঞ্চ করুন।"
 
 msgid "user-report.not-available"
 msgstr "আপনার স্থানীয় স্বাস্থ্য কর্তৃপক্ষ এই মুহুর্তে ব্যবহারকারী সূচিত প্রতিবেদনগুলি গ্রহণ করছে না।"

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -387,6 +387,12 @@ msgstr "Diese ressource existiert nicht."
 msgid "static.redirect-not-found"
 msgstr "Besuchen Sie den Link auf Ihrem Mobilgerät, um einen Exposure Notifications Code einzulösen."
 
+msgid "static.unauthorized"
+msgstr "Nicht autorisiert"
+
+msgid "static.unauthorized-message"
+msgstr "Sie sind nicht berechtigt, diese Aktion auszuführen."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -388,6 +388,12 @@ msgstr "That resource does not exist."
 msgid "static.redirect-not-found"
 msgstr "To redeem an Exposure Notifications code, visit the link on your mobile device."
 
+msgid "static.unauthorized"
+msgstr "Unauthorized"
+
+msgid "static.unauthorized-message"
+msgstr "You are not authorized to perform that action."
+
 
 #
 # User report webview
@@ -430,7 +436,7 @@ msgid "user-report.check-mobile-device"
 msgstr "Please check your text messages on your mobile device."
 
 msgid "user-report.invalid-request"
-msgstr "Invalid request, please launch from your Exposure Notifications application on your mobile device." 
+msgstr "Invalid request, please launch from your Exposure Notifications application on your mobile device."
 
 msgid "user-report.not-available"
 msgstr "Your local health authority is not accepting user initiated reports at this time."

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -387,6 +387,12 @@ msgstr "Ese recurso no existe."
 msgid "static.redirect-not-found"
 msgstr "Para canjear un código Exposure Notifications, visite el vínculo en su dispositivo móvil."
 
+msgid "static.unauthorized"
+msgstr "No autorizado"
+
+msgid "static.unauthorized-message"
+msgstr "No está autorizado para realizar esa acción."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -388,6 +388,12 @@ msgstr "Wala ang mapagkukunang iyon."
 msgid "static.redirect-not-found"
 msgstr "Upang makuha ang isang Exposure Notifications code, bisitahin ang link sa iyong mobile device."
 
+msgid "static.unauthorized"
+msgstr "Hindi pinahintulutan"
+
+msgid "static.unauthorized-message"
+msgstr "Hindi ka pinahintulutan na gawin ang aksyon na iyon."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -388,6 +388,13 @@ msgstr "Cette ressource n'existe pas."
 msgid "static.redirect-not-found"
 msgstr "Pour utiliser un code Exposure Notifications, visitez le lien sur votre appareil mobile."
 
+msgid "static.unauthorized"
+msgstr "Non autorisé"
+
+msgid "static.unauthorized-message"
+msgstr "Vous n'êtes pas autorisé à effectuer cette action."
+
+
 #
 # User report webview
 # ----------

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -388,6 +388,12 @@ msgstr "Sumber daya itu tidak ada."
 msgid "static.redirect-not-found"
 msgstr "Untuk menukarkan kode Exposure Notifications, kunjungi tautan di perangkat seluler Anda."
 
+msgid "static.unauthorized"
+msgstr "Tidak resmi"
+
+msgid "static.unauthorized-message"
+msgstr "Anda tidak diizinkan melakukan tindakan itu."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -388,6 +388,12 @@ msgstr "Quella risorsa non esiste."
 msgid "static.redirect-not-found"
 msgstr "Per riscattare un codice Exposure Notifications, visita il link sul tuo dispositivo mobile."
 
+msgid "static.unauthorized"
+msgstr "Non autorizzato"
+
+msgid "static.unauthorized-message"
+msgstr "Non sei autorizzato a eseguire tale azione."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -388,6 +388,12 @@ msgstr "そのリソースは存在しません。"
 msgid "static.redirect-not-found"
 msgstr "Exposure Notifications コードを利用するには、モバイルデバイスのリンクにアクセスしてください。"
 
+msgid "static.unauthorized"
+msgstr "許可されていない"
+
+msgid "static.unauthorized-message"
+msgstr "そのアクションを実行する権限がありません。"
+
 
 #
 # User report webview

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -388,6 +388,12 @@ msgstr "Тэр нөөц байхгүй."
 msgid "static.redirect-not-found"
 msgstr "Exposure Notifications кодыг зарцуулахын тулд мобайл төхөөрөмж дээрх холбоосоор зочилно уу."
 
+msgid "static.unauthorized"
+msgstr "Зөвшөөрөлгүй"
+
+msgid "static.unauthorized-message"
+msgstr "Та энэ үйлдлийг хийх эрхгүй байна."
+
 #
 # User report webview
 # ----------

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -388,6 +388,12 @@ msgstr "Esse recurso não existe."
 msgid "static.redirect-not-found"
 msgstr "Para resgatar um código Exposure Notifications, visite o link em seu dispositivo móvel."
 
+msgid "static.unauthorized"
+msgstr "Não autorizado"
+
+msgid "static.unauthorized-message"
+msgstr "Você não está autorizado a realizar essa ação."
+
 
 #
 # User report webview

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -388,6 +388,12 @@ msgstr "Bu kaynak mevcut değil."
 msgid "static.redirect-not-found"
 msgstr "Exposure Notifications kodunu kullanmak için mobil cihazınızdaki bağlantıyı ziyaret edin."
 
+msgid "static.unauthorized"
+msgstr "Yetkisiz"
+
+msgid "static.unauthorized-message"
+msgstr "Bu eylemi gerçekleştirme yetkiniz yok."
+
 
 #
 # User report webview

--- a/pkg/controller/mobileapps/create_test.go
+++ b/pkg/controller/mobileapps/create_test.go
@@ -37,7 +37,7 @@ func TestHandleCreate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := c.HandleCreate()
+	handler := harness.WithCommonMiddlewares(c.HandleCreate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/mobileapps/disable_test.go
+++ b/pkg/controller/mobileapps/disable_test.go
@@ -36,7 +36,7 @@ func TestHandleDisable(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := c.HandleDisable()
+	handler := harness.WithCommonMiddlewares(c.HandleDisable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/mobileapps/enable_test.go
+++ b/pkg/controller/mobileapps/enable_test.go
@@ -38,7 +38,7 @@ func TestHandleEnable(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := c.HandleEnable()
+	handler := harness.WithCommonMiddlewares(c.HandleEnable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/mobileapps/index_test.go
+++ b/pkg/controller/mobileapps/index_test.go
@@ -35,7 +35,7 @@ func TestHandleIndex(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(c.HandleIndex())
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/mobileapps/show_test.go
+++ b/pkg/controller/mobileapps/show_test.go
@@ -36,7 +36,7 @@ func TestHandleShow(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := c.HandleShow()
+	handler := harness.WithCommonMiddlewares(c.HandleShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/mobileapps/update_test.go
+++ b/pkg/controller/mobileapps/update_test.go
@@ -38,7 +38,7 @@ func TestHandleUpdate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := mobileapps.New(harness.Database, harness.Renderer)
-	handler := c.HandleUpdate()
+	handler := harness.WithCommonMiddlewares(c.HandleUpdate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/events_test.go
+++ b/pkg/controller/realmadmin/events_test.go
@@ -35,7 +35,7 @@ func TestHandleEvents(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := middleware.InjectCurrentPath()(c.HandleEvents())
+	handler := harness.WithCommonMiddlewares(c.HandleEvents())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/express_disable_test.go
+++ b/pkg/controller/realmadmin/express_disable_test.go
@@ -35,7 +35,7 @@ func TestHandleDisableExpress(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := c.HandleDisableExpress()
+	handler := harness.WithCommonMiddlewares(c.HandleDisableExpress())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/express_enable_test.go
+++ b/pkg/controller/realmadmin/express_enable_test.go
@@ -35,7 +35,7 @@ func TestHandleEnableExpress(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := c.HandleEnableExpress()
+	handler := harness.WithCommonMiddlewares(c.HandleEnableExpress())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/settings_modify_test.go
+++ b/pkg/controller/realmadmin/settings_modify_test.go
@@ -26,7 +26,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
@@ -41,7 +40,7 @@ func TestHandleSettings(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := middleware.InjectCurrentPath()(c.HandleSettings())
+	handler := harness.WithCommonMiddlewares(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/sms_test.go
+++ b/pkg/controller/realmadmin/sms_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
@@ -41,7 +40,7 @@ func TestHandleSettings_SMS(t *testing.T) {
 	}
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := middleware.InjectCurrentPath()(c.HandleSettings())
+	handler := harness.WithCommonMiddlewares(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/smtp_test.go
+++ b/pkg/controller/realmadmin/smtp_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/envstest"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
-	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/realmadmin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/rbac"
@@ -41,7 +40,7 @@ func TestHandleSettings_Email(t *testing.T) {
 	}
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := middleware.InjectCurrentPath()(c.HandleSettings())
+	handler := harness.WithCommonMiddlewares(c.HandleSettings())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmadmin/stats_test.go
+++ b/pkg/controller/realmadmin/stats_test.go
@@ -34,7 +34,7 @@ func TestHandleStats(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := realmadmin.New(harness.Config, harness.Database, harness.RateLimiter, harness.Renderer, harness.Cacher)
-	handler := c.HandleStats()
+	handler := harness.WithCommonMiddlewares(c.HandleStats())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/activate_test.go
+++ b/pkg/controller/realmkeys/activate_test.go
@@ -41,7 +41,7 @@ func TestRealmKeys_SubmitActivate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleActivate()
+	handler := harness.WithCommonMiddlewares(c.HandleActivate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/automatic_rotate_test.go
+++ b/pkg/controller/realmkeys/automatic_rotate_test.go
@@ -40,7 +40,7 @@ func TestHandleAutomaticRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleAutomaticRotate()
+	handler := harness.WithCommonMiddlewares(c.HandleAutomaticRotate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/create_test.go
+++ b/pkg/controller/realmkeys/create_test.go
@@ -39,7 +39,7 @@ func TestRealmKeys_SubmitCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleCreateKey()
+	handler := harness.WithCommonMiddlewares(c.HandleCreateKey())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/destroy_test.go
+++ b/pkg/controller/realmkeys/destroy_test.go
@@ -41,7 +41,7 @@ func TestRealmKeys_SubmitDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleDestroy()
+	handler := harness.WithCommonMiddlewares(c.HandleDestroy())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/index_test.go
+++ b/pkg/controller/realmkeys/index_test.go
@@ -40,7 +40,7 @@ func TestHandleIndex(t *testing.T) {
 	}
 
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleIndex()
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("success", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/manual_rotate_test.go
+++ b/pkg/controller/realmkeys/manual_rotate_test.go
@@ -40,7 +40,7 @@ func TestHandleManualRotate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleManualRotate()
+	handler := harness.WithCommonMiddlewares(c.HandleManualRotate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/save_test.go
+++ b/pkg/controller/realmkeys/save_test.go
@@ -40,7 +40,7 @@ func TestRealmKeys_SubmitSave(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleSave()
+	handler := harness.WithCommonMiddlewares(c.HandleSave())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/realmkeys/upgrade_test.go
+++ b/pkg/controller/realmkeys/upgrade_test.go
@@ -39,7 +39,7 @@ func TestRealmKeys_SubmitUpgrade(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := realmkeys.New(harness.Config, harness.Database, harness.KeyManager, publicKeyCache, harness.Renderer)
-	handler := c.HandleUpgrade()
+	handler := harness.WithCommonMiddlewares(c.HandleUpgrade())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/activate_test.go
+++ b/pkg/controller/smskeys/activate_test.go
@@ -43,7 +43,7 @@ func TestHandleActivate(t *testing.T) {
 	}
 
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleActivate()
+	handler := harness.WithCommonMiddlewares(c.HandleActivate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/create_test.go
+++ b/pkg/controller/smskeys/create_test.go
@@ -45,7 +45,7 @@ func TestHandleCreate(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleCreateKey()
+	handler := harness.WithCommonMiddlewares(c.HandleCreateKey())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/destroy_test.go
+++ b/pkg/controller/smskeys/destroy_test.go
@@ -42,7 +42,7 @@ func TestHandleDestroy(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleDestroy()
+	handler := harness.WithCommonMiddlewares(c.HandleDestroy())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/disable_test.go
+++ b/pkg/controller/smskeys/disable_test.go
@@ -40,7 +40,7 @@ func TestHandleDisable(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleDisable()
+	handler := harness.WithCommonMiddlewares(c.HandleDisable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/enable_test.go
+++ b/pkg/controller/smskeys/enable_test.go
@@ -40,7 +40,7 @@ func TestHandleEnable(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleEnable()
+	handler := harness.WithCommonMiddlewares(c.HandleEnable())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/smskeys/index_test.go
+++ b/pkg/controller/smskeys/index_test.go
@@ -40,7 +40,7 @@ func TestHandleIndex(t *testing.T) {
 		t.Fatal(err)
 	}
 	c := smskeys.New(harness.Config, harness.Database, publicKeyCache, harness.Renderer)
-	handler := c.HandleIndex()
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/bulk_permisisons_test.go
+++ b/pkg/controller/user/bulk_permisisons_test.go
@@ -37,7 +37,7 @@ func TestHandleBulkPermissions(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleBulkPermissions(database.BulkPermissionActionAdd)
+	handler := harness.WithCommonMiddlewares(c.HandleBulkPermissions(database.BulkPermissionActionAdd))
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/create_test.go
+++ b/pkg/controller/user/create_test.go
@@ -38,7 +38,7 @@ func TestHandleCreate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleCreate()
+	handler := harness.WithCommonMiddlewares(c.HandleCreate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/delete_test.go
+++ b/pkg/controller/user/delete_test.go
@@ -37,7 +37,7 @@ func TestHandleDelete(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleDelete()
+	handler := harness.WithCommonMiddlewares(c.HandleDelete())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/export_test.go
+++ b/pkg/controller/user/export_test.go
@@ -37,7 +37,7 @@ func TestHandleExport(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleExport()
+	handler := harness.WithCommonMiddlewares(c.HandleExport())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/import_batch_test.go
+++ b/pkg/controller/user/import_batch_test.go
@@ -35,7 +35,7 @@ func TestHandleImportBatch(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleImportBatch()
+	handler := harness.WithCommonMiddlewares(c.HandleImportBatch())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/import_test.go
+++ b/pkg/controller/user/import_test.go
@@ -34,7 +34,7 @@ func TestHandleImport(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleImport()
+	handler := harness.WithCommonMiddlewares(c.HandleImport())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/index_test.go
+++ b/pkg/controller/user/index_test.go
@@ -37,7 +37,7 @@ func TestHandleIndex(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := middleware.InjectCurrentPath()(c.HandleIndex())
+	handler := harness.WithCommonMiddlewares(c.HandleIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/reset_password_test.go
+++ b/pkg/controller/user/reset_password_test.go
@@ -36,7 +36,7 @@ func TestHandleResetPassword(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleResetPassword()
+	handler := harness.WithCommonMiddlewares(c.HandleResetPassword())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/show_test.go
+++ b/pkg/controller/user/show_test.go
@@ -36,7 +36,7 @@ func TestHandleShow(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleShow()
+	handler := harness.WithCommonMiddlewares(c.HandleShow())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()

--- a/pkg/controller/user/update_test.go
+++ b/pkg/controller/user/update_test.go
@@ -38,7 +38,7 @@ func TestHandleUpdate(t *testing.T) {
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := user.New(harness.AuthProvider, harness.Cacher, harness.Database, harness.Renderer)
-	handler := c.HandleUpdate()
+	handler := harness.WithCommonMiddlewares(c.HandleUpdate())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add missing 401 Unauthorized page to redirect service. Prior to this, 401s on the redirect service would result in 500s due to the missing template. The 401 template is translated into all supported languages.
```
