### PR TITLE
add optional label for short code expr

### DIFF
--- a/assets/server/realmadmin/_form_codes.html
+++ b/assets/server/realmadmin/_form_codes.html
@@ -282,7 +282,7 @@
               short and let the long code be valid for a longer period (up to <code>24</code> hours).
             </small>
           {{end}}
-          <label for="code-duration">Short code expiration</label>
+          <label for="code-duration">Short code {{if $realm.AllowsUserReport}}and user report{{end}} expiration</label>
         </div>
       </div>
 


### PR DESCRIPTION
## Proposed Changes

<img width="1285" alt="image" src="https://user-images.githubusercontent.com/92319/152243941-e89fbb7d-4fdc-4dce-bbcc-cc400e9fa934.png">

**Release Note**

```release-note
realm admin label for short code expiration now includes user report (if enabled) for clarity
```
