### PR TITLE
user report redesign + additional translations

### DIFF
--- a/assets/enx-redirect/report/header.html
+++ b/assets/enx-redirect/report/header.html
@@ -16,7 +16,33 @@
   integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 {{end}}
 
-<title>{{t $.locale "user-report.title"}}</title>
+<style>
+.rounded-corners {
+  border-radius: 20px;
+}
+
+.agreement {
+  border: 1px solid grey;
+}
+
+.agree-button {
+  border-radius: 25px;
+  border: 1px solid;
+}
+
+.pha-logo {
+  margin-bottom: 20px;
+  padding: 10px;
+}
+
+.floating-field {
+  border-radius: 0px;
+  border: none;
+  border-bottom: 1px solid grey;
+}
+</style>
+
+<title>{{tDefault $.realmLocale .realm.Name "agencyDisplayName"}}</title>
 {{end}}
 
 {{define "errorable"}}

--- a/assets/enx-redirect/report/index.html
+++ b/assets/enx-redirect/report/index.html
@@ -10,20 +10,18 @@
 
 <body class="my-4 g-4">
   <main role="main" class="container">
+    <h1 class="display-1 mb-3 w-100"><strong>{{t $.locale "user-report.header"}}</strong></h1>
+
     {{if $currentRealm.AgencyImage}}
-    <div id="logo" style="background-color: {{$currentRealm.AgencyBackgroundColor}};" >
+    <div id="logo" class="rounded-corners pha-logo" style="background-color: {{$currentRealm.AgencyBackgroundColor}};" >
       <img src="{{$currentRealm.AgencyImage}}" style="width:80vw; max-width:720px; content-visibility:auto;"
         loading="lazy" decoding="async"
         alt="{{$currentRealm.Name}} logo" />
     </div>
     {{end}}
 
-    <h1 class="mb-3 w-100 text-center">{{tDefault $.realmLocale .realm.Name "agencyDisplayName"}}</h1>
-
-    <h2 class="w-100 text-center">{{t $.locale "user-report.request-code-from"}}</h2>
-
     {{if not .skipForm}}
-    <div class="alert alert-primary d-flex align-items-center" role="alert">
+    <div class="alert alert-primary d-flex align-items-center rounded-corners" role="alert">
       <svg class="bi flex-shrink-0 me-3" width="24" height="24" role="img" aria-label="Info:">
         <use xlink:href="/static/icons.svg#info-circle-fill"/>
       </svg>
@@ -48,9 +46,25 @@
       <div class="row mb-4">
         <div class="col">
           <div>
-            <input type="tel" id="phone" name="phone" class="form-control{{if .phoneError}} is-invalid{{end}}" autocomplete="off" required
-              placeholder="{{t $.locale "user-report.phone-number-header"}}" value="{{.phoneNumber}}" />
-            <label for="phone">{{t $.locale "user-report.phone-number-header"}}</label>
+            <label for="test-date"><strong>{{t $.locale "user-report.testing-date-label"}}</strong></label>
+            <input type="date" id="test-date" name="testDate" min="{{.minDate}}" max="{{.maxDate}}" class="floating-field form-control w-100{{if .dateError}} is-invalid{{end}}" {{if $currentRealm.RequireDate}}required{{end}}
+              value="{{.date}}"/>            
+          </div>
+          {{if .dateError}}
+            <div class="invalid-feedback">{{.dateError}}</div>
+          {{end}}
+          <div class="form-text">
+            {{tDefault $.realmLocale (t $.locale "user-report.enter-date-instructions") "webReportDateMessage"}}
+          </div>
+        </div>
+      </div>
+
+      <div class="row mb-4">
+        <div class="col">
+          <div>
+            <label for="phone"><strong>{{t $.locale "user-report.phone-number-header"}}</strong></label>
+            <input type="tel" id="phone" name="phone" class="floating-field form-control{{if .phoneError}} is-invalid{{end}}" autocomplete="off" required
+              placeholder="{{t $.locale "user-report.phone-number-placeholder"}}" value="{{.phoneNumber}}" />            
           </div>
           {{if .phoneError}}
             <div class="invalid-feedback">{{.phoneError}}</div>
@@ -67,28 +81,18 @@
       </div>
 
       <div class="row mb-4">
