### PR TITLE
Fix name of backup-worker job in gcloud command

### DIFF
--- a/terraform/database.tf
+++ b/terraform/database.tf
@@ -418,5 +418,5 @@ output "db_encryption_key_secret" {
 }
 
 output "db_backup_command" {
-  value = "gcloud scheduler jobs run backup-database-worker --project ${var.project}"
+  value = "gcloud scheduler jobs run ${google_cloud_scheduler_job.backup-worker.name} --project ${var.project}"
 }


### PR DESCRIPTION
Fixes GH-2226

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix the name for the `backup-worker` job in gcloud command in Terraform output.
```
