### PR TITLE
Fix expanding on per-user and external issuer charts

### DIFF
--- a/assets/server/realmadmin/_stats_external_issuers.html
+++ b/assets/server/realmadmin/_stats_external_issuers.html
@@ -5,11 +5,31 @@
     <i class="bi bi-graph-up me-2"></i>
     Codes issued by external issuers
   </div>
+
   <div id="per_external_issuer_table" class="overflow-auto" style="height:400px">
     <div class="container d-flex h-100 w-100">
       <p class="justify-content-center align-self-center text-center font-italic w-100">Loading data...</p>
     </div>
   </div>
+
+  <div id="external_issuer_row_template" class="d-none">
+    <div class="list-group list-group-flush"></div>
+    <div class="list-group-item list-group-item-action" data-bs-toggle="collapse" aria-expanded="false"></div>
+    <div class="collapse list-group-item p-0 ps-3" data-bs-parent="#per_external_issuer_table">
+      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-start mb-0">
+        <thead>
+          <tr>
+            <th>ID</th>
+            <th width="80">Issued</th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- filled in by javascript -->
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-bs-toggle="modal" data-bs-target="#per-external-issuer-table-modal">Learn more about this table</a>
     <span>
@@ -55,94 +75,5 @@
     </div>
   </div>
 </div>
-
-<script type="text/javascript">
-  window.addEventListener('load', (event) => {
-    let containerChart = document.querySelector('div#per_external_issuer_table');
-
-    let request = new XMLHttpRequest();
-    request.open('GET', '/stats/realm/external-issuers.json?scope=external');
-    request.overrideMimeType('application/json');
-
-    request.onload = (event) => {
-      let pContainer = containerChart.querySelector('p');
-
-      let data = JSON.parse(request.response);
-      if (!data.statistics) {
-        pContainer.innerText = 'There is no external issuing data yet.';
-        return;
-      }
-
-      clearChildren(containerChart)
-
-      let containerListGroup = document.createElement('div');
-      containerListGroup.classList.add('list-group', 'list-group-flush');
-      containerChart.appendChild(containerListGroup);
-
-      data.statistics.forEach(function(row) {
-        let date = utcDate(row.date);
-        let id = `collapse-external-${date.getTime()}`;
-
-        let containerDateRow = document.createElement('div');
-        containerDateRow.classList.add('list-group-item', 'list-group-item-action');
-        containerDateRow.setAttribute('data-bs-toggle', 'collapse');
-        containerDateRow.setAttribute('data-target', `#${id}`);
-        containerDateRow.setAttribute('aria-expanded', false);
-        containerDateRow.setAttribute('aria-controls', id);
-        containerDateRow.innerText = date.toLocaleDateString();
-        containerListGroup.appendChild(containerDateRow);
-
-        let containerIssuerData = document.createElement('div');
-        containerIssuerData.id = id;
-        containerIssuerData.classList.add('collapse', 'list-group-item', 'p-0', 'ps-3');
-        containerIssuerData.setAttribute('data-parent', '#per_external_issuer_table');
-        containerListGroup.appendChild(containerIssuerData);
-
-        let table = document.createElement('table');
-        table.classList.add('table', 'table-bordered', 'table-striped', 'table-fixed', 'table-inner-border-only', 'border-start', 'mb-0');
-        containerIssuerData.appendChild(table);
-
-        let thead = document.createElement('thead');
-        table.appendChild(thead);
-
-        let trhead = document.createElement('tr');
-        table.appendChild(trhead);
-
-        let thID = document.createElement('th');
-        thID.innerText = 'ID';
-        trhead.appendChild(thID);
-
-        let thIssued = document.createElement('th');
-        thIssued.width = '80';
-        thIssued.innerText = 'Issued';
-        trhead.appendChild(thIssued);
-
-        let tbody = document.createElement('tbody');
-        table.appendChild(tbody);
-
-        row.issuer_data.forEach(function(issuer) {
-          let tr = document.createElement('tr');
-          tbody.appendChild(tr);
-
-          let tdID = document.createElement('td');
-          tdID.innerText = issuer.issuer_id;
-          tr.appendChild(tdID);
-
-          let tdCodesIssued = document.createElement('td');
-          tdCodesIssued.align = 'right';
-          tdCodesIssued.innerText = issuer.codes_issued;
-          tr.appendChild(tdCodesIssued);
-        });
-      });
-    };
-
-    request.onerror = (event) => {
-      console.error('error from response: ' + request.response);
-      flash.error('Failed to render external issuer stats: ' + err);
-    }
-
-    request.send();
-  });
-</script>
 
 {{end}}

--- a/assets/server/realmadmin/_stats_users.html
+++ b/assets/server/realmadmin/_stats_users.html
@@ -5,11 +5,32 @@
     <i class="bi bi-graph-up me-2"></i>
     Codes issued by user by day
   </div>
+
   <div id="per_user_table" class="overflow-auto" style="height:400px">
     <div class="container d-flex h-100 w-100">
       <p class="justify-content-center align-self-center text-center font-italic w-100">Loading data...</p>
     </div>
   </div>
