### PR TITLE
reintroduce feature flag to suppress webview for user report

### DIFF
--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -96,7 +96,8 @@ func ENXRedirect(
 	// Handle health.
 	r.Handle("/health", controller.HandleHealthz(db, h)).Methods(http.MethodGet)
 
-	{ // User report web-view configuration.
+	// User report web-view configuration.
+	if cfg.Features.EnableUserReportWeb {
 		// Share static assets with server.
 		{
 			staticFS := assets.ServerStaticFS()

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -18,7 +18,10 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 
 // FeatureConfig represents features that are introduced as off by default allowing
 // for server operators to control their release.
-type FeatureConfig struct { // Currently, there are no feature flags.
+type FeatureConfig struct {
+	// EnableUserReportWeb will host a web page on the enx-redirect service
+	// under a realm's domain IFF that realm has enabled user report.
+	EnableUserReportWeb bool `env:"ENABLE_USER_REPORT_WEB, default=false"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known

--- a/pkg/controller/associated/index_test.go
+++ b/pkg/controller/associated/index_test.go
@@ -41,7 +41,9 @@ func TestIndex(t *testing.T) {
 			"empty": "aa",
 			"okay":  "bb",
 		},
-		Features: config.FeatureConfig{},
+		Features: config.FeatureConfig{
+			EnableUserReportWeb: true,
+		},
 	}
 
 	// Set realm to resolve.


### PR DESCRIPTION
Fixes #2101 

## Proposed Changes

* disable suer report webview by default

**Release Note**

```release-note
Introduces ENABLE_USER_REPORT_WEB feature flag with default value of false. This will disable the user report webview by default.
```
