### PR TITLE
Ensure BindForm failures render as 422

### DIFF
--- a/pkg/controller/admin/email.go
+++ b/pkg/controller/admin/email.go
@@ -63,7 +63,8 @@ func (c *Controller) HandleEmailUpdate() http.Handler {
 
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
-			flash.Error("Failed to process form: %v", err)
+			emailConfig.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShowEmail(ctx, w, emailConfig)
 			return
 		}

--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -124,7 +124,9 @@ func (c *Controller) HandleRealmsCreate() http.Handler {
 		if err := controller.BindForm(w, r, &form); err != nil {
 			var realm database.Realm
 			realm.UseRealmCertificateKey = true
-			flash.Error("Failed to process form: %v", err)
+
+			realm.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderNewRealm(ctx, w, &realm, smsConfig, emailConfig)
 			return
 		}
@@ -274,7 +276,8 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
-			flash.Error("Failed to process form: %v", err)
+			realm.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderEditRealm(ctx, w, realm, membership, smsConfig, emailConfig, chaffEvents, quotaLimit, quotaRemaining, realmTranslations)
 			return
 		}

--- a/pkg/controller/admin/sms.go
+++ b/pkg/controller/admin/sms.go
@@ -73,7 +73,8 @@ func (c *Controller) HandleSMSUpdate() http.Handler {
 
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
-			flash.Error("Failed to process form: %v", err)
+			smsConfig.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShowSMS(ctx, w, smsConfig, smsFromNumbers)
 			return
 		}

--- a/pkg/controller/apikey/disable.go
+++ b/pkg/controller/apikey/disable.go
@@ -62,8 +62,9 @@ func (c *Controller) HandleDisable() http.Handler {
 		now := time.Now().UTC()
 		authApp.DeletedAt = &now
 		if err := c.db.SaveAuthorizedApp(authApp, currentUser); err != nil {
-			flash.Error("Failed to disable API Key: %v", err)
-			http.Redirect(w, r, "/realm/apikeys", http.StatusSeeOther)
+			authApp.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			c.renderShow(ctx, w, authApp)
 			return
 		}
 

--- a/pkg/controller/apikey/enable.go
+++ b/pkg/controller/apikey/enable.go
@@ -60,8 +60,9 @@ func (c *Controller) HandleEnable() http.Handler {
 
 		authApp.DeletedAt = nil
 		if err := c.db.SaveAuthorizedApp(authApp, currentUser); err != nil {
-			flash.Error("Failed to enable API Key: %v", err)
-			http.Redirect(w, r, "/realm/apikeys", http.StatusSeeOther)
+			authApp.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			c.renderShow(ctx, w, authApp)
 			return
 		}
 

--- a/pkg/controller/login/reset_password.go
+++ b/pkg/controller/login/reset_password.go
@@ -58,6 +58,7 @@ func (c *Controller) HandleSubmitResetPassword() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error("Failed to reset password: %v", err)
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderResetPassword(ctx, w, "")
 			return
 		}

--- a/pkg/controller/login/select_password.go
+++ b/pkg/controller/login/select_password.go
@@ -85,6 +85,7 @@ func (c *Controller) HandleSubmitNewPassword() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error("Select password failed: %v", err)
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShowSelectPassword(ctx, w, "", code, false)
 			return
 		}

--- a/pkg/controller/login/select_realm.go
+++ b/pkg/controller/login/select_realm.go
@@ -89,6 +89,7 @@ func (c *Controller) HandleSelectRealm() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error(err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderSelect(ctx, w, memberships)
 			return
 		}

--- a/pkg/controller/login/verify_email_send.go
+++ b/pkg/controller/login/verify_email_send.go
@@ -64,6 +64,7 @@ func (c *Controller) HandleSubmitVerifyEmail() http.Handler {
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
 			flash.Error("Failed to verify email: %v", err)
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderEmailVerify(ctx, w)
 			return
 		}

--- a/pkg/controller/realmkeys/activate.go
+++ b/pkg/controller/realmkeys/activate.go
@@ -51,7 +51,7 @@ func (c *Controller) HandleActivate() http.Handler {
 
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
-			flash.Error("Failed to process form: %v", err)
+			currentRealm.AddError("", err.Error())
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShow(ctx, w, r, currentRealm)
 			return

--- a/pkg/controller/realmkeys/create.go
+++ b/pkg/controller/realmkeys/create.go
@@ -47,7 +47,8 @@ func (c *Controller) HandleCreateKey() http.Handler {
 
 		kid, err := currentRealm.CreateSigningKeyVersion(ctx, c.db, currentUser)
 		if err != nil {
-			flash.Error("Unable to create a new signing key: %v", err)
+			currentRealm.AddError("", err.Error())
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShow(ctx, w, r, currentRealm)
 			return
 		}

--- a/pkg/controller/realmkeys/save.go
+++ b/pkg/controller/realmkeys/save.go
@@ -54,7 +54,7 @@ func (c *Controller) HandleSave() http.Handler {
 
 		var form FormData
 		if err := controller.BindForm(w, r, &form); err != nil {
-			flash.Error("Failed to process form: %v", err)
+			currentRealm.AddError("", err.Error())
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShow(ctx, w, r, currentRealm)
 			return
@@ -70,9 +70,10 @@ func (c *Controller) HandleSave() http.Handler {
 		currentRealm.CertificateDuration.AsString = form.DurationString
 
 		if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
-			flash.Error("Failed to update realm: %v", err)
+			currentRealm.AddError("", err.Error())
 			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderShow(ctx, w, r, currentRealm)
+			return
 		}
 
 		flash.Alert("Updated realm certificate settings.")

--- a/pkg/controller/realmkeys/upgrade.go
+++ b/pkg/controller/realmkeys/upgrade.go
@@ -48,7 +48,8 @@ func (c *Controller) HandleUpgrade() http.Handler {
 		if currentRealm.CanUpgradeToRealmSigningKeys() {
 			currentRealm.UseRealmCertificateKey = true
 			if err := c.db.SaveRealm(currentRealm, currentUser); err != nil {
-				flash.Error("Error upgrading realm: %v", err)
+				currentRealm.AddError("", err.Error())
+				w.WriteHeader(http.StatusUnprocessableEntity)
 				c.renderShow(ctx, w, r, currentRealm)
 				return
 			}

--- a/pkg/controller/userreport/send.go
+++ b/pkg/controller/userreport/send.go
@@ -84,6 +84,7 @@ func (c *Controller) HandleSend() http.Handler {
 		if err := controller.BindForm(w, r, &form); err != nil {
 			logger.Warn("error binding form", "error", err)
 			m["error"] = []string{locale.Get("user-report.invalid-request")}
+			w.WriteHeader(http.StatusUnprocessableEntity)
 			c.renderIndex(w, realm, m)
 			return
 		}


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/2274

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ensure validation errors always return an HTTP 422 response code for the web interface.
```
