### PR TITLE
Expire all stats after 30 days

### DIFF
--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -175,11 +175,50 @@ func (c *Controller) HandleCleanup() http.Handler {
 		func() {
 			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
 			item = tag.Upsert(itemTagKey, "KEY_SERVER_STATS")
-			if count, err := c.db.DeleteOldKeyServerStatsDays(c.config.KeyServerStatsMaxAge); err != nil {
+			if count, err := c.db.DeleteOldKeyServerStatsDays(c.config.StatsMaxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge key-server stats: %w", err))
 				result = enobs.ResultError("FAILED")
 			} else {
 				logger.Infow("purged key-server stats", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// Authorized app stats
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "AUTHORIZED_APP_STATS")
+			if count, err := c.db.PurgeAuthorizedAppStats(c.config.StatsMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge authorized app stats: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged authorized app stats", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// External issuer stats
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "EXTERNAL_ISSUER_STATS")
+			if count, err := c.db.PurgeExternalIssuerStats(c.config.StatsMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge external issuer stats: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged external issuer stats", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// Realm stats
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "REALM_STATS")
+			if count, err := c.db.PurgeRealmStats(c.config.StatsMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge realm stats: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged realm stats", "count", count)
 				result = enobs.ResultOK
 			}
 		}()
@@ -206,6 +245,19 @@ func (c *Controller) HandleCleanup() http.Handler {
 				result = enobs.ResultError("FAILED")
 			} else {
 				logger.Infow("purged unclaimed user reports", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
+		// User stats
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "USER_STATS")
+			if count, err := c.db.PurgeUserStats(c.config.StatsMaxAge); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge user stats: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged user stats", "count", count)
 				result = enobs.ResultOK
 			}
 		}()

--- a/pkg/database/authorized_app_stats.go
+++ b/pkg/database/authorized_app_stats.go
@@ -184,3 +184,18 @@ func (s *AuthorizedAppStats) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+// PurgeAuthorizedAppStats will delete stats that were created longer than
+// maxAge ago.
+func (db *Database) PurgeAuthorizedAppStats(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	createdBefore := time.Now().UTC().Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("date < ?", createdBefore).
+		Delete(&AuthorizedAppStat{})
+	return result.RowsAffected, result.Error
+}

--- a/pkg/database/authorized_app_stats_test.go
+++ b/pkg/database/authorized_app_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -124,5 +125,33 @@ func TestAuthorizedAppStats_MarshalCSV(t *testing.T) {
 				t.Errorf("bad json, expected \n%s\nto be\n%s\n", got, want)
 			}
 		})
+	}
+}
+
+func TestDatabase_PurgeAuthorizedAppStats(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	for i := 1; i < 10; i++ {
+		ts := timeutils.UTCMidnight(time.Now().UTC()).Add(-24 * time.Hour * time.Duration(i))
+		if err := db.RawDB().Create(&AuthorizedAppStat{
+			Date: ts,
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := db.PurgeAuthorizedAppStats(0); err != nil {
+		t.Fatal(err)
+	}
+
+	var entries []*AuthorizedAppStat
+	if err := db.RawDB().Model(&AuthorizedAppStat{}).Find(&entries).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(entries), 0; got != want {
+		t.Errorf("expected %d entries, got %d: %#v", want, got, entries)
 	}
 }

--- a/pkg/database/external_issuer_stats.go
+++ b/pkg/database/external_issuer_stats.go
@@ -154,3 +154,18 @@ func (s *ExternalIssuerStats) UnmarshalJSON(b []byte) error {
 
 	return nil
 }
+
+// PurgeExternalIssuerStats will delete stats that were created longer than
+// maxAge ago.
+func (db *Database) PurgeExternalIssuerStats(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	createdBefore := time.Now().UTC().Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("date < ?", createdBefore).
+		Delete(&ExternalIssuerStat{})
+	return result.RowsAffected, result.Error
+}

--- a/pkg/database/external_issuer_stats_test.go
+++ b/pkg/database/external_issuer_stats_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
 	"github.com/google/go-cmp/cmp"
 )
 
@@ -104,5 +105,33 @@ func TestExternalIssuerStats_MarshalCSV(t *testing.T) {
 				t.Errorf("bad json, expected \n%s\nto be\n%s\n", got, want)
 			}
 		})
+	}
+}
+
+func TestDatabase_PurgeExternalIssuerStats(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	for i := 1; i < 10; i++ {
+		ts := timeutils.UTCMidnight(time.Now().UTC()).Add(-24 * time.Hour * time.Duration(i))
+		if err := db.RawDB().Create(&ExternalIssuerStat{
+			Date: ts,
+		}).Error; err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	if _, err := db.PurgeExternalIssuerStats(0); err != nil {
+		t.Fatal(err)
+	}
+
+	var entries []*ExternalIssuerStat
+	if err := db.RawDB().Model(&ExternalIssuerStat{}).Find(&entries).Error; err != nil {
+		t.Fatal(err)
+	}
+
+	if got, want := len(entries), 0; got != want {
+		t.Errorf("expected %d entries, got %d: %#v", want, got, entries)
 	}
 }

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -283,3 +283,18 @@ func (r *Realm) HistoricalCodesIssued(db *Database, limit uint64) ([]uint64, err
 	}
 	return stats, nil
 }
+
+// PurgeRealmStats will delete stats that were created longer than
+// maxAge ago.
+func (db *Database) PurgeRealmStats(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	createdBefore := time.Now().UTC().Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("date < ?", createdBefore).
+		Delete(&RealmStat{})
+	return result.RowsAffected, result.Error
+}

--- a/pkg/database/user_stats.go
+++ b/pkg/database/user_stats.go
@@ -168,3 +168,18 @@ func (db *Database) SaveUserStat(u *UserStat) error {
 		return nil
 	})
 }
+
+// PurgeUserStats will delete stats that were created longer than
+// maxAge ago.
+func (db *Database) PurgeUserStats(maxAge time.Duration) (int64, error) {
+	if maxAge > 0 {
+		maxAge = -1 * maxAge
+	}
+	createdBefore := time.Now().UTC().Add(maxAge)
+
+	result := db.db.
+		Unscoped().
+		Where("date < ?", createdBefore).
+		Delete(&UserStat{})
+	return result.RowsAffected, result.Error
+}


### PR DESCRIPTION


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Delete statistics that are more than 30 days old. This retention period can be configured by setting `STATS_MAX_AGE` on the cleanup service. The minimum value is 7 days and the maximum retention period is 60 days. This replaces the existing `KEY_SERVER_STATS_MAX_AGE` variable.
```