-        <div class="col">
-          <div>
-            <input type="date" id="test-date" name="testDate" min="{{.minDate}}" max="{{.maxDate}}" class="form-control w-100{{if .dateError}} is-invalid{{end}}" {{if $currentRealm.RequireDate}}required{{end}}
-              value="{{.date}}"/>
-            <label for="test-date">{{t $.locale "user-report.testing-date-label"}}</label>
-          </div>
-          {{if .dateError}}
-            <div class="invalid-feedback">{{.dateError}}</div>
-          {{end}}
-          <div class="form-text">
-            {{tDefault $.realmLocale (t $.locale "user-report.enter-date-instructions") "webReportDateMessage"}}
-          </div>
-        </div>
-      </div>
-
-      <div class="row mb-4">
-        <div class="col">
-          <div class="form-check">
-            <input type="checkbox" name="agreement" id="agreement" class="form-check-input {{if .termsError}} is-invalid{{end}}" value="true" required {{if .agreement}}checked{{end}} />
-            <label for="agreement" class="form-check-label">
-              {{tDefault $.realmLocale (t $.locale "user-report.agreement") "webReportLegalMessage"}}
-            </label>
+        <div class="col alert agreement rounded-corners">
+          <div class="form-check container">
+            <div class="row">
+              <div class="col-1 justify-content-center">
+                <input type="checkbox" name="agreement" id="agreement" class="position-relative top-50 translate-middle-y agree-button form-check-input {{if .termsError}} is-invalid{{end}}" value="true" required {{if .agreement}}checked{{end}} />
+              </div>
+              <div class="col">
+                <label for="agreement" class="form-check-label">
+                  {{t $.locale "user-report.agreement"}}
+                </label>
+              </div>
+            </div>
           </div>
           {{if .termsError}}
             <div class="invalid-feedback">{{.termsError}}</div>

--- a/assets/enx-redirect/report/issue.html
+++ b/assets/enx-redirect/report/issue.html
@@ -19,7 +19,7 @@
     {{end}}
     <h1 class="mb-3">{{t $.locale "user-report.request-code-from"}} {{tDefault $.realmLocale .realm.Name "agencyDisplayName"}}</h1>
 
-    <div class="alert alert-success d-flex align-items-center" role="alert">
+    <div class="alert alert-success d-flex align-items-center rounded-corners" role="alert">
       <svg class="bi flex-shrink-0 me-3" width="24" height="24" role="img" aria-label="Success:">
         <use xlink:href="/static/icons.svg#check-circle-fill"/>
       </svg>

--- a/internal/i18n/locales/ar/default.po
+++ b/internal/i18n/locales/ar/default.po
@@ -417,16 +417,16 @@ msgid "user-report.phone-number-header"
 msgstr "رقم الهاتف المحمول"
 
 msgid "user-report.phone-number-instructions"
-msgstr "يسمح لك رمز التحقق بمشاركة نتائج الاختبار الخاصة بك. سيتم إرسال الرمز الخاص بك إلى الرقم الذي تقدمه."
+msgstr "يجب إدخال رقم هاتف صالح لتلقي رمز التحقق. قد يتم تطبيق رسوم الناقل."
 
 msgid "user-report.agreement-header"
 msgstr "اتفاق"
 
 msgid "user-report.agreement"
-msgstr "لقد تلقيت نتيجة اختبار إيجابية لـ COVID-19 ورقم الهاتف الذي قدمته هو خاص بي."
+msgstr "أقر بأنني تلقيت نتيجة اختبار إيجابية لـ COVID-19 وأن رقم الهاتف الذي قدمته هو خاص بي وأود تلقي رمز للإبلاغ عن نتيجة الاختبار الإيجابية الخاصة بي."
 
 msgid "user-report.request-button"
-msgstr "اطلب رمز التحقق"
+msgstr "يكمل"
 
 msgid "user-report.code-issued"
 msgstr "تم إصدار رمز التحقق"
@@ -471,7 +471,13 @@ msgid "user-report.testing-date-label"
 msgstr "تاريخ اختبار COVID-19 الخاص بك"
 
 msgid "user-report.phone-storage"
-msgstr "لمنع الأشخاص من إرسال أكثر من نتيجة واحدة ، قد يتم تخزين رقم هاتفك مؤقتًا بواسطة هيئة الصحة العامة الخاصة بك."
+msgstr "قد يتم تخزين نسخة محمية مشفرة من رقم هاتفك لمنع عمليات الإرسال الإضافية."
 
 msgid "user-report.learn-more"
 msgstr "يتعلم أكثر..."
