### PR TITLE
add more to admin display

### DIFF
--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -76,6 +76,37 @@
             </label>
           </div>
 
+          <hr/>
+          <h6 class="mb-3">Enabled Features</h6>
+          <ul>
+            <li>Abuse Prevention:
+              {{if $realm.AbusePreventionEnabled}}
+                <span class="text-success">Enabled</span>
+                <ul>
+                  <li>Calculated limit: <span class="text-monospace">{{.quotaLimit}}</span></li>
+                  <li>Remaining: <span class="text-monospace">{{.quotaRemaining}}</span></li>
+                </ul>
+              {{else}}
+                <span class="text-secondary">Disabled</span>
+              {{end}}
+            </li>
+            <li>User Report:
+              {{if $realm.AllowsUserReport}}
+                <span class="text-success">Enabled</span>
+              {{else}}
+                <span class="text-secondary">Disabled</span>
+              {{end}}
+            </li>
+            <li>Authenticated SMS:
+              {{if $realm.UseAuthenticatedSMS}}
+                <span class="text-success">Enabled</span>
+              {{else}}
+                <span class="text-secondary">Disabled</span>
+              {{end}}
+            </li>
+          </ul>
+        
+
           {{if .supportsPerRealmSigning}}
           <hr>
           <h6 class="mb-3">Certificate</h6>
@@ -165,19 +196,10 @@
           </table>
 
           <hr>
-          <h6 class="mb-2">Abuse prevention</h6>
-          {{if $realm.AbusePreventionEnabled}}
-          <div class="text-success">Enabled</div>
-          <div>Calculated limit: <span class="text-monospace">{{.quotaLimit}}</span></div>
-          <div>Remaining: <span class="text-monospace">{{.quotaRemaining}}</span></div>
-          {{else}}
-          <div class="text-secondary">Disabled</div>
-          {{end}}
-
-          <hr>
           <h6 class="mb-2">View</h6>
           <a class="cared-link pr-2" href="/admin/events?realm_id={{$realm.ID}}">Events &rarr;</a>
           <a class="cared-link" href="/admin/mobile-apps?q={{$realm.Name}}">Mobile apps &rarr;</a>
+
           <hr>
           <button type="submit" class="btn btn-primary btn-block">Update realm</button>
         </form>

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -45,17 +45,20 @@
           <thead>
             <tr>
               <th scope="col" width="50" class="text-center">ID</th>
-              <th scope="col">Name</th>
-              <th scope="col" width="90" class="text-center">User Report</th>
-              <th scope="col" width="75" class="text-center">Chaff</th>
               <th scope="col" width="100" class="text-center">Region</th>
-              <th scope="col" width="120" class="text-center">Signing key</th>
+              <th scope="col">Name</th>
+              <th scope="col" width="75" class="text-center">Chaff (7d)</th>                          
+              <th scope="col" width="100" class="text-center">Abuse Modeling</th> 
+              <th scope="col" width="75" class="text-center">Auth SMS</th>
+              <th scope="col" width="90" class="text-center">User Report</th>
+              <th scope="col" width="90" class="text-center">Signing key</th>
             </tr>
           </thead>
           <tbody>
           {{range $realms}}
             <tr>
               <td class="text-center">{{.ID}}</td>
+              <td class="text-center">{{.RegionCode}}</td>
               <td>
                 <a href="/admin/realms/{{.ID}}/edit">
                   {{.Name}}
@@ -63,15 +66,6 @@
                 {{if (index $memberships .ID)}}
                   <span class="small oi oi-circle-check text-success ml-1" aria-hidden="true"
                     data-toggle="tooltip" title="You have permissions on this realm"></span>
-                {{end}}
-              </td>
-              <td class="text-center">
-                {{if .AllowsUserReport}}
-                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
-                    data-toggle="tooltip" title="User report is enabled"></span>
-                {{else}}
-                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
-                    data-toggle="tooltip" title="User report is not enabled"></span>
                 {{end}}
               </td>
               <td class="text-center">
@@ -83,7 +77,33 @@
                     data-toggle="tooltip" title="NO sent a chaff requests in the past 7 days"></span>
                 {{end}}
               </td>
