### PR TITLE
Extend stats retention to 90 days

### DIFF
--- a/internal/project/util.go
+++ b/internal/project/util.go
@@ -39,6 +39,10 @@ var devMode, _ = strconv.ParseBool(os.Getenv("DEV_MODE"))
 // SMS.
 const TestPhoneNumber = "+18558361987"
 
+// StatsDisplayDays is the number of days for which to display statistics. This
+// is separate from stats retention, which is controlled by the cleanup job.
+const StatsDisplayDays = 90
+
 var _, self, _, _ = runtime.Caller(0)
 
 // Root returns the filepath to the root of this project.

--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 
 	"github.com/google/exposure-notifications-server/pkg/observability"
@@ -50,9 +51,9 @@ type CleanupConfig struct {
 	MobileAppMaxAge     time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
 
 	// StatsMaxAge is the maximum amount of time to retain statistics. The default
-	// value is 31d. It can be extended up to 90 days and cannot be less than 30
+	// value is 31d. It can be extended up to 120 days and cannot be less than 30
 	// days.
-	StatsMaxAge time.Duration `env:"STATS_MAX_AGE, default=744h"`
+	StatsMaxAge time.Duration `env:"STATS_MAX_AGE, default=2160h"`
 
 	// RealmChaffEventMaxAge is the maximum amount of time to store whether a
 	// realm had received a chaff request.
@@ -125,7 +126,7 @@ func (c *CleanupConfig) Validate() error {
 	if min := 30; c.StatsMaxAge < time.Duration(min)*24*time.Hour {
 		return fmt.Errorf("STATS_MAX_AGE must be at least %d days", min)
 	}
-	if max := 90; c.StatsMaxAge > time.Duration(max)*24*time.Hour {
+	if max := project.StatsDisplayDays * 2; c.StatsMaxAge > time.Duration(max)*24*time.Hour {
 		return fmt.Errorf("STATS_MAX_AGE must be less than %d days", max)
 	}
 

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -203,7 +203,7 @@ func (db *Database) FindAuthorizedAppByAPIKey(apiKey string) (*AuthorizedApp, er
 // returns an empty array.
 func (a *AuthorizedApp) Stats(db *Database) (AuthorizedAppStats, error) {
 	stop := timeutils.UTCMidnight(time.Now())
-	start := stop.Add(30 * -24 * time.Hour)
+	start := stop.Add(project.StatsDisplayDays * -24 * time.Hour)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1757,11 +1757,11 @@ func (r *Realm) destroyManagedSigningKey(ctx context.Context, db *Database, id i
 	return nil
 }
 
-// Stats returns the 30-day usage statistics for this realm. If no stats exist,
-// returns an empty array.
+// Stats returns the usage statistics for this realm. If no stats exist, returns
+// an empty array.
 func (r *Realm) Stats(db *Database) (RealmStats, error) {
 	stop := timeutils.UTCMidnight(time.Now())
-	start := stop.Add(30 * -24 * time.Hour)
+	start := stop.Add(project.StatsDisplayDays * -24 * time.Hour)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}
@@ -1818,11 +1818,11 @@ func (r *Realm) StatsCached(ctx context.Context, db *Database, cacher cache.Cach
 	return stats, nil
 }
 
-// ExternalIssuerStats returns the 30-day external issuer stats for this realm.
-// If no stats exist, returns an empty slice.
+// ExternalIssuerStats returns the external issuer stats for this realm. If no
+// stats exist, returns an empty slice.
 func (r *Realm) ExternalIssuerStats(db *Database) (ExternalIssuerStats, error) {
 	stop := timeutils.UTCMidnight(time.Now())
-	start := stop.Add(30 * -24 * time.Hour)
+	start := stop.Add(project.StatsDisplayDays * -24 * time.Hour)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}
@@ -1880,10 +1880,10 @@ func (r *Realm) ExternalIssuerStatsCached(ctx context.Context, db *Database, cac
 	return stats, nil
 }
 
-// UserStats returns the 30-day stats by user.
+// UserStats returns the stats by user.
 func (r *Realm) UserStats(db *Database) (RealmUserStats, error) {
 	stop := timeutils.UTCMidnight(time.Now())
-	start := stop.Add(30 * -24 * time.Hour)
+	start := stop.Add(project.StatsDisplayDays * -24 * time.Hour)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}

--- a/pkg/database/user.go
+++ b/pkg/database/user.go
@@ -284,7 +284,7 @@ func (u *User) DeleteFromRealm(db *Database, r *Realm, actor Auditable) error {
 // stats exist, it returns an empty array.
 func (u *User) Stats(db *Database, realm *Realm) (UserStats, error) {
 	stop := timeutils.UTCMidnight(time.Now())
-	start := stop.Add(30 * -24 * time.Hour)
+	start := stop.Add(project.StatsDisplayDays * -24 * time.Hour)
 	if start.After(stop) {
 		return nil, ErrBadDateRange
 	}


### PR DESCRIPTION
I've verified our charts and sliding windows work appropriately. There's no noticeable UI lag.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Extend statistics retention to 90 days.
```