+
+msgid "user-report.header"
+msgstr "ساعد في إعلام الآخرين بالتعرض"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXXXX"

--- a/internal/i18n/locales/bn/default.po
+++ b/internal/i18n/locales/bn/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "আপনার মোবাইল ফোন নম্বর"
 
 msgid "user-report.phone-number-instructions"
-msgstr "একটি যাচাইকরণ কোড আপনাকে আপনার পরীক্ষার ফলাফলগুলি ভাগ করতে দেয়। আপনার কোড আপনি সরবরাহ করা নম্বরে প্রেরণ করা হবে।"
+msgstr "একটি যাচাইকরণ কোড পেতে আপনাকে অবশ্যই একটি বৈধ ফোন নম্বর প্রবেশ করতে হবে। ক্যারিয়ার ফি প্রয়োগ হতে পারে।"
 
 msgid "user-report.agreement-header"
 msgstr "চুক্তি"
 
 msgid "user-report.agreement"
-msgstr "আমি COVID-19 এর জন্য একটি ইতিবাচক পরীক্ষার ফলাফল পেয়েছি এবং আমি যে ফোন নম্বর সরবরাহ করেছি তা আমার নিজের।"
+msgstr "আমি স্বীকার করি যে আমি COVID-19 এর জন্য একটি ইতিবাচক পরীক্ষার ফলাফল পেয়েছি এবং আমি যে ফোন নম্বর সরবরাহ করেছি তা আমার নিজের এবং আমি আমার ইতিবাচক পরীক্ষার ফলাফলের রিপোর্ট করার জন্য একটি কোড পেতে চাই।"
 
 msgid "user-report.request-button"
-msgstr "অনুরোধ যাচাইকরণ কোড"
+msgstr "চালিয়ে যান"
 
 msgid "user-report.code-issued"
 msgstr "যাচাইকরণ কোড জারি"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "আপনার COVID-19 পরীক্ষার তারিখ"
 
 msgid "user-report.phone-storage"
-msgstr "লোককে একাধিক ফলাফল জমা দেওয়া থেকে বিরত রাখতে আপনার ফোন নম্বরটি আপনার জনস্বাস্থ্য কর্তৃপক্ষের দ্বারা অস্থায়ীভাবে সংরক্ষণ করা যেতে পারে।"
+msgstr "অতিরিক্ত জমাগুলি রোধ করতে আপনার ফোন নম্বরটির একটি ক্রিপ্টোগ্রাফিকভাবে সুরক্ষিত সংস্করণ সংরক্ষণ করা যেতে পারে।"
 
 msgid "user-report.learn-more"
 msgstr "আরও জানুন ..."
+
+msgid "user-report.header"
+msgstr "এক্সপোজারের অন্যদের অবহিত করতে সহায়তা করুন"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXXX-XXXXXX"

--- a/internal/i18n/locales/de/default.po
+++ b/internal/i18n/locales/de/default.po
@@ -417,16 +417,16 @@ msgid "user-report.phone-number-header"
 msgstr "Deine Handynummer"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Mit einem Bestätigungscode können Sie Ihre Testergebnisse teilen. Ihr Code wird an die von Ihnen angegebene Nummer gesendet."
+msgstr "Ich bestätige, dass ich ein positives Testergebnis für COVID-19 erhalten habe und die von mir angegebene Telefonnummer meine eigene ist und ich möchte einen Code erhalten, um mein positives Testergebnis zu melden."
 
 msgid "user-report.agreement-header"
 msgstr "Vereinbarung"
 
 msgid "user-report.agreement"
-msgstr "Ich habe ein positives Testergebnis für COVID-19 erhalten und die von mir angegebene Telefonnummer ist meine eigene."
+msgstr "Ich bestätige, dass ich ein positives Testergebnis für COVID-19 erhalten habe und die von mir angegebene Telefonnummer meine eigene ist und ich möchte einen Code erhalten, um mein positives Testergebnis zu melden."
 
 msgid "user-report.request-button"
-msgstr "Bestätigungscode anfordern"
+msgstr "Fortsetzen"
 
 msgid "user-report.code-issued"
 msgstr "Bestätigungscode ausgegeben"
