### PR TITLE
Ensure there's exactly one E2E realm

### DIFF
--- a/internal/envstest/bootstrap.go
+++ b/internal/envstest/bootstrap.go
@@ -69,6 +69,7 @@ func Bootstrap(ctx context.Context, db *database.Database) (*BootstrapResponse, 
 
 		realm = database.NewRealmWithDefaults(RealmName)
 		realm.RegionCode = RegionCode
+		realm.IsE2E = true
 	}
 
 	logger := logging.FromContext(ctx)

--- a/pkg/controller/modeler/modeler.go
+++ b/pkg/controller/modeler/modeler.go
@@ -305,7 +305,7 @@ func (c *Controller) rebuildAnomaliesModel(ctx context.Context, realm *database.
 
 	// If the new ratio is anomalous and it's not the e2e realm, emit a metric.
 	// The e2e realm has its own existing monitoring for successes.
-	if realm.CodesClaimedRatioAnomalous() && !realm.IsE2ERealm() {
+	if realm.CodesClaimedRatioAnomalous() {
 		ctx = observability.WithRealmID(ctx, uint64(realm.ID))
 		stats.Record(ctx, mCodesClaimedRatioAnomaly.M(1))
 	}

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -160,6 +160,22 @@ func TestRealm_BeforeSave(t *testing.T) {
 			Error: "regionCode cannot be more than 10 characters",
 		},
 		{
+			Name: "name_e2e_not_e2e",
+			Input: &Realm{
+				Name:  "E2E-TEST",
+				IsE2E: false,
+			},
+			Error: `name cannot start with "e2e-"`,
+		},
+		{
+			Name: "region_code_e2e_not_e2e",
+			Input: &Realm{
+				RegionCode: "E2E-TEST",
+				IsE2E:      false,
+			},
+			Error: `regionCode cannot start with "E2E-"`,
+		},
+		{
 			Name: "enx_region_code_mismatch",
 			Input: &Realm{
 				RegionCode:      " ",
@@ -420,83 +436,11 @@ func TestRealm_BeforeSave(t *testing.T) {
 						t.Errorf("Expected %q to be %q", got, want)
 					}
 				} else {
-					t.Errorf("bad error: %s", err)
+					t.Errorf("bad error: %s: %q", err, tc.Input.ErrorMessages())
 				}
 			}
 		})
 	}
-}
-
-func TestDatabase_E2ERealm(t *testing.T) {
-	t.Parallel()
-
-	t.Run("none", func(t *testing.T) {
-		t.Parallel()
-
-		db, _ := testDatabaseInstance.NewDatabase(t, nil)
-
-		if _, err := db.E2ERealm(); !IsNotFound(err) {
-			t.Errorf("expected not found, got %#v", err)
-		}
-	})
-
-	t.Run("none_matching", func(t *testing.T) {
-		t.Parallel()
-
-		db, _ := testDatabaseInstance.NewDatabase(t, nil)
-
-		realm := NewRealmWithDefaults("not-the-e2e-realm")
-		realm.RegionCode = "NOT-E2E"
-		if err := db.SaveRealm(realm, SystemTest); err != nil {
-			t.Fatal(err)
-		}
-
-		if _, err := db.E2ERealm(); !IsNotFound(err) {
-			t.Errorf("expected not found, got %#v", err)
-		}
-	})
-
-	t.Run("by_region_code", func(t *testing.T) {
-		t.Parallel()
-
-		db, _ := testDatabaseInstance.NewDatabase(t, nil)
-
-		realm := NewRealmWithDefaults("apple")
-		realm.RegionCode = "E2E-TEST"
-		if err := db.SaveRealm(realm, SystemTest); err != nil {
-			t.Fatal(err)
-		}
-
-		record, err := db.E2ERealm()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if record.ID != realm.ID {
-			t.Errorf("expected %#v to be %#v", record, realm)
-		}
-	})
-
-	t.Run("by_name", func(t *testing.T) {
-		t.Parallel()
-
-		db, _ := testDatabaseInstance.NewDatabase(t, nil)
-
-		realm := NewRealmWithDefaults("e2e-test-realm")
-		realm.RegionCode = "TEST"
-		if err := db.SaveRealm(realm, SystemTest); err != nil {
-			t.Fatal(err)
-		}
-
-		record, err := db.E2ERealm()
-		if err != nil {
-			t.Fatal(err)
-		}
-
-		if record.ID != realm.ID {
-			t.Errorf("expected %#v to be %#v", record, realm)
-		}
-	})
 }
 
 func TestRealm_BuildSMSText(t *testing.T) {


### PR DESCRIPTION
Fixes https://github.com/google/exposure-notifications-verification-server/issues/2285

**Release Note**

```release-note
Ensure there is only one E2E realm and prohibit naming realms similarly to avoid confusion.
```
