### PR TITLE
change redirect defaults, include headless android ENX

### DIFF
--- a/assets/server/mobileapps/show.html
+++ b/assets/server/mobileapps/show.html
@@ -59,6 +59,11 @@
 
             <dt>SHA</dt>
             <dd id="mobileapps-sha" class="text-monospace">{{$app.SHA}}</dd>
+
+            {{if $app.Headless}}
+            <dt>Headless</dt>
+            <dd id="mobileapps-headless" class="text-monospace">EN Express Headless / Settings Based App</dd>
+            {{end}}
           {{end}}
         </dl>
       </div>

--- a/internal/appsync/app_sync.go
+++ b/internal/appsync/app_sync.go
@@ -42,6 +42,7 @@ type App struct {
 	AgencyImage   string          `json:"agency_image"`
 	DefaultLocale string          `json:"default_locale"`
 	Localizations []*Localization `json:"localizations"`
+	Headless      bool            `json:"headless"`
 }
 
 // AndroidTarget holds the android metadata for an App of AppResponse.

--- a/pkg/controller/appsync/helpers.go
+++ b/pkg/controller/appsync/helpers.go
@@ -105,12 +105,13 @@ func (c *Controller) syncApps(ctx context.Context, apps *appsync.AppsResponse) *
 			}
 
 			newApp := &database.MobileApp{
-				Name:    name,
-				RealmID: realm.ID,
-				URL:     playStoreURL.String(),
-				OS:      database.OSTypeAndroid,
-				SHA:     app.SHA256CertFingerprints,
-				AppID:   app.PackageName,
+				Name:     name,
+				RealmID:  realm.ID,
+				URL:      playStoreURL.String(),
+				OS:       database.OSTypeAndroid,
+				SHA:      app.SHA256CertFingerprints,
+				AppID:    app.PackageName,
+				Headless: app.Headless,
 			}
 			if err := c.db.SaveMobileApp(newApp, database.System); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed saving mobile app: %w", err))

--- a/pkg/controller/appsync/helpers_test.go
+++ b/pkg/controller/appsync/helpers_test.go
@@ -78,6 +78,7 @@ func Test_syncApps(t *testing.T) {
 					AgencyColor:   agencyColor,
 					AgencyImage:   agencyImage,
 					DefaultLocale: "en_US",
+					Headless:      true,
 					Localizations: []*appsync.Localization{
 						{
 							MessageID: "greeting",

--- a/pkg/controller/redirect/appstore.go
+++ b/pkg/controller/redirect/appstore.go
@@ -21,9 +21,10 @@ import (
 )
 
 type AppStoreData struct {
-	AndroidURL   string `json:"androidURL"`
-	AndroidAppID string `json:"androidAppID"`
-	IOSURL       string `json:"iosURL"`
+	AndroidURL      string `json:"androidURL"`
+	AndroidAppID    string `json:"androidAppID"`
+	AndroidHeadless bool   `json:"androidHeadless"`
+	IOSURL          string `json:"iosURL"`
 }
 
 // getAppStoreData finds data tied to app store listings.
@@ -31,6 +32,7 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 	// Pick first Android app (in the realm) for Play Store redirect.
 	androidURL := ""
 	androidAppID := ""
+	headless := false
 	androidApps, err := c.db.ListActiveApps(realmID, database.WithAppOS(database.OSTypeAndroid))
 	if err != nil {
 		return nil, fmt.Errorf("failed to get Android Apps: %w", err)
@@ -41,6 +43,7 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 			if !app.DisableRedirect {
 				androidURL = app.URL
 				androidAppID = app.AppID
+				headless = app.Headless
 				break
 			}
 		}
@@ -63,8 +66,9 @@ func (c *Controller) getAppStoreData(realmID uint) (*AppStoreData, error) {
 	}
 
 	return &AppStoreData{
-		AndroidURL:   androidURL,
-		AndroidAppID: androidAppID,
-		IOSURL:       iosURL,
+		AndroidURL:      androidURL,
+		AndroidAppID:    androidAppID,
+		AndroidHeadless: headless,
+		IOSURL:          iosURL,
 	}, nil
 }

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -261,6 +261,11 @@ func TestDecideRedirect(t *testing.T) {
 		AndroidAppID: "gov.moosylvania.app",
 		IOSURL:       "https://ios.example.com/store/moosylvania",
 	}
+	pureHeadlessEnx := AppStoreData{
+		AndroidURL:      "https://android.example.com/store/pizza",
+		AndroidAppID:    "pizza.enx",
+		AndroidHeadless: true,
+	}
 	appLinkNeither := AppStoreData{
 		AndroidURL:   "",
 		AndroidAppID: "",
@@ -308,15 +313,25 @@ func TestDecideRedirect(t *testing.T) {
 			enxEnabled:   true,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
-			expected:     "ens://v?c=123456&r=US-MOO",
+			expected:     "ensonboarding://picker",
 		},
 		{
+			// In this case, there is no app registered, so the link hit the server
+			// send them to built in android onboarding.
 			name:         "android_no_applink",
 			url:          "https://moosylvania.gov/v?c=123456",
 			enxEnabled:   false,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
-			expected:     "",
+			expected:     "ensonboarding://picker",
+		},
+		{
+			name:         "android_headless_onboarding",
+			url:          "https://pizza.gov/onboarding",
+			enxEnabled:   true,
+			userAgent:    userAgentAndroid,
+			appStoreData: &pureHeadlessEnx,
+			expected:     "ensonboarding://picker/us-moo",
 		},
 
 		// iOS

--- a/pkg/controller/redirect/index.go
+++ b/pkg/controller/redirect/index.go
@@ -44,7 +44,20 @@ func (c *Controller) HandleIndex() http.Handler {
 				break
 			}
 		}
+
 		if hostRegion == "" {
+			// If this is a mobile device, redirect into the OS specific picker as a
+			// best effort.
+			userAgent := r.UserAgent()
+			if isAndroid(userAgent) {
+				http.Redirect(w, r, androidOnboardingRedirect, http.StatusSeeOther)
+				return
+			}
+			if isIOS(userAgent) {
+				http.Redirect(w, r, iosOnboardingRedirect, http.StatusSeeOther)
+				return
+			}
+
 			controller.NotFound(w, r, c.h)
 			return
 		}

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -300,7 +300,7 @@ func TestIndex(t *testing.T) {
 		}
 	})
 