@@ -471,7 +471,13 @@ msgid "user-report.testing-date-label"
 msgstr "Datum Ihres COVID-19-Tests"
 
 msgid "user-report.phone-storage"
-msgstr "Um zu verhindern, dass Personen mehr als ein Ergebnis übermitteln, kann Ihre Telefonnummer von Ihrem Gesundheitsamt vorübergehend gespeichert werden."
+msgstr "Eine kryptographisch geschützte Version Ihrer Telefonnummer kann gespeichert werden, um zusätzliche Übermittlungen zu verhindern."
 
 msgid "user-report.learn-more"
 msgstr "Weitere Informationen..."
+
+msgid "user-report.header"
+msgstr "Helfen Sie mit, andere über Gefährdungen zu informieren"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXXX XXXXXXX"

--- a/internal/i18n/locales/en/default.po
+++ b/internal/i18n/locales/en/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Your Mobile Phone number"
 
 msgid "user-report.phone-number-instructions"
-msgstr "A verification code allows you to share your test results. Your code will be sent to the number you provide."
+msgstr "You must enter a valid phone number to receive a verification code. Carrier fees may apply."
 
 msgid "user-report.agreement-header"
 msgstr "Agreement"
 
 msgid "user-report.agreement"
-msgstr "I have received a positive test result for COVID-19 and the phone number I have provided is my own."
+msgstr "I acknowledge I have received a positive test result for COVID-19 and the phone number I have provided is my own and I would like to receive a code to report my positive test result."
 
 msgid "user-report.request-button"
-msgstr "Request verification code"
+msgstr "Continue"
 
 msgid "user-report.code-issued"
 msgstr "Verification code issued"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "Date of Your COVID-19 Test"
 
 msgid "user-report.phone-storage"
-msgstr "To prevent people from submitting more than one result, your phone number may be temporarily stored by your public health authority."
+msgstr "A cryptographically protected version of your phone number may be stored to prevent additional submissions."
 
 msgid "user-report.learn-more"
 msgstr "Learn more..."
+
+msgid "user-report.header"
+msgstr "Help Notify Others of Exposure"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXX XXXX"

--- a/internal/i18n/locales/es/default.po
+++ b/internal/i18n/locales/es/default.po
@@ -417,16 +417,16 @@ msgid "user-report.phone-number-header"
 msgstr "Tu número de teléfono"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Un código de verificación le permite compartir los resultados de su prueba. Su código se enviará al número que proporcione."
+msgstr "Debes ingresar un número de teléfono válido para recibir un código de verificación. Es posible que se apliquen tarifas del operador."
 
 msgid "user-report.agreement-header"
 msgstr "Acuerdo"
 
 msgid "user-report.agreement"
-msgstr "He recibido un resultado positivo en la prueba de COVID-19 y el número de teléfono que he proporcionado es el mío"
+msgstr "Reconozco que he recibido un resultado positivo de la prueba de COVID-19 y que el número de teléfono que he proporcionado es el mío y me gustaría recibir un código para informar el resultado positivo de mi prueba."
 
 msgid "user-report.request-button"
-msgstr "Solicitar código de verificación"
+msgstr "Continuar"
 
 msgid "user-report.code-issued"
 msgstr "Código de verificación emitido"
@@ -471,7 +471,13 @@ msgid "user-report.testing-date-label"
 msgstr "Fecha de su prueba COVID-19"
 
 msgid "user-report.phone-storage"
-msgstr "Para evitar que las personas envíen más de un resultado, su número de teléfono puede ser almacenado temporalmente por su autoridad de salud pública."
+msgstr "Es posible que se almacene una versión protegida criptográficamente de su número de teléfono para evitar envíos adicionales."
 
 msgid "user-report.learn-more"
 msgstr "Más información ..."
+
+msgid "user-report.header"
+msgstr "Ayude a notificar a otros sobre la exposición"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXX XXXX"

--- a/internal/i18n/locales/fil/default.po
+++ b/internal/i18n/locales/fil/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Ang iyong numero ng Mobile Phone"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Pinapayagan ka ng isang verification code na ibahagi ang iyong mga resulta sa pagsubok. Ipapadala ang iyong code sa numerong ibibigay mo."
+msgstr "Dapat kang maglagay ng wastong numero ng telepono upang makatanggap ng isang verification code. Maaaring mailapat ang mga bayarin sa carrier."
 
 msgid "user-report.agreement-header"
 msgstr "Kasunduan"
 
 msgid "user-report.agreement"
