### PR TITLE
scrub phone number from failed SMS log line

### DIFF
--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -169,7 +169,7 @@ func (c *Controller) HandleSend() http.Handler {
 			}
 
 			if !suppressError {
-				logger.Errorw("unable to issue user-report code", "status", result.HTTPCode, "error", result.ErrorReturn.Error)
+				logger.Errorw("unable to issue user-report code", "status", result.HTTPCode, "error", issueapi.ScrubPhoneNumbers(result.ErrorReturn.Error))
 				// The error returned isn't something the user can easily fix, show internal error, but hide form.
 				m["error"] = []string{locale.Get("user-report.internal-error")}
 				m["skipForm"] = true


### PR DESCRIPTION

## Proposed Changes

* scrub phone number in log line from user report
* this function is not in use in production yet 

**Release Note**

```release-note
Scrub phone numbers from user report log lines
```
