### PR TITLE
Add ability to send realm contacts emails

### DIFF
--- a/assets/server/email/anomalies.txt
+++ b/assets/server/email/anomalies.txt
@@ -1,0 +1,19 @@
+{{- define "email/anomalies" -}}
+
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Subject: Exposure Notifications code claim rate anomaly detected
+To: {{.ToEmail | trimSpace}}
+From: {{.FromEmail | trimSpace}}
+
+Hello,
+
+The code claim rate for {{.Realm.Name}} yesterday was {{.Realm.LastCodesClaimedRatio | toPercent}}, which is less than your historical average of {{.Realm.CodesClaimedRatioMean | toPercent}}. This could indicate a problem with your configuration.
+
+Consider reviewing the statistics page for {{.Realm.Name}} at {{.RootURL}}/realm/stats.
+
+---
+
+You received this email because you are listed as a contact email address for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
+
+{{end}}

--- a/assets/server/email/anomalies.txt
+++ b/assets/server/email/anomalies.txt
@@ -1,19 +1,54 @@
 {{- define "email/anomalies" -}}
-
+{{- $fontFamily := "system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans','Liberation Sans',sans-serif" -}}
+{{- $fontFamilyMono := "SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace" -}}
 MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
+Content-Type: text/html; charset="utf-8"
 Subject: Exposure Notifications code claim rate anomaly detected
 To: {{.ToEmail | trimSpace}}
 From: {{.FromEmail | trimSpace}}
 
-Hello,
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Exposure Notifications code claim rate anomaly detected</title>
+  </head>
 
-The code claim rate for {{.Realm.Name}} yesterday was {{.Realm.LastCodesClaimedRatio | toPercent}}, which is less than your historical average of {{.Realm.CodesClaimedRatioMean | toPercent}}. This could indicate a problem with your configuration.
+  <body style="font-family:{{$fontFamily}};">
+    <p style="font-family:{{$fontFamily}};">
+      Hello,
+    </p>
 
-Consider reviewing the statistics page for {{.Realm.Name}} at {{.RootURL}}/realm/stats.
+    <p style="font-family:{{$fontFamily}};">
+      The code claim rate for <strong>{{.Realm.Name}}</strong> yesterday was
+      <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.LastCodesClaimedRatio | toPercent}}</strong>, which is
+      less than your historical average of
+      <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.CodesClaimedRatioMean | toPercent}}</strong>. This could
+      indicate a problem with your configuration.
+    </p>
 
----
+    <p style="font-family:{{$fontFamily}};">
+      Consider reviewing the statistics page for
+      <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats"
+      rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
+    </p>
 
-You received this email because you are listed as a contact email address for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
+    <p style="font-family:{{$fontFamily}};">
+      For more information, please see
+      the <a
+      href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/CodesClaimedRatioAnomaly.md#codesclaimedratioanomaly"
+      rel="noopener noreferrer" target="_blank">playbook for Codes Claimed Ratio anomalies</a>.
+    </p>
+
+    <hr style="border:none; border-top:1px solid #cccccc; width:75%; margin:1.5em auto;">
+
+    <p style="font-family:{{$fontFamily}}; font-style:italic;">
+      You received this email because you are listed as a contact for Exposure
+      Notifications for {{.Realm.Name}}. To be removed from these emails,
+      contact your realm administrator.
+    </p>
+  </body>
+</html>
 
 {{end}}

--- a/assets/server/email/anomalies.txt
+++ b/assets/server/email/anomalies.txt
@@ -21,32 +21,21 @@ From: {{.FromEmail | trimSpace}}
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      The code claim rate for <strong>{{.Realm.Name}}</strong> yesterday was
-      <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.LastCodesClaimedRatio | toPercent}}</strong>, which is
-      less than your historical average of
-      <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.CodesClaimedRatioMean | toPercent}}</strong>. This could
-      indicate a problem with your configuration.
+      The code claim rate for <strong>{{.Realm.Name}}</strong> yesterday was <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.LastCodesClaimedRatio | toPercent}}</strong>, which is less than your historical average of <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.CodesClaimedRatioMean | toPercent}}</strong>. This could indicate a problem with your configuration.
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      Consider reviewing the statistics page for
-      <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats"
-      rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
+      Consider reviewing the statistics page for <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats" rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      For more information, please see
-      the <a
-      href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/CodesClaimedRatioAnomaly.md#codesclaimedratioanomaly"
-      rel="noopener noreferrer" target="_blank">playbook for Codes Claimed Ratio anomalies</a>.
+      For more information, please see the <a href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/CodesClaimedRatioAnomaly.md#codesclaimedratioanomaly" rel="noopener noreferrer" target="_blank">playbook for Codes Claimed Ratio anomalies</a>.
     </p>
 
     <hr style="border:none; border-top:1px solid #cccccc; width:75%; margin:1.5em auto;">
 
     <p style="font-family:{{$fontFamily}}; font-style:italic;">
-      You received this email because you are listed as a contact for Exposure
-      Notifications for {{.Realm.Name}}. To be removed from these emails,
-      contact your realm administrator.
+      You received this email because you are listed as a contact for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
     </p>
   </body>
 </html>

--- a/assets/server/email/sms_errors.txt
+++ b/assets/server/email/sms_errors.txt
@@ -1,0 +1,22 @@
+{{- define "email/sms_errors" -}}
+
+MIME-Version: 1.0
+Content-Type: text/plain; charset="utf-8"
+Subject: Exposure Notifications SMS error rate exceeded
+To: {{.ToEmail | trimSpace}}
+From: {{.FromEmail | trimSpace}}
+
+Hello,
+
+{{/* TODO(sethvargo): Pipe value from Realm */}}
+The number of SMS errors for {{.Realm.Name}} in the past 24 hours is {{.Realm.TODO}}, which exceeds the typical value. This could indicate a problem with your Twilio configuration.
+
+Consider reviewing the statistics page for {{.Realm.Name}} at {{.RootURL}}/realm/stats.
+
+If you manage your own Twilio account, you can also review any logs in the Twilio console. If you are using a sponsored Twilio account, please contact your server operator for support.
+
+---
+
+You received this email because you are listed as a contact email address for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
+
+{{end}}

--- a/assets/server/email/sms_errors.txt
+++ b/assets/server/email/sms_errors.txt
@@ -21,34 +21,21 @@ From: {{.FromEmail | trimSpace}}
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      The number of SMS errors for <strong>{{.Realm.Name}}</strong> yesterday
-      was <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.TODO}}</strong>, which
-      exceeds the typical value. This could indicate a problem with your Twilio
-      configuration or a potential upstream carrier filtering issue.
+      The number of SMS errors for <strong>{{.Realm.Name}}</strong> is <strong style="font-family:{{$fontFamilyMono}};">{{.NumSMSErrors}}</strong>, which exceeds the typical value. This could indicate a problem with your Twilio configuration or a potential upstream carrier filtering issue.
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      Consider reviewing the statistics page for
-      <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats"
-      rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
+      Consider reviewing the statistics page for <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats" rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
     </p>
 
     <p style="font-family:{{$fontFamily}};">
-      If you manage your own Twilio account, review any logs in the Twilio
-      console. If you are using a sponsored or national Twilio account, please
-      contact your server operator for support. For more information, please see
-      the <a
-      href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/ElevatedSMSErrors.md#elevated-sms-errors-alert"
-      rel="noopener noreferrer" target="_blank">playbook for Elevated SMS
-      Errors</a>.
+      If you manage your own Twilio account, review any logs in the Twilio console. If you are using a sponsored or national Twilio account, please contact your server operator for support. For more information, please see the <a href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/ElevatedSMSErrors.md#elevated-sms-errors-alert" rel="noopener noreferrer" target="_blank">playbook for Elevated SMS Errors</a>.
     </p>
 
     <hr style="border:none; border-top:1px solid #cccccc; width:75%; margin:1.5em auto;">
 
     <p style="font-family:{{$fontFamily}}; font-style:italic;">
-      You received this email because you are listed as a contact for Exposure
-      Notifications for {{.Realm.Name}}. To be removed from these emails,
-      contact your realm administrator.
+      You received this email because you are listed as a contact for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
     </p>
   </body>
 </html>

--- a/assets/server/email/sms_errors.txt
+++ b/assets/server/email/sms_errors.txt
@@ -1,22 +1,56 @@
 {{- define "email/sms_errors" -}}
-
+{{- $fontFamily := "system-ui,-apple-system,'Segoe UI',Roboto,'Helvetica Neue',Arial,'Noto Sans','Liberation Sans',sans-serif" -}}
+{{- $fontFamilyMono := "SFMono-Regular,Menlo,Monaco,Consolas,'Liberation Mono','Courier New',monospace" -}}
 MIME-Version: 1.0
-Content-Type: text/plain; charset="utf-8"
+Content-Type: text/html; charset="utf-8"
 Subject: Exposure Notifications SMS error rate exceeded
 To: {{.ToEmail | trimSpace}}
 From: {{.FromEmail | trimSpace}}
 
-Hello,
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+    <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
+    <title>Exposure Notifications SMS error rate exceeded</title>
+  </head>
 
-{{/* TODO(sethvargo): Pipe value from Realm */}}
-The number of SMS errors for {{.Realm.Name}} in the past 24 hours is {{.Realm.TODO}}, which exceeds the typical value. This could indicate a problem with your Twilio configuration.
+  <body style="font-family:{{$fontFamily}};">
+    <p style="font-family:{{$fontFamily}};">
+      Hello,
+    </p>
 
-Consider reviewing the statistics page for {{.Realm.Name}} at {{.RootURL}}/realm/stats.
+    <p style="font-family:{{$fontFamily}};">
+      The number of SMS errors for <strong>{{.Realm.Name}}</strong> yesterday
+      was <strong style="font-family:{{$fontFamilyMono}};">{{.Realm.TODO}}</strong>, which
+      exceeds the typical value. This could indicate a problem with your Twilio
+      configuration or a potential upstream carrier filtering issue.
+    </p>
 
-If you manage your own Twilio account, you can also review any logs in the Twilio console. If you are using a sponsored Twilio account, please contact your server operator for support.
+    <p style="font-family:{{$fontFamily}};">
+      Consider reviewing the statistics page for
+      <strong>{{.Realm.Name}}</strong> at <a href="{{.RootURL}}/realm/stats"
+      rel="noopener noreferrer" target="_blank">{{.RootURL}}/realm/stats</a>.
+    </p>
 
----
+    <p style="font-family:{{$fontFamily}};">
+      If you manage your own Twilio account, review any logs in the Twilio
+      console. If you are using a sponsored or national Twilio account, please
+      contact your server operator for support. For more information, please see
+      the <a
+      href="https://github.com/google/exposure-notifications-verification-server/blob/main/docs/playbooks/alerts/ElevatedSMSErrors.md#elevated-sms-errors-alert"
+      rel="noopener noreferrer" target="_blank">playbook for Elevated SMS
+      Errors</a>.
+    </p>
 
