### PR TITLE
Ignore e2e realm in anomaly detection notifications

### DIFF
--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -303,8 +303,9 @@ func (c *Controller) rebuildAnomaliesModel(ctx context.Context, realm *database.
 		return fmt.Errorf("failed to save model: %w, errors: %q", err, realm.ErrorMessages())
 	}
 
-	// If the new ratio is anomalous, emit a metric.
-	if realm.CodesClaimedRatioAnomalous() {
+	// If the new ratio is anomalous and it's not the e2e realm, emit a metric.
+	// The e2e realm has its own existing monitoring for successes.
+	if realm.CodesClaimedRatioAnomalous() && !realm.IsE2ERealm() {
 		ctx = observability.WithRealmID(ctx, uint64(realm.ID))
 		stats.Record(ctx, mCodesClaimedRatioAnomaly.M(1))
 	}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -453,6 +453,12 @@ func (db *Database) E2ERealm() (*Realm, error) {
 	return &realm, nil
 }
 
+// IsE2ERealm returns true if this realm is the "e2e" realm, false otherwise.
+func (r *Realm) IsE2ERealm() bool {
+	return strings.HasPrefix(strings.ToUpper(r.RegionCode), "E2E-") ||
+		strings.HasPrefix(strings.ToLower(r.Name), "e2e-test-")
+}
+
 // AllowsUserReport returns true if this realm has enabled user initiated
 // test reporting.
 func (r *Realm) AllowsUserReport() bool {


### PR DESCRIPTION
Alternatively, I could inline this in `realm.CodesClaimedRatioAnomalous` so the e2e realm would never be considered anomalous. Open to either.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Ignore e2e realm in anomaly notifications.
```
