### PR TITLE
Don't build models twice

### DIFF
--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -74,12 +74,6 @@ func (c *Controller) HandleModel() http.Handler {
 			return
 		}
 
-		if err := c.rebuildModels(ctx); err != nil {
-			logger.Errorw("failed to build models", "error", err)
-			c.h.RenderJSON500(w, err)
-			return
-		}
-
 		if merr := c.rebuildModels(ctx); merr != nil {
 			if errs := merr.WrappedErrors(); len(errs) > 0 {
 				logger.Errorw("failed to rebuild models", "errors", errs)


### PR DESCRIPTION
Must have been copy-paste, but we don't need to build the models twice in the same invocation 😄 .

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Only rebuild models once on each invocation of the modeler.
```
