### PR TITLE
Return more detailed responses on code expiration errors

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -558,7 +558,21 @@ Expires an unclaimed code. If the code has been claimed an error is returned.
 **ExpireCodeRequest**
 
 ```json
-http 200
+{
+  "uuid": "UUID for code to expire",
+  "padding": "<bytes>"
+}
+```
+
+* `padding` is a _recommended_ field that obfuscates the size of the request
+  body to a network observer. The client should generate and insert a random
+  number of base64-encoded bytes into this field. The server does not process
+  the padding.
+
+**ExpireCodeResponse**
+
+```json
+
 {
   "uuid": "UUID of the code to expire",
   "expiresAtTimestamp": 0,
@@ -573,11 +587,6 @@ or
   "errorCode": "well defined error code from api.go",
 }
 ```
-
-* `padding` is a _recommended_ field that obfuscates the size of the request
-  body to a network observer. The client should generate and insert a random
-  number of base64-encoded bytes into this field. The server does not process
-  the padding.
 
 The timestamps are updated to the new expiration time (which will be in the
 past).

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -270,7 +270,7 @@ func (r *Realm) ExpireCode(db *Database, uuid string, actor Auditable) (*Verific
 		vc.ExpiresAt = time.Now().UTC()
 		vc.LongExpiresAt = vc.ExpiresAt
 		if err := tx.Save(&vc).Error; err != nil {
-			return err
+			return fmt.Errorf("failed to save verification code: %w", err)
 		}
 
 		audit := BuildAuditEntry(actor, "expired verification code", &vc, r.ID)


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Return more detailed responses on code expiration errors. Only return 500 on server-side errors.
```
