### PR TITLE
Automatically cancel existing runs when a new commit is pushed

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -4,17 +4,18 @@ on:
   push:
     branches:
     - main
-    - experimental
   pull_request:
     branches:
     - main
-    - experimental
   schedule:
     - cron: '0 0 */1 * *'
 
-
 env:
   GOMAXPROCS: 7
+
+concurrency:
+  group: '${{ github.head_ref || github.ref }}'
+  cancel-in-progress: true
 
 jobs:
   test:
@@ -22,11 +23,6 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Check out code
         uses: actions/checkout@v2
 
@@ -70,11 +66,6 @@ jobs:
       fail-fast: false
 
     steps:
-      - name: Cancel previous
-        uses: styfle/cancel-workflow-action@0.7.0
-        with:
-          access_token: ${{ github.token }}
-
       - name: Check out code
         uses: actions/checkout@v2
 


### PR DESCRIPTION
This is a native feature now.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
