### PR TITLE
Add admin mobileapps show page

### DIFF
--- a/assets/server/admin/mobileapps/index.html
+++ b/assets/server/admin/mobileapps/index.html
@@ -42,21 +42,21 @@
             </tr>
           </thead>
           <tbody>
-          {{range .apps}}
+          {{range $app := .apps}}
             <tr>
               <td>
-                {{if .MobileApp.DeletedAt}}
+                {{if $app.DeletedAt}}
                   <span class="bi bi-x-square-fill text-danger me-1"
                     data-bs-toggle="tooltip" title="Mobile app is disabled - it will be deleted in a few days"></span>
                 {{else}}
                   <span class="bi bi-check-square-fill text-success me-1"
                     data-bs-toggle="tooltip" title="Mobile app is enabled"></span>
                 {{end}}
-                <a href="/realm/mobile-apps/{{.MobileApp.ID}}" class="text-truncate">{{.MobileApp.Name}}</a>
+                <a href="/admin/mobile-apps/{{$app.ID}}" class="text-truncate">{{$app.Name}}</a>
               </td>
 
               <td>
-                <a href="/admin/realms/{{.Realm.ID}}/edit">{{.Realm.Name}}</a>
+                <a href="/admin/realms/{{$app.RealmID}}/edit">{{.Realm.Name}}</a>
               </td>
             </tr>
           {{end}}

