### PR TITLE
Clean up stale membership entries with no permissions

### DIFF
--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -106,6 +106,19 @@ func (c *Controller) HandleCleanup() http.Handler {
 			}
 		}()
 
+		// Memberships
+		func() {
+			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)
+			item = tag.Upsert(itemTagKey, "MEMBERSHIP")
+			if count, err := c.db.PurgeOrphanedMemberships(); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to purge orphaned memberships: %w", err))
+				result = enobs.ResultError("FAILED")
+			} else {
+				logger.Infow("purged orphaned memberships", "count", count)
+				result = enobs.ResultOK
+			}
+		}()
+
 		// Mobile apps
 		func() {
 			defer enobs.RecordLatency(ctx, time.Now(), mLatencyMs, &result, &item)


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