+
+  <div id="user_row_template" class="d-none">
+    <div class="list-group list-group-flush"></div>
+    <div class="list-group-item list-group-item-action" data-bs-toggle="collapse" aria-expanded="false"></div>
+    <div class="collapse list-group-item p-0 ps-3" data-bs-parent="#per_user_table">
+      <table class="table table-bordered table-striped table-fixed table-inner-border-only border-start mb-0">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Email</th>
+            <th width="80">Issued</th>
+          </tr>
+        </thead>
+        <tbody>
+          <!-- filled in by javascript -->
+        </tbody>
+      </table>
+    </div>
+  </div>
+
   <small class="card-footer d-flex justify-content-between text-muted">
     <a href="#" data-bs-toggle="modal" data-bs-target="#per-user-table-modal">Learn more about this table</a>
     <span>
@@ -49,98 +70,5 @@
     </div>
   </div>
 </div>
-
-<script type="text/javascript">
-  window.addEventListener('load', (event) => {
-    let containerChart = document.querySelector('div#per_user_table');
-
-    let request = new XMLHttpRequest();
-    request.open('GET', '/stats/realm/users.json?scope=user');
-    request.overrideMimeType('application/json');
-
-    request.onload = (event) => {
-      let pContainer = containerChart.querySelector('p');
-
-      let data = JSON.parse(request.response);
-      if (!data.statistics) {
-        pContainer.innerText = 'There is no external issuing data yet.';
-        return;
-      }
-
-      clearChildren(containerChart)
-
-      let containerListGroup = document.createElement('div');
-      containerListGroup.classList.add('list-group', 'list-group-flush');
-      containerChart.appendChild(containerListGroup);
-
-      data.statistics.forEach(function(row) {
-        let date = utcDate(row.date);
-        let id = `collapse-user-${date.getTime()}`;
-
-        let containerDateRow = document.createElement('div');
-        containerDateRow.classList.add('list-group-item', 'list-group-item-action');
-        containerDateRow.setAttribute('data-bs-toggle', 'collapse');
-        containerDateRow.setAttribute('data-target', `#${id}`);
-        containerDateRow.setAttribute('aria-expanded', false);
-        containerDateRow.setAttribute('aria-controls', id);
-        containerDateRow.innerText = date.toLocaleDateString();
-        containerListGroup.appendChild(containerDateRow);
-
-        let containerIssuerData = document.createElement('div');
-        containerIssuerData.id = id;
-        containerIssuerData.classList.add('collapse', 'list-group-item', 'p-0', 'ps-3');
-        containerIssuerData.setAttribute('data-parent', '#per_user_table');
-        containerListGroup.appendChild(containerIssuerData);
-
-        let table = document.createElement('table');
-        table.classList.add('table', 'table-bordered', 'table-striped', 'table-fixed', 'table-inner-border-only', 'border-start', 'mb-0');
-        containerIssuerData.appendChild(table);
-
-        let thead = document.createElement('thead');
-        table.appendChild(thead);
-
-        let trhead = document.createElement('tr');
-        table.appendChild(trhead);
-
-        let thID = document.createElement('th');
-        thID.innerText = 'ID';
-        trhead.appendChild(thID);
-
-        let thIssued = document.createElement('th');
-        thIssued.width = '80';
-        thIssued.innerText = 'Issued';
-        trhead.appendChild(thIssued);
-
-        let tbody = document.createElement('tbody');
-        table.appendChild(tbody);
-
-        row.issuer_data.forEach(function(issuer) {
-          let tr = document.createElement('tr');
-          tbody.appendChild(tr);
-
-          let tdName = document.createElement('td');
-          tdName.innerText = issuer.name;
-          tr.appendChild(tdName);
-
-          let tdEmail = document.createElement('td');
-          tdEmail.innerText = issuer.email;
-          tr.appendChild(tdEmail);
-
-          let tdCodesIssued = document.createElement('td');
-          tdCodesIssued.align = 'right';
-          tdCodesIssued.innerText = issuer.codes_issued;
-          tr.appendChild(tdCodesIssued);
-        });
-      });
-    };
-
-    request.onerror = (event) => {
-      console.error('error from response: ' + request.response);
-      flash.error('Failed to render user stats: ' + err);
-    }
-
-    request.send();
-  });
-</script>
 
 {{end}}

--- a/assets/server/realmadmin/stats.html
+++ b/assets/server/realmadmin/stats.html
@@ -51,6 +51,7 @@
     </div>
 
     {{if .hasKeyServerStats}}
+      <hr class="mb-5" />
       {{template "realmadmin/_stats_keyserver" .}}
     {{end}}
   </main>

