### PR TITLE
use dynamic translations in user report webview. Show translations in…

### DIFF
--- a/assets/enx-redirect/report/index.html
+++ b/assets/enx-redirect/report/index.html
@@ -18,7 +18,8 @@
     </div>
     {{end}}
 
-    <h1 class="mb-3">{{t $.locale "user-report.request-code-from"}} {{.realm.Name}}</h1>
+    <h1 class="mb-3">{{t $.locale "user-report.request-code-from"}}
+      {{tDefault $.realmLocale .realm.Name "agencyDisplayName"}}</h1>
 
     {{if not .skipForm}}
     <div class="alert alert-primary d-flex align-items-center" role="alert">

--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -240,6 +240,33 @@
         </div>
       </div>
     {{end}}
+
+    {{if $.translations}}
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">Synced Localizations</div>
+      <div class="card-body">
+        <p>
+          These localizations are synced to this server through the appsync service.
+        </p>
+        <table class="table table-bordered">
+          <thead>
+            <tr>
+              <th scope="col" width="75">Locale</th>
+              <th scope="col" width="150">Message ID</th>
+              <th scope="col" >Message</th>
+            </tr>
+            {{range $.translations}}
+            <tr>                        
+                <td class="text-left">{{.Locale}}</td>
+                <td class="text-left">{{.MessageID}}</td>                
+                <td class="text-left"><code>{{.Message}}</code></td>              
+            </tr>
+            {{end}}
+          </thead>
+        </table>
+      </div>
+    </div>
+    {{end}}
   </main>
 </body>
 </html>

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -50,6 +50,7 @@
               <th scope="col" width="75" class="text-center d-none d-md-table-cell">Chaff (7d)</th>                          
               <th scope="col" width="100" class="text-center d-none d-md-table-cell">Abuse Modeling</th> 
               <th scope="col" width="75" class="text-center d-none d-md-table-cell">Auth SMS</th>
+              <th scope="col" width="110" class="text-center d-none d-md-table-cell">Generated SMS</th>
               <th scope="col" width="90" class="text-center d-none d-md-table-cell">User Report</th>
               <th scope="col" width="90" class="text-center d-none d-md-table-cell">Signing key</th>
             </tr>
@@ -93,6 +94,15 @@
                 {{else}}
                   <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
                     data-toggle="tooltip" title="Authenticated SMS is not enabled"></span>
+                {{end}}
+              </td>
+              <td class="text-center d-none d-md-table-cell">
+                {{if .AllowGeneratedSMS}}
+                  <span class="small oi oi-circle-check text-success px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Allow generated SMS is enabled"></span>
+                {{else}}
+                  <span class="small oi oi-circle-x text-danger px-2" aria-hidden="true"
+                    data-toggle="tooltip" title="Allow generated SMS is not enabled"></span>
                 {{end}}
               </td>
               <td class="text-center d-none d-md-table-cell">

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -21,9 +21,11 @@ import (
 	"io/fs"
 	"os"
 	"path"
+	"strings"
 	"sync"
 
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/leonelquinteros/gotext"
 	"golang.org/x/text/language"
 )
@@ -49,6 +51,9 @@ type LocaleMap struct {
 	data    map[string]gotext.Translator
 	matcher language.Matcher
 
+	dynamic     map[uint]map[string]gotext.Translator
+	dynamicLock sync.Mutex
+
 	reload     bool
 	reloadLock sync.Mutex
 }
@@ -59,6 +64,89 @@ func TranslatorLanguage(l gotext.Translator) string {
 		return ""
 	}
 	return typ.Language
