### PR TITLE
add maintenance_mode field to health endpoint

### DIFF
--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -95,7 +95,7 @@ func AdminAPI(
 	processFirewall := middleware.ProcessFirewall(h, "adminapi")
 
 	// Health route
-	r.Handle("/health", controller.HandleHealthz(db, h)).Methods(http.MethodGet)
+	r.Handle("/health", controller.HandleHealthz(db, h, cfg.IsMaintenanceMode())).Methods(http.MethodGet)
 
 	// API routes
 	{

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -99,7 +99,7 @@ func APIServer(
 	processFirewall := middleware.ProcessFirewall(h, "apiserver")
 
 	// Health route
-	r.Handle("/health", controller.HandleHealthz(db, h)).Methods(http.MethodGet)
+	r.Handle("/health", controller.HandleHealthz(db, h, cfg.IsMaintenanceMode())).Methods(http.MethodGet)
 
 	// Make verify chaff tracker.
 	verifyChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeVerifyResponse), chaff.DefaultCapacity)

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -94,7 +94,7 @@ func ENXRedirect(
 	r.Use(processDebug)
 
 	// Handle health.
-	r.Handle("/health", controller.HandleHealthz(db, h)).Methods(http.MethodGet)
+	r.Handle("/health", controller.HandleHealthz(db, h, cfg.IsMaintenanceMode())).Methods(http.MethodGet)
 
 	// Share static assets with server.
 	{

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -172,7 +172,7 @@ func Server(
 
 	{
 		sub := sub.PathPrefix("").Subrouter()
-		sub.Handle("/health", controller.HandleHealthz(db, h)).Methods(http.MethodGet)
+		sub.Handle("/health", controller.HandleHealthz(db, h, cfg.IsMaintenanceMode())).Methods(http.MethodGet)
 	}
 
 	{

--- a/pkg/controller/healthz.go
+++ b/pkg/controller/healthz.go
@@ -28,7 +28,7 @@ import (
 	"github.com/sethvargo/go-retry"
 )
 
-func HandleHealthz(pinger driver.Pinger, h *render.Renderer) http.Handler {
+func HandleHealthz(pinger driver.Pinger, h *render.Renderer, isMaintenanceMode bool) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
@@ -58,6 +58,6 @@ func HandleHealthz(pinger driver.Pinger, h *render.Renderer) http.Handler {
 			logger.Warnw("unknown service", "service", service)
 		}
 
-		h.RenderJSON(w, http.StatusOK, map[string]string{"status": "ok"})
+		h.RenderJSON(w, http.StatusOK, map[string]interface{}{"status": "ok", "maintenance_mode": isMaintenanceMode})
 	})
 }


### PR DESCRIPTION
Fixes #2215

**Release Note**

```release-note
Add "maintenance_mode" field to /health endpoints for adminapi, apiserver, server, and enx_redirect
```