--- a/assets/server/static/js/stats-external-issuers.js
+++ b/assets/server/static/js/stats-external-issuers.js
@@ -1,0 +1,73 @@
+(() => {
+  window.addEventListener('load', (event) => {
+    const container = document.querySelector('div#per_external_issuer_table');
+    if (!container) {
+      return;
+    }
+
+    const template = document.querySelector('div#external_issuer_row_template');
+    if (!template) {
+      return;
+    }
+    const templateListGroup = template.querySelector('.list-group');
+    const [templateRow, templateTable] = template.querySelectorAll('.list-group-item');
+
+    const request = new XMLHttpRequest();
+    request.open('GET', '/stats/realm/external-issuers.json');
+    request.overrideMimeType('application/json');
+
+    request.onload = (event) => {
+      const pContainer = container.querySelector('p');
+
+      const data = JSON.parse(request.response);
+      if (!data.statistics) {
+        pContainer.innerText = 'There is no external issuer data yet.';
+        return;
+      }
+
+      const listGroup = templateListGroup.cloneNode(true);
+      for (let i = 0; i < data.statistics.length; i++) {
+        const stat = data.statistics[i];
+        const date = utcDate(stat.date);
+        const id = `collapse-external-${date.getTime()}`;
+
+        const item = templateRow.cloneNode(true);
+        item.classList.remove('d-none');
+        item.setAttribute('data-bs-target', `#${id}`);
+        item.setAttribute('aria-controls', `${id}`);
+        item.innerText = date.toLocaleDateString();
+        listGroup.appendChild(item);
+
+        const tableDiv = templateTable.cloneNode(true);
+        tableDiv.id = id;
+        listGroup.appendChild(tableDiv);
+
+        const tbody = tableDiv.querySelector('table > tbody');
+        for (let j = 0; j < stat.issuer_data.length; j++) {
+          const issuerData = stat.issuer_data[j];
+
+          const tr = document.createElement('tr');
+          tbody.appendChild(tr);
+
+          const tdID = document.createElement('td');
+          tdID.innerText = issuerData.issuer_id;
+          tr.appendChild(tdID);
+
+          const tdIssued = document.createElement('td');
+          tdIssued.innerText = issuerData.codes_issued;
+          tr.appendChild(tdIssued);
+        }
+      }
+
+      clearChildren(container);
+      container.appendChild(listGroup);
+    };
+
+    request.onerror = (event) => {
+      console.error('error from response: ' + request.response);
+      flash.error('Failed to render external issuer stats: ' + err);
+    };
+
+    request.send();
+  });
+})();

--- a/assets/server/static/js/stats-user.js
+++ b/assets/server/static/js/stats-user.js
@@ -1,0 +1,77 @@
+(() => {
+  window.addEventListener('load', (event) => {
+    const container = document.querySelector('div#per_user_table');
+    if (!container) {
+      return;
+    }
+
+    const template = document.querySelector('div#user_row_template');
+    if (!template) {
+      return;
+    }
+    const templateListGroup = template.querySelector('.list-group');
+    const [templateRow, templateTable] = template.querySelectorAll('.list-group-item');
+
+    const request = new XMLHttpRequest();
+    request.open('GET', '/stats/realm/users.json');
+    request.overrideMimeType('application/json');
+
+    request.onload = (event) => {
+      const pContainer = container.querySelector('p');
+
+      const data = JSON.parse(request.response);
+      if (!data.statistics) {
+        pContainer.innerText = 'There is no per-user data yet.';
+        return;
+      }
+
+      const listGroup = templateListGroup.cloneNode(true);
+      for (let i = 0; i < data.statistics.length; i++) {
+        const stat = data.statistics[i];
+        const date = utcDate(stat.date);
+        const id = `collapse-user-${date.getTime()}`;
+
+        const item = templateRow.cloneNode(true);
+        item.classList.remove('d-none');
+        item.setAttribute('data-bs-target', `#${id}`);
+        item.setAttribute('aria-controls', `${id}`);
+        item.innerText = date.toLocaleDateString();
+        listGroup.appendChild(item);
+
+        const tableDiv = templateTable.cloneNode(true);
+        tableDiv.id = id;
+        listGroup.appendChild(tableDiv);
+
+        const tbody = tableDiv.querySelector('table > tbody');
+        for (let j = 0; j < stat.issuer_data.length; j++) {
+          const issuerData = stat.issuer_data[j];
+
+          const tr = document.createElement('tr');
+          tbody.appendChild(tr);
+
+          const tdID = document.createElement('td');
+          tdID.innerText = issuerData.name;
+          tr.appendChild(tdID);
+
+          const tdEmail = document.createElement('td');
+          tdEmail.innerText = issuerData.email;
+          tr.appendChild(tdEmail);
+
+          const tdIssued = document.createElement('td');
+          tdIssued.innerText = issuerData.codes_issued;
+          tr.appendChild(tdIssued);
+        }
+      }
+
+      clearChildren(container);
+      container.appendChild(listGroup);
+    };
+
+    request.onerror = (event) => {
+      console.error('error from response: ' + request.response);
+      flash.error('Failed to render per-user stats: ' + err);
+    };
+
+    request.send();
+  });
+})();


### PR DESCRIPTION
These have apparently been broken for a bit (probably since the Bootstrap 5 upgrade). Since they already needed to be refactored, I moved the javascript into its own file for caching and easier management/auto-formatting.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue with the per-user and external issuer tables on the statistics page that would prevent the nested fields from expanding.
```