+}
+
+// poHeader is used when constructing new po file buffers in memory.
+const poHeader = `msgid ""
+msgstr ""
+"Language: %s\n"
+"MIME-Version: 1.0\n"
+"Content-Type: text/plain; charset=UTF-8\n"
+"Content-Transfer-Encoding: 8bit\n"
+"Plural-Forms: nplurals=2; plural=(n != 1);\n"
+
+`
+
+// SetDynamicTranslations creates realm specific locals with translations
+// based on what's in the database.
+func (l *LocaleMap) SetDynamicTranslations(incoming []*database.DynamicTranslation) {
+	poFiles := make(map[uint]map[string]string)
+
+	// Convert incoming tranlations into PO files, grouped by realm, Language
+	for _, dt := range incoming {
+		realm, ok := poFiles[dt.RealmID]
+		if !ok {
+			realm = make(map[string]string)
+			poFiles[dt.RealmID] = realm
+		}
+
+		locale := strings.ToLower(dt.Locale)
+		curFile, ok := realm[locale]
+		if !ok {
+			// build a new file with the po header fields.
+			curFile = fmt.Sprintf(poHeader, locale)
+		}
+
+		addOn := fmt.Sprintf("msgid \"%s\"\nmsgstr \"%s\"\n\n", dt.MessageID, dt.Message)
+		curFile = curFile + addOn
+
+		realm[locale] = curFile
+	}
+
+	// Parse the completed files into gotext.Translator
+	next := make(map[uint]map[string]gotext.Translator, len(poFiles))
+	for realmId, realmLocales := range poFiles {
+		parsed := make(map[string]gotext.Translator, len(realmLocales))
+
+		for locale, poContent := range realmLocales {
+			translator := gotext.NewPoTranslator()
+			translator.Parse([]byte(poContent))
+			parsed[locale] = translator
+		}
+
+		next[realmId] = parsed
+	}
+
+	// Under a lock, replace the current translation map.
+	l.dynamicLock.Lock()
+	defer l.dynamicLock.Unlock()
+	l.dynamic = next
+}
+
+// LookupDynamic finds the best locale for the given ids.
+func (l *LocaleMap) LookupDynamic(realmID uint, ids ...string) gotext.Translator {
+	// Pull a realm's translations out of the map under a lock to avoid data races.
+	l.dynamicLock.Lock()
+	data := l.dynamic[realmID]
+	l.dynamicLock.Unlock()
+
+	for _, id := range ids {
+		// Convert the id to the "canonical" form.
+		canonical, err := l.Canonicalize(id)
+		if err != nil {
+			continue
+		}
+		locale, ok := data[canonical]
+		if !ok {
+			continue
+		}
+		return locale
+	}
+
+	if def, ok := l.data[defaultLocale]; ok {
+		return def
+	}
+	return gotext.NewPoTranslator()
 }
 
 // Lookup finds the best locale for the given ids. If none exists, the default

