### PR TITLE
Only show anomaly alert with StatsRead permissions

### DIFF
--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -102,14 +102,21 @@
 {{if $.features.NotifyAnomalies}}
 {{if $currentMembership}}
   {{$realm := $currentMembership.Realm}}
-  {{if $realm.CodesClaimedRatioAnomalous}}
+  {{if and $realm.CodesClaimedRatioAnomalous ($currentMembership.Can rbac.StatsRead)}}
     <div class="container">
       <div class="alert alert-warning" role="alert">
-        <div class="d-flex align-items-center">
-          <i class="bi bi-exclamation-square-fill me-3"></i>
-          <span class="alert-message">
-            {{t $.locale "codes.codes-claimed-ratio-anomalous" ($realm.LastCodesClaimedRatio | toPercent) ($realm.CodesClaimedRatioMean | toPercent)}}
-          </span>
+        <div class="d-flex align-items-center justify-content-between">
+          <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-square-fill me-3"></i>
+            <span class="alert-message">
+              {{t $.locale "codes.codes-claimed-ratio-anomalous" ($realm.LastCodesClaimedRatio | toPercent) ($realm.CodesClaimedRatioMean | toPercent)}}
+            </span>
+          </div>
+          <div>
+            <a href="/realm/stats" class="text-reset py-3 ps-2">
+              <i class="bi bi-arrow-right-square-fill"></i>
+            </a>
+          </div>
         </div>
       </div>
     </div>


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```

<img width="1028" alt="CleanShot 2021-10-26 at 16 45 16@2x" src="https://user-images.githubusercontent.com/408570/138958264-7d15e9b3-d2bc-4eac-9990-8f74979b3f9a.png">