### PR TITLE
Use correct EN logo color, cache bust assets on release

### DIFF
--- a/assets/enx-redirect/header.html
+++ b/assets/enx-redirect/header.html
@@ -4,14 +4,14 @@
 <meta name="build-id" content="{{.buildID}}">
 <meta name="build-tag" content="{{.buildTag}}">
 
-<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png">
-<link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png">
-<link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png">
-<link rel="manifest" href="/static/site.webmanifest">
-<link rel="mask-icon" href="/static/safari-pinned-tab.svg" color="#5bbad5">
-<link rel="shortcut icon" href="/static/favicon.ico">
-<meta name="msapplication-TileColor" content="#ff0554">
-<meta name="msapplication-config" content="/static/browserconfig.xml">
+<link rel="apple-touch-icon" sizes="180x180" href="/static/apple-touch-icon.png?{{.buildID}}">
+<link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png?{{.buildID}}">
+<link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png?{{.buildID}}">
+<link rel="manifest" href="/static/site.webmanifest?{{.buildID}}">
+<link rel="mask-icon" href="/static/safari-pinned-tab.svg?{{.buildID}}" color="#d85140">
+<link rel="shortcut icon" href="/static/favicon.ico?{{.buildID}}">
+<meta name="msapplication-TileColor" content="#d85140">
+<meta name="msapplication-config" content="/static/browserconfig.xml?{{.buildID}}">
 <meta name="theme-color" content="#ffffff">
 
 {{if eq $.textDirection "rtl"}}

--- a/assets/enx-redirect/report/header.html
+++ b/assets/enx-redirect/report/header.html
@@ -4,7 +4,7 @@
 <meta name="build-id" content="{{.buildID}}">
 <meta name="build-tag" content="{{.buildTag}}">
 
-<link rel="shortcut icon" href="/static/favicon.ico">
+<link rel="shortcut icon" href="/static/favicon.ico?{{.buildID}}">
 <meta name="theme-color" content="#ffffff">
 {{.csrfMeta}}
 
@@ -67,7 +67,7 @@
   user-select: none;
   padding: 0.8rem, 0.75rem;
   font-size: 1.25rem;
-  border-radius: 20px;   
+  border-radius: 20px;
 }
 </style>
 

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -8,9 +8,9 @@
 <link rel="icon" type="image/png" sizes="32x32" href="/static/favicon-32x32.png?{{.buildID}}">
 <link rel="icon" type="image/png" sizes="16x16" href="/static/favicon-16x16.png?{{.buildID}}">
 <link rel="manifest" href="/static/site.webmanifest?{{.buildID}}">
-<link rel="mask-icon" href="/static/safari-pinned-tab.svg?{{.buildID}}" color="#5bbad5">
+<link rel="mask-icon" href="/static/safari-pinned-tab.svg?{{.buildID}}" color="#d85140">
 <link rel="shortcut icon" href="/static/favicon.ico?{{.buildID}}">
-<meta name="msapplication-TileColor" content="#ff0554">
+<meta name="msapplication-TileColor" content="#d85140">
 <meta name="msapplication-config" content="/static/browserconfig.xml?{{.buildID}}">
 <meta name="theme-color" content="#ffffff">
 {{.csrfMeta}}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update logo colors and purge favicon caches on release.
```
