### PR TITLE
Change default pagination to be 24 elements

### DIFF
--- a/pkg/pagination/pagination.go
+++ b/pkg/pagination/pagination.go
@@ -32,7 +32,7 @@ const (
 	QueryKeyLimit = "limit"
 
 	// DefaultLimit is the default pagination limit, if one is not provided.
-	DefaultLimit = uint64(14)
+	DefaultLimit = uint64(24)
 
 	// MaxLimit is the maximum size for a single pagination. If a limit higher
 	// than this is provided, it's capped.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change default pagination to be 24 elements per page.
```
