### PR TITLE
fix issue w/ generated SMS long code expiry time

### DIFF
--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -128,7 +128,7 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, internalRequest 
 		}
 	}
 
-	if request.Phone == "" || smsProvider == nil {
+	if request.Phone == "" || (smsProvider == nil && !request.OnlyGenerateSMS) {
 		// If this isn't going to be send via SMS, make the long code expiration time same as short.
 		// This is because the long code will never be shown or sent.
 		vCode.LongExpiresAt = vCode.ExpiresAt


### PR DESCRIPTION

## Proposed Changes

* add tests for this case
* ensure that long expiry doesn't get erased w/ only generate SMS is used AND no SMS provider

**Release Note**


```release-note
When using generated SMS, the long expiry time isn't collapsed to the short expiry time.
```
