### PR TITLE
upgrade chaff library, add max latency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -30,7 +30,7 @@ require (
 	github.com/leonelquinteros/gotext v1.5.0
 	github.com/lib/pq v1.10.3
 	github.com/microcosm-cc/bluemonday v1.0.16
-	github.com/mikehelmick/go-chaff v0.5.0
+	github.com/mikehelmick/go-chaff v0.6.0
 	github.com/nyaruka/phonenumbers v1.0.73
 	github.com/opencensus-integrations/redigo v2.0.1+incompatible
 	github.com/ory/dockertest v3.3.5+incompatible

--- a/go.sum
+++ b/go.sum
@@ -1194,6 +1194,8 @@ github.com/miekg/pkcs11 v1.0.2/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WT
 github.com/miekg/pkcs11 v1.0.3/go.mod h1:XsNlhZGX73bx86s2hdc/FuaLm2CPZJemRLMA+WTFxgs=
 github.com/mikehelmick/go-chaff v0.5.0 h1:u8lrTCbUsyVBFRHPs8Nn3i0830XAOrbcA5dbQl8tk78=
 github.com/mikehelmick/go-chaff v0.5.0/go.mod h1:mFry3zNW17oxNGmZpQV3PEOmzTNyly3nLDYawCT/iCE=
+github.com/mikehelmick/go-chaff v0.6.0 h1:RWn4tP+YI+MyCh+PsAyjr1zPFWpKX12Vzx1VXZYvcqk=
+github.com/mikehelmick/go-chaff v0.6.0/go.mod h1:mFry3zNW17oxNGmZpQV3PEOmzTNyly3nLDYawCT/iCE=
 github.com/mistifyio/go-zfs v2.1.2-0.20190413222219-f784269be439+incompatible/go.mod h1:8AuVvqP/mXw1px98n46wfvcGfQ4ci2FwoAjKYxuo3Z4=
 github.com/mitchellh/cli v1.0.0/go.mod h1:hNIlj7HEI86fIcpObd7a0FcrxTWetlwJDGcceTlRvqc=
 github.com/mitchellh/copystructure v1.0.0/go.mod h1:SNtv71yrdKgLRyLFxmLdkAbkKEFWgYaq1OVrnRcwhnw=

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -102,7 +102,10 @@ func APIServer(
 	r.Handle("/health", controller.HandleHealthz(db, h, cfg.IsMaintenanceMode())).Methods(http.MethodGet)
 
 	// Make verify chaff tracker.
-	verifyChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeVerifyResponse), chaff.DefaultCapacity)
+	verifyChaffTracker, err := chaff.NewTracker(
+		chaff.NewJSONResponder(encodeVerifyResponse),
+		chaff.DefaultCapacity,
+		chaff.WithMaxLatency(cfg.ChaffMaxLatencyMs))
 	if err != nil {
 		return nil, closer, fmt.Errorf("error creating verify chaffer: %w", err)
 	}
@@ -111,7 +114,10 @@ func APIServer(
 	}
 
 	// Make cert chaff tracker.
-	certChaffTracker, err := chaff.NewTracker(chaff.NewJSONResponder(encodeCertificateResponse), chaff.DefaultCapacity)
+	certChaffTracker, err := chaff.NewTracker(
+		chaff.NewJSONResponder(encodeCertificateResponse),
+		chaff.DefaultCapacity,
+		chaff.WithMaxLatency(cfg.ChaffMaxLatencyMs))
 	if err != nil {
 		return nil, closer, fmt.Errorf("error creating cert chaffer: %w", err)
 	}

--- a/pkg/config/api_server_config.go
+++ b/pkg/config/api_server_config.go
@@ -47,7 +47,8 @@ type APIServerConfig struct {
 	// If MaintenanceMode is true, the server is temporarily read-only and will not issue codes.
 	MaintenanceMode bool `env:"MAINTENANCE_MODE"`
 
-	Port string `env:"PORT,default=8080"`
+	Port              string `env:"PORT,default=8080"`
+	ChaffMaxLatencyMs uint64 `env:"CHAFF_MAX_LATENCY_MS, default=1000"`
 
 	APIKeyCacheDuration time.Duration `env:"API_KEY_CACHE_DURATION,default=5m"`
 


### PR DESCRIPTION

**Release Note**

```release-note
Allows for a max latency injected for chaff requests, default is set to 1000 ms and is configurable.
```