-	// Android redirect where enx is enabled
+	// Android redirect where enx is enabled, but no app, so we redirect to picker.
 	t.Run("android_redirect_enx", func(t *testing.T) {
 		t.Parallel()
 
@@ -324,7 +324,7 @@ func TestIndex(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", got, want, body)
 		}
 
-		if got, want := resp.Header.Get("Location"), "ens://app?c=123456&r=CC"; got != want {
+		if got, want := resp.Header.Get("Location"), "ensonboarding://picker"; got != want {
 			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})

--- a/pkg/controller/redirect/redirect.go
+++ b/pkg/controller/redirect/redirect.go
@@ -28,7 +28,8 @@ import (
 const (
 	// androidOnboardingRedirect and iosOnboardingRedirect are the URLs to
 	// redirect to for onboarding.
-	androidOnboardingRedirect = "market://search?q=exposure%20notifications"
+	androidOnboardingRedirect = "ensonboarding://picker"
+	androidHeadlessOnboarding = "ensonboarding://picker/%s" // Region is the substitute.
 	iosOnboardingRedirect     = "ens://onboarding"
 	genericOnboardingRedirect = "https://www.google.com/covid19/exposurenotifications/"
 )

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2383,6 +2383,19 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return nil
 			},
 		},
+		{
+			ID: "00111-AddMobileAppHeadless",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE mobile_apps
+						ADD COLUMN IF NOT EXISTS headless BOOL NOT NULL DEFAULT FALSE`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE mobile_apps
+						DROP COLUMN IF EXISTS headless`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -76,6 +76,10 @@ type MobileApp struct {
 	// OS is the type of the application we're using (eg, iOS, Android).
 	OS OSType `gorm:"column:os; type:int;"`
 
+	// Headless indicates that this an and android EN Express headless app.
+	// This is only settable through the app sync service.
+	Headless bool `gorm:"column:headless; type:bool; default:false; not null"`
+
 	// AppID is a unique string representing the app.
 	//
 	// For iOS this should include the team ID or app ID prefix followed by


### PR DESCRIPTION

## Proposed Changes

* introduce headless android from the apps.json feed
* display that status
* change default redirect for android devices to the built in picker

**Release Note**

```release-note
Adds support for Android Headles ENX picker protcol. By default redirect to OS pickers when nothing else is known.
```
