### PR TITLE
when SMS send fails, delete code by ID not by code.

### DIFF
--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -140,7 +140,7 @@ func (c *Controller) doSend(ctx context.Context, realm *database.Realm, smsProvi
 		}
 
 		// Delete the token
-		if err := c.db.DeleteVerificationCode(result.VerCode.Code); err != nil {
+		if err := c.db.DeleteVerificationCode(result.VerCode.ID); err != nil {
 			logger.Errorw("failed to delete verification code", "error", err)
 			// fallthrough to the error
 		}

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -307,15 +307,10 @@ func (db *Database) SaveVerificationCode(vc *VerificationCode, realm *Realm) err
 	})
 }
 
-// DeleteVerificationCode deletes the code if it exists. This is a hard delete.
-func (db *Database) DeleteVerificationCode(code string) error {
-	hmacedCodes, err := db.generateVerificationCodeHMACs(code)
-	if err != nil {
-		return fmt.Errorf("failed to create hmac: %w", err)
-	}
-
+// DeleteVerificationCode deletes the code by ID, this is a hard delete.
+func (db *Database) DeleteVerificationCode(id uint) error {
 	return db.db.Unscoped().
-		Where("code IN (?) OR long_code IN (?)", hmacedCodes, hmacedCodes).
+		Where("id = ?", id).
 		Delete(&VerificationCode{}).
 		Error
 }

--- a/pkg/database/vercode_test.go
+++ b/pkg/database/vercode_test.go
@@ -388,7 +388,7 @@ func TestDeleteVerificationCode(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := db.DeleteVerificationCode("12345678"); err != nil {
+	if err := db.DeleteVerificationCode(code.ID); err != nil {
 		t.Fatal(err)
 	}
 


### PR DESCRIPTION

**Release Note**

```release-note
When deleting a verification code post-SMS send fail, use the primary key for more efficient deletion
```