--- a/assets/server/admin/mobileapps/show.html
+++ b/assets/server/admin/mobileapps/show.html
@@ -1,0 +1,80 @@
+{{define "admin/mobileapps/show"}}
+
+{{$app := .app}}
+{{$realm := $app.Realm}}
+
+<!doctype html>
+<html dir="{{$.textDirection}}" lang="{{$.textLanguage}}">
+<head>
+  {{template "head" .}}
+</head>
+
+<body id="admin-mobileapps-index" class="tab-content">
+  {{template "admin/navbar" .}}
+
+  <main role="main" class="container">
+    {{template "flash" .}}
+
+    <div class="card mb-3 shadow-sm">
+      <div class="card-header">
+        <i class="bi bi-phone me-2"></i>
+        {{$app.Name}} ({{$realm.Name}})
+      </div>
+
+      <div class="card-body">
+        <dl class="mb-0">
+          <dt>App name</dt>
+          <dd>{{$app.Name}}</dd>
+
+          <dt>AppStore link</dt>
+          <dd><a href="{{$app.URL | pathUnescape}}" rel="noopener noreferrer" target="_blank">{{$app.URL | pathUnescape}}</a></dd>
+
+          <dt>AppStore redirect</dt>
+          <dd>{{not $app.DisableRedirect}}</dd>
+
+          <dt>Headless</dt>
+          <dd>{{$app.Headless}}</dd>
+
+          <dt>OS</dt>
+          <dd>
+            {{$app.OS.Display}}
+          </dd>
+
+          {{if $app.OS.IsIOS}}
+          <dt>Application ID</dt>
+          <dd id="mobileapps-app-id" class="font-monospace">{{$app.AppID}}</dd>
+          {{end}}
+
+          {{if $app.OS.IsAndroid}}
+            <dt>Package name</dt>
+            <dd id="mobileapps-package-name" class="font-monospace">{{$app.AppID}}</dd>
+
+            <dt>SHA</dt>
+            <dd id="mobileapps-sha" class="font-monospace">{{$app.SHA}}</dd>
+
+            {{if $app.Headless}}
+            <dt>Headless</dt>
+            <dd id="mobileapps-headless" class="font-monospace">EN Express headless (settings-based app)</dd>
+            {{end}}
+          {{end}}
+
+          <dt>Created</dt>
+          <dd>
+            <span data-timestamp="{{$app.CreatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">
+              {{$app.CreatedAt.Format "2006-02-01 15:04"}}
+            </span>
+          </dd>
+
+          <dt>Updated</dt>
+          <dd>
+            <span data-timestamp="{{$app.UpdatedAt.Format "1/02/2006 3:04:05 PM UTC"}}">
+              {{$app.UpdatedAt.Format "2006-02-01 15:04"}}
+            </span>
+          </dd>
+        </dl>
+      </div>
+    </div>
+  </main>
+</body>
+</html>
+{{end}}

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -495,7 +495,8 @@ func systemAdminRoutes(r *mux.Router, c *admin.Controller) {
 	r.Handle("/users/new", c.HandleSystemAdminCreate()).Methods(http.MethodGet)
 	r.Handle("/users/{id:[0-9]+}/revoke", c.HandleSystemAdminRevoke()).Methods(http.MethodDelete)
 
-	r.Handle("/mobile-apps", c.HandleMobileAppsShow()).Methods(http.MethodGet)
+	r.Handle("/mobile-apps", c.HandleMobileAppsIndex()).Methods(http.MethodGet)
+	r.Handle("/mobile-apps/{id:[0-9]+}", c.HandleMobileAppsShow()).Methods(http.MethodGet)
 	r.Handle("/sms", c.HandleSMSUpdate()).Methods(http.MethodGet, http.MethodPost)
 	r.Handle("/email", c.HandleEmailUpdate()).Methods(http.MethodGet, http.MethodPost)
 	r.Handle("/events", c.HandleEventsShow()).Methods(http.MethodGet)

--- a/pkg/controller/admin/mobile_apps_test.go
+++ b/pkg/controller/admin/mobile_apps_test.go
@@ -15,6 +15,7 @@
 package admin_test
 
 import (
+	"fmt"
 	"net/http"
 	"testing"
 
@@ -24,17 +25,18 @@ import (
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/admin"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
+	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
 )
 
-func TestAdminMobileApps(t *testing.T) {
+func TestAdminMobileAppsIndex(t *testing.T) {
 	t.Parallel()
 
 	ctx := project.TestContext(t)
 	harness := envstest.NewServerConfig(t, testDatabaseInstance)
 
 	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-	handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
+	handler := harness.WithCommonMiddlewares(c.HandleMobileAppsIndex())
 
 	t.Run("middleware", func(t *testing.T) {
 		t.Parallel()
@@ -47,7 +49,7 @@ func TestAdminMobileApps(t *testing.T) {
 		t.Parallel()
 
 		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
-		handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
+		handler := harness.WithCommonMiddlewares(c.HandleMobileAppsIndex())
 
 		ctx := ctx
 		ctx = controller.WithSession(ctx, &sessions.Session{})
@@ -84,6 +86,74 @@ func TestAdminMobileApps(t *testing.T) {
 		ctx = controller.WithUser(ctx, &database.User{})
 
 		w, r := envstest.BuildFormRequest(ctx, t, http.MethodGet, "/?q=appy", nil)
+		handler.ServeHTTP(w, r)
+
+		if got, want := w.Code, http.StatusOK; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
+	})
+}
+
+func TestAdminMobileAppsShow(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	harness := envstest.NewServerConfig(t, testDatabaseInstance)
+
+	realm, err := harness.Database.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	app := &database.MobileApp{
+		Name:  "app1",
+		Realm: realm,
+		URL:   "https://example1.com",
+		OS:    database.OSTypeIOS,
+		AppID: "app1",
+	}
+	if err := harness.Database.SaveMobileApp(app, database.SystemTest); err != nil {
+		t.Fatal(err, app.ErrorMessages())
+	}
+
+	c := admin.New(harness.Config, harness.Cacher, harness.Database, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
+	handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
+
+	t.Run("middleware", func(t *testing.T) {
+		t.Parallel()
+
+		envstest.ExerciseSessionMissing(t, handler)
+	})
+
+	t.Run("failure", func(t *testing.T) {
+		t.Parallel()
+
+		c := admin.New(harness.Config, harness.Cacher, harness.BadDatabase, harness.AuthProvider, harness.RateLimiter, harness.Renderer)
+		handler := harness.WithCommonMiddlewares(c.HandleMobileAppsShow())
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithUser(ctx, &database.User{})
+
+		w, r := envstest.BuildFormRequest(ctx, t, http.MethodGet, "/", nil)
+		handler.ServeHTTP(w, r)
+
+		if got, want := w.Code, http.StatusInternalServerError; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
+	})
+
+	t.Run("finds", func(t *testing.T) {
+		t.Parallel()
+
+		ctx := ctx
+		ctx = controller.WithSession(ctx, &sessions.Session{})
+		ctx = controller.WithUser(ctx, &database.User{})
+
+		w, r := envstest.BuildFormRequest(ctx, t, http.MethodGet, "/", nil)
+		r = mux.SetURLVars(r, map[string]string{
+			"id": fmt.Sprintf("%d", app.ID),
+		})
 		handler.ServeHTTP(w, r)
 
 		if got, want := w.Code, http.StatusOK; got != want {

--- a/pkg/database/scopes.go
+++ b/pkg/database/scopes.go
@@ -246,7 +246,7 @@ func WithMobileAppSearch(q string) Scope {
 		q = project.TrimSpace(q)
 		if q != "" {
 			q = `%` + q + `%`
-			return db.Where("mobile_apps.name ILIKE ?", q)
+			return db.Where("mobile_apps.name ILIKE ? OR realms.name ILIKE ?", q, q)
 		}
 		return db
 	}


### PR DESCRIPTION
This was previously broken because it links to the mobile app ID of the currently-selected realm instead of a system-wide view.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add a page for system administrators to view information about a realm's mobile apps. This is useful for diagnosing syncing issues without needing to join the realm.
```
