### PR TITLE
Use a custom transport on all clients

### DIFF
--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -25,6 +25,8 @@ import (
 	"net/url"
 	"strings"
 	"time"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 )
 
 // Option is a customization option for the client.
@@ -113,7 +115,8 @@ func newClient(base, apiKey string, opts ...Option) (*client, error) {
 
 	client := &client{
 		httpClient: &http.Client{
-			Timeout: 5 * time.Second,
+			Timeout:   5 * time.Second,
+			Transport: project.DefaultHTTPTransport(),
 		},
 		baseURL:     u,
 		apiKey:      apiKey,

--- a/internal/project/transport.go
+++ b/internal/project/transport.go
@@ -1,0 +1,40 @@
+// Copyright 2021 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package project
+
+import (
+	"net"
+	"net/http"
+	"runtime"
+	"time"
+)
+
+// DefaultHTTPTransport returns a clean, non-globally-modifiable HTTP transport
+// with the same defaults as http.DefaultTransport.
+func DefaultHTTPTransport() *http.Transport {
+	return &http.Transport{
+		Proxy: http.ProxyFromEnvironment,
+		DialContext: (&net.Dialer{
+			Timeout:   30 * time.Second,
+			KeepAlive: 30 * time.Second,
+		}).DialContext,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       90 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ResponseHeaderTimeout: 10 * time.Second,
+		ForceAttemptHTTP2:     true,
+		MaxIdleConnsPerHost:   runtime.GOMAXPROCS(0) + 1,
+	}
+}

--- a/pkg/controller/backup/handle_backup.go
+++ b/pkg/controller/backup/handle_backup.go
@@ -25,6 +25,7 @@ import (
 	"path"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/kelseyhightower/run"
 	"go.opencensus.io/stats"
 )
@@ -119,7 +120,8 @@ func (c *Controller) authorizationToken(ctx context.Context) (string, error) {
 // take O(minutes) in some cases.
 func (c *Controller) executeBackup(req *http.Request) error {
 	client := &http.Client{
-		Timeout: c.config.Timeout,
+		Timeout:   c.config.Timeout,
+		Transport: project.DefaultHTTPTransport(),
 	}
 
 	resp, err := client.Do(req)

--- a/pkg/controller/userreport/controller.go
+++ b/pkg/controller/userreport/controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/i18n"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
@@ -61,7 +62,8 @@ func New(locales *i18n.LocaleMap, cacher cache.Cacher, cfg *config.RedirectConfi
 	localCache, _ := memcache.New(30 * time.Second)
 
 	httpClient := &http.Client{
-		Timeout: 10 * time.Second,
+		Timeout:   10 * time.Second,
+		Transport: project.DefaultHTTPTransport(),
 	}
 
 	return &Controller{

--- a/pkg/controller/userreport/send_test.go
+++ b/pkg/controller/userreport/send_test.go
@@ -80,7 +80,8 @@ func TestSendWebhookRequest(t *testing.T) {
 	ctx := project.TestContext(t)
 
 	client := &http.Client{
-		Timeout: 2 * time.Second,
+		Timeout:   2 * time.Second,
+		Transport: project.DefaultHTTPTransport(),
 	}
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
Even if this doesn't _fix_ the issue, I think it's a reasonable change. My suspicion is that, since `http.DefaultTransport` is a global variable, another package is modifying the value of the dial timeout to be very low, and we are inheriting it everywhere. I haven't been able to _prove_ that, but that's my theory as to why we're seeing timeouts for such small times. 

This introduces a new project-level helper, `DefaultHTTPTransport` which returns a pointer to a new allocation of an `http.Transport` on each invocation with no shared state. Even if this doesn't end up being the root cause, it will prevent the situation I described above from ever arising.

**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
NONE
```
