### PR TITLE
Revert "read header color instead of agency color"

### DIFF
--- a/internal/appsync/app_sync.go
+++ b/internal/appsync/app_sync.go
@@ -39,7 +39,6 @@ type App struct {
 	IsEnx                 bool   `json:"is_enx,omitempty"`
 	AndroidTarget         `json:"android_target"`
 	AgencyColor           string          `json:"agency_color"`
-	AgencyHeaderTextColor string          `json:"agency_header_text_color"`
 	AgencyImage           string          `json:"agency_image"`
 	DefaultLocale         string          `json:"default_locale"`
 	WebReportLearnMoreURL string          `json:"web_report_learn_more_url"`

--- a/pkg/controller/appsync/helpers.go
+++ b/pkg/controller/appsync/helpers.go
@@ -52,11 +52,7 @@ func (c *Controller) syncApps(ctx context.Context, apps *appsync.AppsResponse) *
 			continue
 		}
 
-		// TODO(mikehelmick): Remove AgencyColor once AgencyHeaderTextColor is fully rolled out
 		realm.AgencyBackgroundColor = strings.ToLower(app.AgencyColor)
-		if app.AgencyHeaderTextColor != "" {
-			realm.AgencyBackgroundColor = strings.ToLower(app.AgencyHeaderTextColor)
-		}
 		realm.AgencyImage = app.AgencyImage
 		realm.DefaultLocale = app.DefaultLocale
 		realm.UserReportLearnMoreURL = app.WebReportLearnMoreURL

--- a/pkg/controller/appsync/helpers_test.go
+++ b/pkg/controller/appsync/helpers_test.go
@@ -55,7 +55,6 @@ func Test_syncApps(t *testing.T) {
 		}
 
 		agencyColor := "#000000"
-		agencyBackgroundColor := "#ffffff"
 		agencyImage := "https://example.com/logo.png"
 
 		resp := &appsync.AppsResponse{
@@ -77,7 +76,6 @@ func Test_syncApps(t *testing.T) {
 						SHA256CertFingerprints: "BB:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA:AA",
 					},
 					AgencyColor:           agencyColor,
-					AgencyHeaderTextColor: agencyBackgroundColor,
 					AgencyImage:           agencyImage,
 					DefaultLocale:         "en_US",
 					WebReportLearnMoreURL: "https://g.co/ens",
@@ -119,8 +117,8 @@ func Test_syncApps(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		if gotRealm.AgencyBackgroundColor != agencyBackgroundColor {
-			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyBackgroundColor, agencyBackgroundColor)
+		if gotRealm.AgencyBackgroundColor != agencyColor {
+			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyBackgroundColor, agencyColor)
 		}
 		if gotRealm.AgencyImage != agencyImage {
 			t.Errorf("wrong agency color, got %q want %q", gotRealm.AgencyImage, agencyImage)


### PR DESCRIPTION
Reverts google/exposure-notifications-verification-server#2303

This is unnecessary - the source of the drift was found somewhere else