### PR TITLE
use common API constants instead of redefining

### DIFF
--- a/pkg/database/vercode.go
+++ b/pkg/database/vercode.go
@@ -44,17 +44,13 @@ const (
 	CodeTypeLong
 )
 
-const (
-	userReportTestType = "user-report"
-)
-
 var (
 	// ValidTestTypes is a map containing the valid test types.
 	ValidTestTypes = map[string]struct{}{
-		"confirmed":        {},
-		"likely":           {},
-		"negative":         {},
-		userReportTestType: {},
+		verifyapi.ReportTypeConfirmed:  {},
+		verifyapi.ReportTypeClinical:   {},
+		verifyapi.ReportTypeNegative:   {},
+		verifyapi.ReportTypeSelfReport: {},
 	}
 
 	ErrInvalidTestType     = errors.New("invalid test type, must be confirmed, likely, negative, or self_report")
@@ -142,7 +138,7 @@ func (v *VerificationCode) FormatSymptomDate() string {
 }
 
 func (v *VerificationCode) IsUserReport() bool {
-	return v.TestType == userReportTestType
+	return v.TestType == verifyapi.ReportTypeSelfReport
 }
 
 // IsCodeExpired checks to see if the actual code provided is the short or long


### PR DESCRIPTION
## Proposed Changes

* Use common constants from public API package instead of re-defining private versions.

**Release Note**

```release-note
NONE
```
