### PR TITLE
Alert for Cloud Run deployments that bypass Binary Authorization

### DIFF
--- a/docs/playbooks/alerts/CloudRunBreakglass.md
+++ b/docs/playbooks/alerts/CloudRunBreakglass.md
@@ -1,0 +1,25 @@
+# CloudRunBreakglass
+
+This alert fires when a Cloud Run service is deployed that bypassed Binary
+Authorization using breakglass.
+
+## Triage Steps
+
+Check with your team. There may have been a legitimate reason for a breakglass
+deployment. However, you should try to get on a non-breakglass deployment as
+quickly as possible.
+
+To identify the incident(s), go to Logs Explorer and use the following filter:
+
+```text
+protoPayload.@type="type.googleapis.com/google.cloud.audit.AuditLog"
+protoPayload.serviceName="run.googleapis.com"
+protoPayload.status.message:"breakglass"
+resource.labels.revision_name!=""
+```
+
+The principal that did the breakglass deploy can be found at:
+
+```text
+protoPayload.response.metadata.annotations."serving.knative.dev/creator"
+```

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -436,3 +436,44 @@ resource "google_monitoring_alert_policy" "UserReportWebhookError" {
     null_resource.manual-step-to-enable-workspace,
   ]
 }
+
+resource "google_monitoring_alert_policy" "CloudRunBreakglass" {
+  count = var.alert_on_cloud_run_breakglass ? 1 : 0
+
+  project      = var.project
+  display_name = "CloudRunBreakglass"
+  combiner     = "OR"
+
+  conditions {
+    display_name = "A service was deployed that bypassed Binary Authorization"
+
+    condition_monitoring_query_language {
+      duration = "0s"
+
+      query = <<-EOT
+      fetch global
+      | metric 'logging.googleapis.com/user/${google_logging_metric.cloud_run_breakglass.name}'
+      | align rate(5m)
+      | every 1m
+      | group_by [resource.project_id],
+          [val: aggregate(value.cloud_run_breakglass)]
+      | condition val > 0
+      EOT
+
+      trigger {
+        count = 1
+      }
+    }
+  }
+
+  documentation {
+    content   = "${local.playbook_prefix}/CloudRunBreakglass.md"
+    mime_type = "text/markdown"
+  }
+
+  notification_channels = [for x in values(google_monitoring_notification_channel.paging) : x.id]
+
+  depends_on = [
+    null_resource.manual-step-to-enable-workspace,
+  ]
+}

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -85,6 +85,13 @@ variable "alert_on_human_decrypted_value" {
   description = "Alert when a human accesses a secret. You must enable DATA_READ audit logs for Cloud KMS."
 }
 
+variable "alert_on_cloud_run_breakglass" {
+  type    = bool
+  default = true
+
+  description = "Alert when a service is deployed that bypassed Binary Authorization."
+}
+
 variable "forward_progress_indicators" {
   type = map(object({
     metric = string


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add alerts for when a Cloud Run service is deployed using breakglass (without Binary Authorization). Like the `HumanAccessedSecret` alert, there may be legitimate reasons for a human to perform this operation, but it should be carefully checked and audited. Due to eventual consistency, the initial Terraform apply may fail due to missing metric. After 5 minutes, you can run the Terraform apply again to converge.
```
