### PR TITLE
Set custom user-agent headers for clients

### DIFF
--- a/internal/clients/admin_api.go
+++ b/internal/clients/admin_api.go
@@ -28,6 +28,7 @@ type AdminAPIServerClient struct {
 
 // NewAdminAPIServerClient creates a new admin API server http client.
 func NewAdminAPIServerClient(base, apiKey string, opts ...Option) (*AdminAPIServerClient, error) {
+	opts = append([]Option{WithUserAgent("en/adminapi-client")}, opts...)
 	client, err := newClient(base, apiKey, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/clients/api_server.go
+++ b/internal/clients/api_server.go
@@ -28,6 +28,7 @@ type APIServerClient struct {
 
 // NewAPIServerClient creates a new API server http client.
 func NewAPIServerClient(base, apiKey string, opts ...Option) (*APIServerClient, error) {
+	opts = append([]Option{WithUserAgent("en/apiserver-client")}, opts...)
 	client, err := newClient(base, apiKey, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/clients/app_sync.go
+++ b/internal/clients/app_sync.go
@@ -28,6 +28,7 @@ type AppSyncClient struct {
 
 // NewAppSyncClient creates a new app sync service http client.
 func NewAppSyncClient(base string, opts ...Option) (*AppSyncClient, error) {
+	opts = append([]Option{WithUserAgent("en/appsync-client")}, opts...)
 	client, err := newClient(base, "", opts...)
 	if err != nil {
 		return nil, err

--- a/internal/clients/e2e.go
+++ b/internal/clients/e2e.go
@@ -82,19 +82,22 @@ func RunEndToEnd(ctx context.Context, cfg *config.E2ERunnerConfig) error {
 	logger := logging.FromContext(ctx)
 
 	adminAPIClient, err := NewAdminAPIServerClient(cfg.VerificationAdminAPIServer, cfg.VerificationAdminAPIKey,
-		WithTimeout(timeout))
+		WithTimeout(timeout),
+		WithUserAgent("en/e2e-client"))
 	if err != nil {
 		return fmt.Errorf("failed to make adminapi server client: %w", err)
 	}
 
 	apiServerClient, err := NewAPIServerClient(cfg.VerificationAPIServer, cfg.VerificationAPIServerKey,
-		WithTimeout(timeout))
+		WithTimeout(timeout),
+		WithUserAgent("en/e2e-client"))
 	if err != nil {
 		return fmt.Errorf("failed to make apiserver client: %w", err)
 	}
 
 	keyServerClient, err := NewKeyServerClient(cfg.KeyServer,
-		WithTimeout(timeout))
+		WithTimeout(timeout),
+		WithUserAgent("en/e2e-client"))
 	if err != nil {
 		return fmt.Errorf("failed to make keyserver client: %w", err)
 	}

--- a/internal/clients/enx_redirect.go
+++ b/internal/clients/enx_redirect.go
@@ -30,6 +30,7 @@ type ENXRedirectClient struct {
 
 // NewENXRedirectClient creates a new enx-redirect service http client.
 func NewENXRedirectClient(base string, opts ...Option) (*ENXRedirectClient, error) {
+	opts = append([]Option{WithUserAgent("en/enxredirect-client")}, opts...)
 	client, err := newClient(base, "", opts...)
 	if err != nil {
 		return nil, err

--- a/internal/clients/enx_web.go
+++ b/internal/clients/enx_web.go
@@ -29,6 +29,7 @@ type ENXRedirectWebClient struct {
 
 // NewENXRedirectWebClient creates a new enx-redirect service http client for user-report.
 func NewENXRedirectWebClient(base string, apiKey string, opts ...Option) (*ENXRedirectWebClient, error) {
+	opts = append([]Option{WithUserAgent("en/enxweb-client")}, opts...)
 	client, err := newClient(base, apiKey, opts...)
 	if err != nil {
 		return nil, err

--- a/internal/clients/key_server.go
+++ b/internal/clients/key_server.go
@@ -30,6 +30,7 @@ type KeyServerClient struct {
 
 // NewKeyServerClient creates a new key-server http client.
 func NewKeyServerClient(base string, opts ...Option) (*KeyServerClient, error) {
+	opts = append([]Option{WithUserAgent("en/keyserver-client")}, opts...)
 	client, err := newClient(base, "", opts...)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
This will help debug issues, especially with the e2e runners

```release-note
Set a custom user-agent header when running e2e tests to make log identification easier
```