-              <td class="text-center">{{.RegionCode}}</td>
+              <td class="text-center">
+                {{if .AbusePreventionEnabled}}
+                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Abuse prevention is enabled"></span>
+                {{else}}
+                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Abuse prevention is not enabled"></span>
+                {{end}}
+              </td>
+              <td class="text-center">
+                {{if .UseAuthenticatedSMS}}
+                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Authenticated SMS is enabled"></span>
+                {{else}}
+                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Authenticated SMS is not enabled"></span>
+                {{end}}
+              </td>
+              <td class="text-center">
+                {{if .AllowsUserReport}}
+                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="User report is enabled"></span>
+                {{else}}
+                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="User report is not enabled"></span>
+                {{end}}
+              </td>
               <td class="text-center">
                 {{if .UseRealmCertificateKey}}Realm{{else}}System{{end}}
               </td>

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -47,11 +47,11 @@
               <th scope="col" width="50" class="text-center">ID</th>
               <th scope="col" width="100" class="text-center">Region</th>
               <th scope="col">Name</th>
-              <th scope="col" width="75" class="text-center">Chaff (7d)</th>                          
-              <th scope="col" width="100" class="text-center">Abuse Modeling</th> 
-              <th scope="col" width="75" class="text-center">Auth SMS</th>
-              <th scope="col" width="90" class="text-center">User Report</th>
-              <th scope="col" width="90" class="text-center">Signing key</th>
+              <th scope="col" width="75" class="text-center d-none d-md-table-cell">Chaff (7d)</th>                          
+              <th scope="col" width="100" class="text-center d-none d-md-table-cell">Abuse Modeling</th> 
+              <th scope="col" width="75" class="text-center d-none d-md-table-cell">Auth SMS</th>
+              <th scope="col" width="90" class="text-center d-none d-md-table-cell">User Report</th>
+              <th scope="col" width="90" class="text-center d-none d-md-table-cell">Signing key</th>
             </tr>
           </thead>
           <tbody>
@@ -68,7 +68,7 @@
                     data-toggle="tooltip" title="You have permissions on this realm"></span>
                 {{end}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if (index $realmChaffEvents .ID)}}
                   <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
                     data-toggle="tooltip" title="Chaff requests in the past 7 days"></span>
@@ -77,7 +77,7 @@
                     data-toggle="tooltip" title="NO sent a chaff requests in the past 7 days"></span>
                 {{end}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if .AbusePreventionEnabled}}
                   <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
                     data-toggle="tooltip" title="Abuse prevention is enabled"></span>
@@ -86,7 +86,7 @@
                     data-toggle="tooltip" title="Abuse prevention is not enabled"></span>
                 {{end}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if .UseAuthenticatedSMS}}
                   <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
                     data-toggle="tooltip" title="Authenticated SMS is enabled"></span>
@@ -95,7 +95,7 @@
                     data-toggle="tooltip" title="Authenticated SMS is not enabled"></span>
                 {{end}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if .AllowsUserReport}}
                   <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
                     data-toggle="tooltip" title="User report is enabled"></span>
@@ -104,7 +104,7 @@
                     data-toggle="tooltip" title="User report is not enabled"></span>
                 {{end}}
               </td>
-              <td class="text-center">
+              <td class="text-center d-none d-md-table-cell">
                 {{if .UseRealmCertificateKey}}Realm{{else}}System{{end}}
               </td>
             </tr>

--- a/assets/server/realmadmin/smskeys.html
+++ b/assets/server/realmadmin/smskeys.html
@@ -40,10 +40,8 @@
         {{if not $realm.UseAuthenticatedSMS}}
           <div class="card-body">
             <p>
-              <strong>Warning!</strong> Authenticated SMS is an experimental
-              feature for iOS. Do not enable this unless Apple has instructed
-              you to do so. This feature is not currently available for
-              Android devices.
+              <strong>Warning!</strong> Do not enable this unless you are working
+              with Apple and Google to enable this feature.
             </p>
 
             <p>


### PR DESCRIPTION

## Proposed Changes

* Add more at-a-glance info to system admin overview
 
![image](https://user-images.githubusercontent.com/92319/119053338-c956f500-b97a-11eb-9012-f54451b167c5.png)


**Release Note**

```release-note
Add additional info to system admin realm overview including if abuse prevention is enabled and if authenticated SMS is enabled.
```
