### PR TITLE
run git validation commands from inside the root folder

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -18,7 +18,7 @@ set -eEuo pipefail
 
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 
-if [ -n "$(git status --porcelain)" ]; then
+if [ -n "$(git -C ${ROOT} status --porcelain)" ]; then
   echo "✋ Uncommitted local changes!" >&2
   exit 1
 fi
@@ -29,7 +29,7 @@ if [ -z "${PROJECT_ID:-}" ]; then
 fi
 
 if [ -z "${TAG:-}" ]; then
-  TAG="$(git describe --dirty)"
+  TAG="$(git -C ${ROOT} describe --dirty)"
   echo "🎈 Using ${TAG}!" >&2
 fi
 echo "🎉 Building all services in ${PROJECT_ID}"

--- a/scripts/deploy
+++ b/scripts/deploy
@@ -24,7 +24,7 @@ if [ -z "${PROJECT_ID:-}" ]; then
 fi
 
 if [ -z "${TAG:-}" ]; then
-  TAG="$(git describe --dirty)"
+  TAG="$(git -C ${ROOT} describe --dirty)"
   echo "🎈 Using ${TAG}!" >&2
 fi
 echo "🎉 Deploying all services in ${PROJECT_ID} with 0% traffic"

--- a/scripts/migrate
+++ b/scripts/migrate
@@ -19,7 +19,7 @@ set -eEuo pipefail
 ROOT="$(cd "$(dirname "$0")/.." &>/dev/null; pwd -P)"
 
 if [ -z "${TAG:-}" ]; then
-  TAG="$(git describe --dirty)"
+  TAG="$(git -C ${ROOT} describe --dirty)"
   echo "🎈 Using ${TAG}!" >&2
 fi
 


### PR DESCRIPTION
## Proposed Changes

* Force git commands in build scripts to run inside root project directory.  Fixes an issue where git commands are run in another repository (for example, when this repository is pulled as a terraform module in a separate repo)

**Release Note**

```release-note
Force git commands in build scripts to run inside root project directory
```
