### PR TITLE
Make scheduler timezone configurable, default to UTC

### DIFF
--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -169,7 +169,7 @@ resource "google_cloud_scheduler_job" "appsync-worker" {
   name             = "appsync-worker"
   region           = var.cloudscheduler_location
   schedule         = "0 */4 * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.appsync.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_backup.tf
+++ b/terraform/service_backup.tf
@@ -162,7 +162,7 @@ resource "google_cloud_scheduler_job" "backup-worker" {
   name             = "backup-worker"
   region           = var.cloudscheduler_location
   schedule         = "0 */4 * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.backup.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -182,7 +182,7 @@ resource "google_cloud_scheduler_job" "cleanup-worker" {
   name             = "cleanup-worker"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.cleanup.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -169,7 +169,7 @@ resource "google_cloud_scheduler_job" "e2e-default-workflow" {
   name             = "e2e-default-workflow"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.e2e-runner.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {
@@ -196,7 +196,7 @@ resource "google_cloud_scheduler_job" "e2e-revise-workflow" {
   name             = "e2e-revise-workflow"
   region           = var.cloudscheduler_location
   schedule         = "2-59/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.e2e-runner.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {
@@ -223,7 +223,7 @@ resource "google_cloud_scheduler_job" "e2e-user-report-workflow" {
   name             = "e2e-user-report-workflow"
   region           = var.cloudscheduler_location
   schedule         = "3-59/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.e2e-runner.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {
@@ -250,7 +250,7 @@ resource "google_cloud_scheduler_job" "e2e-enx-redirect-workflow" {
   name             = "e2e-enx-redirect-workflow"
   region           = var.cloudscheduler_location
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.e2e-runner.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -163,7 +163,7 @@ resource "google_cloud_scheduler_job" "modeler-worker" {
   name             = "modeler-worker"
   region           = var.cloudscheduler_location
   schedule         = "0 */4 * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.modeler.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -193,7 +193,7 @@ resource "google_cloud_scheduler_job" "rotation-worker-token-signing-key" {
   name             = "rotation-worker-token-signing-key"
   region           = var.cloudscheduler_location
   schedule         = "2,32 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.rotation.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {
@@ -222,7 +222,7 @@ resource "google_cloud_scheduler_job" "rotation-worker-realm-verification-keys" 
 
   // This schedule is offset from the token rotation schedule.
   schedule         = "*/15 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.rotation.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {
@@ -250,7 +250,7 @@ resource "google_cloud_scheduler_job" "rotation-worker-secrets" {
   region = var.cloudscheduler_location
 
   schedule         = "*/5 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.rotation.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/service_stats_puller.tf
+++ b/terraform/service_stats_puller.tf
@@ -173,7 +173,7 @@ resource "google_cloud_scheduler_job" "stats-puller-worker" {
   name             = "stats-puller-worker"
   region           = var.cloudscheduler_location
   schedule         = "*/15 * * * *"
-  time_zone        = "America/Los_Angeles"
+  time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.stats-puller.template[0].spec[0].timeout_seconds + 60}s"
 
   retry_config {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -42,6 +42,11 @@ variable "region" {
   default = "us-central1"
 }
 
+variable "cloud_scheduler_timezone" {
+  type    = string
+  default = "Etc/UTC"
+}
+
 variable "database_tier" {
   type    = string
   default = "db-custom-8-30720"


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Make Cloud Scheduler timezone configurable in Terraform via `var.cloud_scheduler_timezone` and update the default value to UTC time.
```