--- a/internal/i18n/i18n.go
+++ b/internal/i18n/i18n.go
@@ -105,7 +105,7 @@ func (l *LocaleMap) SetDynamicTranslations(incoming []*database.DynamicTranslati
 
 	// Parse the completed files into gotext.Translator
 	next := make(map[uint]map[string]gotext.Translator, len(poFiles))
-	for realmId, realmLocales := range poFiles {
+	for realmID, realmLocales := range poFiles {
 		parsed := make(map[string]gotext.Translator, len(realmLocales))
 
 		for locale, poContent := range realmLocales {
@@ -114,7 +114,7 @@ func (l *LocaleMap) SetDynamicTranslations(incoming []*database.DynamicTranslati
 			parsed[locale] = translator
 		}
 
-		next[realmId] = parsed
+		next[realmID] = parsed
 	}
 
 	// Under a lock, replace the current translation map.

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -134,7 +134,16 @@ func ENXRedirect(
 			return nil, fmt.Errorf("failed to create limiter middleware: %w", err)
 		}
 
-		userReportController, err := userreport.New(cacher, cfg, db, limiterStore, smsSigner, h)
+		// Load localization
+		locales, err := i18n.Load(i18n.WithReloading(cfg.DevMode))
+		if err != nil {
+			return nil, fmt.Errorf("failed to setup i18n: %w", err)
+		}
+
+		// Process localization parameters.
+		processLocale := middleware.ProcessLocale(locales)
+
+		userReportController, err := userreport.New(locales, cacher, cfg, db, limiterStore, smsSigner, h)
 		if err != nil {
 			return nil, fmt.Errorf("failed to create code request controller: %w", err)
 		}
@@ -145,15 +154,6 @@ func ENXRedirect(
 
 		// Using a different name, makes it so cookies don't interfer in local dev.
 		requireSession := middleware.RequireNamedSession(sessions, "en-user-report", h)
-
-		// Load localization
-		locales, err := i18n.Load(i18n.WithReloading(cfg.DevMode))
-		if err != nil {
-			return nil, fmt.Errorf("failed to setup i18n: %w", err)
-		}
-
-		// Process localization parameters.
-		processLocale := middleware.ProcessLocale(locales)
 
 		{ // handler for /report/issue, required values must be in the established session.
 			sub := r.Path("/report/issue").Subrouter()
@@ -168,6 +168,7 @@ func ENXRedirect(
 
 		{ // handler for the /report path - requires API KEY and NONCE headers.
 			sub := r.Path("/report").Subrouter()
+			sub.Use(middleware.LoadDynamicTranslations(locales, db, cacher, cfg.TranslationRefreshPeriod))
 			sub.Use(hostHeaderCheck)
 			sub.Use(requireSession)
 			sub.Use(httplimiter.Handle)

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -168,7 +168,11 @@ func ENXRedirect(
 
 		{ // handler for the /report path - requires API KEY and NONCE headers.
 			sub := r.Path("/report").Subrouter()
-			sub.Use(middleware.LoadDynamicTranslations(locales, db, cacher, cfg.TranslationRefreshPeriod))
+			loadTranslations, err := middleware.LoadDynamicTranslations(locales, db, cacher, cfg.TranslationRefreshPeriod)
+			if err != nil {
+				return nil, fmt.Errorf("failed to load initial set of translations: %w", err)
+			}
+			sub.Use(loadTranslations)
 			sub.Use(hostHeaderCheck)
 			sub.Use(requireSession)
 			sub.Use(httplimiter.Handle)

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -48,6 +48,8 @@ type RedirectConfig struct {
 	SessionDuration    time.Duration `env:"SESSION_DURATION, default=1h"`
 	SessionIdleTimeout time.Duration `env:"SESSION_IDLE_TIMEOUT, default=20m"`
 
+	TranslationRefreshPeriod time.Duration `env:"TRANSLATION_REFRESH_PERIOD, default=30m"`
+
 	// Issue config is pulled in for the ENX_REDIRECT_DOMAIN
 	Issue IssueAPIVars
 

--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -257,6 +257,7 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 		allTranslations, err := c.db.ListDynamicTranslationsCached(ctx, c.cacher)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
+			return
 		}
 		realmTranslations := make([]*database.DynamicTranslation, 0, len(allTranslations))
 		for _, t := range allTranslations {

--- a/pkg/controller/userreport/index.go
+++ b/pkg/controller/userreport/index.go
@@ -49,6 +49,9 @@ func (c *Controller) HandleIndex() http.Handler {
 			return
 		}
 
+		m := controller.TemplateMapFromContext(ctx)
+		m = c.addDynamicTranslations(realm.ID, m)
+
 		session := controller.SessionFromContext(ctx)
 		if session == nil {
 			controller.MissingSession(w, r, c.h)
@@ -61,8 +64,6 @@ func (c *Controller) HandleIndex() http.Handler {
 			controller.InternalError(w, r, c.h, fmt.Errorf("internal error, please try again"))
 			return
 		}
-
-		m := controller.TemplateMapFromContext(ctx)
 
 		now := time.Now().UTC()
 		pastDaysDuration := -1 * c.config.IssueConfig().AllowedSymptomAge

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -65,6 +65,9 @@ func (c *Controller) HandleSend() http.Handler {
 		}
 		ctx = controller.WithRealm(ctx, realm)
 
+		m := controller.TemplateMapFromContext(ctx)
+		m = c.addDynamicTranslations(realm.ID, m)
+
 		if !realm.AllowsUserReport() {
 			stats.Record(ctx, mUserReportNotAllowed.M(1))
 			controller.NotFound(w, r, c.h)
@@ -77,7 +80,6 @@ func (c *Controller) HandleSend() http.Handler {
 			return
 		}
 
-		m := controller.TemplateMapFromContext(ctx)
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			logger.Warn("error binding form", "error", err)

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -216,6 +216,20 @@ func disabledIf(v bool) htmltemplate.HTMLAttr {
 	return ""
 }
 
+// translateWithFallback accepts a message printer and prints the translation,
+// and also accepts a fallback string if the key isn't known.
+func translateWithFallback(t gotext.Translator, fallback string, key string, vars ...interface{}) string {
+	if t == nil {
+		return fmt.Sprintf(fallback, vars...)
+	}
+
+	v := t.Get(key, vars...)
+	if v == "" || v == key {
+		return fmt.Sprintf(fallback, vars...)
+	}
+	return v
+}
+
 // translate accepts a message printer (populated by middleware) and prints the
 // translated text for the given key. If the printer is nil, an error is
 // returned.
@@ -342,6 +356,7 @@ func templateFuncs() htmltemplate.FuncMap {
 		"readonlyIf":       readonlyIf,
 		"disabledIf":       disabledIf,
 		"t":                translate,
+		"tDefault":         translateWithFallback,
 		"passwordSentinel": pwdSentinel,
 		"hasOne":           hasOne,
 		"hasMany":          hasMany,


### PR DESCRIPTION
… admin screens

Towards #2102

## Proposed Changes

* Make use of dynamic translations in the user report UI
* Add middleware to reload and rebuild the translator structs on a 30 minute interval
* Show synced translations for a realm in the system admin page

**Release Note**

```release-note
For Exposure Notifications Express realms, localizations that are synced from the Google feed will be used when rendering the user report web view with sensible fallbacks.
```
