### PR TITLE
allow different language matchers for static and dynamic translations

### DIFF
--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -169,6 +169,8 @@ func TestLocaleMap_Canonicalize(t *testing.T) {
 }
 
 func TestDynamicTranslations(t *testing.T) {
+	t.Parallel()
+
 	defaultLocale := "en"
 	translations := []*database.DynamicTranslation{
 		{

--- a/internal/i18n/i18n_test.go
+++ b/internal/i18n/i18n_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/leonelquinteros/gotext"
 )
@@ -155,7 +156,7 @@ func TestLocaleMap_Canonicalize(t *testing.T) {
 		t.Run(tc.in, func(t *testing.T) {
 			t.Parallel()
 
-			result, err := localeMap.Canonicalize(tc.in)
+			result, err := localeMap.Canonicalize(tc.in, localeMap.matcher)
 			if (err != nil) != tc.err {
 				t.Fatal(err)
 			}
@@ -164,5 +165,38 @@ func TestLocaleMap_Canonicalize(t *testing.T) {
 				t.Errorf("Expected %q to be %q", got, want)
 			}
 		})
+	}
+}
+
+func TestDynamicTranslations(t *testing.T) {
+	defaultLocale := "en"
+	translations := []*database.DynamicTranslation{
+		{
+			RealmID:   1,
+			MessageID: "greeting",
+			Locale:    "en",
+			Message:   "hello",
+		},
+		{
+			RealmID:   1,
+			MessageID: "greeting",
+			Locale:    "es",
+			Message:   "hola",
+		},
+	}
+
+	l := &LocaleMap{}
+	l.SetDynamicTranslations(translations)
+
+	translator := l.LookupDynamic(1, defaultLocale, "en")
+
+	if res := translator.Get("greeting"); res != "hello" {
+		t.Fatalf("wrong translation, got %q want %q", res, "hello")
+	}
+
+	translator = l.LookupDynamic(1, defaultLocale, "fr")
+	// Should get the default
+	if res := translator.Get("greeting"); res != "hello" {
+		t.Fatalf("wrong translation, got %q want %q", res, "hello")
 	}
 }

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -409,7 +409,7 @@ msgid "user-report.request-code-from"
 msgstr "からコードをリクエストする"
 
 msgid "user-report.instructions"
-msgstr "COVID-19の検査で陽性であったが、テキストまたは電話で保健当局からコードを受け取っていない場合は、ここでコードをリクエストできます。
+msgstr "COVID-19の検査で陽性であったが、テキストまたは電話で保健当局からコードを受け取っていない場合は、ここでコードをリクエストできます。"
 
 msgid "user-report.enter-date-instructions"
 msgstr "COVID-19テストの日付を入力してください"

--- a/pkg/controller/userreport/controller.go
+++ b/pkg/controller/userreport/controller.go
@@ -79,9 +79,9 @@ func New(locales *i18n.LocaleMap, cacher cache.Cacher, cfg *config.RedirectConfi
 	}, nil
 }
 
-func (c *Controller) addDynamicTranslations(realmID uint, m controller.TemplateMap) controller.TemplateMap {
+func (c *Controller) addDynamicTranslations(realm *database.Realm, m controller.TemplateMap) controller.TemplateMap {
 	accept := m["acceptLanguage"].([]string)
-	locale := c.locales.LookupDynamic(realmID, accept...)
+	locale := c.locales.LookupDynamic(realm.ID, realm.DefaultLocale, accept...)
 	m["realmLocale"] = locale
 	return m
 }

--- a/pkg/controller/userreport/index.go
+++ b/pkg/controller/userreport/index.go
@@ -50,7 +50,7 @@ func (c *Controller) HandleIndex() http.Handler {
 		}
 
 		m := controller.TemplateMapFromContext(ctx)
-		m = c.addDynamicTranslations(realm.ID, m)
+		m = c.addDynamicTranslations(realm, m)
 
 		session := controller.SessionFromContext(ctx)
 		if session == nil {

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -66,7 +66,7 @@ func (c *Controller) HandleSend() http.Handler {
 		ctx = controller.WithRealm(ctx, realm)
 
 		m := controller.TemplateMapFromContext(ctx)
-		m = c.addDynamicTranslations(realm.ID, m)
+		m = c.addDynamicTranslations(realm, m)
 
 		if !realm.AllowsUserReport() {
 			stats.Record(ctx, mUserReportNotAllowed.M(1))


### PR DESCRIPTION

## Proposed Changes

* Fixes bug where the matcher didn't allow a realm to have a wider language set than the system language set.
* Adds test coverage
* Fixes syntax issue in JA translations

**Release Note**

```release-note
Synced realm translations can be a wider set than the system translations (EN Express only)
```
