### PR TITLE
add space between message and signature

### DIFF
--- a/pkg/signatures/sms.go
+++ b/pkg/signatures/sms.go
@@ -32,7 +32,7 @@ const (
 	colon = ":"
 
 	// authPrefix is the prefix to the authentication bits.
-	authPrefix = "\nAuthentication:"
+	authPrefix = " \nAuthentication:"
 )
 
 // SMSPurpose is an SMS purpose, used in signature calculation.


### PR DESCRIPTION

## Proposed Changes

* Workaround a bug in Android SMS intercept where if the last piece of the SMS template is a link, the `\nAuthenticated` doesn't allow the link to get parsed correctly. Inserting a space reliably solves this problem.

**Release Note**

```release-note
Fix an issue where SMS templates that end in a link might cause SMS intercept to not fire on Android.
```
