### PR TITLE
adding routes for realm api-key stats

### DIFF
--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -133,6 +133,9 @@ func AdminAPI(
 		sub.Handle("/realm/users/{id}.csv", statsController.HandleRealmUserStats(stats.TypeCSV)).Methods(http.MethodGet)
 		sub.Handle("/realm/users/{id}.json", statsController.HandleRealmUserStats(stats.TypeJSON)).Methods(http.MethodGet)
 
+		sub.Handle("/realm/api-keys/{id}.csv", statsController.HandleRealmAuthorizedAppStats(stats.TypeCSV)).Methods(http.MethodGet)
+		sub.Handle("/realm/api-keys/{id}.json", statsController.HandleRealmAuthorizedAppStats(stats.TypeJSON)).Methods(http.MethodGet)
+
 		sub.Handle("/realm/external-issuers.csv", statsController.HandleRealmExternalIssuersStats(stats.TypeCSV)).Methods(http.MethodGet)
 		sub.Handle("/realm/external-issuers.json", statsController.HandleRealmExternalIssuersStats(stats.TypeJSON)).Methods(http.MethodGet)
 


### PR DESCRIPTION
Fixes lack of route supporting `/api/stats/realm/api-keys/:id.{csv,json}` path from api doc:
[https://github.com/google/exposure-notifications-verification-server/blob/5de1965a9d735895067be6f8b69a421fa639ec3b/docs/api.md](url)

**Release Note**

```release-note
Add route for api-key stats to adminapi
```
