### PR TITLE
Upgrade Terraform and provider versions

### DIFF
--- a/.github/workflows/terraform.yml
+++ b/.github/workflows/terraform.yml
@@ -32,7 +32,7 @@ jobs:
     - name: 'setup-terraform'
       uses: 'hashicorp/setup-terraform@v1'
       with:
-        terraform_version: '0.14.5'
+        terraform_version: '1.0.5'
 
     - name: 'init'
       working-directory: './terraform'
@@ -63,7 +63,7 @@ jobs:
     - name: 'setup-terraform'
       uses: 'hashicorp/setup-terraform@v1'
       with:
-        terraform_version: '0.14.5'
+        terraform_version: '1.0.5'
 
     - name: 'init'
       working-directory: './terraform/alerting'

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -103,16 +103,16 @@ variable "forward_progress_indicators" {
 }
 
 terraform {
-  required_version = ">= 0.14.2"
+  required_version = "~> 1.0"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.51"
+      version = "~> 3.82"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.51"
+      version = "~> 3.82"
     }
   }
 }

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -350,28 +350,28 @@ variable "e2e_skip_sms" {
 }
 
 terraform {
-  required_version = ">= 0.14.2"
+  required_version = "~> 1.0"
 
   required_providers {
     google = {
       source  = "hashicorp/google"
-      version = "~> 3.55"
+      version = "~> 3.82"
     }
     google-beta = {
       source  = "hashicorp/google-beta"
-      version = "~> 3.55"
+      version = "~> 3.82"
     }
     local = {
       source  = "hashicorp/local"
-      version = "~> 2.0"
+      version = "~> 2.1"
     }
     null = {
       source  = "hashicorp/null"
-      version = "~> 3.0"
+      version = "~> 3.1"
     }
     random = {
       source  = "hashicorp/random"
-      version = "~> 2.3"
+      version = "~> 3.1"
     }
   }
 }


### PR DESCRIPTION
This bumps providers to their latest versions, which support Apple Silicon.

Fixes https://github.com/google/exposure-notifications-verification-server/issues/2211

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Update required Terraform and Terraform provider versions to the latest available to support Apple Silicon (M1).

```
