### PR TITLE
Ensure minimum number of key server stats

### DIFF
--- a/assets/server/static/js/stats-codes.js
+++ b/assets/server/static/js/stats-codes.js
@@ -1,6 +1,6 @@
 (() => {
   window.addEventListener('load', async (event) => {
-    const containerChart = document.querySelector('div#keyserver_chart_div');
+    const containerChart = document.querySelector('div#realm_chart_div');
     if (!containerChart) {
       return;
     }
@@ -156,7 +156,8 @@
         }
 
         const hasKeyServerStats = data.has_key_server_stats;
-        const startChart = new Date(data.statistics[30].date);
+        const win = Math.min(30, data.statistics.length - 1);
+        const startChart = new Date(data.statistics[win].date);
 
         const dataTable = new google.visualization.DataTable();
         chart.headerFunc(dataTable, hasKeyServerStats);
@@ -241,7 +242,8 @@
         return;
       }
 
-      const startChart = new Date(data.statistics[30].date);
+      const win = Math.min(30, data.statistics.length - 1);
+      const startChart = new Date(data.statistics[win].date);
 
       const dataTable = new google.visualization.DataTable();
       dataTable.addColumn('date', 'Date');

--- a/assets/server/static/js/stats-keyserver.js
+++ b/assets/server/static/js/stats-keyserver.js
@@ -69,7 +69,8 @@
         dataTable.addRow([utcDate(stat.day), stat.total_teks_published]);
       }
 
-      const startChart = new Date(data[30].day);
+      const win = Math.min(30, data.length - 1);
+      const startChart = new Date(data[win].day);
 
       const dateFormatter = new google.visualization.DateFormat({
         pattern: 'MMM dd',
@@ -154,6 +155,9 @@
         return;
       }
 
+      const win = Math.min(30, data.length - 1);
+      const startChart = new Date(data[win].day);
+
       const dataTable = new google.visualization.DataTable();
       dataTable.addColumn('date', 'Date');
       dataTable.addColumn('number', 'Total');
@@ -214,8 +218,6 @@
         );
         dataTable.addRow(row);
       }
-
-      const startChart = new Date(data[30].day);
 
       const dateFormatter = new google.visualization.DateFormat({
         pattern: 'MMM dd',

--- a/assets/server/static/js/stats-sms-errors.js
+++ b/assets/server/static/js/stats-sms-errors.js
@@ -29,7 +29,7 @@
         const pContainer = chartContainer.querySelector('p');
 
         const data = JSON.parse(request.response);
-        if (!data.statistics || !data.statistics[0].error_data) {
+        if (!data.statistics || !data.statistics[0] || !data.statistics[0].error_data) {
           pContainer.innerText = 'There is no sms error data yet.';
           return;
         }
@@ -56,7 +56,8 @@
           dataTable.addRow(row);
         }
 
-        const startChart = new Date(data.statistics[30].date);
+        const win = Math.min(30, data.statistics.length - 1);
+        const startChart = new Date(data.statistics[win].date);
 
         const dateFormatter = new google.visualization.DateFormat({
           pattern: 'MMM dd',

--- a/pkg/database/key_server_stats_test.go
+++ b/pkg/database/key_server_stats_test.go
@@ -18,6 +18,9 @@ import (
 	"reflect"
 	"testing"
 	"time"
+
+	"github.com/google/exposure-notifications-server/pkg/timeutils"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 const thirtyDays = 30 * 24 * time.Hour
@@ -76,7 +79,7 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	now := time.Now()
+	now := timeutils.UTCMidnight(time.Now())
 
 	err = db.SaveKeyServerStatsDay(&KeyServerStatsDay{
 		RealmID:            realm.ID,
@@ -92,6 +95,7 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+
 	if got, want := stats[0].TotalTEKsPublished, int64(50); got != want {
 		t.Errorf("failed retrieving KeyServerStats. got %d, wanted %d", got, want)
 	}
@@ -113,7 +117,7 @@ func TestSaveKeyServerStatsDay(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	if got, want := len(stats), 2; got != want {
+	if got, want := len(stats), project.StatsDisplayDays+1; got != want {
 		t.Errorf("incorrect number of stats. got %d, want %d", got, want)
 	}
 


### PR DESCRIPTION
Also be more defensive about having less data when rendering charts.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue with rendering charts when realms had less than 30 days worth of key server statistics.
```
