### PR TITLE
extend stats retention by 24h to avoid the 90th day being blank depen…

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -51,9 +51,9 @@ type CleanupConfig struct {
 	MobileAppMaxAge     time.Duration `env:"MOBILE_APP_MAX_AGE, default=168h"`
 
 	// StatsMaxAge is the maximum amount of time to retain statistics. The default
-	// value is 31d. It can be extended up to 120 days and cannot be less than 30
+	// value is 91d. It can be extended up to 120 days and cannot be less than 30
 	// days.
-	StatsMaxAge time.Duration `env:"STATS_MAX_AGE, default=2160h"`
+	StatsMaxAge time.Duration `env:"STATS_MAX_AGE, default=2184h"`
 
 	// RealmChaffEventMaxAge is the maximum amount of time to store whether a
 	// realm had received a chaff request.


### PR DESCRIPTION
…ding on UTC time

Fixes #

<!-- Please include the 'why' behind your changes if no issue exists -->
## Proposed Changes

*
*
*

**Release Note**

```release-note
Extends stats retention default by 1d to avoid the last day being cleaned up and still being shown.
```