-msgstr "Nakatanggap ako ng positibong resulta sa pagsubok para sa COVID-19 at ang ibinigay kong numero ng telepono ay aking sarili."
+msgstr "Kinikilala ko na nakatanggap ako ng positibong resulta sa pagsubok para sa COVID-19 at ang numero ng telepono na ibinigay ko ay aking sarili at nais kong makatanggap ng isang code upang iulat ang aking positibong resulta sa pagsubok."
 
 msgid "user-report.request-button"
-msgstr "Humiling ng verification code"
+msgstr "Magpatuloy"
 
 msgid "user-report.code-issued"
 msgstr "Inisyu ang verification code"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "Petsa ng Iyong Pagsubok sa COVID-19"
 
 msgid "user-report.phone-storage"
-msgstr "Upang maiwasan ang mga tao na magsumite ng higit sa isang resulta, ang iyong numero ng telepono ay maaaring pansamantalang maiimbak ng iyong awtoridad sa kalusugan sa publiko."
+msgstr "Ang isang bersyon na protektado ng cryptographically ng iyong numero ng telepono ay maaaring maimbak upang maiwasan ang karagdagang mga pagsusumite."
 
 msgid "user-report.learn-more"
 msgstr "Matuto nang higit pa ..."
+
+msgid "user-report.header"
+msgstr "Tulungan Ipaalam sa Iba ang Pagkakalantad"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXX XXX XXXX"

--- a/internal/i18n/locales/fr/default.po
+++ b/internal/i18n/locales/fr/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Numéro de téléphone"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Numéro de téléphone portable (pour recevoir le code de vérification)"
+msgstr "Vous devez entrer un numéro de téléphone valide pour recevoir un code de vérification. Des frais de transporteur peuvent s'appliquer."
 
 msgid "user-report.agreement-header"
 msgstr "Accord"
 
 msgid "user-report.agreement"
-msgstr "J'ai reçu un résultat de test positif pour COVID-19 et le numéro de téléphone que j'ai fourni est le mien."
+msgstr "Je reconnais avoir reçu un résultat de test positif pour COVID-19 et le numéro de téléphone que j'ai fourni est le mien et j'aimerais recevoir un code pour signaler mon résultat de test positif."
 
 msgid "user-report.request-button"
-msgstr "Demander le code de vérification"
+msgstr "Continuer"
 
 msgid "user-report.code-issued"
 msgstr "Code de vérification émis"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "Date de votre test COVID-19"
 
 msgid "user-report.phone-storage"
-msgstr "Pour empêcher les gens de soumettre plus d'un résultat, votre numéro de téléphone peut être temporairement stocké par votre autorité de santé publique."
+msgstr "Une version protégée par cryptographie de votre numéro de téléphone peut être stockée pour empêcher des soumissions supplémentaires."
 
 msgid "user-report.learn-more"
 msgstr "En savoir plus..."
+
+msgid "user-report.header"
+msgstr "Aidez à informer les autres de l'exposition"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XX XX XX XX XX"

--- a/internal/i18n/locales/id/default.po
+++ b/internal/i18n/locales/id/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Nomor Ponsel Anda"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Kode verifikasi memungkinkan Anda untuk membagikan hasil pengujian Anda. Kode Anda akan dikirim ke nomor yang Anda berikan."
+msgstr "Anda harus memasukkan nomor telepon yang valid untuk menerima kode verifikasi. Biaya operator mungkin berlaku."
 
 msgid "user-report.agreement-header"
 msgstr "Perjanjian"
 
 msgid "user-report.agreement"
-msgstr "Saya telah menerima hasil tes positif untuk COVID-19 dan nomor telepon yang saya berikan adalah nomor saya sendiri."
+msgstr "Saya mengakui bahwa saya telah menerima hasil tes positif COVID-19 dan nomor telepon yang saya berikan adalah milik saya sendiri dan saya ingin menerima kode untuk melaporkan hasil tes positif saya."
 
 msgid "user-report.request-button"
-msgstr "Minta kode verifikasi"
+msgstr "Terus"
 
 msgid "user-report.code-issued"
 msgstr "Kode verifikasi dikeluarkan"
@@ -472,7 +472,14 @@ msgid "user-report.testing-date-label"
 msgstr "Tanggal Tes COVID-19 Anda"
 
 msgid "user-report.phone-storage"
