### PR TITLE
support GET when launching user report webview

### DIFF
--- a/docs/user-report-webview.md
+++ b/docs/user-report-webview.md
@@ -1,17 +1,11 @@
 <!-- TOC depthFrom:1 -->
 
-- [Experimental Notice](#experimental-notice)
 - [Access](#access)
 - [Initiate](#initiate)
 - [Client side throttling](#client-side-throttling)
 - [Validate](#validate)
 
 <!-- /TOC -->
-
-# Experimental Notice
-
-The user initiated report webview is an experimental feature. It should
-not be deployed in production environments until this notice is removed.
 
 # Access
 
@@ -22,8 +16,8 @@ To access the user report webview you need
 
 # Initiate
 
-Open a webview with a POST request to the base URL for the EN Express
-redirect service for your installation.
+Open a webview with a POST (recommended) or GET request to the base URL for the 
+EN Express redirect service for your installation, at the path `/report`.
 
 Pass in these required headers:
 

--- a/internal/clients/enx_web.go
+++ b/internal/clients/enx_web.go
@@ -42,8 +42,13 @@ func NewENXRedirectWebClient(base string, apiKey string, opts ...Option) (*ENXRe
 // SendUserReportIndex request "/report" on the ENX Redirect server which is the landing page
 // for a client embedded webview. This requires a client with an installed cookiejar to work correctly
 // since this will create a session cookie that embeds the nonce provided in the header.
-func (c *ENXRedirectWebClient) SendUserReportIndex(ctx context.Context, nonce string) error {
-	req, err := c.newRequest(ctx, http.MethodPost, "/report", nil)
+func (c *ENXRedirectWebClient) SendUserReportIndex(ctx context.Context, useGet bool, nonce string) error {
+	method := http.MethodPost
+	if useGet {
+		method = http.MethodGet
+	}
+
+	req, err := c.newRequest(ctx, method, "/report", nil)
 	if err != nil {
 		return err
 	}

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -179,8 +179,8 @@ func ENXRedirect(
 			sub.Use(processLocale)
 
 			// This allows developers to send GET requests in a browser with query params
-			// to test the UI. Normally this is required to be initiated via POST and headers.
-			if cfg.DevMode || cfg.AllowUserReportGet {
+			// to test the UI. Normally these fields must be set in HTTP headers.
+			if cfg.DevMode {
 				sub.Use(middleware.QueryHeaderInjection(middleware.APIKeyHeader, "apikey"))
 				sub.Use(middleware.QueryHeaderInjection(middleware.NonceHeader, "nonce"))
 			}
@@ -191,11 +191,7 @@ func ENXRedirect(
 			sub.Use(requireAPIKey)
 			sub.Use(middleware.ProcessNonce(h))
 
-			indexMethods := []string{http.MethodPost}
-			if cfg.DevMode || cfg.AllowUserReportGet {
-				indexMethods = append(indexMethods, http.MethodGet)
-			}
-			sub.Handle("", userReportController.HandleIndex()).Methods(indexMethods...)
+			sub.Handle("", userReportController.HandleIndex()).Methods(http.MethodPost, http.MethodGet)
 		}
 	}
 

--- a/pkg/config/redirect_config.go
+++ b/pkg/config/redirect_config.go
@@ -62,8 +62,6 @@ type RedirectConfig struct {
 	// If MaintenanceMode is true, the server is temporarily read-only and will not issue codes.
 	MaintenanceMode bool `env:"MAINTENANCE_MODE"`
 
-	AllowUserReportGet bool `env:"USER_REPORT_GET, default=false"`
-
 	// A map of hostnames to redirect to ens:// and a mapping to the region.
 	// For example to redirect
 	//   region.example.com to region US-AA

--- a/tools/user-report-web/main.go
+++ b/tools/user-report-web/main.go
@@ -39,6 +39,7 @@ var (
 	timeoutFlag = flag.Duration("timeout", 5*time.Second, "request time out duration in the format: 0h0m0s")
 	apikeyFlag  = flag.String("apikey", "", "API Key to use")
 	addrFlag    = flag.String("addr", "http://localhost:8080", "protocol, address and port on which to make the API call")
+	sendGetFlag = flag.Bool("send-get", false, "If true, will use GET instead of POST to initiate the request")
 )
 
 func main() {
@@ -82,7 +83,7 @@ func realMain(ctx context.Context) error {
 		return fmt.Errorf("unable to create client: %w", err)
 	}
 
-	if err := client.SendUserReportIndex(ctx, nonce); err != nil {
+	if err := client.SendUserReportIndex(ctx, *sendGetFlag, nonce); err != nil {
 		return err
 	}
 	logger.Debugw("session established")


### PR DESCRIPTION

## Proposed Changes

**Release Note**

```release-note
Allows HTTP GET request method (in addition to POST) for initiating the user report webview. The API key and nonce must still be passed as HTTP headers (unless dev mode is also enabled). dev mode should NOT be enabled in production to avoid logging the API key query params.
```
