### PR TITLE
Add chaff tracking to HTML user-report pages

### DIFF
--- a/cmd/enx-redirect/main.go
+++ b/cmd/enx-redirect/main.go
@@ -110,7 +110,8 @@ func realMain(ctx context.Context) error {
 	}
 
 	// Setup routes
-	mux, err := routes.ENXRedirect(ctx, cfg, db, cacher, smsSigner, limiterStore)
+	mux, closer, err := routes.ENXRedirect(ctx, cfg, db, cacher, smsSigner, limiterStore)
+	defer closer()
 	if err != nil {
 		return fmt.Errorf("failed to setup routes: %w", err)
 	}

--- a/internal/envstest/enx_redirect.go
+++ b/internal/envstest/enx_redirect.go
@@ -111,7 +111,8 @@ func NewENXRedirectServerConfig(tb testing.TB, testDatabaseInstance *database.Te
 // NewServer creates a new server.
 func (r *ENXRedirectServerConfigResponse) NewServer(tb testing.TB) *ENXRedirectServerResponse {
 	ctx := context.Background()
-	mux, err := routes.ENXRedirect(ctx, r.Config, r.Database, r.Cacher, r.KeyManager, r.RateLimiter)
+	mux, closer, err := routes.ENXRedirect(ctx, r.Config, r.Database, r.Cacher, r.KeyManager, r.RateLimiter)
+	tb.Cleanup(closer)
 	if err != nil {
 		tb.Fatal(err)
 	}

--- a/internal/routes/enx_redirect_test.go
+++ b/internal/routes/enx_redirect_test.go
@@ -43,7 +43,8 @@ func TestENXRedirect(t *testing.T) {
 
 	signer := keys.TestKeyManager(t)
 
-	mux, err := ENXRedirect(ctx, cfg, db, cacher, signer, limiterStore)
+	mux, closer, err := ENXRedirect(ctx, cfg, db, cacher, signer, limiterStore)
+	t.Cleanup(closer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/associated/index_test.go
+++ b/pkg/controller/associated/index_test.go
@@ -87,7 +87,8 @@ func TestIndex(t *testing.T) {
 	}
 
 	// Build routes.
-	mux, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	mux, closer, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	t.Cleanup(closer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/middleware/chaff.go
+++ b/pkg/controller/middleware/chaff.go
@@ -46,12 +46,8 @@ func ChaffHeaderDetector() chaff.Detector {
 // error here.
 var localChaffCache, _ = cache.New(48 * time.Hour)
 
-// ProcessChaff injects the chaff processing middleware. If chaff requests send
-// a value of "daily" (case-insensitive), they will be counted toward the
-// realm's total active users and return a chaff response. Any other values will
-// only return a chaff response.
-//
-// This must come after RequireAPIKey.
+// ProcessChaff injects the chaff processing middleware. This must come after
+// RequireAPIKey.
 func ProcessChaff(db *database.Database, t *chaff.Tracker, det chaff.Detector) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -103,7 +103,8 @@ func TestIndex(t *testing.T) {
 	}
 
 	// Build routes.
-	mux, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	mux, closer, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	t.Cleanup(closer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/userreport/index_test.go
+++ b/pkg/controller/userreport/index_test.go
@@ -78,7 +78,8 @@ func TestIndex(t *testing.T) {
 	}
 
 	// Build routes.
-	mux, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	mux, closer, err := routes.ENXRedirect(ctx, cfg, harness.Database, harness.Cacher, harness.KeyManager, harness.RateLimiter)
+	t.Cleanup(closer)
 	if err != nil {
 		t.Fatal(err)
 	}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/2121

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add optional chaff tracking to HTML user-report pages.
```