-msgstr "Untuk mencegah orang mengirimkan lebih dari satu hasil, nomor telepon Anda mungkin disimpan sementara oleh otoritas kesehatan masyarakat Anda."
+msgstr "Versi nomor telepon Anda yang dilindungi secara kriptografis dapat disimpan untuk mencegah pengiriman tambahan."
 
 msgid "user-report.learn-more"
 msgstr "Pelajari lebih lanjut..."
+
+msgid "user-report.header"
+msgstr "Bantu Beri Tahu Orang Lain tentang Paparan"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXX XXX XXX"
+

--- a/internal/i18n/locales/it/default.po
+++ b/internal/i18n/locales/it/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Il tuo numero di cellulare"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Un codice di verifica ti consente di condividere i risultati del test. Il tuo codice verrà inviato al numero da te fornito."
+msgstr "Devi inserire un numero di telefono valido per ricevere un codice di verifica. Potrebbero essere applicate le tariffe del vettore."
 
 msgid "user-report.agreement-header"
 msgstr "Accordo"
 
 msgid "user-report.agreement"
-msgstr "Ho ricevuto un risultato positivo del test per COVID-19 e il numero di telefono che ho fornito è il mio."
+msgstr "Riconosco di aver ricevuto un risultato del test positivo per COVID-19 e il numero di telefono che ho fornito è il mio e vorrei ricevere un codice per segnalare il risultato del test positivo."
 
 msgid "user-report.request-button"
-msgstr "Richiedi codice di verifica"
+msgstr "Continua"
 
 msgid "user-report.code-issued"
 msgstr "Codice di verifica emesso"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "Data del tuo test COVID-19"
 
 msgid "user-report.phone-storage"
-msgstr "Per impedire alle persone di inviare più di un risultato, il tuo numero di telefono potrebbe essere temporaneamente memorizzato dalla tua autorità sanitaria pubblica."
+msgstr "Una versione protetta crittograficamente del tuo numero di telefono potrebbe essere archiviata per impedire ulteriori invii."
 
 msgid "user-report.learn-more"
 msgstr "Ulteriori informazioni..."
+
+msgid "user-report.header"
+msgstr "Aiuta a informare gli altri dell'esposizione"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXX XXXX"

--- a/internal/i18n/locales/ja/default.po
+++ b/internal/i18n/locales/ja/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "あなたの携帯電話番号"
 
 msgid "user-report.phone-number-instructions"
-msgstr "検証コードを使用すると、テスト結果を共有できます。 あなたのコードはあなたが提供した番号に送られます。"
+msgstr "確認コードを受け取るには、有効な電話番号を入力する必要があります。 運送業者の手数料がかかる場合があります。"
 
 msgid "user-report.agreement-header"
 msgstr "合意"
 
 msgid "user-report.agreement"
-msgstr "COVID-19の検査結果が陽性で、提供した電話番号は自分のものです。"
+msgstr "COVID-19の検査結果が陽性であり、提供した電話番号は自分のものであり、陽性の検査結果を報告するためのコードを受け取りたいと思います。"
 
 msgid "user-report.request-button"
-msgstr "確認コードのリクエスト"
+msgstr "継続する"
 
 msgid "user-report.code-issued"
 msgstr "確認コードが発行されました"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "COVID-19テストの日付"
 
 msgid "user-report.phone-storage"
-msgstr "他の人が複数の結果を送信するのを防ぐために、あなたの電話番号はあなたの公衆衛生当局によって一時的に保存されるかもしれません。"
+msgstr "追加の送信を防ぐために、暗号で保護されたバージョンの電話番号が保存される場合があります。"
 
 msgid "user-report.learn-more"
 msgstr "詳細..."
+
+msgid "user-report.header"
+msgstr "他の人に露出を通知するのを手伝ってください"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXXX XXXX"

--- a/internal/i18n/locales/mn/default.po
+++ b/internal/i18n/locales/mn/default.po
@@ -417,16 +417,16 @@ msgid "user-report.phone-number-header"
 msgstr "Таны гар утасны дугаар"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Баталгаажуулах код нь тестийн үр дүнг хуваалцах боломжийг танд олгоно. Таны оруулсан дугаар руу кодоо илгээх болно."
