### PR TITLE
improve sms template validation

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -408,7 +408,7 @@
       val = val.replace(/\[longexpires\]/g, longExpires);
 
       if (val.length > {{$realm.SMSTemplateExpansionMax}}) {
-        errors.push('Fully expanded SMS Templates must be <= {{$realm.SMSTemplateExpansionMax}} characters, currently ' + val.length + ' characters.');
+        errors.push('Fully expanded SMS Templates must be at most {{$realm.SMSTemplateExpansionMax}} characters, currently ' + val.length + ' characters.');
       }
 
       if (errors.length > 0) {
@@ -544,11 +544,7 @@
 
       let $textArea = $newNode.find('textarea');
       $textArea.attr('name', `sms_text_template_${next}`);
-      if (enxEnabled) {
-        $textArea.val('{{$realm.DefaultENXSMSTextTemplate}}');
-      } else {
-        $textArea.val('{{$realm.DefaultSMSTextTemplate}}');
-      }
+      $textArea.val('{{$realm.DefaultSMSTextTemplate}}');
 
       let $deleteButton = $newNode.find('button');
       $deleteButton.click(() => removeTemplate(`sms-template-${next}`));

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -414,7 +414,7 @@
       if (errors.length > 0) {
         $("#sms-preview-errors").removeClass("d-none");
         $("#sms-preview-errors").empty();   
-        let msg = $('<ul>');
+        let msg = $('<ul class="mb-0">>');
         for (i = 0; i < errors.length; i++) {
           item = ($('<li>').html(errors[i]));
           msg.append(item);

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -163,22 +163,16 @@
           For the <strong>User Report</strong> template it is strongly recommended that you
           indicate that the user should not use the code if they did not request it.
         </div>
-
-        <div class="alert alert-info" role="alert">
-          The <strong>User Report</strong> template:
-          <ul>
-            <li>MUST have the <code>[code]</code> expansion (short code) for auto fill in the operating system / application.</li>
-            <li>SHOULD also contain [enxlink] if you are using Exposure Notifications Express</li>
-          </ul>
-          Other fields can be included.
-        </div>
       {{end}}
-      {{if or (not $realm.AllowsUserReport) (ne "User Report" $v.Label)}}
+      {{if and (not $realm.AllowsUserReport) (ne "User Report" $v.Label)}}
       <button class="btn btn-danger mb-3 {{if eq $i 0}}d-none{{end}}" type="button" {{if ne $i 0}}onClick="removeTemplate('sms-template-{{$i}}');"{{end}}>Delete template</button>
       {{end}}
     </div>
     {{end}}
     <span id="templates-end"></span>
+
+    <div id="sms-preview-errors" class="d-none alert alert-danger">
+    </div>
 
     <div id="sms-preview">
       <p>
@@ -344,6 +338,7 @@
     const shortExpires = {{$realm.GetCodeDurationMinutes}};
     const longCode = randLongCode({{$realm.LongCodeLength}});
     const longExpires = {{$realm.GetLongCodeDurationHours}};
+    const enxEnabled = {{$realm.EnableENExpress}};
     const ensLink = buildENSLink(longCode);
     const $messageBubbles = $('div#message-bubbles');
     const $messageBubble = $('<div class="alert alert-secondary" role="alert"></div>');
@@ -375,13 +370,59 @@
         return;
       }
 
+      let errors = new Array();
       let val = ($(target).val() || '').trim();
-      val = val.replace(/\[region\]/g, region);
+
+      if (val.length > {{$realm.SMSTemplateMaxLength}}) {
+        errors.push('SMS Templates must be <= {{$realm.SMSTemplateMaxLength}} characters, currently ' + val.length + ' characters.');
+      }
+
+      // Provide live feedback on errors in the SMS Template construction.
+      if (enxEnabled) {
+        if (!val.includes("[enslink]")) {
+          errors.push("SMS template must contains [enslink]");
+        }
+        if (val.includes("[region]")) {
+          errors.push("cannot contain `[region]`, this is automatically included in [enslink]");
+        }
+        if (val.includes("[longcode]")) {
+          errors.push("cannot contain `[longcode]`, this is automatically included in [enslink]");
+        }
+        val = val.replace(/\[enslink\]/g, ensLink);      
+      } else {
+        if (val.includes("[enslink]")) {
+          errors.push("`[enslink]` is not allowed when Exposure Notifications Express is not enabled.");
+        }
+
+        hasSC = val.includes("[code]");
+        hasLC = val.includes("[longcode]");
+        if (!(hasSC || hasLC) || (hasSC && hasLC)) {
+          errors.push('must contain exactly one of `[code]` or `[longcode]`');
+        }
+
+        val = val.replace(/\[region\]/g, region);
+        val = val.replace(/\[longcode\]/g, longCode);
+      }    
       val = val.replace(/\[code\]/g, shortCode);
-      val = val.replace(/\[expires\]/g, shortExpires);
-      val = val.replace(/\[longcode\]/g, longCode);
+      val = val.replace(/\[expires\]/g, shortExpires);      
       val = val.replace(/\[longexpires\]/g, longExpires);
-      val = val.replace(/\[enslink\]/g, ensLink);
+
+      if (val.length > {{$realm.SMSTemplateExpansionMax}}) {
+        errors.push('Fully expanded SMS Templates must be <= {{$realm.SMSTemplateExpansionMax}} characters, currently ' + val.length + ' characters.');
+      }
+
+      if (errors.length > 0) {
+        $("#sms-preview-errors").removeClass("d-none");
+        $("#sms-preview-errors").empty();   
+        let msg = $('<ul>');
+        for (i = 0; i < errors.length; i++) {
+          item = ($('<li>').html(errors[i]));
+          msg.append(item);
+        }
+        $("#sms-preview-errors").append(msg);
+      } else {
+        $("#sms-preview-errors").addClass("d-none");
+      }
 
       let parts = val.match(smsSplitter);
       if(!parts) {
@@ -503,7 +544,11 @@
 
       let $textArea = $newNode.find('textarea');
       $textArea.attr('name', `sms_text_template_${next}`);
-      $textArea.val('Your Exposure Notifications verification link: [enslink] Expires in [longexpires] hours (click for mobile device only)');
+      if (enxEnabled) {
+        $textArea.val('{{$realm.DefaultENXSMSTextTemplate}}');
+      } else {
+        $textArea.val('{{$realm.DefaultSMSTextTemplate}}');
+      }
 
       let $deleteButton = $newNode.find('button');
       $deleteButton.click(() => removeTemplate(`sms-template-${next}`));

--- a/pkg/controller/realmadmin/express_disable.go
+++ b/pkg/controller/realmadmin/express_disable.go
@@ -17,7 +17,6 @@ package realmadmin
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -55,19 +54,7 @@ func (c *Controller) HandleDisableExpress() http.Handler {
 		}
 
 		currentRealm.EnableENExpress = false
-		currentRealm.SMSTextTemplate = database.DefaultSMSTextTemplate
-		// If there is a UserReport - upgrade that message as well
-		if _, ok := currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel]; ok {
-			m := database.UserReportDefaultText
-			currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel] = &m
-		}
-		// For other SMS templates, rewrite them as necessary.
-		for k, v := range currentRealm.SMSTextAlternateTemplates {
-			if strings.Contains(*v, database.SMSENExpressLink) {
-				m := database.DefaultSMSTextTemplate
-				currentRealm.SMSTextAlternateTemplates[k] = &m
-			}
-		}
+		currentRealm.ResetSMSTextTemplates()
 
 		if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
 			if database.IsValidationError(err) {

--- a/pkg/controller/realmadmin/express_enable.go
+++ b/pkg/controller/realmadmin/express_enable.go
@@ -60,7 +60,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		currentRealm.CodeDuration = enxSettings.CodeDuration
 		currentRealm.LongCodeLength = enxSettings.LongCodeLength
 		currentRealm.LongCodeDuration = enxSettings.LongCodeDuration
-		currentRealm.SMSTextTemplate = "Your Exposure Notifications verification link: [enslink] Expires in [longexpires] hours (click for mobile device only)"
+		currentRealm.SMSTextTemplate = database.DefaultENXSMSTextTemplate
 		// If there is a UserReport - upgrade that message as well
 		if _, ok := currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel]; ok {
 			m := database.UserReportDefaultENXText

--- a/pkg/controller/realmadmin/express_enable.go
+++ b/pkg/controller/realmadmin/express_enable.go
@@ -17,6 +17,7 @@ package realmadmin
 import (
 	"fmt"
 	"net/http"
+	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -65,6 +66,13 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		if _, ok := currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel]; ok {
 			m := database.UserReportDefaultENXText
 			currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel] = &m
+		}
+		// Upgrade other messages
+		for k, v := range currentRealm.SMSTextAlternateTemplates {
+			if !strings.Contains(*v, database.SMSENExpressLink) {
+				m := database.DefaultENXSMSTextTemplate
+				currentRealm.SMSTextAlternateTemplates[k] = &m
+			}
 		}
 
 		// Confirmed is the only allowed test type for EN Express.

--- a/pkg/controller/realmadmin/express_enable.go
+++ b/pkg/controller/realmadmin/express_enable.go
@@ -17,7 +17,6 @@ package realmadmin
 import (
 	"fmt"
 	"net/http"
-	"strings"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
@@ -61,19 +60,7 @@ func (c *Controller) HandleEnableExpress() http.Handler {
 		currentRealm.CodeDuration = enxSettings.CodeDuration
 		currentRealm.LongCodeLength = enxSettings.LongCodeLength
 		currentRealm.LongCodeDuration = enxSettings.LongCodeDuration
-		currentRealm.SMSTextTemplate = database.DefaultENXSMSTextTemplate
-		// If there is a UserReport - upgrade that message as well
-		if _, ok := currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel]; ok {
-			m := database.UserReportDefaultENXText
-			currentRealm.SMSTextAlternateTemplates[database.UserReportTemplateLabel] = &m
-		}
-		// Upgrade other messages
-		for k, v := range currentRealm.SMSTextAlternateTemplates {
-			if !strings.Contains(*v, database.SMSENExpressLink) {
-				m := database.DefaultENXSMSTextTemplate
-				currentRealm.SMSTextAlternateTemplates[k] = &m
-			}
-		}
+		currentRealm.ResetSMSTextTemplates()
 
 		// Confirmed is the only allowed test type for EN Express.
 		currentRealm.AllowedTestTypes = database.TestTypeConfirmed

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -357,26 +357,49 @@ func NewRealmWithDefaults(name string) *Realm {
 	}
 }
 
-// DefaultSMSTextTemplate returns database.DefaultSMSTextTemplate.
-// Convenance for unitizing in HTML templates.
+// DefaultSMSTextTemplate returns correct default SMS Template for the realm.
 func (r *Realm) DefaultSMSTextTemplate() string {
+	if r.EnableENExpress {
+		return DefaultENXSMSTextTemplate
+	}
 	return DefaultSMSTextTemplate
 }
 
-// DefaultENXSMSTextTemplate returns database.DefaultENXSMSTextTemplate.
-// Convenance for unitizing in HTML templates.
-func (r *Realm) DefaultENXSMSTextTemplate() string {
-	return DefaultENXSMSTextTemplate
+// DefaultUserReportSMSTextTemplate returns the correct default User Report
+// template for the realm.
+func (r *Realm) DefaultUserReportSMSTextTemplate() string {
+	if r.EnableENExpress {
+		return UserReportDefaultENXText
+	}
+	return UserReportDefaultText
+}
+
+// ResetSMSTextTemplates will update all of the templates based on the
+// ENX Redirect setting
+func (r *Realm) ResetSMSTextTemplates() {
+	r.SMSTextTemplate = r.DefaultSMSTextTemplate()
+	// If there is a UserReport - upgrade that message as well
+	if _, ok := r.SMSTextAlternateTemplates[UserReportTemplateLabel]; ok {
+		m := r.DefaultUserReportSMSTextTemplate()
+		r.SMSTextAlternateTemplates[UserReportTemplateLabel] = &m
+	}
+	// Upgrade other messages
+	for k, v := range r.SMSTextAlternateTemplates {
+		if !strings.Contains(*v, SMSENExpressLink) {
+			m := r.DefaultSMSTextTemplate()
+			r.SMSTextAlternateTemplates[k] = &m
+		}
+	}
 }
 
 // SMSTemplateMaxLength returns database.SMSTemplateMaxLength.
-// Convenance for unitizing in HTML templates.
+// Convenance for utilizing in HTML templates.
 func (r *Realm) SMSTemplateMaxLength() int {
 	return SMSTemplateMaxLength
 }
 
 // SMSTemplateExpansionMax returns database.SMSTemplateExpansionMax.
-// Convenance for unitizing in HTML templates.
+// Convenance for utilizing in HTML templates.
 func (r *Realm) SMSTemplateExpansionMax() int {
 	return SMSTemplateExpansionMax
 }

--- a/pkg/integration/enx_redirect_test.go
+++ b/pkg/integration/enx_redirect_test.go
@@ -43,7 +43,7 @@ func TestENXRedirect(t *testing.T) {
 	realm := bs.Realm
 	realm.EnableENExpress = true
 	template := "[enslink]"
-	urTemplate := "[code]"
+	urTemplate := "[enslink]"
 	realm.SMSTextTemplate = template
 	for k := range realm.SMSTextAlternateTemplates {
 		if k == database.UserReportTemplateLabel {


### PR DESCRIPTION
Fixes #2152 

## Proposed Changes

* Uniformity in default templates
* adds dynamic / live validation of SMS templates on the page
* Makes "user report" validation rules non-special (same as other templates)

ENX Enabled Example

![image](https://user-images.githubusercontent.com/92319/122971852-5d362b00-d344-11eb-8e8a-36bd131df3a8.png)

Non-ENX example

![image](https://user-images.githubusercontent.com/92319/122972636-35939280-d345-11eb-8556-2f1b1560058c.png)

Too long

![image](https://user-images.githubusercontent.com/92319/122972752-552abb00-d345-11eb-8b43-5ac43f4a5d25.png)


**Release Note**

```release-note
Fixes default SMS template and SMS template validation issues. SMS Template validation is now also done in the live preview on the settings page.
```
