### PR TITLE
Allow separating css/js assets into multiple files

### DIFF
--- a/assets/assets.go
+++ b/assets/assets.go
@@ -24,7 +24,11 @@ import (
 )
 
 //go:embed server server/**/*
-var serverFS embed.FS
+var _serverFS embed.FS
+
+// This gets around an inconsistency where the embed is rooted at server/, but
+// the os.DirFS is rooted after server/.
+var serverFS, _ = fs.Sub(_serverFS, "server")
 
 // ServerFS returns the file system for the server assets.
 func ServerFS() fs.FS {
@@ -35,7 +39,7 @@ func ServerFS() fs.FS {
 	return serverFS
 }
 
-var serverStaticFS, _ = fs.Sub(serverFS, "server/static")
+var serverStaticFS, _ = fs.Sub(serverFS, "static")
 
 // ServerStaticFS returns the file system for the server static assets, rooted
 // at static/.

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -16,14 +16,11 @@
 
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.0/dist/css/bootstrap.min.css"
   integrity="sha384-B0vP5xmATw1+K9KRQjQERJvTumQW0nPEzvF6L/Z6nronJ3oUOFUFpCjEUQouq2+l" crossorigin="anonymous">
-<link rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css"
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/open-iconic/1.1.1/font/css/open-iconic-bootstrap.min.css"
   integrity="sha384-wWci3BOzr88l+HNsAtr3+e5bk9qh5KfjU6gl/rbzfTYdsAVHBEbxB33veLYmFg/a" crossorigin="anonymous">
-<link rel="stylesheet"
-  href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/css/intlTelInput.min.css"
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/css/intlTelInput.min.css"
   integrity="sha384-+0L34NtZQE8CdqKYXA1psEH5gRnPhYm5Yrfl6+zHBC9rK+SuCkyS99e/a4wRIf3B" crossorigin="anonymous">
-<link rel="stylesheet"
-  href="/static/css/application.css?{{.buildID}}" crossorigin="anonymous" />
+{{ cssIncludeTag }}
 
 <script defer src="https://code.jquery.com/jquery-3.5.1.min.js"
   integrity="sha384-ZvpUoO/+PpLXR1lu4jmpXWu80pZlYUAfxl5NsBMWOEPSjUn/6Z/hRTt8+pR6L4N2" crossorigin="anonymous"></script>
@@ -33,7 +30,7 @@
   integrity="sha384-+YQ4JLhjyBLPDQt//I+STsc9iw4uQqACwlvpslubQzn4u2UU2UFM80nGisd026JF" crossorigin="anonymous"></script>
 <script defer src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/js/intlTelInput.min.js"
   integrity="sha384-lZ7BQV5Pg5PjeG4uM5qkYztFBL5dtUWhiAtkcz6j/vj1tjZFA+3zhwsiGUmsqulm" crossorigin="anonymous"></script>
-<script defer src="/static/js/application.js?{{.buildID}}" crossorigin="anonymous"></script>
+{{ jsIncludeTag }}
 
 <title>{{if .title}}{{.title}}{{else}}Exposure Notifications Verification Server{{end}}</title>
 {{end}}

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -65,13 +65,23 @@ steps:
 #
 # Minify static assets
 #
-- id: 'minify'
+- id: 'minify-css'
   name: 'tdewolff/minify:latest'
-  dir: 'assets/server'
+  dir: 'assets/server/static/css'
   entrypoint: '/bin/sh'
   args:
   - '-c'
-  - 'minify --recursive --output=./static ./static/css/*.css ./static/js/*.js'
+  - 'mv *.css /tmp/ && minify --output ./application.css /tmp/*.css'
+  waitFor:
+  - '-'
+
+- id: 'minify-js'
+  name: 'tdewolff/minify:latest'
+  dir: 'assets/server/static/js'
+  entrypoint: '/bin/sh'
+  args:
+  - '-c'
+  - 'mv *.js /tmp/ && minify --output ./application.js /tmp/*.js'
   waitFor:
   - '-'
 
@@ -84,6 +94,8 @@ steps:
   args:
   - 'mkdir'
   - 'bin'
+  waitFor:
+  - '-'
 
 - id: 'build'
   name: 'golang:1.16'
@@ -98,7 +110,8 @@ steps:
   waitFor:
   - 'restore-cache'
   - 'mkdir-bin'
-  - 'minify'
+  - 'minify-css'
+  - 'minify-js'
 
 - id: 'save-cache'
   name: 'us-docker.pkg.dev/vargolabs/gcs-cacher/gcs-cacher:0.1'

--- a/pkg/render/assets.go
+++ b/pkg/render/assets.go
@@ -1,0 +1,134 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package render
+
+import (
+	"bytes"
+	"crypto/sha512"
+	"encoding/base64"
+	"fmt"
+	htmltemplate "html/template"
+	"io"
+	"io/fs"
+	"path/filepath"
+	"strings"
+	"sync"
+
+	"github.com/google/exposure-notifications-verification-server/internal/buildinfo"
+)
+
+const sriPrefix = "sha384-"
+
+var (
+	cssIncludeTmpl = htmltemplate.Must(htmltemplate.New(`cssIncludeTmpl`).Parse(strings.TrimSpace(`
+{{ range . -}}
+<link rel="stylesheet" href="/{{.Path}}?{{.BuildID}}"
+  integrity="{{.SRI}}" crossorigin="anonymous">
+{{ end }}
+`)))
+
+	cssIncludeTagCache htmltemplate.HTML
+)
+
+var (
+	jsIncludeTmpl = htmltemplate.Must(htmltemplate.New(`jsIncludeTmpl`).Parse(strings.TrimSpace(`
+{{ range . -}}
+<script defer src="/{{.Path}}?{{.BuildID}}"
+  integrity="{{.SRI}}" crossorigin="anonymous"></script>
+{{ end }}
+`)))
+	jsIncludeTagCache htmltemplate.HTML
+)
+
+// asset represents a javascript or css asset.
+type asset struct {
+	// Path is the virtual path, relative to the URL root.
+	Path string
+
+	// SRI is the sha384 resource integrity.
+	SRI string
+}
+
+// BuildID is a helper to get the current ID (for cache busting).
+func (a *asset) BuildID() string {
+	return buildinfo.BuildID
+}
+
+// assetIncludeTag searches the fs for all assets of the given search type and
+// renders the template. In non-dev mode, the results are cached on the first
+// invocation.
+func assetIncludeTag(fsys fs.FS, search string, tmpl *htmltemplate.Template, cache *htmltemplate.HTML, devMode bool) func() (htmltemplate.HTML, error) {
+	var mu sync.Mutex
+
+	return func() (htmltemplate.HTML, error) {
+		if !devMode {
+			mu.Lock()
+			defer mu.Unlock()
+			if *cache != "" {
+				return *cache, nil
+			}
+		}
+
+		entries, err := fs.ReadDir(fsys, search)
+		if err != nil {
+			return "", fmt.Errorf("failed to read entries: %w", err)
+		}
+
+		list := make([]*asset, 0, len(entries))
+		for _, entry := range entries {
+			name := entry.Name()
+			pth := filepath.Join(search, name)
+
+			f, err := fsys.Open(pth)
+			if err != nil {
+				return "", fmt.Errorf("failed to open %s: %w", name, err)
+			}
+
+			integrity, err := generateSRI(f)
+			if err != nil {
+				return "", fmt.Errorf("failed to generate SRI for %s: %w", name, err)
+			}
+
+			list = append(list, &asset{
+				Path: pth,
+				SRI:  integrity,
+			})
+		}
+
+		var b bytes.Buffer
+		if err := tmpl.Execute(&b, list); err != nil {
+			return "", fmt.Errorf("failed to render %s asset: %w", search, err)
+		}
+		result := htmltemplate.HTML(b.String())
+
+		if !devMode {
+			*cache = result
+		}
+
+		return result, nil
+	}
+}
+
+// generateSRI is a helper that generates an SRI from the given reader. It
+// closes the given reader.
+func generateSRI(r io.ReadCloser) (string, error) {
+	defer r.Close()
+
+	h := sha512.New384()
+	if _, err := io.Copy(h, r); err != nil {
+		return "", err
+	}
+	return sriPrefix + base64.RawURLEncoding.EncodeToString(h.Sum(nil)), nil
+}

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -139,10 +139,10 @@ func (r *Renderer) loadTemplates() error {
 
 	htmltmpl := htmltemplate.New("").
 		Option("missingkey=zero").
-		Funcs(templateFuncs())
+		Funcs(r.templateFuncs())
 
 	texttmpl := texttemplate.New("").
-		Funcs(textFuncs())
+		Funcs(r.textFuncs())
 
 	if err := loadTemplates(r.fs, htmltmpl, texttmpl); err != nil {
 		return fmt.Errorf("failed to load templates: %w", err)
@@ -339,8 +339,11 @@ func toSentence(i interface{}, joiner string) (string, error) {
 	}
 }
 
-func templateFuncs() htmltemplate.FuncMap {
+func (r *Renderer) templateFuncs() htmltemplate.FuncMap {
 	return map[string]interface{}{
+		"jsIncludeTag":  assetIncludeTag(r.fs, "static/js", jsIncludeTmpl, &jsIncludeTagCache, r.debug),
+		"cssIncludeTag": assetIncludeTag(r.fs, "static/css", cssIncludeTmpl, &cssIncludeTagCache, r.debug),
+
 		"joinStrings":      joinStrings,
 		"toSentence":       toSentence,
 		"trimSpace":        project.TrimSpace,
@@ -392,7 +395,7 @@ func pwdSentinel() string {
 	return project.PasswordSentinel
 }
 
-func textFuncs() texttemplate.FuncMap {
+func (r *Renderer) textFuncs() texttemplate.FuncMap {
 	return map[string]interface{}{
 		"trimSpace": project.TrimSpace,
 	}


### PR DESCRIPTION
In dev, they'll remain separate. In prod, they'll be combined and minified into a single file. This also adds SRI integrity hashes.

This doesn't _actually_ separate any of the files. It just adds the ability to do so in the future.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add SRI integrity hashes to custom css and javascript. SRI was already present for external assets, but this includes the check on internal assets as well.
```
