### PR TITLE
Don't set DB_ENCRYPTION_KEY in init script

### DIFF
--- a/scripts/dev
+++ b/scripts/dev
@@ -25,7 +25,6 @@ DB_CONTAINER_IMAGE="registry.hub.docker.com/library/postgres:13-alpine"
 KEY_MANAGER="IN_MEMORY"
 
 # Database parameters
-DB_ENCRYPTION_KEY="O04ZjG4WuoceRd0k2pTqDN0r8omr6sbFL0U3T5b12Lo="
 DB_HOST="${DB_HOST:-"127.0.0.1"}"
 DB_NAME="${DB_NAME:-"en-verification-server-db"}"
 DB_PASSWORD="${DB_PASSWORD:-"c0546931436d1e4e"}"
@@ -51,7 +50,6 @@ function init() {
   echo "export KEY_MANAGER=\"${KEY_MANAGER}\""
   echo "export SERVER_NAME=\"${SERVER_NAME}\""
 
-  echo "export DB_ENCRYPTION_KEY=\"${DB_ENCRYPTION_KEY}\""
   echo "export DB_HOST=\"${DB_HOST}\""
   echo "export DB_NAME=\"${DB_NAME}\""
   echo "export DB_USER=\"${DB_USER}\""


### PR DESCRIPTION
This is an old artifact since it's set in .env now, but it messes up your environment if you run init after sourcing env, since it overwrites the value.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
