### PR TITLE
Handle bcc addresses correctly

### DIFF
--- a/assets/server/email/anomalies.txt
+++ b/assets/server/email/anomalies.txt
@@ -9,10 +9,7 @@ From: {{.FromAddress | trimSpace}}
 To: {{(joinStrings .ToAddresses ",") | trimSpace}}
 {{- end }}
 {{- if .CCAddresses }}
-CC: {{(joinStrings .CCAddresses ",") | trimSpace}}
-{{- end }}
-{{- if .BCCAddresses }}
-BCC: {{(joinStrings .BCCAddresses ",") | trimSpace}}
+Cc: {{(joinStrings .CCAddresses ",") | trimSpace}}
 {{- end }}
 
 <!DOCTYPE html>

--- a/assets/server/email/sms_errors.txt
+++ b/assets/server/email/sms_errors.txt
@@ -9,10 +9,7 @@ From: {{.FromAddress | trimSpace}}
 To: {{(joinStrings .ToAddresses ",") | trimSpace}}
 {{- end }}
 {{- if .CCAddresses }}
-CC: {{(joinStrings .CCAddresses ",") | trimSpace}}
-{{- end }}
-{{- if .BCCAddresses }}
-BCC: {{(joinStrings .BCCAddresses ",") | trimSpace}}
+Cc: {{(joinStrings .CCAddresses ",") | trimSpace}}
 {{- end }}
 
 <!DOCTYPE html>

--- a/pkg/controller/emailer/handle_anomalies.go
+++ b/pkg/controller/emailer/handle_anomalies.go
@@ -104,12 +104,11 @@ func (c *Controller) sendAnomaliesEmails(ctx context.Context, realm *database.Re
 	}
 
 	msg, err := c.h.RenderEmail("email/anomalies", map[string]interface{}{
-		"FromAddress":  from,
-		"ToAddresses":  tos,
-		"CCAddresses":  ccs,
-		"BCCAddresses": bccs,
-		"Realm":        realm,
-		"RootURL":      c.config.ServerEndpoint,
+		"FromAddress": from,
+		"ToAddresses": tos,
+		"CCAddresses": ccs,
+		"Realm":       realm,
+		"RootURL":     c.config.ServerEndpoint,
 	})
 	if err != nil {
 		return fmt.Errorf("failed to render template: %w", err)

--- a/pkg/controller/emailer/handle_anomalies_test.go
+++ b/pkg/controller/emailer/handle_anomalies_test.go
@@ -141,12 +141,11 @@ func TestSendAnomaliesEmail(t *testing.T) {
 			t.Parallel()
 
 			msg, err := c.h.RenderEmail("email/anomalies", map[string]interface{}{
-				"FromAddress":  "from@example.com",
-				"ToAddresses":  []string{"to1@example.com", "to2@example.com"},
-				"CCAddresses":  []string{"cc1@example.com", "cc2@example.com"},
-				"BCCAddresses": []string{"bcc1@example.com", "bcc2@example.com"},
-				"Realm":        realm,
-				"RootURL":      "https://example.com",
+				"FromAddress": "from@example.com",
+				"ToAddresses": []string{"to1@example.com", "to2@example.com"},
+				"CCAddresses": []string{"cc1@example.com", "cc2@example.com"},
+				"Realm":       realm,
+				"RootURL":     "https://example.com",
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -158,10 +157,7 @@ func TestSendAnomaliesEmail(t *testing.T) {
 			if got, want := string(msg), "To: to1@example.com,to2@example.com\n"; !strings.Contains(got, want) {
 				t.Errorf("expectd %q to contain %q", got, want)
 			}
-			if got, want := string(msg), "CC: cc1@example.com,cc2@example.com\n"; !strings.Contains(got, want) {
-				t.Errorf("expectd %q to contain %q", got, want)
-			}
-			if got, want := string(msg), "BCC: bcc1@example.com,bcc2@example.com\n"; !strings.Contains(got, want) {
+			if got, want := string(msg), "Cc: cc1@example.com,cc2@example.com\n"; !strings.Contains(got, want) {
 				t.Errorf("expectd %q to contain %q", got, want)
 			}
 		})

--- a/pkg/controller/emailer/handle_sms_errors.go
+++ b/pkg/controller/emailer/handle_sms_errors.go
@@ -113,7 +113,6 @@ func (c *Controller) sendSMSErrorsEmails(ctx context.Context, realm *database.Re
 		"FromAddress":  from,
 		"ToAddresses":  tos,
 		"CCAddresses":  ccs,
-		"BCCAddresses": bccs,
 		"Realm":        realm,
 		"RootURL":      c.config.ServerEndpoint,
 		"NumSMSErrors": count,

--- a/pkg/controller/emailer/handle_sms_errors_test.go
+++ b/pkg/controller/emailer/handle_sms_errors_test.go
@@ -140,12 +140,11 @@ func TestSendSMSErrorsEmails(t *testing.T) {
 			t.Parallel()
 
 			msg, err := c.h.RenderEmail("email/sms_errors", map[string]interface{}{
-				"FromAddress":  "from@example.com",
-				"ToAddresses":  []string{"to1@example.com", "to2@example.com"},
-				"CCAddresses":  []string{"cc1@example.com", "cc2@example.com"},
-				"BCCAddresses": []string{"bcc1@example.com", "bcc2@example.com"},
-				"Realm":        realm,
-				"RootURL":      "http://example.com",
+				"FromAddress": "from@example.com",
+				"ToAddresses": []string{"to1@example.com", "to2@example.com"},
+				"CCAddresses": []string{"cc1@example.com", "cc2@example.com"},
+				"Realm":       realm,
+				"RootURL":     "http://example.com",
 			})
 			if err != nil {
 				t.Fatal(err)
@@ -157,10 +156,7 @@ func TestSendSMSErrorsEmails(t *testing.T) {
 			if got, want := string(msg), "To: to1@example.com,to2@example.com\n"; !strings.Contains(got, want) {
 				t.Errorf("expectd %q to contain %q", got, want)
 			}
-			if got, want := string(msg), "CC: cc1@example.com,cc2@example.com\n"; !strings.Contains(got, want) {
-				t.Errorf("expectd %q to contain %q", got, want)
-			}
-			if got, want := string(msg), "BCC: bcc1@example.com,bcc2@example.com\n"; !strings.Contains(got, want) {
+			if got, want := string(msg), "Cc: cc1@example.com,cc2@example.com\n"; !strings.Contains(got, want) {
 				t.Errorf("expectd %q to contain %q", got, want)
 			}
 		})


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Fix an issue where BCCed addresses would incorrectly appear on the email envelope, defeating the purpose of BCC.
```