+msgstr "Баталгаажуулах кодыг хүлээн авахын тулд та зөв утасны дугаар оруулах шаардлагатай. Оператор компанийн төлбөр шаардагдаж магадгүй юм."
 
 msgid "user-report.agreement-header"
 msgstr "Гэрээ"
 
 msgid "user-report.agreement"
-msgstr "Би COVID-19-ийн туршилтын эерэг хариу авсан бөгөөд миний өгсөн утасны дугаар минийх байна."
+msgstr "Би COVID-19-ийн шинжилгээний эерэг үр дүнг хүлээн авсан гэдгээ мэдэгдэж байгаа бөгөөд миний өгсөн утасны дугаар минийх бөгөөд миний эерэг тестийн үр дүнг тайлагнах кодыг авахыг хүсч байна."
 
 msgid "user-report.request-button"
-msgstr "Баталгаажуулах код хүсэх"
+msgstr "Үргэлжлүүлэх"
 
 msgid "user-report.code-issued"
 msgstr "Баталгаажуулах код гаргасан"
@@ -471,7 +471,13 @@ msgid "user-report.testing-date-label"
 msgstr "Таны COVID-19 туршилтын огноо"
 
 msgid "user-report.phone-storage"
-msgstr "Хүмүүс нэгээс илүү үр дүн илгээхээс урьдчилан сэргийлэхийн тулд таны утасны дугаарыг таны нийгмийн эрүүл мэндийн байгууллагад түр хадгалах боломжтой."
+msgstr "Таны утасны дугаарын криптографийн хамгаалалттай хувилбарыг хадгалах боломжтой бөгөөд нэмэлт мэдээлэл оруулахаас сэргийлнэ."
 
 msgid "user-report.learn-more"
 msgstr "Дэлгэрэнгүй үзэх ..."
+
+msgid "user-report.header"
+msgstr "Бусад өртөлтийн талаар мэдэгдэхэд тусална уу"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXX XXXX"

--- a/internal/i18n/locales/pt/default.po
+++ b/internal/i18n/locales/pt/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Seu número de celular"
 
 msgid "user-report.phone-number-instructions"
-msgstr "Um código de verificação permite que você compartilhe os resultados do seu teste. Seu código será enviado para o número que você fornecer."
+msgstr "Você deve inserir um número de telefone válido para receber um código de verificação. Taxas da operadora podem ser aplicadas."
 
 msgid "user-report.agreement-header"
 msgstr "Acordo"
 
 msgid "user-report.agreement"
-msgstr "Recebi um resultado de teste positivo para COVID-19 e o número de telefone que indiquei é o meu."
+msgstr "Confirmo que recebi um resultado de teste positivo para COVID-19 e o número de telefone que indiquei é o meu próprio e gostaria de receber um código para relatar o meu resultado de teste positivo."
 
 msgid "user-report.request-button"
-msgstr "Solicitar código de verificação"
+msgstr "Prosseguir"
 
 msgid "user-report.code-issued"
 msgstr "Código de verificação emitido"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "Data do seu teste COVID-19"
 
 msgid "user-report.phone-storage"
-msgstr "Para evitar que as pessoas enviem mais de um resultado, seu número de telefone pode ser armazenado temporariamente pela autoridade de saúde pública."
+msgstr "Uma versão criptograficamente protegida do seu número de telefone pode ser armazenada para evitar envios adicionais."
 
 msgid "user-report.learn-more"
 msgstr "Saiba mais ..."
+
+msgid "user-report.header"
+msgstr "Ajude a notificar outras pessoas sobre a exposição"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XX XXXXX XXXX"

--- a/internal/i18n/locales/th/default.po
+++ b/internal/i18n/locales/th/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "หมายเลขโทรศัพท์มือถือของคุณ"
 
 msgid "user-report.phone-number-instructions"
-msgstr "รหัสยืนยันช่วยให้คุณแชร์ผลการทดสอบได้ รหัสของคุณจะถูกส่งไปยังหมายเลขที่คุณระบุ"
+msgstr "คุณต้องป้อนหมายเลขโทรศัพท์ที่ถูกต้องเพื่อรับรหัสยืนยัน อาจมีค่าธรรมเนียมผู้ให้บริการ"
 
 msgid "user-report.agreement-header"
 msgstr "ข้อตกลง"
 
 msgid "user-report.agreement"
