### PR TITLE
switch code already expired response to BadRequest instead of an InternalError

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -553,14 +553,27 @@ or
 
 ## `/api/expirecode`
 
-Expires an unclaimed code. If the code has been claimed an error is returned.
+Expires an unclaimed code. If the code has been claimed or is already expired, an error is returned.
 
 **ExpireCodeRequest**
 
 ```json
+{
+  "uuid": "UUID for code to expire",
+  "padding": "<bytes>"
+}
+```
+
+* `padding` is a _recommended_ field that obfuscates the size of the request
+  body to a network observer. The client should generate and insert a random
+  number of base64-encoded bytes into this field. The server does not process
+  the padding.
+
+**ExpireCodeResponse**
+
+```json
 http 200
 {
-  "uuid": "UUID of the code to expire",
   "expiresAtTimestamp": 0,
   "longExpiresAtTimestamp": 0,
   "padding": "<bytes>"
@@ -573,11 +586,6 @@ or
   "errorCode": "well defined error code from api.go",
 }
 ```
-
-* `padding` is a _recommended_ field that obfuscates the size of the request
-  body to a network observer. The client should generate and insert a random
-  number of base64-encoded bytes into this field. The server does not process
-  the padding.
 
 The timestamps are updated to the new expiration time (which will be in the
 past).

--- a/pkg/controller/codes/expire.go
+++ b/pkg/controller/codes/expire.go
@@ -41,7 +41,7 @@ func (c *Controller) HandleExpireAPI() http.Handler {
 
 		code, err := c.db.ExpireCode(request.UUID)
 		if err != nil {
-			controller.InternalError(w, r, c.h, err)
+			c.h.RenderJSON(w, http.StatusBadRequest, api.Error(err).WithCode(api.ErrVerifyCodeInvalid))
 			return
 		}
 

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -16,6 +16,7 @@ package codes_test
 
 import (
 	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -251,6 +252,7 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		}
 
 		// attempt to expire the same code again
+		w = httptest.NewRecorder()
 		handler.ServeHTTP(w, r)
 		if got, want := w.Code, http.StatusBadRequest; got != want {
 			t.Errorf("Expected %d to be %d", got, want)

--- a/pkg/controller/codes/expire_test.go
+++ b/pkg/controller/codes/expire_test.go
@@ -249,5 +249,11 @@ func TestHandleExpireAPI_ExpireCode(t *testing.T) {
 		if now := time.Now().UTC(); record.ExpiresAt.After(now) {
 			t.Errorf("expected code expired. got %s but now is %s", code.ExpiresAt, now)
 		}
+
+		// attempt to expire the same code again
+		handler.ServeHTTP(w, r)
+		if got, want := w.Code, http.StatusBadRequest; got != want {
+			t.Errorf("Expected %d to be %d", got, want)
+		}
 	})
 }


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Switch code already expired or code already claimed scenario to a 4xx response (was previously 5xx).  Currently returning a 400; I think a 410 could also be an appropriate response.
* Fixing some documentation for this API.
* Added check for this response to the end of "success" subtest for code expiration API.  Code and tests for code expiration via form submission is unchanged.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Switch response code for expiring a code via API which is already expired or claimed
```
