### PR TITLE
Retry Twilio communication on transient network errors

### DIFF
--- a/pkg/sms/twilio.go
+++ b/pkg/sms/twilio.go
@@ -24,6 +24,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/sethvargo/go-retry"
 )
 
 // TwilioMessagingServiceSidPrefix is the prefix for a 34 character messaging service identifier
@@ -52,42 +54,51 @@ func NewTwilio(ctx context.Context, accountSid, authToken, from string) (Provide
 
 // SendSMS sends a message using the Twilio API.
 func (p *Twilio) SendSMS(ctx context.Context, to, message string) error {
-	params := url.Values{}
-	params.Set("To", to)
-	if strings.HasPrefix(p.from, TwilioMessagingServiceSidPrefix) {
-		params.Set("MessagingServiceSid", p.from)
-	} else {
-		params.Set("From", p.from)
-	}
-
-	params.Set("Body", message)
-	body := strings.NewReader(params.Encode())
-
-	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/Messages.json", body)
+	b, err := retry.NewFibonacci(250 * time.Millisecond)
 	if err != nil {
-		return fmt.Errorf("failed to build request: %w", err)
+		return fmt.Errorf("failed to create backoff: %w", err)
 	}
+	b = retry.WithMaxRetries(4, b)
 
-	resp, err := p.client.Do(req)
-	if err != nil {
-		return fmt.Errorf("failed to make request: %w", err)
-	}
-	defer resp.Body.Close()
-
-	respBody, err := io.ReadAll(resp.Body)
-	if err != nil {
-		return fmt.Errorf("failed to read response body: %w", err)
-	}
-
-	if code := resp.StatusCode; code < http.StatusOK || code >= http.StatusMultipleChoices {
-		var terr TwilioError
-		if err := json.Unmarshal(respBody, &terr); err != nil {
-			return fmt.Errorf("twilio error %d: %s", code, respBody)
+	return retry.Do(ctx, b, func(ctx context.Context) error {
+		params := url.Values{}
+		params.Set("To", to)
+		if strings.HasPrefix(p.from, TwilioMessagingServiceSidPrefix) {
+			params.Set("MessagingServiceSid", p.from)
+		} else {
+			params.Set("From", p.from)
 		}
-		return &terr
-	}
 
-	return nil
+		params.Set("Body", message)
+		body := strings.NewReader(params.Encode())
+
+		req, err := http.NewRequestWithContext(ctx, http.MethodPost, "/Messages.json", body)
+		if err != nil {
+			return fmt.Errorf("failed to build request: %w", err)
+		}
+		req.Close = true
+
+		resp, err := p.client.Do(req)
+		if err != nil {
+			return retry.RetryableError(fmt.Errorf("failed to make request: %w", err))
+		}
+		defer resp.Body.Close()
+
+		respBody, err := io.ReadAll(resp.Body)
+		if err != nil {
+			return fmt.Errorf("failed to read response body: %w", err)
+		}
+
+		if code := resp.StatusCode; code < http.StatusOK || code >= http.StatusMultipleChoices {
+			var terr TwilioError
+			if err := json.Unmarshal(respBody, &terr); err != nil {
+				return fmt.Errorf("twilio error %d: %s", code, respBody)
+			}
+			return &terr
+		}
+
+		return nil
+	})
 }
 
 // twilioAuthRoundTripper is an http.RoundTripper that updates the


### PR DESCRIPTION
There are a few failed errors in our logs indicating that sometimes Twilio responds with an EOF. According to a few threads I found online and in GitHub issues, this can occur when the client Keep-Alive isn't honored by the server, but the server doesn't communicate this properly. To mitigate this, this commit does two things:

1. Set req.Close = true. This disables the client from requesting a Keep-Alive.

2. Retry on network-level connectivity issues. Note that we explicitly do NOT retry on HTTP responses, even if they are a non-200. http.Do only returns an error when the underlying transport failed at the network layer, which is explicitly what we want to retry.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add resiliency against temporary network connectivity issues when sending SMS. 
```
