### PR TITLE
Fix NPE when queue is full

### DIFF
--- a/pkg/controller/issueapi/send_sms.go
+++ b/pkg/controller/issueapi/send_sms.go
@@ -73,7 +73,7 @@ func (c *Controller) SendSMS(ctx context.Context, realm *database.Realm, smsProv
 	if err := c.doSend(ctx, realm, smsProvider, signer, keyID, request, result); err != nil {
 		result.HTTPCode = http.StatusBadRequest
 		if sms.IsSMSQueueFull(err) {
-			result.ErrorReturn = result.ErrorReturn.WithCode(api.ErrSMSQueueFull)
+			result.ErrorReturn = api.Errorf("failed to send sms: queue is full: %s", err).WithCode(api.ErrSMSQueueFull)
 		} else {
 			result.ErrorReturn = api.Errorf("failed to send sms: %s", err).WithCode(api.ErrSMSFailure)
 		}


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue where the server might crash when a large number of codes were submitted to the SMS provider and the SMS provider rejects the request due to a queueing issue.
```
