### PR TITLE
allow user report to use different SMS queue

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -73,7 +73,21 @@
           reduce the chance that your message will be flagged as spam.
         </small>
       </div>
+
+      {{if $realm.AllowsUserReport}}
+      <div class="form-floating mb-3">
+        <input type="tel" name="twilio_user_report_from_number" id="twilio-user-report-from-number" class="form-control font-monospace {{invalidIf ($smsConfig.ErrorsFor "twilioUserReportFromNumber")}}"
+          placeholder="Twilio user report number" value="{{$smsConfig.TwilioUserReportFromNumber}}">
+        <label for="twilio-user-report-from-number">Twilio user report number</label>
+        {{template "errorable" $smsConfig.ErrorsFor "twilioUserReportFromNumber"}}
+        <small class="form-text text-muted">
+          This is the Twilio From Number only for <strong>User Report</strong>. If present, user report codes will be
+          sent on a different queue from regular and bulk issue codes.
+        </small>
+      </div>
+      {{end}}
     </div>
+
 
     <div class="sms-system-form collapse{{if $realm.UseSystemSMSConfig}} show{{end}}">
       <div class="form-floating mb-3">

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -82,7 +82,8 @@
         {{template "errorable" $smsConfig.ErrorsFor "twilioUserReportFromNumber"}}
         <small class="form-text text-muted">
           This is the Twilio From Number only for <strong>User Report</strong>. If present, user report codes will be
