### PR TITLE
Ensure routes order preference is respected

### DIFF
--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -332,20 +332,20 @@ func Server(
 
 		realmSMSKeysController := smskeys.New(cfg, db, publicKeyCache, h)
 		realmSMSkeysRoutes(sub, realmSMSKeysController)
+	}
 
-		// webhooks
-		if cfg.Features.EnableSMSErrorWebhook {
-			// We don't need locales or template parsing, minimize middleware stack by
-			// forking from r instead of sub.
-			sub := r.PathPrefix("/webhooks").Subrouter()
-			sub.Use(populateRequestID)
-			sub.Use(populateLogger)
-			sub.Use(recovery)
-			sub.Use(obs)
+	// webhooks
+	if cfg.Features.EnableSMSErrorWebhook {
+		// We don't need locales or template parsing, minimize middleware stack by
+		// forking from r instead of sub.
+		sub := r.PathPrefix("/webhooks").Subrouter()
+		sub.Use(populateRequestID)
+		sub.Use(populateLogger)
+		sub.Use(recovery)
+		sub.Use(obs)
 
-			webhooksController := webhooks.New(cacher, db, h)
-			webhooksRoutes(sub, webhooksController)
-		}
+		webhooksController := webhooks.New(cacher, db, h)
+		webhooksRoutes(sub, webhooksController)
 	}
 
 	// JWKs


### PR DESCRIPTION
The NotFound handler was triggered before other subs because it was on sub, instead of r.


**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
