### PR TITLE
Extract GCP trace ID onto context and inject in clients

### DIFF
--- a/cmd/appsync/main.go
+++ b/cmd/appsync/main.go
@@ -107,6 +107,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/backup/main.go
+++ b/cmd/backup/main.go
@@ -107,6 +107,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/cleanup/main.go
+++ b/cmd/cleanup/main.go
@@ -119,6 +119,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/e2e-runner/main.go
+++ b/cmd/e2e-runner/main.go
@@ -148,6 +148,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/metrics-registrar/main.go
+++ b/cmd/metrics-registrar/main.go
@@ -97,6 +97,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/modeler/main.go
+++ b/cmd/modeler/main.go
@@ -118,6 +118,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/rotation/main.go
+++ b/cmd/rotation/main.go
@@ -130,6 +130,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/cmd/stats-puller/main.go
+++ b/cmd/stats-puller/main.go
@@ -110,6 +110,10 @@ func realMain(ctx context.Context) error {
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logger)
 	r.Use(populateLogger)

--- a/internal/clients/clients.go
+++ b/internal/clients/clients.go
@@ -28,6 +28,7 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 )
 
 // Option is a customization option for the client.
@@ -136,10 +137,7 @@ func newClient(base, apiKey string, opts ...Option) (*client, error) {
 	}
 
 	client := &client{
-		httpClient: &http.Client{
-			Timeout:   5 * time.Second,
-			Transport: project.DefaultHTTPTransport(),
-		},
+		httpClient:  controller.TracedHTTPClient(5 * time.Second),
 		baseURL:     u,
 		apiKey:      apiKey,
 		maxBodySize: 65536, // 64 KiB

--- a/internal/envstest/server.go
+++ b/internal/envstest/server.go
@@ -295,6 +295,7 @@ func (r *ServerConfigResponse) WithCommonMiddlewares(next http.Handler) http.Han
 		middleware.PopulateTemplateVariables(r.Config),
 		middleware.ProcessLocale(r.Locales),
 		middleware.PopulateRequestID(r.Renderer),
+		middleware.PopulateTraceID(),
 		middleware.InjectCurrentPath(),
 	}
 

--- a/internal/project/transport.go
+++ b/internal/project/transport.go
@@ -22,7 +22,7 @@ import (
 )
 
 // DefaultHTTPTransport returns a clean, non-globally-modifiable HTTP transport