-          sent on a different queue from regular and bulk issue codes.
+          sent on a different queue from regular and bulk issue codes. If unspecified, user report will use the same
+          queue and phone number as regular and bulk issue codes.
         </small>
       </div>
       {{end}}

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -191,6 +191,9 @@ func (c *Controller) recordStats(ctx context.Context, results []*IssueResult) {
 func (c *Controller) smsProviderFor(ctx context.Context, realm *database.Realm, opts ...database.SMSProviderOption) (sms.Provider, error) {
 	appendKey := ""
 	for _, o := range opts {
+		if o == nil {
+			continue
+		}
 		appendKey = fmt.Sprintf("%s:%s", appendKey, o.Name())
 	}
 

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -189,12 +189,12 @@ func (c *Controller) recordStats(ctx context.Context, results []*IssueResult) {
 // smsProviderFor returns the sms provider for the given realm. It pulls the
 // value from a local in-memory cache.
 func (c *Controller) smsProviderFor(ctx context.Context, realm *database.Realm, opts ...database.SMSProviderOption) (sms.Provider, error) {
-	append := ""
+	appendKey := ""
 	for _, o := range opts {
-		append = fmt.Sprintf("%s:%s", append, o.Name())
+		appendKey = fmt.Sprintf("%s:%s", appendKey, o.Name())
 	}
 
-	key := fmt.Sprintf("realm:%d:sms_provider:user_report:%v", realm.ID, append)
+	key := fmt.Sprintf("realm:%d:sms_provider:user_report:%v", realm.ID, appendKey)
 	result, err := c.localCache.WriteThruLookup(key, func() (interface{}, error) {
 		return realm.SMSProvider(c.db, opts...)
 	})

--- a/pkg/controller/issueapi/send_sms_test.go
+++ b/pkg/controller/issueapi/send_sms_test.go
@@ -111,7 +111,7 @@ func TestSMS_sendSMS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	smsProvider, err := realm.SMSProvider(harness.Database, false)
+	smsProvider, err := realm.SMSProvider(harness.Database)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestSMS_sendSMS_integration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	smsProvider, err := realm.SMSProvider(harness.Database, false)
+	smsProvider, err := realm.SMSProvider(harness.Database)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/issueapi/send_sms_test.go
+++ b/pkg/controller/issueapi/send_sms_test.go
@@ -111,7 +111,7 @@ func TestSMS_sendSMS(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	smsProvider, err := realm.SMSProvider(harness.Database)
+	smsProvider, err := realm.SMSProvider(harness.Database, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -259,7 +259,7 @@ func TestSMS_sendSMS_integration(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	smsProvider, err := realm.SMSProvider(harness.Database)
+	smsProvider, err := realm.SMSProvider(harness.Database, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -109,7 +109,7 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, internalRequest 
 	var smsProvider sms.Provider
 	if !request.OnlyGenerateSMS && request.Phone != "" {
 		var err error
-		smsProvider, err = realm.SMSProvider(c.db)
+		smsProvider, err = realm.SMSProvider(c.db, vCode.IsUserReport())
 		if err != nil {
 			logger.Errorw("failed to get sms provider", "error", err)
 			return nil, &IssueResult{

--- a/pkg/controller/issueapi/validate_code.go
+++ b/pkg/controller/issueapi/validate_code.go
@@ -109,7 +109,12 @@ func (c *Controller) BuildVerificationCode(ctx context.Context, internalRequest 
 	var smsProvider sms.Provider
 	if !request.OnlyGenerateSMS && request.Phone != "" {
 		var err error
-		smsProvider, err = realm.SMSProvider(c.db, vCode.IsUserReport())
+
+		opts := make([]database.SMSProviderOption, 0)
+		if vCode.IsUserReport() {
+			opts = append(opts, &database.SMSProviderUserReport{})
+		}
+		smsProvider, err = realm.SMSProvider(c.db, opts...)
 		if err != nil {
 			logger.Errorw("failed to get sms provider", "error", err)
 			return nil, &IssueResult{

--- a/pkg/controller/realmadmin/settings_modify.go
+++ b/pkg/controller/realmadmin/settings_modify.go
@@ -77,16 +77,17 @@ type formData struct {
 	LongCodeLength          uint              `form:"long_code_length"`
 	LongCodeDurationHours   int64             `form:"long_code_duration"`
 
-	SMS                       bool               `form:"sms"`
-	UseSystemSMSConfig        bool               `form:"use_system_sms_config"`
-	SMSCountry                string             `form:"sms_country"`
-	SMSFromNumberID           uint               `form:"sms_from_number_id"`
-	TwilioAccountSid          string             `form:"twilio_account_sid"`
-	TwilioAuthToken           string             `form:"twilio_auth_token"`
-	TwilioFromNumber          string             `form:"twilio_from_number"`
-	SMSTextTemplate           string             `form:"-"`
-	SMSTextAlternateTemplates map[string]*string `form:"-"`
-	SMSTextUserReportAppend   string             `form:"sms_text_user_report_append"`
+	SMS                        bool               `form:"sms"`
+	UseSystemSMSConfig         bool               `form:"use_system_sms_config"`
+	SMSCountry                 string             `form:"sms_country"`
+	SMSFromNumberID            uint               `form:"sms_from_number_id"`
+	TwilioAccountSid           string             `form:"twilio_account_sid"`
+	TwilioAuthToken            string             `form:"twilio_auth_token"`
+	TwilioFromNumber           string             `form:"twilio_from_number"`
+	TwilioUserReportFromNumber string             `form:"twilio_user_report_from_number"`
+	SMSTextTemplate            string             `form:"-"`
+	SMSTextAlternateTemplates  map[string]*string `form:"-"`
+	SMSTextUserReportAppend    string             `form:"sms_text_user_report_append"`
 
 	Email                      bool   `form:"email"`
 	UseSystemEmailConfig       bool   `form:"use_system_email_config"`
@@ -374,15 +375,17 @@ func (c *Controller) HandleSettings() http.Handler {
 					smsConfig.TwilioAuthToken = form.TwilioAuthToken
 				}
 				smsConfig.TwilioFromNumber = form.TwilioFromNumber
+				smsConfig.TwilioUserReportFromNumber = form.TwilioUserReportFromNumber
 			} else {
 				// There's no record or the existing record was the system config so we
 				// want to create our own.
 				smsConfig = &database.SMSConfig{
-					RealmID:          currentRealm.ID,
-					ProviderType:     sms.ProviderTypeTwilio,
-					TwilioAccountSid: form.TwilioAccountSid,
-					TwilioAuthToken:  form.TwilioAuthToken,
-					TwilioFromNumber: form.TwilioFromNumber,
+					RealmID:                    currentRealm.ID,
+					ProviderType:               sms.ProviderTypeTwilio,
+					TwilioAccountSid:           form.TwilioAccountSid,
+					TwilioAuthToken:            form.TwilioAuthToken,
+					TwilioFromNumber:           form.TwilioFromNumber,
+					TwilioUserReportFromNumber: form.TwilioUserReportFromNumber,
 				}
 			}
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2547,6 +2547,19 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				)
 			},
 		},
+		{
+			ID: "00121-UserReportFromNumber",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE sms_configs ADD COLUMN IF NOT EXISTS twilio_user_report_from_number VARCHAR(255) NOT NULL DEFAULT ''`,
+				)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE sms_configs DROP COLUMN IF EXISTS twilio_user_report_from_number`,
+				)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -901,7 +901,7 @@ func (r *Realm) HasSMSConfig(db *Database) (bool, error) {
 // SMSProvider returns the SMS provider for the realm. If no sms configuration
 // exists, it returns nil. If any errors occur creating the provider, they are
 // returned.
-func (r *Realm) SMSProvider(db *Database) (sms.Provider, error) {
+func (r *Realm) SMSProvider(db *Database, userReport bool) (sms.Provider, error) {
 	smsConfig, err := r.SMSConfig(db)
 	if err != nil {
 		if IsNotFound(err) {
@@ -910,12 +910,17 @@ func (r *Realm) SMSProvider(db *Database) (sms.Provider, error) {
 		return nil, err
 	}
 
+	fromNumber := smsConfig.TwilioFromNumber
+	if userReport && smsConfig.TwilioUserReportFromNumber != "" {
+		fromNumber = smsConfig.TwilioUserReportFromNumber
+	}
+
 	ctx := context.Background()
 	provider, err := sms.ProviderFor(ctx, &sms.Config{
 		ProviderType:     smsConfig.ProviderType,
 		TwilioAccountSid: smsConfig.TwilioAccountSid,
 		TwilioAuthToken:  smsConfig.TwilioAuthToken,
-		TwilioFromNumber: smsConfig.TwilioFromNumber,
+		TwilioFromNumber: fromNumber,
 	})
 	if err != nil {
 		return nil, err

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -898,13 +898,16 @@ func (r *Realm) HasSMSConfig(db *Database) (bool, error) {
 	return len(id) > 0, nil
 }
 
+// SMSProviderOption specifies options that can be used when
+// requesting SMS providers.
 type SMSProviderOption interface {
 	Apply(smsConfig *SMSConfig, modify *sms.Config)
 	Name() string
 }
 
-type SMSProviderUserReport struct {
-}
+// SMSProviderUSerReport is an SMSProviderOption that will utilize a separate
+// from number for user-report if one exists.
+type SMSProviderUserReport struct{}
 
 func (s *SMSProviderUserReport) Apply(smsConfig *SMSConfig, modify *sms.Config) {
 	if smsConfig.TwilioUserReportFromNumber != "" {
@@ -937,6 +940,9 @@ func (r *Realm) SMSProvider(db *Database, opts ...SMSProviderOption) (sms.Provid
 
 	// Resolve options. Last writer wins
 	for _, o := range opts {
+		if o == nil {
+			continue
+		}
 		o.Apply(smsConfig, config)
 	}
 

--- a/pkg/database/sms_config_test.go
+++ b/pkg/database/sms_config_test.go
@@ -221,7 +221,7 @@ func TestSMSProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := realm.SMSProvider(db, false)
+	provider, err := realm.SMSProvider(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -241,7 +241,7 @@ func TestSMSProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err = realm.SMSProvider(db, false)
+	provider, err = realm.SMSProvider(db)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -249,7 +249,7 @@ func TestSMSProvider(t *testing.T) {
 		t.Errorf("expected %v to be not nil", provider)
 	}
 
-	urProvider, err := realm.SMSProvider(db, true)
+	urProvider, err := realm.SMSProvider(db, &SMSProviderUserReport{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/database/sms_config_test.go
+++ b/pkg/database/sms_config_test.go
@@ -221,7 +221,7 @@ func TestSMSProvider(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	provider, err := realm.SMSProvider(db)
+	provider, err := realm.SMSProvider(db, false)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -230,22 +230,31 @@ func TestSMSProvider(t *testing.T) {
 	}
 
 	smsConfig := &SMSConfig{
-		RealmID:          realm.ID,
-		ProviderType:     sms.ProviderType("TWILIO"),
-		TwilioAccountSid: "abc123",
-		TwilioAuthToken:  "my-secret-ref",
-		TwilioFromNumber: "+11234567890",
+		RealmID:                    realm.ID,
+		ProviderType:               sms.ProviderType("TWILIO"),
+		TwilioAccountSid:           "abc123",
+		TwilioAuthToken:            "my-secret-ref",
+		TwilioFromNumber:           "+11234567890",
+		TwilioUserReportFromNumber: "+11234567891",
 	}
 	if err := db.SaveSMSConfig(smsConfig); err != nil {
 		t.Fatal(err)
 	}
 
-	provider, err = realm.SMSProvider(db)
+	provider, err = realm.SMSProvider(db, false)
 	if err != nil {
 		t.Fatal(err)
 	}
 	if provider == nil {
 		t.Errorf("expected %v to be not nil", provider)
+	}
+
+	urProvider, err := realm.SMSProvider(db, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if urProvider == nil {
+		t.Errorf("expected %v to be not nil", urProvider)
 	}
 }
 

--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -44,13 +44,17 @@ const (
 	CodeTypeLong
 )
 
+const (
+	userReportTestType = "user-report"
+)
+
 var (
 	// ValidTestTypes is a map containing the valid test types.
 	ValidTestTypes = map[string]struct{}{
-		"confirmed":   {},
-		"likely":      {},
-		"negative":    {},
-		"user-report": {},
+		"confirmed":        {},
+		"likely":           {},
+		"negative":         {},
+		userReportTestType: {},
 	}
 
 	ErrInvalidTestType     = errors.New("invalid test type, must be confirmed, likely, negative, or self_report")
@@ -135,6 +139,10 @@ func (v *VerificationCode) FormatSymptomDate() string {
 		return ""
 	}
 	return v.SymptomDate.Format(project.RFC3339Date)
+}
+
+func (v *VerificationCode) IsUserReport() bool {
+	return v.TestType == userReportTestType
 }
 
 // IsCodeExpired checks to see if the actual code provided is the short or long


### PR DESCRIPTION
## Proposed Changes

* Address queuing issues we've seen as case #s have risen
* Allow for user report to use a different phone number

**Release Note**

```release-note
Allow user report to utilize a different "from" number for SMS sending. This can help reduce queuing and self report codes being blocked by a large bulk issue in a jurisdiction.
```
