### PR TITLE
Re-add system-level feature configuration to disable user report webview

### DIFF
--- a/internal/envstest/enx_redirect.go
+++ b/internal/envstest/enx_redirect.go
@@ -77,7 +77,9 @@ func NewENXRedirectServerConfig(tb testing.TB, testDatabaseInstance *database.Te
 			"e2e-test.test.local": "e2e-test",
 		},
 
-		Features: config.FeatureConfig{},
+		Features: config.FeatureConfig{
+			EnableUserReportWeb: true,
+		},
 
 		RateLimit: *harness.RateLimiterConfig,
 

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -21,9 +21,8 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 type FeatureConfig struct {
 	// EnableUserReportWeb hosts a public page on the enx-redirect service under a
 	// realm's domain for users to self-report. Even if enabled, realm's must
-	// still opt into self-report for the page to be displayed. Disabling this
-	// completely disables the web view, regardless of per-realm status.
-	EnableUserReportWeb bool `env:"ENABLE_USER_REPORT_WEB, default=true"`
+	// still opt into self-report for the page to be displayed.
+	EnableUserReportWeb bool `env:"ENABLE_USER_REPORT_WEB, default=false"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -18,7 +18,12 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 
 // FeatureConfig represents features that are introduced as off by default allowing
 // for server operators to control their release.
-type FeatureConfig struct { // Currently, there are no feature flags.
+type FeatureConfig struct {
+	// EnableUserReportWeb hosts a public page on the enx-redirect service under a
+	// realm's domain for users to self-report. Even if enabled, realm's must
+	// still opt into self-report for the page to be displayed. Disabling this
+	// completely disables the web view, regardless of per-realm status.
+	EnableUserReportWeb bool `env:"ENABLE_USER_REPORT_WEB, default=true"`
 }
 
 // AddToTemplate takes TemplateMap and writes the status of all known

--- a/pkg/controller/userreport/index.go
+++ b/pkg/controller/userreport/index.go
@@ -39,7 +39,12 @@ func (c *Controller) HandleIndex() http.Handler {
 		}
 
 		realm := controller.RealmFromContext(ctx)
+		if realm == nil {
+			controller.MissingMembership(w, r, c.h)
+			return
+		}
 		if !realm.AllowsUserReport() {
+			stats.Record(ctx, mUserReportNotAllowed.M(1))
 			controller.NotFound(w, r, c.h)
 			return
 		}

--- a/pkg/controller/userreport/index_test.go
+++ b/pkg/controller/userreport/index_test.go
@@ -43,7 +43,9 @@ func TestIndex(t *testing.T) {
 		DevMode:        true,
 		HostnameConfig: map[string]string{},
 
-		Features: config.FeatureConfig{},
+		Features: config.FeatureConfig{
+			EnableUserReportWeb: true,
+		},
 	}
 	cfg.Issue.ENExpressRedirectDomain = "127.0.0.1"
 


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/2101

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add system-level feature configuration `ENABLE_USER_REPORT_WEB` to enable user report webview. This was previously always enabled, but **this changes the default behavior** to be disabled by default. System admins should set `ENABLE_USER_REPORT_WEB` to `true` to continue to support the webview on their system.
```
