### PR TITLE
Move API key session storage into a helper, add log statement

### DIFF
--- a/assets/server/apikeys/show.html
+++ b/assets/server/apikeys/show.html
@@ -34,7 +34,7 @@
               must securely save this API key elsewhere!</strong>
           </div>
 
-          <textarea id="apikey-value" class="form-control" rows="4" readonly>{{$apiKey}}</textarea>
+          <textarea id="apikey-value" class="form-control font-monospace" rows="4" readonly>{{$apiKey}}</textarea>
         </div>
       </div>
     {{end}}

--- a/pkg/controller/apikey/create.go
+++ b/pkg/controller/apikey/create.go
@@ -77,7 +77,7 @@ func (c *Controller) HandleCreate() http.Handler {
 
 		// Store the API key on the session temporarily so it can be displayed on
 		// the next page.
-		session.Values["apiKey"] = apiKey
+		controller.StoreSessionAPIKey(session, apiKey)
 
 		flash.Alert("Successfully created API Key for %q", authApp.Name)
 		http.Redirect(w, r, fmt.Sprintf("/realm/apikeys/%d", authApp.ID), http.StatusSeeOther)

--- a/pkg/controller/apikey/create_test.go
+++ b/pkg/controller/apikey/create_test.go
@@ -126,8 +126,8 @@ func TestHandleCreate(t *testing.T) {
 			t.Errorf("Expected %d to be %d", got, want)
 		}
 
-		apiKey, ok := session.Values["apiKey"].(string)
-		if !ok {
+		apiKey := controller.APIKeyFromSession(session)
+		if apiKey == "" {
 			t.Fatalf("expected apiKey in session: %#v", session.Values)
 		}
 

--- a/pkg/controller/session.go
+++ b/pkg/controller/session.go
@@ -30,6 +30,7 @@ const (
 	emailVerificationPrompted         = sessionKey("emailVerificationPrompted")
 	mfaPrompted                       = sessionKey("mfaPrompted")
 	passwordExpireWarned              = sessionKey("passwordExpireWarned")
+	sessionKeyAPIKey                  = sessionKey("apiKey")
 	sessionKeyCSRFToken               = sessionKey("csrfToken")
 	sessionKeyLastActivity            = sessionKey("lastActivity")
 	sessionKeyRealmID                 = sessionKey("realmID")
@@ -86,6 +87,35 @@ func RegionFromSession(session *sessions.Session) string {
 		return ""
 	}
 	return strVal
+}
+
+// StoreSessionAPIKey stores the API key on the session.
+func StoreSessionAPIKey(session *sessions.Session, apiKey string) {
+	if session == nil || len(apiKey) == 0 {
+		return
+	}
+	session.Values[sessionKeyAPIKey] = apiKey
+}
+
+// ClearSessionAPIKey clears the API key from the session.
+func ClearSessionAPIKey(session *sessions.Session) {
+	sessionClear(session, sessionKeyAPIKey)
+}
+
+// APIKeyFromSession extracts the API key from the session.
+func APIKeyFromSession(session *sessions.Session) string {
+	v := sessionGet(session, sessionKeyAPIKey)
+	if v == nil {
+		return ""
+	}
+
+	t, ok := v.(string)
+	if !ok {
+		delete(session.Values, sessionKeyAPIKey)
+		return ""
+	}
+
+	return t
 }
 
 // StoreSessionCSRFToken stores the CSRF token on the session.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Centralize logic on how API keys are injected into the session.
```
