### PR TITLE
trim leading empty days from composite stats

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -24,7 +24,7 @@ require (
 	github.com/gonum/internal v0.0.0-20181124074243-f884aa714029 // indirect
 	github.com/gonum/lapack v0.0.0-20181123203213-e4cdc5a0bff9 // indirect
 	github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9
-	github.com/google/exposure-notifications-server v0.34.1-0.20210804215831-6fa52e62e20d
+	github.com/google/exposure-notifications-server v0.34.1-0.20210805183820-b0016757bf72
 	github.com/google/go-cmp v0.5.6
 	github.com/google/uuid v1.3.0
 	github.com/gorilla/handlers v1.5.1

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,10 @@ github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 h1:V2IgdyerlBa/MxaEFR
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/exposure-notifications-server v0.34.1-0.20210804215831-6fa52e62e20d h1:fTa+TBohrfTiiF3vop5G2ITeBQ7a6Kchk54MBQEy0cE=
-github.com/google/exposure-notifications-server v0.34.1-0.20210804215831-6fa52e62e20d/go.mod h1:pRCNPtvty7GiaOaePC2xBwWeRSgZ7EcSVmuhL70BCEQ=
+github.com/google/exposure-notifications-server v0.34.0 h1:m6kXax/OEyLCisCNmtZhN9oduvwQBmrdmTmnmZ4ae38=
+github.com/google/exposure-notifications-server v0.34.0/go.mod h1:pRCNPtvty7GiaOaePC2xBwWeRSgZ7EcSVmuhL70BCEQ=
+github.com/google/exposure-notifications-server v0.34.1-0.20210805183820-b0016757bf72 h1:/FbD10/wyY5w2lyac0goPkDt6IyyJzC75dQ8L+R0kAM=
+github.com/google/exposure-notifications-server v0.34.1-0.20210805183820-b0016757bf72/go.mod h1:pRCNPtvty7GiaOaePC2xBwWeRSgZ7EcSVmuhL70BCEQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=

--- a/go.sum
+++ b/go.sum
@@ -407,8 +407,6 @@ github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9 h1:V2IgdyerlBa/MxaEFR
 github.com/gonum/matrix v0.0.0-20181209220409-c518dec07be9/go.mod h1:0EXg4mc1CNP0HCqCz+K4ts155PXIlUywf0wqN+GfPZw=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
-github.com/google/exposure-notifications-server v0.34.0 h1:m6kXax/OEyLCisCNmtZhN9oduvwQBmrdmTmnmZ4ae38=
-github.com/google/exposure-notifications-server v0.34.0/go.mod h1:pRCNPtvty7GiaOaePC2xBwWeRSgZ7EcSVmuhL70BCEQ=
 github.com/google/exposure-notifications-server v0.34.1-0.20210805183820-b0016757bf72 h1:/FbD10/wyY5w2lyac0goPkDt6IyyJzC75dQ8L+R0kAM=
 github.com/google/exposure-notifications-server v0.34.1-0.20210805183820-b0016757bf72/go.mod h1:pRCNPtvty7GiaOaePC2xBwWeRSgZ7EcSVmuhL70BCEQ=
 github.com/google/flatbuffers v1.11.0/go.mod h1:1AeVuKshWv4vARoZatz6mlQ0JxURH0Kv5+zNeJKJCa8=

--- a/pkg/controller/stats/composite.go
+++ b/pkg/controller/stats/composite.go
@@ -83,6 +83,17 @@ func (c *Controller) HandleComposite(typ Type) http.Handler {
 			})
 		}
 
+		// Trim empty days.
+		trimIdx := 0
+		for i, v := range stats {
+			if v.IsEmpty() {
+				trimIdx = i + 1
+			} else {
+				break
+			}
+		}
+		stats = stats[trimIdx:]
+
 		switch typ {
 		case TypeCSV:
 			c.h.RenderCSV(w, http.StatusOK, csvFilename("composite-stats"), stats)

--- a/pkg/database/composite_stats.go
+++ b/pkg/database/composite_stats.go
@@ -45,6 +45,10 @@ type CompositeDay struct {
 	KeyServerStats *keyserver.StatsDay
 }
 
+func (c *CompositeDay) IsEmpty() bool {
+	return c.RealmStats.IsEmpty() && c.KeyServerStats.IsEmpty()
+}
+
 type jsonCompositeStat struct {
 	RealmID           uint                      `json:"realm_id"`
 	HasKeyServerStats bool                      `json:"has_key_server_stats"`

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -79,6 +79,45 @@ type RealmStat struct {
 	CodeClaimMeanAge DurationSeconds `gorm:"column:code_claim_mean_age; type:bigint; not null; default: 0;"`
 }
 
+func (s *RealmStat) IsEmpty() bool {
+	if s == nil {
+		return true
+	}
+
+	if s.CodesIssued > 0 {
+		return false
+	}
+	if s.CodesClaimed > 0 {
+		return false
+	}
+	if s.CodesInvalid > 0 {
+		return false
+	}
+	if s.UserReportsIssued > 0 {
+		return false
+	}
+	if s.UserReportsClaimed > 0 {
+		return false
+	}
+	if s.TokensClaimed > 0 {
+		return false
+	}
+	if s.TokensInvalid > 0 {
+		return false
+	}
+	if s.UserReportTokensClaimed > 0 {
+		return false
+	}
+
+	for _, v := range s.CodeClaimAgeDistribution {
+		if v > 0 {
+			return false
+		}
+	}
+
+	return true
+}
+
 func (s *RealmStat) AfterFind(tx *gorm.DB) (err error) {
 	if len(s.CodesInvalidByOS) == 0 {
 		s.CodesInvalidByOS = make([]int64, OSTypeUnknown.Len())


### PR DESCRIPTION


**Release Note**

```release-note
Trim leading empty days from stats charts and exports. This has become more frequent with longer retention and display period.
```
