### PR TITLE
Do not crash on unique indexes for user input

### DIFF
--- a/assets/server/apikeys/new.html
+++ b/assets/server/apikeys/new.html
@@ -57,7 +57,7 @@
             <button type="submit" id="submit" class="btn btn-primary">Create API key</button>
           </div>
           <div class="d-grid d-lg-inline">
-            <a href="/realm/apikeys/{{$authApp.ID}}" class="btn btn-danger mt-2 mt-lg-0">
+            <a href="/realm/apikeys" class="btn btn-danger mt-2 mt-lg-0">
               Cancel
             </a>
           </div>

--- a/pkg/database/authorized_app.go
+++ b/pkg/database/authorized_app.go
@@ -282,6 +282,10 @@ func (db *Database) SaveAuthorizedApp(a *AuthorizedApp, actor Auditable) error {
 
 		// Save the app
 		if err := tx.Unscoped().Save(a).Error; err != nil {
+			if IsUniqueViolation(err, "realm_apikey_name") {
+				a.AddError("name", "must be unique")
+				return ErrValidationFailed
+			}
 			return err
 		}
 

--- a/pkg/database/database.go
+++ b/pkg/database/database.go
@@ -46,7 +46,17 @@ import (
 
 	// ensure the postgres dialiect is compiled in.
 	"contrib.go.opencensus.io/integrations/ocsql"
+	"github.com/lib/pq"
 	postgres "github.com/lib/pq"
+)
+
+const (
+	// Postgres error codes:
+	//   https://www.postgresql.org/docs/13/errcodes-appendix.html
+	//
+	// pgCodeUniqueViolation is the error code for uniquess violations
+	// (constraints/indexes).
+	pgCodeUniqueViolation = "23505"
 )
 
 // callbackLock prevents multiple callbacks from being registered
@@ -395,6 +405,16 @@ func IsNotFound(err error) bool {
 // error), or false otherwise.
 func IsValidationError(err error) bool {
 	return errors.Is(err, ErrValidationFailed)
+}
+
+// IsUniqueViolation returns true if the given error corresponds to a "duplicate
+// index" error on the given index.
+func IsUniqueViolation(err error, idx string) bool {
+	var typ *pq.Error
+	if !errors.As(err, &typ) {
+		return false
+	}
+	return typ.Code == pgCodeUniqueViolation && typ.Constraint == idx
 }
 
 // callbackIncrementMetric increments the provided metric

--- a/pkg/database/mobile_app.go
+++ b/pkg/database/mobile_app.go
@@ -240,6 +240,10 @@ func (db *Database) SaveMobileApp(a *MobileApp, actor Auditable) error {
 
 		// Save the app
 		if err := tx.Unscoped().Save(a).Error; err != nil {
+			if IsUniqueViolation(err, "uix_name_realm_id_os") {
+				a.AddError("name", "must be unique")
+				return ErrValidationFailed
+			}
 			return err
 		}
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1302,6 +1302,14 @@ func (db *Database) SaveRealm(r *Realm, actor Auditable) error {
 
 		// Save the realm
 		if err := tx.Save(r).Error; err != nil {
+			switch {
+			case IsUniqueViolation(err, "uix_realms_name"):
+				r.AddError("name", "must be unique")
+				return ErrValidationFailed
+			case IsUniqueViolation(err, "uix_realms_region_code"):
+				r.AddError("regionCode", "must be unique")
+				return ErrValidationFailed
+			}
 			return err
 		}
 


### PR DESCRIPTION
I encountered a situation where we generate a 500 for user errors: duplicate key violations on index constraints. This fixes that.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
More gracefully handle validation errors for duplicate names on authorized apps, mobile apps, and the system admin view for creating realms.
```
