### PR TITLE
Ensure external links specify noopener and noreferrer

### DIFF
--- a/assets/enx-redirect/report/index.html
+++ b/assets/enx-redirect/report/index.html
@@ -59,7 +59,7 @@
             <p>{{tDefault $.realmLocale (t $.locale "user-report.phone-number-instructions") "webReportPhoneNumberMessage"}}</p>
             <p>{{t $.locale "user-report.phone-storage"}}
             {{if $currentRealm.UserReportLearnMoreURL}}
-              <a href="{{$currentRealm.UserReportLearnMoreURL}}" target="_blank">{{t $.locale "user-report.learn-more"}}</a>
+              <a href="{{$currentRealm.UserReportLearnMoreURL}}" rel="noopener noreferrer" target="_blank">{{t $.locale "user-report.learn-more"}}</a>
             {{end}}
             </p>
           </div>

--- a/assets/server/codes/bulk-issue.html
+++ b/assets/server/codes/bulk-issue.html
@@ -32,7 +32,7 @@
             </div>
             <small class="form-text text-muted">
               {{t $.locale "codes.bulk-issue.csv-format1" `<code>phone,testDate,[optional]symptomDate,[optional]testType</code>` | safeHTML}}
-              {{t $.locale "codes.bulk-issue.csv-format2" `<a href="https://www.twilio.com/docs/glossary/what-e164" target="_blank">E.164</a>` `<a href="https://www.iso.org/iso-8601-date-and-time-format.html" target="_blank">ISO 8601</a>` | safeHTML}}
+              {{t $.locale "codes.bulk-issue.csv-format2" `<a href="https://www.twilio.com/docs/glossary/what-e164" rel="noopener noreferrer" target="_blank">E.164</a>` `<a href="https://www.iso.org/iso-8601-date-and-time-format.html" rel="noopener noreferrer" target="_blank">ISO 8601</a>` | safeHTML}}
             </small>
           </div>
 

--- a/assets/server/login/login.html
+++ b/assets/server/login/login.html
@@ -51,7 +51,7 @@
           {{template "login/factorsdiv" .}}
 
           <div class="d-flex justify-content-between pt-2 px-1">
-            <a class="text-muted small" target="_blank" href="https://www.google.com/covid19/exposurenotifications">
+            <a class="text-muted small" rel="noopener noreferrer" target="_blank" href="https://www.google.com/covid19/exposurenotifications">
               {{t $.locale "login.about-exposure-notifications" }}
             </a>
             <a class="small text-muted" href="/login/reset-password">

--- a/assets/server/mobileapps/show.html
+++ b/assets/server/mobileapps/show.html
@@ -38,7 +38,7 @@
           <dd id="mobileapps-name">{{$app.Name}}</dd>
 
           <dt>AppStore link</dt>
-          <dd id="mobileapps-url"><a href="{{$app.URL | pathUnescape}}" rel="noreferrer" target="_blank">{{$app.URL | pathUnescape}}</a></dd>
+          <dd id="mobileapps-url"><a href="{{$app.URL | pathUnescape}}" rel="noopener noreferrer" target="_blank">{{$app.URL | pathUnescape}}</a></dd>
 
           <dt>Enable AppStore redirect</dt>
           <dd>{{not $app.DisableRedirect}}</dd>

--- a/assets/server/realmadmin/_form_security.html
+++ b/assets/server/realmadmin/_form_security.html
@@ -95,7 +95,8 @@
       <strong>Admin API</strong> which can be used to generate codes. If blank,
       all traffic is allowed from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
-      target="_BLANK">CIDR notation</a>
+      rel="noopener noreferrer"
+      target="_blank">CIDR notation</a>
       of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
       post-authentication.
     </small>
@@ -113,7 +114,8 @@
       service publicly accessible</strong>. If blank, all traffic is allowed
       from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
-      target="_BLANK">CIDR notation</a>
+      rel="noopener noreferrer"
+      target="_blank">CIDR notation</a>
       of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
       post-authentication.
     </small>
@@ -129,7 +131,8 @@
       <strong>UI server</strong> (this server). If blank, all traffic is allowed
       from all IPs. These should be of <a
       href="https://en.wikipedia.org/wiki/Classless_Inter-Domain_Routing"
-      target="_BLANK">CIDR notation</a>
+      rel="noopener noreferrer"
+      target="_blank">CIDR notation</a>
       of the format (e.g. <code>192.1.2.0/24</code>). This is only enforced
       post-authentication.
     </small>

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -63,8 +63,8 @@
       {{template "errorable" $smsConfig.ErrorsFor "twilioFromNumber"}}
       <small class="form-text text-muted">
         This is the Twilio From Number.
-        It should be either a <a href="https://www.twilio.com/docs/glossary/what-e164" target="_blank">E.164</a> formatted phone number or
-        a <a href="https://www.twilio.com/docs/messaging/services" target="_blank">Twilio Messaging Service</a> Sid.
+        It should be either a <a href="https://www.twilio.com/docs/glossary/what-e164" rel="noopener noreferrer" target="_blank">E.164</a> formatted phone number or
+        a <a href="https://www.twilio.com/docs/messaging/services" rel="noopener noreferrer" target="_blank">Twilio Messaging Service</a> Sid.
         Get this value from the Twilio console.
         If you plan on sending more than 100 codes per day, we <strong>strongly
         recommend</strong> acquiring a toll free number or SMS short code to

--- a/assets/server/realmadmin/_stats_external_issuers.html
+++ b/assets/server/realmadmin/_stats_external_issuers.html
@@ -36,7 +36,7 @@
           client-supplied string when issuing a code via the Admin API.
           See the <a
           href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/api.md#apiissue"
-          target="_BLANK" rel="noopener">API documentation</a> for
+          target="_blank" rel="noopener noreferrer">API documentation</a> for
           information on how to populate this value when issuing codes.
         </p>
 

--- a/assets/server/realmadmin/keys.html
+++ b/assets/server/realmadmin/keys.html
@@ -205,7 +205,7 @@
         </div>
         <div class="card-footer text-right">
           <small>
-          <a href="/jwks/{{$realm.ID}}" target="_blank" rel="noopener">View public key discovery</a>
+          <a href="/jwks/{{$realm.ID}}" target="_blank">View public key discovery</a>
           </small>
         </div>
       </div>


### PR DESCRIPTION
HTML links that open in a new tab or window allow the target page to access the DOM of the origin page using `window.opener`. These are mostly trusted sources, but the introduction of user-supplied "learn-more" links necessitates this now.

Note that internal (relative) links do not require this rel.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure all external links specify noopener and noreferrer.
```