-You received this email because you are listed as a contact email address for Exposure Notifications for {{.Realm.Name}}. To be removed from these emails, contact your realm administrator.
+    <hr style="border:none; border-top:1px solid #cccccc; width:75%; margin:1.5em auto;">
+
+    <p style="font-family:{{$fontFamily}}; font-style:italic;">
+      You received this email because you are listed as a contact for Exposure
+      Notifications for {{.Realm.Name}}. To be removed from these emails,
+      contact your realm administrator.
+    </p>
+  </body>
+</html>
 
 {{end}}

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -110,7 +110,6 @@
           <div class="d-flex align-items-center">
             <i class="bi bi-exclamation-square-fill me-3"></i>
             <span class="alert-message">
-              <!-- TODO(sethvargo): localize -->
               Please configure at least one contact email address to receive
               system notifications.
             </span>

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -101,6 +101,31 @@
 
 {{if $currentMembership}}
   {{$realm := $currentMembership.Realm}}
+
+  {{if $.features.EnableEmailer}}
+  {{if and (not $realm.ContactEmailAddresses) ($currentMembership.Can rbac.SettingsWrite)}}
+    <div class="container">
+      <div class="alert alert-warning" role="alert">
+        <div class="d-flex align-items-center justify-content-between">
+          <div class="d-flex align-items-center">
+            <i class="bi bi-exclamation-square-fill me-3"></i>
+            <span class="alert-message">
+              <!-- TODO(sethvargo): localize -->
+              Please configure at least one contact email address to receive
+              system notifications.
+            </span>
+          </div>
+          <div>
+            <a href="/realm/settings#general" class="text-reset py-3 ps-2">
+              <i class="bi bi-arrow-right-square-fill"></i>
+            </a>
+          </div>
+        </div>
+      </div>
+    </div>
+  {{end}}
+  {{end}}
+
   {{if and $realm.CodesClaimedRatioAnomalous ($currentMembership.Can rbac.StatsRead)}}
     <div class="container">
       <div class="alert alert-warning" role="alert">

--- a/assets/server/realmadmin/_form_general.html
+++ b/assets/server/realmadmin/_form_general.html
@@ -54,7 +54,7 @@
       <div class="col-lg-12">
         <div class="form-floating">
           <textarea name="welcome_message" id="welcome-message" class="form-control font-monospace{{if $realm.ErrorsFor "welcomeMessage"}} is-invalid{{end}}"
-            rows="5" placeholder="Welcome message">{{$realm.WelcomeMessage}}</textarea>
+            style="height:10em;" placeholder="Welcome message">{{$realm.WelcomeMessage}}</textarea>
           <label for="welcome-message">Welcome message</label>
           {{template "errorable" $realm.ErrorsFor "welcomeMessage"}}
           <small class="form-text text-muted">
@@ -65,6 +65,22 @@
           </small>
         </div>
       </div>
+
+      {{if $.features.EnableEmailer}}
+      <div class="col-lg-12">
+        <div class="form-floating">
+          <textarea name="contact_email_addresses" id="contact-email-addresses" class="form-control font-monospace{{if $realm.ErrorsFor "contactEmailAddresses"}} is-invalid{{end}}"
+            style="height:10em;" placeholder="Contact email addresses">{{joinStrings $realm.ContactEmailAddresses "\n"}}</textarea>
+          <label for="contact-email-addresses">Contact email addresses</label>
+          {{template "errorable" $realm.ErrorsFor "contactEmailAddresses"}}
+          <small class="form-text text-muted">
+            A list of email addresses (one per line) to receive critical system
+            notifications. Email addresses must be of the format "<span
+            class="font-monospace">user@example.com</span>".
+          </small>
+        </div>
+      </div>
+      {{end}}
     </div>
   </div>
 

--- a/assets/server/realmadmin/_form_general.html
+++ b/assets/server/realmadmin/_form_general.html
@@ -76,7 +76,9 @@
           <small class="form-text text-muted">
             A list of email addresses (one per line) to receive critical system
             notifications. Email addresses must be of the format "<span
-            class="font-monospace">user@example.com</span>".
+            class="font-monospace">user@example.com</span>". These email
+            addresses are also visible to the server operator and may appear in
+            system logs.
           </small>
         </div>
       </div>

--- a/assets/server/static/js/stats-codes.js
+++ b/assets/server/static/js/stats-codes.js
@@ -149,6 +149,10 @@
         const dashboardContainer = document.querySelector(chart.dashboardDiv);
         const filterContainer = document.querySelector(chart.filterDiv);
 
