### PR TITLE
Add support for cc and bcc on system emails

### DIFF
--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -64,6 +64,10 @@
                   <span class="small bi bi-exclamation-triangle-fill text-warning"
                     data-bs-toggle="tooltip" title="The ratio between codes issued and codes claimed has deviated from the historical norm"></span>
                 {{end}}
+                {{if not .ContactEmailAddresses}}
+                  <span class="small bi bi-envelope-x-fill text-danger"
+                    data-bs-toggle="tooltip" title="There are no contact email addresses for this realm"></span>
+                {{end}}
               </td>
               <td class="text-center d-none d-md-table-cell">
                 {{if (index $realmChaffEvents .ID)}}

--- a/assets/server/email/anomalies.txt
+++ b/assets/server/email/anomalies.txt
@@ -6,6 +6,12 @@ Content-Type: text/html; charset="utf-8"
 Subject: Exposure Notifications code claim rate anomaly detected
 To: {{.ToEmail | trimSpace}}
 From: {{.FromEmail | trimSpace}}
+{{- if .CCEmail }}
+CC: {{.CCEmail | trimSpace}}
+{{- end }}
+{{- if .BCCEmail }}
+BCC: {{.BCCEmail | trimSpace}}
+{{- end }}
 
 <!DOCTYPE html>
 <html>

--- a/assets/server/email/sms_errors.txt
+++ b/assets/server/email/sms_errors.txt
@@ -6,6 +6,12 @@ Content-Type: text/html; charset="utf-8"
 Subject: Exposure Notifications SMS error rate exceeded
 To: {{.ToEmail | trimSpace}}
 From: {{.FromEmail | trimSpace}}
+{{- if .CCEmail }}
+CC: {{.CCEmail | trimSpace}}
+{{- end }}
+{{- if .BCCEmail }}
+BCC: {{.BCCEmail | trimSpace}}
+{{- end }}
 
 <!DOCTYPE html>
 <html>

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -22,8 +22,8 @@
 <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
   integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
 {{end}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.5.0/font/bootstrap-icons.css"
-  integrity="sha384-tKLJeE1ALTUwtXlaGjJYM3sejfssWdAaWR2s97axw4xkiAdMzQjtOjgcyw0Y50KU" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"
+  integrity="sha384-EvBWSlnoFgZlXJvpzS+MAUEjvN7+gcCwH+qh7GRFOGgZO0PuwOFro7qPOJnLfe7l" crossorigin="anonymous">
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/css/intlTelInput.min.css"
   integrity="sha384-+0L34NtZQE8CdqKYXA1psEH5gRnPhYm5Yrfl6+zHBC9rK+SuCkyS99e/a4wRIf3B" crossorigin="anonymous">
 {{ cssIncludeTag }}

--- a/docs/production.md
+++ b/docs/production.md
@@ -382,6 +382,21 @@ The verification server is capable of sending email through a Google Workspace S
     }
     ```
 
+1. Optionally CC or BCC your help desk or support staff on all outbound emails:
+
+    ```terraform
+      module "en" {
+      // ...
+
+      service_environment = {
+        emailer = {
+          EMAIL_CC  = "cc@example.com"
+          EMAIL_BCC = "bcc@example.com"
+        }
+      }
+    }
+    ```
+
 
 ## End-to-end (e2e) test runner
 

--- a/pkg/config/emailer_config.go
+++ b/pkg/config/emailer_config.go
@@ -56,6 +56,11 @@ type EmailerConfig struct {
 	// domain (no https:// or port).
 	MailDomain string `env:"MAIL_DOMAIN"`
 
+	// EmailCC and EmailBCC is the address to CC and BCC (respectively) on all
+	// emails.
+	EmailCC  string `env:"EMAIL_CC"`
+	EmailBCC string `env:"EMAIL_BCC"`
+
 	// ServerEndpoint is the URL to the main verification server component - the
 	// UI server. It should be the full URL with no trailing slash.
 	ServerEndpoint string `env:"SERVER_ENDPOINT"`

--- a/pkg/controller/emailer/handle_anomalies.go
+++ b/pkg/controller/emailer/handle_anomalies.go
@@ -81,8 +81,12 @@ func (c *Controller) sendAnomaliesEmails(ctx context.Context, realm *database.Re
 		With("realm_id", realm.ID)
 
 	if len(realm.ContactEmailAddresses) == 0 {
-		logger.Debugw("no contact email addresses registered, skipping")
-		return nil
+		logger.Warnw("no contact email addresses registered")
+
+		if len(c.config.EmailCC) == 0 && len(c.config.EmailBCC) == 0 {
+			logger.Warnw("no cc or bcc emails registered either, skipping")
+			return nil
+		}
 	}
 
 	if !realm.CodesClaimedRatioAnomalous() {
@@ -95,6 +99,8 @@ func (c *Controller) sendAnomaliesEmails(ctx context.Context, realm *database.Re
 		msg, err := c.h.RenderEmail("email/anomalies", map[string]interface{}{
 			"ToEmail":   addr,
 			"FromEmail": c.config.FromAddress,
+			"CCEmail":   c.config.EmailCC,
+			"BCCEmail":  c.config.EmailBCC,
 			"Realm":     realm,
 			"RootURL":   c.config.ServerEndpoint,
 		})

--- a/pkg/controller/emailer/handle_sms_errors_test.go
+++ b/pkg/controller/emailer/handle_sms_errors_test.go
@@ -64,7 +64,7 @@ func TestSendSMSErrorsEmails(t *testing.T) {
 			t.Fatal(err)
 		}
 
-		testExpectLog(t, logObserver, "no contact email addresses registered, skipping")
+		testExpectLog(t, logObserver, "no contact email addresses registered")
 	})
 
 	t.Run("no_errors", func(t *testing.T) {
@@ -112,18 +112,41 @@ func TestSendSMSErrorsEmails(t *testing.T) {
 
 		c := New(cfg, db, h)
 
-		msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
-			"ToEmail":   "to@example.com",
-			"FromEmail": "from@example.com",
-			"Realm":     realm,
-			"RootURL":   "http://example.com",
-		})
-		if err != nil {
-			t.Fatal(err)
-		}
+		t.Run("without_ccs", func(t *testing.T) {
+			t.Parallel()
 
-		if got, want := string(msg), "exceeds the typical value"; !strings.Contains(got, want) {
-			t.Errorf("expectd %q to be %q", got, want)
-		}
+			msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
+				"ToEmail":   "to@example.com",
+				"FromEmail": "from@example.com",
+				"Realm":     realm,
+				"RootURL":   "http://example.com",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := string(msg), "exceeds the typical value"; !strings.Contains(got, want) {
+				t.Errorf("expectd %q to contain %q", got, want)
+			}
+		})
+
+		t.Run("with_cc", func(t *testing.T) {
+			t.Parallel()
+
+			msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
+				"ToEmail":   "to@example.com",
+				"FromEmail": "from@example.com",
+				"CCEmail":   "cc@example.com",
+				"Realm":     realm,
+				"RootURL":   "http://example.com",
+			})
+			if err != nil {
+				t.Fatal(err)
+			}
+
+			if got, want := string(msg), "CC: cc@example.com"; !strings.Contains(got, want) {
+				t.Errorf("expectd %q to contain %q", got, want)
+			}
+		})
 	})
 }


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Add support for setting CC and BCC on all system-sent emails. To configure this, see the production guide for sending system emails.
```
