### PR TITLE
Remove code and update defaults for next release

### DIFF
--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -99,7 +99,6 @@
   {{end}}
 </header>
 
-{{if $.features.NotifyAnomalies}}
 {{if $currentMembership}}
   {{$realm := $currentMembership.Realm}}
   {{if and $realm.CodesClaimedRatioAnomalous ($currentMembership.Can rbac.StatsRead)}}
@@ -121,7 +120,6 @@
       </div>
     </div>
   {{end}}
-{{end}}
 {{end}}
 
 {{end}}

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -102,7 +102,7 @@
       </div>
     </div>
 
-    <div class="form-floating">
+    <div class="form-floating mb-3">
       <select name="sms_country" id="sms-country" class="form-control form-select {{invalidIf ($realm.ErrorsFor "smsCountry")}}">
         <option selected disabled>Choose...</option>
         {{range $name, $value := $countries}}
@@ -118,8 +118,7 @@
       </small>
     </div>
 
-    {{if $.features.EnableSMSErrorWebhook}}
-    <div class="col-lg-12 mt-3"> {{/* TODO(sethvargo): move mt-3 to mb-3 above once revealed */}}
+    <div class="col-lg-12">
       <div class="form-label-group">
         <div class="input-group">
           <input type="text" readonly id="twilio-alerts-webhook-url" class="form-control font-monospace"
@@ -138,7 +137,6 @@
         </small>
       </div>
     </div>
-    {{end}}
   </div>
 
   <div class="bg-light border rounded p-3 mb-3">

--- a/assets/server/realmadmin/stats.html
+++ b/assets/server/realmadmin/stats.html
@@ -34,10 +34,8 @@
 
     {{template "realmadmin/_stats_codes" .}}
 
-    {{if $.features.EnableSMSErrorWebhook}}
     {{if $hasSMSConfig}}
       {{template "realmadmin/_stats_sms_errors" .}}
-    {{end}}
     {{end}}
 
     <div class="row">

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -335,7 +335,7 @@ func Server(
 	}
 
 	// webhooks
-	if cfg.Features.EnableSMSErrorWebhook {
+	{
 		// We don't need locales or template parsing, minimize middleware stack by
 		// forking from r instead of sub.
 		sub := r.PathPrefix("/webhooks").Subrouter()

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -18,15 +18,7 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 
 // FeatureConfig represents features that are introduced as off by default allowing
 // for server operators to control their release.
-type FeatureConfig struct {
-	// NotifyAnomalies enables anomaly notification for realm admins.
-	// TODO(sethvargo): remove in 1.0.4+
-	NotifyAnomalies bool `env:"NOTIFY_ANOMALIES, default=true"`
-
-	// EnableSMSErrorWebhook enables the configuration for Twilio webhooks.
-	// TODO(sethvargo): remove in 1.0.4+
-	EnableSMSErrorWebhook bool `env:"ENABLE_SMS_ERROR_WEBHOOK, default=true"`
-}
+type FeatureConfig struct{}
 
 // AddToTemplate takes TemplateMap and writes the status of all known
 // feature flags for use in HTML templates.

--- a/pkg/controller/flash/flash.go
+++ b/pkg/controller/flash/flash.go
@@ -101,35 +101,14 @@ func (f *Flash) add(key flashKey, msg string, vars ...interface{}) {
 	if _, ok := f.values[key]; !ok {
 		f.values[key] = make(map[string]struct{})
 	}
-
-	// Legacy implementation for when storage was []string - convert to map.
-	// TODO(sethvargo): remove slice handling in 1.1.0+.
-	switch typ := f.values[key].(type) {
-	case []string:
-		m := make(map[string]struct{}, len(typ))
-		for _, v := range typ {
-			m[v] = struct{}{}
-		}
-		f.values[key] = m
-	}
-
 	m := fmt.Sprintf(msg, vars...)
 	f.values[key].(map[string]struct{})[m] = struct{}{}
 }
 
 // get returns the messages in the key, clearing the values stored at the key.
-//
-// TODO(sethvargo): remove slice handling in 1.1.0+.
 func (f *Flash) get(key flashKey) []string {
 	if v, ok := f.values[key]; ok {
 		delete(f.values, key)
-
-		// Legacy implementation for when storage was []string.
-		// TODO(sethvargo): remove slice handling in 1.1.0+.
-		switch typ := v.(type) {
-		case []string:
-			return typ
-		}
 
 		m := v.(map[string]struct{})
 		flashes := make([]string, 0, len(m))

--- a/pkg/controller/flash/flash_test.go
+++ b/pkg/controller/flash/flash_test.go
@@ -169,20 +169,6 @@ func TestFlash_add(t *testing.T) {
 			t.Errorf("expected %v to be %v", got, want)
 		}
 	})
-
-	// Legacy implementation for when storage was []string.
-	// TODO(sethvargo): remove slice handling in 1.1.0+.
-	t.Run("slice", func(t *testing.T) {
-		t.Parallel()
-
-		f := New(nil)
-		f.values[flashKeyError] = []string{"b", "c"}
-		f.add(flashKeyError, "a")
-
-		if got, want := f.values[flashKeyError], map[string]struct{}{"a": {}, "b": {}, "c": {}}; !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %v to be %v", got, want)
-		}
-	})
 }
 
 func TestFlash_get(t *testing.T) {
@@ -193,19 +179,6 @@ func TestFlash_get(t *testing.T) {
 		f.values[flashKeyError] = map[string]struct{}{"b": {}, "c": {}, "a": {}}
 
 		if got, want := f.get(flashKeyError), []string{"a", "b", "c"}; !reflect.DeepEqual(got, want) {
-			t.Errorf("expected %v to be %v", got, want)
-		}
-	})
-
-	// Legacy implementation for when storage was []string.
-	// TODO(sethvargo): remove slice handling in 1.1.0+.
-	t.Run("slice", func(t *testing.T) {
-		t.Parallel()
-
-		f := New(nil)
-		f.values[flashKeyError] = []string{"b", "c", "a"}
-
-		if got, want := f.get(flashKeyError), []string{"b", "c", "a"}; !reflect.DeepEqual(got, want) {
 			t.Errorf("expected %v to be %v", got, want)
 		}
 	})


### PR DESCRIPTION
This removes the TODOs in prep for the next release.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NotifyAnomalies and EnableSMSErrorWebhook are now enabled by default and cannot be disabled.
```