+        if (!chartContainer || !dashboardContainer || !filterContainer) {
+          continue;
+        }
+
         if (!data || !data.statistics) {
           const pContainer = chartContainer.querySelector('p');
           pContainer.innerText = 'No data yet.';

--- a/builders/build.yaml
+++ b/builders/build.yaml
@@ -361,6 +361,46 @@ steps:
 
 
 #
+# emailer
+#
+- id: 'dockerize-emailer'
+  name: 'docker:19'
+  args:
+  - 'build'
+  - '--file=builders/service.dockerfile'
+  - '--tag=gcr.io/${PROJECT_ID}/${_REPO}/emailer:${_TAG}'
+  - '--build-arg=SERVICE=emailer'
+  - '.'
+  waitFor:
+  - 'build'
+
+- id: 'push-emailer'
+  name: 'docker:19'
+  args:
+  - 'push'
+  - 'gcr.io/${PROJECT_ID}/${_REPO}/emailer:${_TAG}'
+  waitFor:
+  - 'dockerize-emailer'
+
+- id: 'attest-emailer'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:365.0.0'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    ARTIFACT_URL=$(docker inspect gcr.io/${PROJECT_ID}/${_REPO}/emailer:${_TAG} --format='{{index .RepoDigests 0}}')
+    gcloud beta container binauthz attestations sign-and-create \
+      --project "${PROJECT_ID}" \
+      --artifact-url "$${ARTIFACT_URL}" \
+      --attestor "${_BINAUTHZ_ATTESTOR}" \
+      --keyversion "${_BINAUTHZ_KEY_VERSION}"
+  waitFor:
+  - 'push-emailer'
+
+
+#
 # enx-redirect
 #
 - id: 'dockerize-enx-redirect'

--- a/builders/deploy.yaml
+++ b/builders/deploy.yaml
@@ -149,6 +149,27 @@ steps:
   - '-'
 
 #
+# emailer
+#
+- id: 'deploy-emailer'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:365.0.0-alpine'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    gcloud run deploy "emailer" \
+      --quiet \
+      --project "${PROJECT_ID}" \
+      --platform "managed" \
+      --region "${_REGION}" \
+      --image "gcr.io/${PROJECT_ID}/${_REPO}/emailer:${_TAG}" \
+      --no-traffic
+  waitFor:
+  - '-'
+
+#
 # enx-redirect
 #
 - id: 'deploy-enx-redirect'

--- a/builders/promote.yaml
+++ b/builders/promote.yaml
@@ -143,6 +143,26 @@ steps:
   - '-'
 
 #
+# emailer
+#
+- id: 'promote-emailer'
+  name: 'gcr.io/google.com/cloudsdktool/cloud-sdk:365.0.0-alpine'
+  args:
+  - 'bash'
+  - '-eEuo'
+  - 'pipefail'
+  - '-c'
+  - |-
+    gcloud run services update-traffic "emailer" \
+      --quiet \
+      --project "${PROJECT_ID}" \
+      --platform "managed" \
+      --region "${_REGION}" \
+      --to-revisions "${_REVISION}=${_PERCENTAGE}"
+  waitFor:
+  - '-'
+
+#
 # enx-redirect
 #
 - id: 'promote-enx-redirect'

--- a/cmd/emailer/main.go
+++ b/cmd/emailer/main.go
@@ -31,7 +31,6 @@ import (
 
 	"github.com/google/exposure-notifications-server/pkg/logging"
 	"github.com/google/exposure-notifications-server/pkg/observability"
-	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-server/pkg/server"
 
 	"github.com/gorilla/mux"
@@ -93,16 +92,6 @@ func realMain(ctx context.Context) error {
 	}
 	defer db.Close()
 
-	// Get secret manager.
-	secretManager, err := secrets.SecretManagerFor(ctx, &cfg.Secrets)
-	if err != nil {
-		return fmt.Errorf("failed to get secret manager: %w", err)
-	}
-	secretManagerTyp, ok := secretManager.(secrets.SecretVersionManager)
-	if !ok {
-		return fmt.Errorf("secret manager is not a secret version manager (is %T)", secretManager)
-	}
-
 	// Create the router
 	r := mux.NewRouter()
 
@@ -138,7 +127,7 @@ func realMain(ctx context.Context) error {
 	processDebug := middleware.ProcessDebug()
 	r.Use(processDebug)
 
-	emailerController := emailer.New(cfg, db, secretManagerTyp, h)
+	emailerController := emailer.New(cfg, db, h)
 	r.Handle("/anomalies", emailerController.HandleAnomalies()).Methods(http.MethodGet)
 	r.Handle("/sms-errors", emailerController.HandleSMSErrors()).Methods(http.MethodGet)
 

--- a/cmd/emailer/main.go
+++ b/cmd/emailer/main.go
@@ -1,0 +1,151 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// This server implements sending periodic emails invoked by a scheduler.
+package main
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os/signal"
+	"syscall"
+
+	"github.com/google/exposure-notifications-verification-server/assets"
+	"github.com/google/exposure-notifications-verification-server/internal/buildinfo"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/emailer"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller/middleware"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-server/pkg/secrets"
+	"github.com/google/exposure-notifications-server/pkg/server"
+
+	"github.com/gorilla/mux"
+)
+
+func main() {
+	ctx, done := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+
+	logger := logging.NewLoggerFromEnv().
+		With("build_id", buildinfo.BuildID).
+		With("build_tag", buildinfo.BuildTag)
+	ctx = logging.WithLogger(ctx, logger)
+
+	defer func() {
+		done()
+		if r := recover(); r != nil {
+			logger.Fatalw("application panic", "panic", r)
+		}
+	}()
+
+	err := realMain(ctx)
+	done()
+
+	if err != nil {
+		logger.Fatal(err)
+	}
+	logger.Info("successful shutdown")
+}
+
+func realMain(ctx context.Context) error {
+	logger := logging.FromContext(ctx)
+
+	cfg, err := config.NewEmailerConfig(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to process config: %w", err)
+	}
+
+	// Setup monitoring
+	logger.Info("configuring observability exporter")
+	oeConfig := cfg.ObservabilityExporterConfig()
+	oe, err := observability.NewFromEnv(ctx, oeConfig)
+	if err != nil {
+		return fmt.Errorf("unable to create ObservabilityExporter provider: %w", err)
+	}
+	if err := oe.StartExporter(); err != nil {
+		return fmt.Errorf("error initializing observability exporter: %w", err)
+	}
+	defer oe.Close()
+	ctx, obs := middleware.WithObservability(ctx)
+	logger.Infow("observability exporter", "config", oeConfig)
+
+	// Setup database
+	db, err := cfg.Database.Load(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to load database config: %w", err)
+	}
+	if err := db.Open(ctx); err != nil {
+		return fmt.Errorf("failed to connect to database: %w", err)
+	}
+	defer db.Close()
+
+	// Get secret manager.
+	secretManager, err := secrets.SecretManagerFor(ctx, &cfg.Secrets)
+	if err != nil {
+		return fmt.Errorf("failed to get secret manager: %w", err)
+	}
+	secretManagerTyp, ok := secretManager.(secrets.SecretVersionManager)
+	if !ok {
+		return fmt.Errorf("secret manager is not a secret version manager (is %T)", secretManager)
+	}
+
+	// Create the router
+	r := mux.NewRouter()
+
+	// Common observability context
+	r.Use(obs)
+
+	// Create the renderer
+	h, err := render.New(ctx, assets.ServerFS(), cfg.DevMode)
+	if err != nil {
+		return fmt.Errorf("failed to create renderer: %w", err)
+	}
+
+	// Request ID injection
+	populateRequestID := middleware.PopulateRequestID(h)
+	r.Use(populateRequestID)
+
+	// Trace ID injection
+	populateTraceID := middleware.PopulateTraceID()
+	r.Use(populateTraceID)
+
+	// Logger injection
+	populateLogger := middleware.PopulateLogger(logging.FromContext(ctx))
+	r.Use(populateLogger)
+
+	// Recovery injection
+	recovery := middleware.Recovery(h)
+	r.Use(recovery)
+
+	// Install common security headers
+	r.Use(middleware.SecureHeaders(cfg.DevMode, "html"))
+
+	// Enable debug headers
+	processDebug := middleware.ProcessDebug()
+	r.Use(processDebug)
+
+	emailerController := emailer.New(cfg, db, secretManagerTyp, h)
+	r.Handle("/anomalies", emailerController.HandleAnomalies()).Methods(http.MethodGet)
+	r.Handle("/sms-errors", emailerController.HandleSMSErrors()).Methods(http.MethodGet)
+
+	srv, err := server.New(cfg.Port)
+	if err != nil {
+		return fmt.Errorf("failed to create server: %w", err)
+	}
+	logger.Infow("server listening", "port", cfg.Port)
+	return srv.ServeHTTPHandler(ctx, r)
+}

--- a/docs/playbooks/alerts/ElevatedSMSErrors.md
+++ b/docs/playbooks/alerts/ElevatedSMSErrors.md
@@ -1,8 +1,8 @@
 # Elevated SMS Errors Alert
 
-This alert fires when one or more realms have an increased number of errors
-returned from the Twilio API. Specifically, if there are more than 50 errors in
-a 5 minute period.
+This alert fires when your realm has an increased number of errors returned from
+the Twilio API. Specifically, if there are more than 50 errors in a 24 hour
+period.
 
 **This alert can have false positives**. There could be legitimate reasons why
 SMS messages might be failing, such as invalid phone numbers, which do not
@@ -33,21 +33,7 @@ resolve.
 
 ## Tuning
 
-You may find that particular error codes are the source of false positives.
-Specifically, `30003` and `30006` can be noisy if the input data is not properly
-checked. These error codes generally mean that the PHA tried to send a text
-message to a non-SMS capable phone such as a landline (home phone). It may be
-helpful to _exclude_ these particular error codes from the alerting threshold.
-To do this, edit the Terraform configuration for the `en-alerting` module and
-set the "ignored_twilio_error_codes" value to an array of codes to ignore:
-
-```terraform
-module "en-alerting" {
-  // ...
-
-  ignored_twilio_error_codes = ["30003", "30006"]
-}
-```
-
-Error codes added to this list will still appear in the PHA's statistics
-dashboard, but they will not trigger an alert.
+You may find that particular error codes are the source of false positives. It
+may be helpful to _exclude_ these particular error codes from the alerting
+threshold. To do this, contact your server operator with the codes to omit from
+alerting.

--- a/docs/playbooks/alerts/ForwardProgressFailed.md
+++ b/docs/playbooks/alerts/ForwardProgressFailed.md
@@ -14,6 +14,10 @@ This alert fires when background jobs have not made forward progress in an accep
 
 - `e2e-revise` - Runs the same end to end test to the revise endpoint.
 
+- `emailer-anomalies` - Generates and sends emails to realm contacts if the code claim ratio drops below the historical average.
+
+- `emailer-sms-errors` - Generates and sends emails to realm contacts if the number of SMS errors in the current UTC day exceeds a provided threshold.
+
 - `modeler-worker` - Implements periodic statistical calculations.
 
 - `realm-key-rotation-worker` - Rotates realm signing keys.
@@ -43,3 +47,9 @@ resource.labels.service_name="appsync"
 ```
 
 Check for errors in the logs.
+
+### Service-specific triage steps
+
+- `emailer-anomalies` - The most likely reason this job is failing is because one of the email addresses provided by a realm admin is invalid or inaccessible. The logs will show the invalid email address(es). You can remove the invalid email address(es) or ask the other realm administrators to update their configuration.
+
+- `emailer-sms-errors` - Same as `emailer-anomalies`.

--- a/docs/production.md
+++ b/docs/production.md
@@ -311,6 +311,41 @@ The verification server uses the Google Identity Platform for authorization.
 
 3. Visit [Google Identity Platform Settings](https://console.cloud.google.com/customer-identity/settings) and ensure that 'Enable create (sign-up)' and 'Enable delete' are unchecked. This system is intended to be invite-only and these flows are handled by administrators.
 
+## Setup System Email
+
+The verification server is capable of sending email through a Google Workspace SMTP relay. You must have administrator permissions on the Google Workspace Account to enable this setting. More detailed instructions are available in the [Google Workspace SMTP relay documentation](https://support.google.com/a/answer/2956491).
+
+1. Visit https://admin.google.com and authenticate as a Google Workspace administrator account.
+
+1. From the sidebar, navigate to `Apps > Google Workspace > Gmail` and then click on the `Routing` box.
+
+1. Scroll down to the "SMTP relay service" option and click `Configure`.
+
+    1. Enter a description (e.g. "Exposure Notifications").
+
+    1. Under "Allowed Senders", choose "Only addresses in my domains".
+
+    1. Under "Authentication", choose "Only accept mail from the specified IP address.
+
+    1. In the "IP addresses / ranges" table, click "Add" and enter the egress IP address(es) for your installation. These can be obtained from the Google Cloud Console or the Terraform configurations. **Only enter these IP addresses!** Requests originating from these IP addresses will automatically be considered "trusted".
+
+    1. Check the "Require TLS encryption" box.
+
+    1. Click save. Note, it can take up to 24 hours for the configuration to finish, but it is usually less than 5 minutes.
+
+1. After configured, update the Terraform configuration to enable the emailer service:
+
+    ```terraform
+    module "en" {
+      // ...
+
+      enable_emailer = true
+      emailer_from_address = "no-reply@your-domain.com"
+      emailer_mail_domain = "your-domain.com"
+    }
+    ```
+
+
 ## End-to-end (e2e) test runner
 
 Log in as a system admin and view realms, select the `e2e-test-realm`. If this

--- a/docs/production.md
+++ b/docs/production.md
@@ -311,7 +311,7 @@ The verification server uses the Google Identity Platform for authorization.
 
 3. Visit [Google Identity Platform Settings](https://console.cloud.google.com/customer-identity/settings) and ensure that 'Enable create (sign-up)' and 'Enable delete' are unchecked. This system is intended to be invite-only and these flows are handled by administrators.
 
-## Setup System Email
+## Setup system emails
 
 The verification server is capable of sending email through a Google Workspace SMTP relay. You must have administrator permissions on the Google Workspace Account to enable this setting. More detailed instructions are available in the [Google Workspace SMTP relay documentation](https://support.google.com/a/answer/2956491).
 
@@ -342,6 +342,23 @@ The verification server is capable of sending email through a Google Workspace S
       enable_emailer = true
       emailer_from_address = "no-reply@your-domain.com"
       emailer_mail_domain = "your-domain.com"
+    }
+    ```
+
+1. Optionally override the defaults for ignored SMS error codes and the SMS
+   errors alerting threshold. Do this by setting `SMS_IGNORED_ERROR_CODES` or
+   `SMS_ERRORS_EMAIL_THRESHOLD` respectively on the `emailer` service:
+
+    ```terraform
+    module "en" {
+      // ...
+
+      service_environment = {
+        emailer = {
+          SMS_IGNORED_ERROR_CODES    = "30003,30004,30005,30008"
+          SMS_ERRORS_EMAIL_THRESHOLD = "50"
+        }
+      }
     }
     ```
 

--- a/docs/realm-admin-guide.md
+++ b/docs/realm-admin-guide.md
@@ -60,7 +60,7 @@ A member of the realm should be responsible for monitoring the number of codes i
 
 ## Settings, enabling EN Express
 
-Go to the realm setting by selecting the `settings` drop down menu (shown under your name).
+Go to the realm settings by selecting the `settings` drop down menu (shown under your name).
 
 Under general settings, confirm the `Name` (display name only) and `Region code` settings.
 
@@ -73,6 +73,22 @@ for the geographic region that you cover.
 Once that is confirmed and saved, click the `Enable EN Express` button.
 
 ![](images/settings-enable-enx.png)
+
+
+## Settings, adding system contacts
+
+Go to the realm settings by selecting the `settings` drop down menu (shown under
+your name).
+
+Under general settings, you can add up to 10 system contacts ("emergency
+contacts") which will receive automated alerts when the system detects critical
+issues with your realm. These issues include a sudden drop in code claim rate or
+potential issues with your SMS configuration.
+
+Although recommended, the email addresses in this list do not need to be users
+in the system. To alert more than 10 contacts, consider creating a Google Group
+or similar mailing list system.
+
 
 ## Settings, code settings
 
@@ -218,6 +234,10 @@ create, update, and delete permissions. Always practice the Principle of Least
 Privilege and only grant the most minimal set of permissions.
 
 Note, you can only grant permissions at or below your current level.
+
+Note, you may also want to configure [System
+contacts](#settings-adding-system-contacts), which is a list of contacts to
+receive critical system notifications.
 
 ## API keys
 

--- a/go.mod
+++ b/go.mod
@@ -118,11 +118,12 @@ require (
 	github.com/fatih/color v1.13.0 // indirect
 	github.com/fatih/structtag v1.2.0 // indirect
 	github.com/felixge/httpsnoop v1.0.2 // indirect
-	github.com/fsnotify/fsnotify v1.4.9 // indirect
+	github.com/fsnotify/fsnotify v1.5.1 // indirect
 	github.com/fzipp/gocyclo v0.3.1 // indirect
 	github.com/go-critic/go-critic v0.5.6 // indirect
 	github.com/go-kit/log v0.2.0 // indirect
 	github.com/go-logfmt/logfmt v0.5.1 // indirect
+	github.com/go-sql-driver/mysql v1.6.0 // indirect
 	github.com/go-toolsmith/astcast v1.0.0 // indirect
 	github.com/go-toolsmith/astcopy v1.0.0 // indirect
 	github.com/go-toolsmith/astequal v1.0.0 // indirect
@@ -136,6 +137,7 @@ require (
 	github.com/gobwas/pool v0.2.1 // indirect
 	github.com/gobwas/ws v1.1.0 // indirect
 	github.com/gofrs/flock v0.8.1 // indirect
+	github.com/gofrs/uuid v4.1.0+incompatible // indirect
 	github.com/golang-jwt/jwt/v4 v4.2.0 // indirect
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
@@ -194,6 +196,7 @@ require (
 	github.com/jinzhu/inflection v1.0.0 // indirect
 	github.com/jirfag/go-printf-func-name v0.0.0-20200119135958-7558a9eaa5af // indirect
 	github.com/jmespath/go-jmespath v0.4.0 // indirect
+	github.com/joho/godotenv v1.4.0 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
 	github.com/julz/importas v0.0.0-20210419104244-841f0c0fe66d // indirect
 	github.com/kisielk/errcheck v1.6.0 // indirect
@@ -212,6 +215,7 @@ require (
 	github.com/mattn/go-ieproxy v0.0.1 // indirect
 	github.com/mattn/go-isatty v0.0.14 // indirect
 	github.com/mattn/go-runewidth v0.0.9 // indirect
+	github.com/mattn/go-sqlite3 v1.14.9 // indirect
 	github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 // indirect
 	github.com/mbilski/exhaustivestruct v1.2.0 // indirect
 	github.com/mgechev/dots v0.0.0-20190921121421-c36f7dcfbb81 // indirect
@@ -221,6 +225,7 @@ require (
 	github.com/mitchellh/go-testing-interface v1.14.1 // indirect
 	github.com/mitchellh/mapstructure v1.4.3 // indirect
 	github.com/mitchellh/reflectwalk v1.0.2 // indirect
+	github.com/mocktools/go-smtp-mock v1.4.3 // indirect
 	github.com/moricho/tparallel v0.2.1 // indirect
 	github.com/nakabonne/nestif v0.3.0 // indirect
 	github.com/nbutton23/zxcvbn-go v0.0.0-20210217022336-fa2cb2858354 // indirect

--- a/go.sum
+++ b/go.sum
@@ -529,8 +529,9 @@ github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM
 github.com/frankban/quicktest v1.13.0 h1:yNZif1OkDfNoDfb9zZa9aXIpejNR4F23Wely0c+Qdqk=
 github.com/frankban/quicktest v1.13.0/go.mod h1:qLE0fzW0VuyUAJgPU19zByoIr0HtCHN/r/VLSOOIySU=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
-github.com/fsnotify/fsnotify v1.4.9 h1:hsms1Qyu0jgnwNXIxa+/V/PDsU6CfLf6CNO8H7IWoS4=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
+github.com/fsnotify/fsnotify v1.5.1 h1:mZcQUHVQUQWoPXXtuf9yuEXKudkV2sx1E06UadKWpgI=
+github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
 github.com/fsouza/fake-gcs-server v1.17.0/go.mod h1:D1rTE4YCyHFNa99oyJJ5HyclvN/0uQR+pM/VdlL83bw=
 github.com/fullsailor/pkcs7 v0.0.0-20190404230743-d7302db945fa/go.mod h1:KnogPXtdwXqoenmZCw6S+25EAm2MkxbG0deNDu4cbSA=
 github.com/fullstorydev/grpcurl v1.6.0/go.mod h1:ZQ+ayqbKMJNhzLmbpCiurTVlaK2M/3nqZCxaQ2Ze/sM=
@@ -577,8 +578,9 @@ github.com/go-openapi/swag v0.19.5/go.mod h1:POnQmlKehdgb5mhVOsnJFsivZCEZ/vjK9gh
 github.com/go-redis/redis v6.15.8+incompatible/go.mod h1:NAIEuMOZ/fxfXJIrKDQDz8wamY7mA7PouImQ2Jvg6kA=
 github.com/go-sql-driver/mysql v1.4.0/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
 github.com/go-sql-driver/mysql v1.4.1/go.mod h1:zAC/RDZ24gD3HViQzih4MyKcchzm+sOG5ZlKdlhCg5w=
-github.com/go-sql-driver/mysql v1.5.0 h1:ozyZYNQW3x3HtqT1jira07DN2PArx2v7/mN66gGcHOs=
 github.com/go-sql-driver/mysql v1.5.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
+github.com/go-sql-driver/mysql v1.6.0 h1:BCTh4TKNUYmOmMUcQ3IipzF5prigylS7XXjEkfCHuOE=
+github.com/go-sql-driver/mysql v1.6.0/go.mod h1:DCzpHaOWr8IXmIStZouvnhqoel9Qv2LBy8hT2VhHyBg=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/go-task/slim-sprig v0.0.0-20210107165309-348f09dbbbc0/go.mod h1:fyg7847qk6SyHyPtNmDHnmrv/HOrqktSC+C9fM+CJOE=
 github.com/go-test/deep v1.0.2 h1:onZX1rnHT3Wv6cqNgYyFOOlgVKJrksuCMCRvJStbMYw=
@@ -645,8 +647,9 @@ github.com/godbus/dbus/v5 v5.0.4/go.mod h1:xhWf0FNVPg57R7Z0UbKHbJfkEywrmjJnf7w5x
 github.com/gofrs/flock v0.8.1 h1:+gYjHKf32LDeiEEFhQaotPbLuUXjY5ZqxKgXy7n59aw=
 github.com/gofrs/flock v0.8.1/go.mod h1:F1TvTiK9OcQqauNUHlbJvyl9Qa1QvF/gOUDKA14jxHU=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
-github.com/gofrs/uuid v4.0.0+incompatible h1:1SD/1F5pU8p29ybwgQSwpQk+mwdRrXCYuPhW6m+TnJw=
 github.com/gofrs/uuid v4.0.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
+github.com/gofrs/uuid v4.1.0+incompatible h1:sIa2eCvUTwgjbqXrPLfNwUf9S3i3mpH1O1atV+iL/Wk=
+github.com/gofrs/uuid v4.1.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
 github.com/gogo/googleapis v1.2.0/go.mod h1:Njal3psf3qN6dwBtQfUmBZh2ybovJ0tlu3o/AC7HYjU=
 github.com/gogo/googleapis v1.4.0/go.mod h1:5YRNX2z1oM5gXdAkurHa942MDgEJyk02w4OecKY87+c=
 github.com/gogo/protobuf v1.1.1/go.mod h1:r8qH/GZQm5c6nD/R0oafs1akxWv10x8SbQlK7atdtwQ=
@@ -1040,8 +1043,9 @@ github.com/jmespath/go-jmespath/internal/testify v1.5.1 h1:shLQSRRSCCPj3f2gpwzGw
 github.com/jmespath/go-jmespath/internal/testify v1.5.1/go.mod h1:L3OGu8Wl2/fWfCI6z80xFu9LTZmf1ZRjMHUOPmWr69U=
 github.com/jmoiron/sqlx v1.2.0/go.mod h1:1FEQNm3xlJgrMD+FBdI9+xvCksHtbpVBBw5dYhBSsks=
 github.com/jmoiron/sqlx v1.3.1/go.mod h1:2BljVx/86SuTyjE+aPYlHCTNvZrnJXghYGpNiXLBMCQ=
-github.com/joho/godotenv v1.3.0 h1:Zjp+RcGpHhGlrMbJzXTrZZPrWj+1vfm90La1wgB6Bhc=
 github.com/joho/godotenv v1.3.0/go.mod h1:7hK45KPybAkOC6peb+G5yklZfMxEjkZhHbwpqxOKXbg=
+github.com/joho/godotenv v1.4.0 h1:3l4+N6zfMWnkbPEXKng2o2/MR5mSwTrBih4ZEkkz1lg=
+github.com/joho/godotenv v1.4.0/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/jonboulle/clockwork v0.1.0/go.mod h1:Ii8DK3G1RaLaWxj9trq07+26W01tbo22gdxWY5EU2bo=
 github.com/jonboulle/clockwork v0.2.0/go.mod h1:Pkfl5aHPm1nk2H9h0bjmnJD/BcgbGXUBGnn1kMkgxc8=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=
@@ -1179,8 +1183,9 @@ github.com/mattn/go-shellwords v1.0.3/go.mod h1:3xCvwCdWdlDJUrvuMn7Wuy9eWs4pE8vq
 github.com/mattn/go-sqlite3 v1.9.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.10.0/go.mod h1:FPy6KqzDD04eiIsT53CuJW3U88zkxoIYsOqkbpncsNc=
 github.com/mattn/go-sqlite3 v1.14.0/go.mod h1:JIl7NbARA7phWnGvh0LKTyg7S9BA+6gx71ShQilpsus=
-github.com/mattn/go-sqlite3 v1.14.6 h1:dNPt6NO46WmLVt2DLNpwczCmdV5boIZ6g/tlDrlRUbg=
 github.com/mattn/go-sqlite3 v1.14.6/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
+github.com/mattn/go-sqlite3 v1.14.9 h1:10HX2Td0ocZpYEjhilsuo6WWtUqttj2Kb0KtD86/KYA=
+github.com/mattn/go-sqlite3 v1.14.9/go.mod h1:NyWgC/yNuGj7Q9rpYnZvas74GogHl5/Z4A/KQRfk6bU=
 github.com/mattn/goveralls v0.0.2/go.mod h1:8d1ZMHsd7fW6IRPKQh46F2WRpyib5/X4FOpevwGNQEw=
 github.com/matttproud/golang_protobuf_extensions v1.0.1/go.mod h1:D8He9yQNgCq6Z5Ld7szi9bcBfOoFv/3dc6xSMkL2PC0=
 github.com/matttproud/golang_protobuf_extensions v1.0.2-0.20181231171920-c182affec369 h1:I0XW9+e1XWDxdcEniV4rQAIOPUGDq67JSCiRCgGCZLI=
@@ -1234,6 +1239,8 @@ github.com/moby/sys/symlink v0.1.0/go.mod h1:GGDODQmbFOjFsXvfLVn3+ZRxkch54RkSiGq
 github.com/moby/term v0.0.0-20200312100748-672ec06f55cd/go.mod h1:DdlQx2hp0Ss5/fLikoLlEeIYiATotOjgB//nb973jeo=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6 h1:dcztxKSvZ4Id8iPpHERQBbIJfabdt4wUm5qy3wOL2Zc=
 github.com/moby/term v0.0.0-20210619224110-3f7ff695adc6/go.mod h1:E2VnQOmVuvZB6UYnnDB0qG5Nq/1tD9acaOpo6xmt0Kw=
+github.com/mocktools/go-smtp-mock v1.4.3 h1:BRakeQppuIKtC/8wICbvqw8kB3shWgQwNVbVHS4KbDE=
+github.com/mocktools/go-smtp-mock v1.4.3/go.mod h1:2f2yancePWnqjyYGHDi/mOtSHwg336e/G9kltjAs7V8=
 github.com/modern-go/concurrent v0.0.0-20180228061459-e0a39a4cb421/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd/go.mod h1:6dJC0mAP4ikYIbvyc7fijjWJddQyLn8Ig3JB5CqoB9Q=
 github.com/modern-go/reflect2 v0.0.0-20180701023420-4b7aa43c6742/go.mod h1:bx2lNnkwVCuqBIxFjflWJWanXIb3RllmbCylyMrvgv0=

--- a/pkg/config/emailer_config.go
+++ b/pkg/config/emailer_config.go
@@ -64,6 +64,19 @@ type EmailerConfig struct {
 	// default values should be appropriate for most situations.
 	SMTPRelayHost string `env:"SMTP_RELAY_HOST, default=smtp-relay.gmail.com"`
 	SMTPRelayPort string `env:"SMTP_RELAY_PORT, default=587"`
+
+	// SMSIgnoredErrorCodes is a list of SMS error codes to ignore.
+	//
+	// 30003 - Phone is off
+	// 30004 - User blocked receiving messages from this number
+	// 30005 - Invalid phone number
+	// 30006 - Landline error
+	SMSIgnoredErrorCodes []string `env:"SMS_IGNORED_ERROR_CODES, default=30003,30004,30005,30006"`
+
+	// SMSErrorsEmailThreshold is the number of SMS errors in a given 24 hour UTC
+	// period at which email alerts will begin being generated. This applies to
+	// all realms on the system.
+	SMSErrorsEmailThreshold int64 `env:"SMS_ERRORS_EMAIL_THRESHOLD, default=50"`
 }
 
 // NewEmailerConfig returns the config for the emailer service.

--- a/pkg/config/emailer_config.go
+++ b/pkg/config/emailer_config.go
@@ -1,0 +1,98 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package config
+
+import (
+	"context"
+	"time"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+
+	"github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-server/pkg/secrets"
+
+	"github.com/sethvargo/go-envconfig"
+)
+
+// EmailerConfig represents the environment-based configuration for the emailer
+// service.
+type EmailerConfig struct {
+	Database      database.Config
+	Observability observability.Config
+	Features      FeatureConfig
+	Secrets       secrets.Config
+
+	// Port is the port upon which to bind.
+	Port string `env:"PORT, default=8080"`
+
+	// DevMode produces additional debugging information. Do not enable in
+	// production environments.
+	DevMode bool `env:"DEV_MODE"`
+
+	// MinTTL is the minimum amount of time that must elapse between attempting
+	// emailer events. This is used to control whether emails are actually sent at
+	// the controller layer, independent of being invoked via a scheduler.
+	MinTTL time.Duration `env:"MIN_TTL, default=4h"`
+
+	// FromAddress is the address from which to send emails. This must be an
+	// address that resides in the Google Workspace domain. It can be of the
+	// format "user@example.com". The recommended value is
+	// "no-reply@your-server.com".
+	FromAddress string `env:"FROM_ADDRESS"`
+
+	// MailDomain is the domain from which to send email. It should be just the
+	// domain (no https:// or port).
+	MailDomain string `env:"MAIL_DOMAIN"`
+
+	// ServerEndpoint is the URL to the main verification server component - the
+	// UI server. It should be the full URL with no trailing slash.
+	ServerEndpoint string `env:"SERVER_ENDPOINT"`
+
+	// SMTPRelayHost and SMTPRelayPort are the URLs for the SMTP server. The
+	// default values should be appropriate for most situations.
+	SMTPRelayHost string `env:"SMTP_RELAY_HOST, default=smtp-relay.gmail.com"`
+	SMTPRelayPort string `env:"SMTP_RELAY_PORT, default=587"`
+}
+
+// NewEmailerConfig returns the config for the emailer service.
+func NewEmailerConfig(ctx context.Context) (*EmailerConfig, error) {
+	var config EmailerConfig
+	if err := ProcessWith(ctx, &config, envconfig.OsLookuper()); err != nil {
+		return nil, err
+	}
+	return &config, nil
+}
+
+func (c *EmailerConfig) Validate() error {
+	fields := []struct {
+		Var  time.Duration
+		Name string
+		Min  time.Duration
+	}{
+		{c.MinTTL, "MIN_TTL", 0},
+	}
+
+	for _, f := range fields {
+		if err := checkPositiveDuration(f.Var, f.Name); err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (c *EmailerConfig) ObservabilityExporterConfig() *observability.Config {
+	return &c.Observability
+}

--- a/pkg/config/feature_config.go
+++ b/pkg/config/feature_config.go
@@ -18,7 +18,9 @@ import "github.com/google/exposure-notifications-verification-server/pkg/control
 
 // FeatureConfig represents features that are introduced as off by default allowing
 // for server operators to control their release.
-type FeatureConfig struct{}
+type FeatureConfig struct {
+	EnableEmailer bool `env:"ENABLE_EMAILER, default=false"`
+}
 
 // AddToTemplate takes TemplateMap and writes the status of all known
 // feature flags for use in HTML templates.

--- a/pkg/controller/emailer/emailer.go
+++ b/pkg/controller/emailer/emailer.go
@@ -21,7 +21,6 @@ import (
 	"net/mail"
 	"net/smtp"
 
-	"github.com/google/exposure-notifications-server/pkg/secrets"
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
@@ -33,18 +32,16 @@ const (
 )
 
 type Controller struct {
-	config        *config.EmailerConfig
-	db            *database.Database
-	secretManager secrets.SecretVersionManager
-	h             *render.Renderer
+	config *config.EmailerConfig
+	db     *database.Database
+	h      *render.Renderer
 }
 
-func New(cfg *config.EmailerConfig, db *database.Database, secretManager secrets.SecretVersionManager, h *render.Renderer) *Controller {
+func New(cfg *config.EmailerConfig, db *database.Database, h *render.Renderer) *Controller {
 	return &Controller{
-		config:        cfg,
-		db:            db,
-		secretManager: secretManager,
-		h:             h,
+		config: cfg,
+		db:     db,
+		h:      h,
 	}
 }
 

--- a/pkg/controller/emailer/emailer.go
+++ b/pkg/controller/emailer/emailer.go
@@ -1,0 +1,107 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package email implements periodic email sending.
+package emailer
+
+import (
+	"crypto/tls"
+	"fmt"
+	"net/mail"
+	"net/smtp"
+
+	"github.com/google/exposure-notifications-server/pkg/secrets"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+)
+
+const (
+	emailerAnomaliesLock = "emailerAnomaliesLock"
+	emailerSMSErrorsLock = "emailerSMSErrorsLock"
+)
+
+type Controller struct {
+	config        *config.EmailerConfig
+	db            *database.Database
+	secretManager secrets.SecretVersionManager
+	h             *render.Renderer
+}
+
+func New(cfg *config.EmailerConfig, db *database.Database, secretManager secrets.SecretVersionManager, h *render.Renderer) *Controller {
+	return &Controller{
+		config:        cfg,
+		db:            db,
+		secretManager: secretManager,
+		h:             h,
+	}
+}
+
+// sendMail sends a single message through the Google Workspace SMTP relay.
+func (c *Controller) sendMail(to string, msg []byte) error {
+	toAddr, err := mail.ParseAddress(to)
+	if err != nil {
+		return fmt.Errorf("failed to parse to address %q: %w", to, err)
+	}
+
+	from := c.config.FromAddress
+	fromAddr, err := mail.ParseAddress(from)
+	if err != nil {
+		return fmt.Errorf("failed to parse from address %q: %w", from, err)
+	}
+
+	client, err := smtp.Dial(c.config.SMTPRelayHost + ":" + c.config.SMTPRelayPort)
+	if err != nil {
+		return fmt.Errorf("failed to dial connection: %w", err)
+	}
+	defer client.Close()
+
+	if err := client.Hello(c.config.MailDomain); err != nil {
+		return fmt.Errorf("failed to HELLO: %w", err)
+	}
+
+	if err := client.StartTLS(&tls.Config{
+		ServerName: c.config.SMTPRelayHost,
+		MinVersion: tls.VersionTLS13,
+	}); err != nil {
+		return fmt.Errorf("failed to start tls: %w", err)
+	}
+
+	if err := client.Mail(fromAddr.Address); err != nil {
+		return fmt.Errorf("failed to set FROM: %w", err)
+	}
+
+	if err := client.Rcpt(toAddr.Address); err != nil {
+		return fmt.Errorf("failed to set TO: %w", err)
+	}
+
+	w, err := client.Data()
+	if err != nil {
+		return fmt.Errorf("failed to create data stream: %w", err)
+	}
+
+	if _, err := w.Write(msg); err != nil {
+		return fmt.Errorf("failed to write body: %w", err)
+	}
+
+	if err := w.Close(); err != nil {
+		return fmt.Errorf("failed to close connection: %w", err)
+	}
+
+	if err := client.Quit(); err != nil {
+		return fmt.Errorf("failed to quit client: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/controller/emailer/emailer_test.go
+++ b/pkg/controller/emailer/emailer_test.go
@@ -1,0 +1,29 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	"testing"
+
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+)
+
+var testDatabaseInstance *database.TestInstance
+
+func TestMain(m *testing.M) {
+	testDatabaseInstance = database.MustTestInstance()
+	defer testDatabaseInstance.MustClose()
+	m.Run()
+}

--- a/pkg/controller/emailer/emailer_test.go
+++ b/pkg/controller/emailer/emailer_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"go.uber.org/zap/zaptest/observer"
 )
 
 var testDatabaseInstance *database.TestInstance
@@ -26,4 +27,17 @@ func TestMain(m *testing.M) {
 	testDatabaseInstance = database.MustTestInstance()
 	defer testDatabaseInstance.MustClose()
 	m.Run()
+}
+
+func testExpectLog(tb testing.TB, lo *observer.ObservedLogs, msg string) {
+	logs := lo.All()
+	msgs := make([]string, 0, len(logs))
+	for _, message := range logs {
+		msgs = append(msgs, message.Message)
+		if got, want := message.Message, msg; got == want {
+			return
+		}
+	}
+
+	tb.Errorf("expected one of %q to contain %q", msgs, msg)
 }

--- a/pkg/controller/emailer/handle_anomalies.go
+++ b/pkg/controller/emailer/handle_anomalies.go
@@ -1,0 +1,112 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
+	"github.com/hashicorp/go-multierror"
+	"go.opencensus.io/stats"
+)
+
+// HandleAnomalies handles a request to send emails about code ratio anomalies.
+func (c *Controller) HandleAnomalies() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("emailer.HandleAnomalies")
+		logger.Debugw("starting")
+		defer logger.Debugw("finishing")
+
+		ok, err := c.db.TryLock(ctx, emailerAnomaliesLock, c.config.MinTTL)
+		if err != nil {
+			logger.Errorw("failed to acquire lock", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+		if !ok {
+			logger.Debugw("skipping (too early)")
+			c.h.RenderJSON(w, http.StatusOK, fmt.Errorf("too early"))
+			return
+		}
+
+		// Get the list of realms.
+		realms, _, err := c.db.ListRealms(pagination.UnlimitedResults)
+		if err != nil {
+			logger.Errorw("failed to list realms", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		var merr *multierror.Error
+		for _, realm := range realms {
+			if err := c.sendAnomaliesEmails(ctx, realm); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to send emails for realm %d: %w", realm.ID, err))
+				continue
+			}
+		}
+
+		if err := merr.ErrorOrNil(); err != nil {
+			logger.Errorw("failed to send anomalies emails", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		stats.Record(ctx, mAnomaliesSuccess.M(1))
+		c.h.RenderJSON(w, http.StatusOK, nil)
+	})
+}
+
+// sendAnomaliesEmails sends anomalies emails to all contacts configured in the
+// realm if the current values are anomalous.
+func (c *Controller) sendAnomaliesEmails(ctx context.Context, realm *database.Realm) error {
+	logger := logging.FromContext(ctx).Named("emailer.sendAnomaliesEmails").
+		With("realm_id", realm.ID)
+
+	if len(realm.ContactEmailAddresses) == 0 {
+		logger.Debugw("no contact email addresses registered, skipping")
+		return nil
+	}
+
+	if !realm.CodesClaimedRatioAnomalous() {
+		logger.Debugw("codes claimed ratio is not anomalous, skipping")
+		return nil
+	}
+
+	var merr *multierror.Error
+	for _, addr := range realm.ContactEmailAddresses {
+		msg, err := c.h.RenderEmail("email/anomalies", map[string]interface{}{
+			"ToEmail":   addr,
+			"FromEmail": c.config.FromAddress,
+			"Realm":     realm,
+			"RootURL":   c.config.ServerEndpoint,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to render template: %w", err)
+		}
+
+		logger.Debugw("sending email", "email", addr)
+		if err := c.sendMail(addr, msg); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to send to %q: %w", addr, err))
+		}
+	}
+
+	return merr.ErrorOrNil()
+}

--- a/pkg/controller/emailer/handle_anomalies_test.go
+++ b/pkg/controller/emailer/handle_anomalies_test.go
@@ -1,0 +1,130 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/assets"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestSendAnomaliesEmail(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	h, err := render.New(ctx, assets.ServerFS(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("no_contacts", func(t *testing.T) {
+		t.Parallel()
+
+		logCore, logObserver := observer.New(zap.DebugLevel)
+		ctx := logging.WithLogger(ctx, zap.New(logCore).Sugar())
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		realm.ContactEmailAddresses = []string{}
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{}
+
+		c := New(cfg, db, h)
+
+		if err := c.sendAnomaliesEmails(ctx, realm); err != nil {
+			t.Fatal(err)
+		}
+
+		testExpectLog(t, logObserver, "no contact email addresses registered, skipping")
+	})
+
+	t.Run("not_anomalous", func(t *testing.T) {
+		t.Parallel()
+
+		logCore, logObserver := observer.New(zap.DebugLevel)
+		ctx := logging.WithLogger(ctx, zap.New(logCore).Sugar())
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		realm.ContactEmailAddresses = []string{"user@example.com"}
+		realm.LastCodesClaimedRatio = 1.00
+		realm.CodesClaimedRatioMean = 0.01
+		realm.CodesClaimedRatioStddev = 0.01
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{}
+
+		c := New(cfg, db, h)
+
+		if err := c.sendAnomaliesEmails(ctx, realm); err != nil {
+			t.Fatal(err)
+		}
+
+		testExpectLog(t, logObserver, "codes claimed ratio is not anomalous, skipping")
+	})
+
+	t.Run("renders", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{}
+
+		c := New(cfg, db, h)
+
+		msg, err := c.h.RenderEmail("email/anomalies", map[string]interface{}{
+			"ToEmail":   "to@example.com",
+			"FromEmail": "from@example.com",
+			"Realm":     realm,
+			"RootURL":   "http://example.com",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := string(msg), "less than your historical average"; !strings.Contains(got, want) {
+			t.Errorf("expectd %q to be %q", got, want)
+		}
+	})
+}

--- a/pkg/controller/emailer/handle_sms_errors.go
+++ b/pkg/controller/emailer/handle_sms_errors.go
@@ -1,0 +1,115 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/pagination"
+	"github.com/hashicorp/go-multierror"
+	"go.opencensus.io/stats"
+)
+
+// HandleSMSErrors handles a request to send emails about code ratio anomalies.
+func (c *Controller) HandleSMSErrors() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ctx := r.Context()
+
+		logger := logging.FromContext(ctx).Named("emailer.HandleSMSErrors")
+		logger.Debugw("starting")
+		defer logger.Debugw("finishing")
+
+		ok, err := c.db.TryLock(ctx, emailerSMSErrorsLock, c.config.MinTTL)
+		if err != nil {
+			logger.Errorw("failed to acquire lock", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+		if !ok {
+			logger.Debugw("skipping (too early)")
+			c.h.RenderJSON(w, http.StatusOK, fmt.Errorf("too early"))
+			return
+		}
+
+		// Get the list of realms.
+		realms, _, err := c.db.ListRealms(pagination.UnlimitedResults)
+		if err != nil {
+			logger.Errorw("failed to list realms", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		var merr *multierror.Error
+		for _, realm := range realms {
+			if err := c.sendSMSErrorsEmails(ctx, realm); err != nil {
+				merr = multierror.Append(merr, fmt.Errorf("failed to send emails for realm %d: %w", realm.ID, err))
+				continue
+			}
+		}
+
+		if err := merr.ErrorOrNil(); err != nil {
+			logger.Errorw("failed to send sms errors emails", "error", err)
+			c.h.RenderJSON(w, http.StatusInternalServerError, err)
+			return
+		}
+
+		stats.Record(ctx, mSMSErrorsSuccess.M(1))
+		c.h.RenderJSON(w, http.StatusOK, nil)
+	})
+}
+
+// sendSMSErrorsEmails sends emails to all email contacts in the realm if SMS
+// errors are above the acceptable thresholds.
+func (c *Controller) sendSMSErrorsEmails(ctx context.Context, realm *database.Realm) error {
+	logger := logging.FromContext(ctx).Named("emailer.sendSMSErrorsEmails").
+		With("realm_id", realm.ID)
+
+	if len(realm.ContactEmailAddresses) == 0 {
+		logger.Debugw("no contact email addresses registered, skipping")
+		return nil
+	}
+
+	// TODO(sethvargo): build a metric on which to alert, probably correlate
+	// errors to codes issued and also have a max cap of like 50 errors. "If more
+	// than 20% of messages of today have failed...". Probably need to exclude
+	// error codes for landlines.
+	if true {
+		return nil
+	}
+
+	var merr *multierror.Error
+	for _, addr := range realm.ContactEmailAddresses {
+		msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
+			"ToEmail":   addr,
+			"FromEmail": c.config.FromAddress,
+			"Realm":     realm,
+			"RootURL":   c.config.ServerEndpoint,
+		})
+		if err != nil {
+			return fmt.Errorf("failed to render template: %w", err)
+		}
+
+		logger.Debugw("sending email", "email", addr)
+		if err := c.sendMail(addr, msg); err != nil {
+			merr = multierror.Append(merr, fmt.Errorf("failed to send to %q: %w", addr, err))
+		}
+	}
+
+	return merr.ErrorOrNil()
+}

--- a/pkg/controller/emailer/handle_sms_errors_test.go
+++ b/pkg/controller/emailer/handle_sms_errors_test.go
@@ -1,0 +1,129 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/google/exposure-notifications-server/pkg/logging"
+	"github.com/google/exposure-notifications-verification-server/assets"
+	"github.com/google/exposure-notifications-verification-server/internal/project"
+	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/database"
+	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"go.uber.org/zap"
+	"go.uber.org/zap/zaptest/observer"
+)
+
+func TestSendSMSErrorsEmails(t *testing.T) {
+	t.Parallel()
+
+	ctx := project.TestContext(t)
+
+	h, err := render.New(ctx, assets.ServerFS(), true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	t.Run("no_contacts", func(t *testing.T) {
+		t.Parallel()
+
+		logCore, logObserver := observer.New(zap.DebugLevel)
+		ctx := logging.WithLogger(ctx, zap.New(logCore).Sugar())
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		realm.ContactEmailAddresses = []string{}
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{}
+
+		c := New(cfg, db, h)
+
+		if err := c.sendSMSErrorsEmails(ctx, realm); err != nil {
+			t.Fatal(err)
+		}
+
+		testExpectLog(t, logObserver, "no contact email addresses registered, skipping")
+	})
+
+	t.Run("no_errors", func(t *testing.T) {
+		t.Parallel()
+
+		logCore, logObserver := observer.New(zap.DebugLevel)
+		ctx := logging.WithLogger(ctx, zap.New(logCore).Sugar())
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		realm.ContactEmailAddresses = []string{"user@example.com"}
+		if err := db.SaveRealm(realm, database.SystemTest); err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{
+			SMSErrorsEmailThreshold: 50,
+		}
+
+		c := New(cfg, db, h)
+
+		if err := c.sendSMSErrorsEmails(ctx, realm); err != nil {
+			t.Fatal(err)
+		}
+
+		testExpectLog(t, logObserver, "sms errors is less than minimum value, skipping")
+	})
+
+	t.Run("renders", func(t *testing.T) {
+		t.Parallel()
+
+		db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+		realm, err := db.FindRealm(1)
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		cfg := &config.EmailerConfig{}
+
+		c := New(cfg, db, h)
+
+		msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
+			"ToEmail":   "to@example.com",
+			"FromEmail": "from@example.com",
+			"Realm":     realm,
+			"RootURL":   "http://example.com",
+		})
+		if err != nil {
+			t.Fatal(err)
+		}
+
+		if got, want := string(msg), "exceeds the typical value"; !strings.Contains(got, want) {
+			t.Errorf("expectd %q to be %q", got, want)
+		}
+	})
+}

--- a/pkg/controller/emailer/metrics.go
+++ b/pkg/controller/emailer/metrics.go
@@ -1,0 +1,49 @@
+// Copyright 2022 the Exposure Notifications Verification Server authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package emailer
+
+import (
+	enobs "github.com/google/exposure-notifications-server/pkg/observability"
+	"github.com/google/exposure-notifications-verification-server/pkg/observability"
+
+	"go.opencensus.io/stats"
+	"go.opencensus.io/stats/view"
+)
+
+const metricPrefix = observability.MetricRoot + "/emailer"
+
+var (
+	mAnomaliesSuccess = stats.Int64(metricPrefix+"/anomalies_success", "successful anomalies emails", stats.UnitDimensionless)
+	mSMSErrorsSuccess = stats.Int64(metricPrefix+"/sms_errors_success", "successful SMS errors emails", stats.UnitDimensionless)
+)
+
+func init() {
+	enobs.CollectViews([]*view.View{
+		{
+			Name:        metricPrefix + "/anomalies/success",
+			Description: "Number of anomalies email successes",
+			TagKeys:     observability.CommonTagKeys(),
+			Measure:     mAnomaliesSuccess,
+			Aggregation: view.Count(),
+		},
+		{
+			Name:        metricPrefix + "/sms_errors/success",
+			Description: "Number of SMS errors email successes",
+			TagKeys:     observability.CommonTagKeys(),
+			Measure:     mSMSErrorsSuccess,
+			Aggregation: view.Count(),
+		},
+	}...)
+}

--- a/pkg/controller/metricsregistrar/all_metrics.go
+++ b/pkg/controller/metricsregistrar/all_metrics.go
@@ -8,6 +8,7 @@ import (
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/certapi"
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/cleanup"
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/e2erunner"
+	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/emailer"
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/issueapi"
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/modeler"
 	_ "github.com/google/exposure-notifications-verification-server/pkg/controller/rotation"

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -517,8 +517,6 @@ func explodeSortAndDedupe(in string) []string {
 	m := make(map[string]struct{}, len(pieces))
 	for _, piece := range pieces {
 		piece := project.TrimSpaceAndNonPrintable(piece)
-		piece = strings.Trim(piece, ",")
-		piece = project.TrimSpaceAndNonPrintable(piece)
 		if piece == "" {
 			continue
 		}

--- a/pkg/database/membership.go
+++ b/pkg/database/membership.go
@@ -35,8 +35,9 @@ type Membership struct {
 	// DefaultSMSTemplateLabel is the label of realm.SMSTextAlternateTemplates or "Default SMS template"
 	// that the user last used to issue codes. This helps the UI remember the default user preference.
 	// Note: This label may not exist if it has been deleted or modified on the realm.
-	DefaultSMSTemplateLabel string `gorm:"type:varchar(255);"`
+	DefaultSMSTemplateLabel string
 
+	// Permissions are the compiled RBAC permissions the user has on the realm.
 	Permissions rbac.Permission
 
 	// CreatedAt is when the user was added to the realm. UpdatedAt is when the

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2521,6 +2521,32 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				)
 			},
 		},
+		{
+			ID: "00119-MembershipsSMSLabelText",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE memberships ALTER COLUMN default_sms_template_label TYPE TEXT`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE memberships ALTER COLUMN default_sms_template_label TYPE VARCHAR(255)`,
+				)
+			},
+		},
+		{
+			ID: "00120-AddRealmContacts",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS contact_email_addresses TEXT[] NOT NULL DEFAULT '{}'`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS contact_email_addresses`,
+				)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -420,6 +420,20 @@ func TestRealm_BeforeSave(t *testing.T) {
 			},
 			Error: "userReportWebhookSecret must be at least 12 characters",
 		},
+		{
+			Name: "contact_email_addresses_too_long",
+			Input: &Realm{
+				ContactEmailAddresses: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"},
+			},
+			Error: "contactEmailAddresses must have less than 10 entries",
+		},
+		{
+			Name: "contact_email_addresses_invalid",
+			Input: &Realm{
+				ContactEmailAddresses: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n", "o", "p"},
+			},
+			Error: "contactEmailAddresses includes invalid email address \"a\"",
+		},
 	}
 
 	for _, tc := range cases {

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -946,6 +946,66 @@ func TestRealm_ListMemberships(t *testing.T) {
 	}
 }
 
+func TestRealm_RecentSMSErrorsCount(t *testing.T) {
+	t.Parallel()
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+
+	realm, err := db.FindRealm(1)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	otherRealm := NewRealmWithDefaults("other")
+	if err := db.SaveRealm(otherRealm, SystemTest); err != nil {
+		t.Fatal(err)
+	}
+
+	// Initial value should be 0
+	{
+		qty, err := realm.RecentSMSErrorsCount(db, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := qty, int64(0); got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+	}
+
+	// Create some errors
+	for i := 0; i < 5; i++ {
+		code := fmt.Sprintf("3000%d", i)
+		if err := db.InsertSMSErrorStat(realm.ID, code); err != nil {
+			t.Fatal(err)
+		}
+		if err := db.InsertSMSErrorStat(otherRealm.ID, code); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	// Now there should be 5
+	{
+		qty, err := realm.RecentSMSErrorsCount(db, nil)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := qty, int64(5); got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+	}
+
+	// There's 3 if we exclude 2 codes
+	{
+		qty, err := realm.RecentSMSErrorsCount(db, []string{"30000", "30003"})
+		if err != nil {
+			t.Fatal(err)
+		}
+		if got, want := qty, int64(3); got != want {
+			t.Errorf("expected %d to be %d", got, want)
+		}
+	}
+}
+
 func TestRealm_SMSConfig(t *testing.T) {
 	t.Parallel()
 

--- a/pkg/render/email.go
+++ b/pkg/render/email.go
@@ -17,8 +17,6 @@ package render
 import (
 	"bytes"
 	"fmt"
-
-	"github.com/microcosm-cc/bluemonday"
 )
 
 // RenderEmail renders the given email HTML template by name. It attempts to
@@ -44,5 +42,5 @@ func (r *Renderer) RenderEmail(tmpl string, data interface{}) ([]byte, error) {
 	if err := r.executeTextTemplate(b, tmpl, data); err != nil {
 		return nil, fmt.Errorf("error executing email template: %w", err)
 	}
-	return bluemonday.UGCPolicy().SanitizeBytes(b.Bytes()), nil
+	return b.Bytes(), nil
 }

--- a/pkg/render/renderer.go
+++ b/pkg/render/renderer.go
@@ -110,7 +110,7 @@ func (r *Renderer) executeHTMLTemplate(w io.Writer, name string, data interface{
 	defer r.templatesLock.RUnlock()
 
 	if r.templates == nil {
-		return fmt.Errorf("no templates are defined")
+		return fmt.Errorf("no html templates are defined")
 	}
 
 	return r.templates.ExecuteTemplate(w, name, data)
@@ -121,8 +121,8 @@ func (r *Renderer) executeTextTemplate(w io.Writer, name string, data interface{
 	r.templatesLock.RLock()
 	defer r.templatesLock.RUnlock()
 
-	if r.templates == nil {
-		return fmt.Errorf("no templates are defined")
+	if r.textTemplates == nil {
+		return fmt.Errorf("no text templates are defined")
 	}
 
 	return r.textTemplates.ExecuteTemplate(w, name, data)
@@ -406,7 +406,16 @@ func pwdSentinel() string {
 
 func (r *Renderer) textFuncs() texttemplate.FuncMap {
 	return map[string]interface{}{
-		"trimSpace": project.TrimSpace,
+		"joinStrings":    joinStrings,
+		"toSentence":     toSentence,
+		"trimSpace":      project.TrimSpace,
+		"stringContains": strings.Contains,
+		"toLower":        strings.ToLower,
+		"toUpper":        strings.ToUpper,
+		"toJSON":         json.Marshal,
+		"humanizeTime":   humanizeTime,
+		"toBase64":       base64.StdEncoding.EncodeToString,
+		"toPercent":      toPercent,
 	}
 }
 

--- a/terraform/alerting/variables.tf
+++ b/terraform/alerting/variables.tf
@@ -102,13 +102,6 @@ variable "forward_progress_indicators" {
   default     = {}
 }
 
-variable "ignored_twilio_error_codes" {
-  type = list(string)
-
-  description = "List of error codes to exclude from the alerting condition."
-  default     = []
-}
-
 terraform {
   required_version = "~> 1.0"
 

--- a/terraform/dos.tf
+++ b/terraform/dos.tf
@@ -124,4 +124,8 @@ resource "google_compute_security_policy" "cloud-armor" {
     preview  = false
     priority = 2147483647
   }
+
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"],
+  ]
 }

--- a/terraform/network.tf
+++ b/terraform/network.tf
@@ -1,0 +1,55 @@
+# Copyright 2021 the Exposure Notifications Verification Server authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_compute_address" "serverless-vpc-addresses" {
+  count = var.num_serverless_egress_ips
+
+  project = var.project
+
+  name   = "serverless-vpc-addresses-${count.index}"
+  region = var.region
+
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"],
+  ]
+}
+
+resource "google_compute_router" "serverless-vpc-router" {
+  project = var.project
+
+  name    = "serverless-vpc-router"
+  region  = var.region
+  network = "default"
+
+  depends_on = [
+    google_project_service.services["compute.googleapis.com"],
+  ]
+}
+
+resource "google_compute_router_nat" "serverless-vpc-nat" {
+  project = var.project
+
+  name   = "serverless-vpc-nat-nat"
+  region = var.region
+  router = google_compute_router.serverless-vpc-router.name
+
+  nat_ip_allocate_option = "MANUAL_ONLY"
+  nat_ips                = google_compute_address.serverless-vpc-addresses.*.self_link
+
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+}
+
+output "serverless_ips" {
+  value = google_compute_address.serverless-vpc-addresses.*.address
+}

--- a/terraform/service_admin_apiserver.tf
+++ b/terraform/service_admin_apiserver.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-adminapi" {
   service_account_id = google_service_account.adminapi.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "adminapi-observability" {
@@ -91,6 +95,7 @@ resource "google_cloud_run_service" "adminapi" {
           for_each = merge(
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.gcp_config,
             local.rate_limit_config,
             local.issue_config,

--- a/terraform/service_apiserver.tf
+++ b/terraform/service_apiserver.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-apiserver" {
   service_account_id = google_service_account.apiserver.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "apiserver-observability" {
@@ -90,6 +94,7 @@ resource "google_cloud_run_service" "apiserver" {
           for_each = merge(
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.firebase_config,
             local.gcp_config,
             local.issue_config,

--- a/terraform/service_appsync.tf
+++ b/terraform/service_appsync.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-appsync" {
   service_account_id = google_service_account.appsync.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "appsync-observability" {
@@ -86,6 +90,7 @@ resource "google_cloud_run_service" "appsync" {
             local.appsync_config,
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.firebase_config,
             local.gcp_config,
             local.signing_config,

--- a/terraform/service_backup.tf
+++ b/terraform/service_backup.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-backup" {
   service_account_id = google_service_account.backup.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "backup-observability" {
@@ -88,6 +92,7 @@ resource "google_cloud_run_service" "backup" {
             local.gcp_config,
             local.backup_config,
             local.database_config,
+            local.feature_config,
 
             // This MUST come last to allow overrides!
             lookup(var.service_environment, "_all", {}),

--- a/terraform/service_cleanup.tf
+++ b/terraform/service_cleanup.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-cleanup" {
   service_account_id = google_service_account.cleanup.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "cleanup-observability" {
@@ -97,6 +101,7 @@ resource "google_cloud_run_service" "cleanup" {
           for_each = merge(
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.firebase_config,
             local.gcp_config,
             local.signing_config,

--- a/terraform/service_e2e_runner.tf
+++ b/terraform/service_e2e_runner.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-e2e-runner" {
   service_account_id = google_service_account.e2e-runner.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "e2e-runner-observability" {
@@ -85,6 +89,7 @@ resource "google_cloud_run_service" "e2e-runner" {
           for_each = merge(
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.firebase_config,
             local.gcp_config,
             local.signing_config,

--- a/terraform/service_emailer.tf
+++ b/terraform/service_emailer.tf
@@ -1,0 +1,219 @@
+# Copyright 2022 the Exposure Notifications Verification Server authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+resource "google_service_account" "emailer" {
+  project      = var.project
+  account_id   = "en-verification-emailer-sa"
+  display_name = "Verification emailer"
+}
+
+resource "google_service_account_iam_member" "cloudbuild-deploy-emailer" {
+  service_account_id = google_service_account.emailer.id
+  role               = "roles/iam.serviceAccountUser"
+  member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
+}
+
+resource "google_project_iam_member" "emailer-observability" {
+  for_each = local.observability_iam_roles
+  project  = var.project
+  role     = each.key
+  member   = "serviceAccount:${google_service_account.emailer.email}"
+}
+
+locals {
+  emailer_secrets = flatten([
+    local.database_secrets,
+    local.redis_secrets,
+  ])
+}
+
+resource "google_secret_manager_secret_iam_member" "emailer-secrets-accessor" {
+  count     = length(local.emailer_secrets)
+  secret_id = element(local.emailer_secrets, count.index)
+  role      = "roles/secretmanager.secretAccessor"
+  member    = "serviceAccount:${google_service_account.emailer.email}"
+}
+
+resource "google_cloud_run_service" "emailer" {
+  name     = "emailer"
+  location = var.region
+
+  autogenerate_revision_name = true
+
+  metadata {
+    annotations = merge(
+      local.default_service_annotations,
+      var.default_service_annotations_overrides,
+      lookup(var.service_annotations, "emailer", {})
+    )
+  }
+
+  template {
+    spec {
+      service_account_name = google_service_account.emailer.email
+      timeout_seconds      = 900
+
+      containers {
+        image = "gcr.io/${var.project}/github.com/google/exposure-notifications-verification-server/emailer:initial"
+
+        resources {
+          limits = {
+            cpu    = "1"
+            memory = "512Mi"
+          }
+        }
+
+
+        dynamic "env" {
+          for_each = merge(
+            local.database_config,
+            local.gcp_config,
+            local.emailer_config,
+            local.feature_config,
+            local.observability_config,
+
+            // This MUST come last to allow overrides!
+            lookup(var.service_environment, "_all", {}),
+            lookup(var.service_environment, "emailer", {}),
+          )
+
+          content {
+            name  = env.key
+            value = env.value
+          }
+        }
+      }
+    }
+
+    metadata {
+      annotations = merge(
+        local.default_revision_annotations,
+        var.default_revision_annotations_overrides,
+        // Force all traffic to go through the specific egress IPs, which is
+        // required for email authentication.
+        {
+          "run.googleapis.com/vpc-access-connector" : google_vpc_access_connector.connector.self_link,
+          "run.googleapis.com/vpc-access-egress" : "all-traffic",
+        },
+        lookup(var.revision_annotations, "emailer", {})
+      )
+    }
+  }
+
+  depends_on = [
+    google_project_service.services["run.googleapis.com"],
+
+    google_project_iam_member.emailer-observability,
+    google_secret_manager_secret_iam_member.emailer-secrets-accessor,
+
+    null_resource.build,
+    null_resource.migrate,
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      metadata[0].annotations["client.knative.dev/user-image"],
+      metadata[0].annotations["run.googleapis.com/client-name"],
+      metadata[0].annotations["run.googleapis.com/client-version"],
+      metadata[0].annotations["run.googleapis.com/ingress-status"],
+      metadata[0].annotations["serving.knative.dev/creator"],
+      metadata[0].annotations["serving.knative.dev/lastModifier"],
+      metadata[0].labels["cloud.googleapis.com/location"],
+      template[0].metadata[0].annotations["client.knative.dev/user-image"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-name"],
+      template[0].metadata[0].annotations["run.googleapis.com/client-version"],
+      template[0].metadata[0].annotations["serving.knative.dev/creator"],
+      template[0].metadata[0].annotations["serving.knative.dev/lastModifier"],
+      template[0].spec[0].containers[0].image,
+    ]
+  }
+}
+
+resource "google_service_account" "emailer-invoker" {
+  project      = data.google_project.project.project_id
+  account_id   = "en-emailer-invoker-sa"
+  display_name = "Verification emailer invoker"
+}
+
+resource "google_cloud_run_service_iam_member" "emailer-invoker" {
+  project  = google_cloud_run_service.emailer.project
+  location = google_cloud_run_service.emailer.location
+  service  = google_cloud_run_service.emailer.name
+  role     = "roles/run.invoker"
+  member   = "serviceAccount:${google_service_account.emailer-invoker.email}"
+}
+
+resource "google_cloud_scheduler_job" "emailer-anomalies" {
+  count = var.enable_emailer ? 1 : 0
+
+  name             = "emailer-anomalies"
+  region           = var.cloudscheduler_location
+  schedule         = "0 18 * * *"
+  time_zone        = var.cloud_scheduler_timezone
+  attempt_deadline = "${google_cloud_run_service.emailer.template[0].spec[0].timeout_seconds + 60}s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.emailer.status.0.url}/anomalies"
+    oidc_token {
+      audience              = google_cloud_run_service.emailer.status.0.url
+      service_account_email = google_service_account.emailer-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.emailer-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}
+
+resource "google_cloud_scheduler_job" "emailer-sms-errors" {
+  count = var.enable_emailer ? 1 : 0
+
+  name   = "emailer-sms-errors"
+  region = var.cloudscheduler_location
+
+  // This schedule is offset from the token emailer schedule.
+  schedule         = "5 */12 * * *"
+  time_zone        = var.cloud_scheduler_timezone
+  attempt_deadline = "${google_cloud_run_service.emailer.template[0].spec[0].timeout_seconds + 60}s"
+
+  retry_config {
+    retry_count = 1
+  }
+
+  http_target {
+    http_method = "GET"
+    uri         = "${google_cloud_run_service.emailer.status.0.url}/sms-errors"
+    oidc_token {
+      audience              = google_cloud_run_service.emailer.status.0.url
+      service_account_email = google_service_account.emailer-invoker.email
+    }
+  }
+
+  depends_on = [
+    google_app_engine_application.app,
+    google_cloud_run_service_iam_member.emailer-invoker,
+    google_project_service.services["cloudscheduler.googleapis.com"],
+  ]
+}

--- a/terraform/service_emailer.tf
+++ b/terraform/service_emailer.tf
@@ -193,7 +193,6 @@ resource "google_cloud_scheduler_job" "emailer-sms-errors" {
   name   = "emailer-sms-errors"
   region = var.cloudscheduler_location
 
-  // This schedule is offset from the token emailer schedule.
   schedule         = "5 */12 * * *"
   time_zone        = var.cloud_scheduler_timezone
   attempt_deadline = "${google_cloud_run_service.emailer.template[0].spec[0].timeout_seconds + 60}s"

--- a/terraform/service_metrics_registrar.tf
+++ b/terraform/service_metrics_registrar.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-metrics-registra
   service_account_id = google_service_account.metrics-registrar.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "metrics-registrar-observability" {
@@ -62,6 +66,7 @@ resource "google_cloud_run_service" "metrics-registrar" {
 
         dynamic "env" {
           for_each = merge(
+            local.feature_config,
             local.gcp_config,
             local.observability_config,
             local.metrics_registrar_config,

--- a/terraform/service_modeler.tf
+++ b/terraform/service_modeler.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-modeler" {
   service_account_id = google_service_account.modeler.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "modeler-observability" {
@@ -85,6 +89,7 @@ resource "google_cloud_run_service" "modeler" {
             local.anomaly_config,
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.gcp_config,
             local.rate_limit_config,
             local.observability_config,

--- a/terraform/service_redirect.tf
+++ b/terraform/service_redirect.tf
@@ -23,6 +23,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-enx-redirect" {
   service_account_id = google_service_account.enx-redirect.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "enx-redirect-observability" {
@@ -99,6 +103,7 @@ resource "google_cloud_run_service" "enx-redirect" {
             local.enx_redirect_config,
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.observability_config,
             local.rate_limit_config,
             local.signing_config,

--- a/terraform/service_rotation.tf
+++ b/terraform/service_rotation.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-rotation" {
   service_account_id = google_service_account.rotation.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "rotation-observability" {
@@ -108,6 +112,7 @@ resource "google_cloud_run_service" "rotation" {
           for_each = merge(
             local.database_config,
             local.gcp_config,
+            local.feature_config,
             local.rotation_config,
             local.signing_config,
             local.observability_config,

--- a/terraform/service_server.tf
+++ b/terraform/service_server.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-server" {
   service_account_id = google_service_account.server.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "server-observability" {
@@ -104,6 +108,7 @@ resource "google_cloud_run_service" "server" {
             local.anomaly_config,
             local.cache_config,
             local.database_config,
+            local.feature_config,
             local.firebase_config,
             local.gcp_config,
             local.rate_limit_config,

--- a/terraform/service_stats_puller.tf
+++ b/terraform/service_stats_puller.tf
@@ -22,6 +22,10 @@ resource "google_service_account_iam_member" "cloudbuild-deploy-stats-puller" {
   service_account_id = google_service_account.stats-puller.id
   role               = "roles/iam.serviceAccountUser"
   member             = "serviceAccount:${local.cloudbuild_email}"
+
+  depends_on = [
+    google_project_service.services["cloudbuild.googleapis.com"],
+  ]
 }
 
 resource "google_project_iam_member" "stats-puller-observability" {
@@ -90,6 +94,7 @@ resource "google_cloud_run_service" "stats-puller" {
         dynamic "env" {
           for_each = merge(
             local.database_config,
+            local.feature_config,
             local.gcp_config,
             local.signing_config,
             local.observability_config,

--- a/terraform/services.tf
+++ b/terraform/services.tf
@@ -59,6 +59,12 @@ locals {
     DB_USER        = google_sql_user.user.name
   }
 
+  emailer_config = {
+    SERVER_ENDPOINT = trimsuffix(local.enable_lb ? "https://${var.server_hosts[0]}" : google_cloud_run_service.server.status.0.url, "/")
+    FROM_ADDRESS    = var.emailer_from_address
+    MAIL_DOMAIN     = var.emailer_mail_domain
+  }
+
   firebase_config = {
     FIREBASE_API_KEY           = data.google_firebase_web_app_config.default.api_key
     FIREBASE_APP_ID            = google_firebase_web_app.default.app_id
@@ -105,6 +111,10 @@ locals {
     VERIFICATION_ADMIN_API  = local.enable_lb ? "https://${var.adminapi_hosts[0]}" : google_cloud_run_service.adminapi.status.0.url
     VERIFICATION_SERVER_API = local.enable_lb ? "https://${var.apiserver_hosts[0]}" : google_cloud_run_service.apiserver.status.0.url
     E2E_SKIP_SMS            = var.e2e_skip_sms
+  }
+
+  feature_config = {
+    ENABLE_EMAILER = var.enable_emailer
   }
 
   issue_config = {

--- a/terraform/variables.tf
+++ b/terraform/variables.tf
@@ -354,6 +354,34 @@ variable "e2e_skip_sms" {
   description = "Skip SMS tests when executing the e2e runner. Set this to true to not send SMS. You must also configure the e2e realm with proper test credentials."
 }
 
+variable "enable_emailer" {
+  type    = bool
+  default = false
+
+  description = "Enable the email sending service."
+}
+
+variable "emailer_from_address" {
+  type    = string
+  default = ""
+
+  description = "Email address from which the emailer will send emails. This must be a domain in your Google Workspace account and you must follow the instructions for configuring the Google Workspace SMTP relay."
+}
+
+variable "emailer_mail_domain" {
+  type    = string
+  default = ""
+
+  description = "Domain against which to authenticate to send email. This should be your Google Workspace root domain (no https://)."
+}
+
+variable "num_serverless_egress_ips" {
+  type    = number
+  default = 2
+
+  description = "Number of serverless egress IP addresses to create."
+}
+
 terraform {
   required_version = "~> 1.0"
 


### PR DESCRIPTION
- [x] Add alerts for email failures
- [x] Add to realm admin guide
- [x] Figure out if we actually want this to be a property on individual memberships instead of a realm property
- [x] Tests

**Release Note**

```release-note
Add functionality for sending alert emails to realm contacts for SMS and code anomalies. This removes the server operator from the loop in alerting realms of potential issues with SMS error rates or code claim ratios. However, this does require configuration and setup. For detailed setup instructions, see https://github.com/google/exposure-notifications-verification-server/blob/main/docs/production.md#setup-system-emails.
```