### PR TITLE
android picker region redirects when possible

### DIFF
--- a/pkg/controller/appsync/helpers.go
+++ b/pkg/controller/appsync/helpers.go
@@ -114,6 +114,9 @@ func (c *Controller) syncApps(ctx context.Context, apps *appsync.AppsResponse) *
 				AppID:    app.PackageName,
 				Headless: app.Headless,
 			}
+			if newApp.Headless {
+				newApp.DisableRedirect = true
+			}
 			if err := c.db.SaveMobileApp(newApp, database.System); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed saving mobile app: %w", err))
 				continue

--- a/pkg/controller/redirect/helpers.go
+++ b/pkg/controller/redirect/helpers.go
@@ -48,19 +48,20 @@ func decideRedirect(region, userAgent string, u *url.URL, enxEnabled bool, appSt
 	// On Android redirect to Play Store if App Link doesn't trigger and an a link
 	// is set up.
 	if onAndroid {
-		if noQuery {
-			// Is it headless ENX, special case w/ internal protocol.
-			if appStoreData.AndroidHeadless {
-				return fmt.Sprintf(androidHeadlessOnboarding, strings.ToLower(region)), true
-			}
+		// Is it headless ENX, special case w/ internal protocol.
+		// If the server has been reached, we know ENX isn't active
+		if appStoreData.AndroidHeadless {
+			return fmt.Sprintf(androidHeadlessOnboarding, strings.ToLower(region)), true
+		}
 
+		if noQuery {
 			// Is it an app that redirects to the play store.
 			if v := appStoreData.AndroidURL; v != "" {
 				return v, true
 			}
 
-			// Generic onboarding, this is a play store search redirect.
-			return androidOnboardingRedirect, true
+			// Generic onboarding, w/ hint to region.
+			return fmt.Sprintf(androidHeadlessOnboarding, strings.ToLower(region)), true
 		}
 
 		// There is an app for this host, build an intent into that app, passing the path and query params.
@@ -70,7 +71,7 @@ func decideRedirect(region, userAgent string, u *url.URL, enxEnabled bool, appSt
 		}
 
 		// we know it's android so generic onboarding
-		return androidOnboardingRedirect, true
+		return fmt.Sprintf(androidHeadlessOnboarding, strings.ToLower(region)), true
 	}
 
 	// On iOS redirect to App Store if App Link doesn't trigger and an a link is set up.

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -313,7 +313,7 @@ func TestDecideRedirect(t *testing.T) {
 			enxEnabled:   true,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
-			expected:     "ensonboarding://picker",
+			expected:     "ensonboarding://picker/us-moo",
 		},
 		{
 			// In this case, there is no app registered, so the link hit the server
@@ -323,7 +323,7 @@ func TestDecideRedirect(t *testing.T) {
 			enxEnabled:   false,
 			userAgent:    userAgentAndroid,
 			appStoreData: &appLinkNeither,
-			expected:     "ensonboarding://picker",
+			expected:     "ensonboarding://picker/us-moo",
 		},
 		{
 			name:         "android_headless_onboarding",

--- a/pkg/controller/redirect/index_test.go
+++ b/pkg/controller/redirect/index_test.go
@@ -324,7 +324,7 @@ func TestIndex(t *testing.T) {
 			t.Errorf("expected %d to be %d: %s", got, want, body)
 		}
 
-		if got, want := resp.Header.Get("Location"), "ensonboarding://picker"; got != want {
+		if got, want := resp.Header.Get("Location"), "ensonboarding://picker/cc"; got != want {
 			t.Errorf("Expected %q to be %q", got, want)
 		}
 	})


### PR DESCRIPTION


**Release Note**

```release-note
For Android redirects, always hint to the region where possible when redirecting to the picker.
```
