### PR TITLE
Add configuration for number of stdevs to be considered anomaly

### DIFF
--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -82,6 +82,7 @@ resource "google_cloud_run_service" "modeler" {
 
         dynamic "env" {
           for_each = merge(
+            local.anomaly_config,
             local.cache_config,
             local.database_config,
             local.gcp_config,

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -101,6 +101,7 @@ resource "google_cloud_run_service" "server" {
 
         dynamic "env" {
           for_each = merge(
+            local.anomaly_config,
             local.cache_config,
             local.database_config,
             local.firebase_config,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -13,6 +13,10 @@
 # limitations under the License.
 
 locals {
+  anomaly_config = {
+    ANOMALY_ALLOWED_STDEVS = "2.0"
+  }
+
   appsync_config = {
     APP_SYNC_URL = "https://www.gstatic.com/exposurenotifications/apps.json"
   }


### PR DESCRIPTION
**Release Note**

```release-note
Add a global configuration option (applies to all realms) to configure the number of standard deviations away from the norm before behavior is consider an anomaly. You can configure this value by setting `ANOMALY_ALLOWED_STDEVS` on the `server` and `modeler` components to any positive float value. The default value is 2.0.
```