-// with the same defaults as http.DefaultTransport.
+// with similar defaults as http.DefaultTransport.
 func DefaultHTTPTransport() *http.Transport {
 	return &http.Transport{
 		Proxy: http.ProxyFromEnvironment,

--- a/internal/routes/adminapi.go
+++ b/internal/routes/adminapi.go
@@ -62,6 +62,10 @@ func AdminAPI(
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
 	r.Use(populateLogger)

--- a/internal/routes/apiserver.go
+++ b/internal/routes/apiserver.go
@@ -67,6 +67,10 @@ func APIServer(
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
 	r.Use(populateLogger)

--- a/internal/routes/enx_redirect.go
+++ b/internal/routes/enx_redirect.go
@@ -78,6 +78,10 @@ func ENXRedirect(
 	populateRequestID := middleware.PopulateRequestID(h)
 	r.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
 	r.Use(populateLogger)

--- a/internal/routes/server.go
+++ b/internal/routes/server.go
@@ -111,6 +111,10 @@ func Server(
 	populateRequestID := middleware.PopulateRequestID(h)
 	sub.Use(populateRequestID)
 
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
 	// Logger injection
 	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
 	sub.Use(populateLogger)

--- a/pkg/controller/backup/handle_backup.go
+++ b/pkg/controller/backup/handle_backup.go
@@ -25,7 +25,7 @@ import (
 	"path"
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
-	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/kelseyhightower/run"
 	"go.opencensus.io/stats"
 )
@@ -119,10 +119,7 @@ func (c *Controller) authorizationToken(ctx context.Context) (string, error) {
 // executeBackup calls the backup API. This is a *blocking* operation that can
 // take O(minutes) in some cases.
 func (c *Controller) executeBackup(req *http.Request) error {
-	client := &http.Client{
-		Timeout:   c.config.Timeout,
-		Transport: project.DefaultHTTPTransport(),
-	}
+	client := controller.TracedHTTPClient(c.config.Timeout)
 
 	resp, err := client.Do(req)
 	if err != nil {

--- a/pkg/controller/context.go
+++ b/pkg/controller/context.go
@@ -32,16 +32,17 @@ type contextKey string
 const (
 	contextKeyAuthorizedApp = contextKey("authorizedApp")
 	contextKeyFirebaseUser  = contextKey("firebaseUser")
+	contextKeyLocale        = contextKey("locale")
 	contextKeyMembership    = contextKey("membership")
 	contextKeyMemberships   = contextKey("memberships")
+	contextKeyNonce         = contextKey("nonce")
+	contextKeyOS            = contextKey("os")
 	contextKeyRealm         = contextKey("realm")
 	contextKeyRequestID     = contextKey("requestID")
 	contextKeySession       = contextKey("session")
 	contextKeyTemplate      = contextKey("template")
+	contextKeyTraceID       = contextKey("traceID")
 	contextKeyUser          = contextKey("user")
-	contextKeyOS            = contextKey("os")
-	contextKeyNonce         = contextKey("nonce")
-	contextKeyLocale        = contextKey("locale")
 )
 
 // WithOperatingSystem stores the operating system enum in the context.
@@ -330,6 +331,30 @@ func FirebaseUserFromContext(ctx context.Context) *auth.UserRecord {
 	t, ok := v.(*auth.UserRecord)
 	if !ok {
 		return nil
+	}
+	return t
+}
+
+// WithTraceID stores the trace ID on the context.
+func WithTraceID(ctx context.Context, id string) context.Context {
+	m := TemplateMapFromContext(ctx)
+	m["traceID"] = id
+	ctx = WithTemplateMap(ctx, m)
+
+	return context.WithValue(ctx, contextKeyTraceID, id)
+}
+
+// TraceIDFromContext retrieves the trace ID from the context. If no value
+// exists, it returns the empty string.
+func TraceIDFromContext(ctx context.Context) string {
+	v := ctx.Value(contextKeyTraceID)
+	if v == nil {
+		return ""
+	}
+
+	t, ok := v.(string)
+	if !ok {
+		return ""
 	}
 	return t
 }

--- a/pkg/controller/middleware/logger.go
+++ b/pkg/controller/middleware/logger.go
@@ -36,7 +36,8 @@ const (
 // deployment.
 var googleCloudProjectID = os.Getenv("PROJECT_ID")
 
-// PopulateLogger populates the logger onto the context.
+// PopulateLogger populates the logger onto the context. This must come AFTER
+// PopulateRequestID and PopulateTraceID.
 func PopulateLogger(originalLogger *zap.SugaredLogger) mux.MiddlewareFunc {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/pkg/controller/middleware/trace_id.go
+++ b/pkg/controller/middleware/trace_id.go
@@ -1,0 +1,50 @@
+// Copyright 2021 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+
+	"github.com/gorilla/mux"
+)
+
+// googleCloudTraceHeader is the header with trace data.
+const googleCloudTraceHeader = "X-Cloud-Trace-Context"
+
+// PopulateTraceID populates the trace ID injected by Google Cloud (if it
+// exists).
+func PopulateTraceID() mux.MiddlewareFunc {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			ctx := r.Context()
+
+			if existing := controller.TraceIDFromContext(ctx); existing == "" {
+				if v := r.Header.Get(googleCloudTraceHeader); v != "" {
+					parts := strings.Split(v, "/")
+					if len(parts) > 0 && len(parts[0]) > 0 {
+						ctx = controller.WithTraceID(ctx, project.TrimSpace(parts[0]))
+						r = r.Clone(ctx)
+					}
+				}
+			}
+
+			next.ServeHTTP(w, r)
+		})
+	}
+}

--- a/pkg/controller/middleware/trace_id_test.go
+++ b/pkg/controller/middleware/trace_id_test.go
@@ -1,0 +1,49 @@
+// Copyright 2021 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package middleware_test
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+)
+
+func TestPopulateTraceID(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+	populateTraceID := middleware.PopulateTraceID()
+
+	r := httptest.NewRequest(http.MethodGet, "/", nil)
+	r = r.Clone(ctx)
+	r.Header.Set("Accept", "application/json")
+	r.Header.Set("X-Cloud-Trace-Context", " 1234567890 /apple")
+
+	w := httptest.NewRecorder()
+
+	// Verify the proper fields are added to the template map.
+	populateTraceID(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		id := controller.TraceIDFromContext(ctx)
+		if got, want := id, "1234567890"; got != want {
+			t.Errorf("expected %q to be %q", got, want)
+		}
+	})).ServeHTTP(w, r)
+}

--- a/pkg/controller/userreport/controller.go
+++ b/pkg/controller/userreport/controller.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/i18n"
-	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
@@ -61,10 +60,7 @@ func New(locales *i18n.LocaleMap, cacher cache.Cacher, cfg *config.RedirectConfi
 
 	localCache, _ := memcache.New(30 * time.Second)
 
-	httpClient := &http.Client{
-		Timeout:   10 * time.Second,
-		Transport: project.DefaultHTTPTransport(),
-	}
+	httpClient := controller.TracedHTTPClient(10 * time.Second)
 
 	return &Controller{
 		locales:          locales,

--- a/pkg/controller/userreport/controller.go
+++ b/pkg/controller/userreport/controller.go
@@ -21,6 +21,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/i18n"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
 	"github.com/google/exposure-notifications-verification-server/pkg/cache"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller"
@@ -49,7 +50,6 @@ type Controller struct {
 	issueController *issueapi.Controller
 }
 
-// New creates a new login controller.
 func New(locales *i18n.LocaleMap, cacher cache.Cacher, cfg *config.RedirectConfig, db *database.Database, limiter limiter.Store, smsSigner keys.KeyManager, h *render.Renderer) (*Controller, error) {
 	cfgMap, err := cfg.HostnameToRegion()
 	if err != nil {
@@ -60,7 +60,10 @@ func New(locales *i18n.LocaleMap, cacher cache.Cacher, cfg *config.RedirectConfi
 
 	localCache, _ := memcache.New(30 * time.Second)
 
-	httpClient := controller.TracedHTTPClient(10 * time.Second)
+	httpClient := &http.Client{
+		Timeout:   10 * time.Second,
+		Transport: project.DefaultHTTPTransport(),
+	}
 
 	return &Controller{
 		locales:          locales,

--- a/pkg/controller/userreport/send_test.go
+++ b/pkg/controller/userreport/send_test.go
@@ -22,6 +22,7 @@ import (
 	"time"
 
 	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 )
@@ -79,10 +80,7 @@ func TestSendWebhookRequest(t *testing.T) {
 
 	ctx := project.TestContext(t)
 
-	client := &http.Client{
-		Timeout:   2 * time.Second,
-		Transport: project.DefaultHTTPTransport(),
-	}
+	client := controller.TracedHTTPClient(2 * time.Second)
 
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		defer r.Body.Close()


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Improve tracing of requests that span multiple services (like the e2e runer)
```
