### PR TITLE
Allow ignoring Twilio codes from alerts

### DIFF
--- a/docs/playbooks/alerts/ElevatedSMSErrors.md
+++ b/docs/playbooks/alerts/ElevatedSMSErrors.md
@@ -1,9 +1,12 @@
 # Elevated SMS Errors Alert
 
-This alert fires when one or more realms have an increased number of errors returned from the Twilio API.
+This alert fires when one or more realms have an increased number of errors
+returned from the Twilio API. Specifically, if there are more than 50 errors in
+a 5 minute period.
 
 **This alert can have false positives**. There could be legitimate reasons why
-the percentage of codes claimed decreases by more than one standard deviation.
+SMS messages might be failing, such as invalid phone numbers, which do not
+indicate an issue in the system.
 
 
 ## Triage Steps
@@ -26,3 +29,25 @@ In the event the phone number or message is being filtered as spam, immediately
 file a ticket with Twilio and communicate with the PHA to stop issuing codes
 until the issue resolves. Note, sometimes this can take up to 72 hours to
 resolve.
+
+
+## Tuning
+
+You may find that particular error codes are the source of false positives.
+Specifically, `30003` and `30006` can be noisy if the input data is not properly
+checked. These error codes generally mean that the PHA tried to send a text
+message to a non-SMS capable phone such as a landline (home phone). It may be
+helpful to _exclude_ these particular error codes from the alerting threshold.
+To do this, edit the Terraform configuration for the `en-alerting` module and
+set the "ignored_twilio_error_codes" value to an array of codes to ignore:
+
+```terraform
+module "en-alerting" {
+  // ...
+
+  ignored_twilio_error_codes = ["30003", "30006"]
+}
+```
+
+Error codes added to this list will still appear in the PHA's statistics
+dashboard, but they will not trigger an alert.

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -102,6 +102,13 @@ variable "forward_progress_indicators" {
   default     = {}
 }
 
+variable "ignored_twilio_error_codes" {
+  type = list(string)
+
+  description = "List of error codes to exclude from the alerting condition."
+  default     = []
+}
+
 terraform {
   required_version = "~> 1.0"
 


### PR DESCRIPTION
```release-note
Allow server operators to ignore specific Twilio error codes in SMS alerts. Server operators can set the `ignored_twilio_error_codes` variable in the alerting module to a string list of error codes that should be ignored when determined if there are elevated SMS errors for a realm. This can be helpful for Twilio errors that are non-actionable, such as "30006" which means a message was sent to a landline phone number. This is a global configuration that applies to all realms on the server; there is no realm-specific configuration. This change affects the monitoring and alerting policy, not the data collection. Realms will still see all SMS errors in their statistics dashboard, even if that error code is excluded from the alerting policy.
```