-msgstr "ฉันได้รับผลการทดสอบ COVID-19 ในเชิงบวกและหมายเลขโทรศัพท์ที่ฉันให้ไว้เป็นของฉันเอง"
+msgstr "ฉันรับทราบว่าได้ผลการทดสอบในเชิงบวกสำหรับ COVID-19 และหมายเลขโทรศัพท์ที่ฉันให้ไว้นั้นเป็นหมายเลขของฉันเอง และฉันต้องการรับรหัสเพื่อรายงานผลการทดสอบที่เป็นบวก"
 
 msgid "user-report.request-button"
-msgstr "ขอรหัสยืนยัน"
+msgstr "ดำเนินการต่อ"
 
 msgid "user-report.code-issued"
 msgstr "ออกรหัสยืนยันแล้ว"
@@ -472,7 +472,14 @@ msgid "user-report.testing-date-label"
 msgstr "วันที่คุณตรวจโควิด-19"
 
 msgid "user-report.phone-storage"
-msgstr "เพื่อป้องกันไม่ให้ผู้อื่นส่งผลลัพธ์มากกว่าหนึ่งรายการ หมายเลขโทรศัพท์ของคุณอาจถูกจัดเก็บไว้ชั่วคราวโดยหน่วยงานด้านสาธารณสุขของคุณ"
+msgstr "อาจมีการจัดเก็บหมายเลขโทรศัพท์ของคุณในเวอร์ชันที่ป้องกันด้วยการเข้ารหัสเพื่อป้องกันการส่งเพิ่มเติม"
 
 msgid "user-report.learn-more"
 msgstr "เรียนรู้เพิ่มเติม..."
+
+msgid "user-report.header"
+msgstr "ช่วยแจ้งให้ผู้อื่นทราบถึงความเสี่ยง"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXX XXX XXXX"
+

--- a/internal/i18n/locales/tr/default.po
+++ b/internal/i18n/locales/tr/default.po
@@ -418,16 +418,16 @@ msgid "user-report.phone-number-header"
 msgstr "Jübi telefonyňyzyň belgisi"
 
 msgid "user-report.phone-number-instructions"
-msgstr "A verification code allows you to share your test results. Your code will be sent to the number you provide."
+msgstr "Doğrulama kodu almak için geçerli bir telefon numarası girmelisiniz. Taşıyıcı ücretleri geçerli olabilir."
 
 msgid "user-report.agreement-header"
 msgstr "Sözleşme"
 
 msgid "user-report.agreement"
-msgstr "COVID-19 için pozitif bir test sonucu aldım ve verdiğim telefon numarası bana ait."
+msgstr "COVID-19 için pozitif bir test sonucu aldığımı ve verdiğim telefon numarasının bana ait olduğunu ve pozitif test sonucumu bildirmek için bir kod almak istediğimi kabul ediyorum."
 
 msgid "user-report.request-button"
-msgstr "Doğrulama kodu iste"
+msgstr "Devam et"
 
 msgid "user-report.code-issued"
 msgstr "Doğrulama kodu verildi"
@@ -472,7 +472,13 @@ msgid "user-report.testing-date-label"
 msgstr "COVID-19 synagyňyzyň senesi"
 
 msgid "user-report.phone-storage"
-msgstr "Adamlaryň birden köp netije bermeginiň öňüni almak üçin telefon belgiňiz wagtlaýyn saglygy goraýyş edarasy tarapyndan saklanyp bilner."
+msgstr "Ek gönderimleri önlemek için telefon numaranızın kriptografik olarak korunan bir sürümü saklanabilir."
 
 msgid "user-report.learn-more"
 msgstr "Has giňişleýin öwren ..."
+
+msgid "user-report.header"
+msgstr "Maruz Kalma Durumunda Diğerlerini Bildirmeye Yardımcı Olun"
+
+msgid "user-report.phone-number-placeholder"
+msgstr "XXXX XXX XX XX"


### PR DESCRIPTION

## Proposed Changes

* UI changes for user report web view - rounded corners, floating form fields, label reorder.
* agreement text will not be PHA customizable

(just using CA logo as demonstration, it does not imply endorsement of this feature in any way)

![image](https://user-images.githubusercontent.com/92319/124965551-1d737280-dfd7-11eb-9c69-2679c2f1596d.png)


**Release Note**

```release-note
User report web view redesign and refresh of default strings and translations.
```
