### PR TITLE
Fix splitting for new alerts and aggregate over full modeler interval for CodesClaimedRatioAnomaly

### DIFF
--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -270,9 +270,9 @@ resource "google_monitoring_alert_policy" "CodesClaimedRatioAnomaly" {
       threshold_value = 1
 
       aggregations {
-        alignment_period     = "60s"
+        alignment_period     = "${8 * local.hour + 10 * local.minute}s"
         per_series_aligner   = "ALIGN_DELTA"
-        group_by_fields      = ["resource.labels.realm"]
+        group_by_fields      = ["metric.realm"]
         cross_series_reducer = "REDUCE_SUM"
       }
 
@@ -312,7 +312,7 @@ resource "google_monitoring_alert_policy" "ElevatedSMSErrors" {
       aggregations {
         alignment_period     = "60s"
         per_series_aligner   = "ALIGN_DELTA"
-        group_by_fields      = ["resource.labels.realm"]
+        group_by_fields      = ["metric.realm"]
         cross_series_reducer = "REDUCE_SUM"
       }
 

--- a/terraform/alerting/alerts.tf
+++ b/terraform/alerting/alerts.tf
@@ -310,7 +310,7 @@ resource "google_monitoring_alert_policy" "ElevatedSMSErrors" {
       threshold_value = 50
 
       aggregations {
-        alignment_period     = "60s"
+        alignment_period     = "${5 * local.minute}s"
         per_series_aligner   = "ALIGN_DELTA"
         group_by_fields      = ["metric.realm"]
         cross_series_reducer = "REDUCE_SUM"


### PR DESCRIPTION
<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

* Change `alignment_period` for the CodesClaimedRatioAnomaly alert so that counts can be added up over the full duration of the alerting period.  Otherwise, the alert will never fire, since the modeler runs every 4 hrs
* Fix `group_by_fields` to match correct field
* Change `alignment_period` for ElevatedSMSErrors to 5 min

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix parameters for the CodesClaimedRatioAnomaly and ElevatedSMSErrors alerts
```
