### PR TITLE
Add realm level maintenance mode

### DIFF
--- a/assets/server/admin/realms/edit.html
+++ b/assets/server/admin/realms/edit.html
@@ -52,6 +52,38 @@
           </div>
 
           <div class="bg-light border rounded p-3 mb-3">
+            <h5 class="mb-3">Maintenance mode</h5>
+
+            <div class="row g-3">
+              <div class="col-lg">
+                <div class="form-check">
+                  <input type="radio" name="maintenance_mode" id="maintenance-mode-true" class="form-check-input"
+                    value="true" {{checkedIf $realm.MaintenanceMode}} />
+                  <label for="maintenance-mode-true" class="form-check-label">
+                    <div>Enabled</div>
+                    <div class="small text-muted">
+                      Stops this realm from issuing new codes.
+                    </div>
+                  </label>
+                </div>
+              </div>
+
+              <div class="col-lg">
+                <div class="form-check">
+                  <input type="radio" name="maintenance_mode" id="maintenance-mode-false" class="form-check-input"
+                    value="false" {{checkedIf (not $realm.MaintenanceMode)}} />
+                  <label for="allow-bulk-false" class="form-check-label">
+                    <div>Disabled</div>
+                    <div class="small text-muted">
+                      Normal operations.
+                    </div>
+                  </label>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div class="bg-light border rounded p-3 mb-3">
             <h5 class="mb-3">Verification code settings</h5>
 
             <div class="row g-3">

--- a/assets/server/admin/realms/index.html
+++ b/assets/server/admin/realms/index.html
@@ -45,6 +45,7 @@
               <th scope="col" width="50" class="text-center">ID</th>
               <th scope="col" width="100" class="text-center">Region</th>
               <th scope="col">Name</th>
+              <th scope="col" width="150" class="text-center d-none d-md-table-cell">Maintenance?</th>
               <th scope="col" width="100" class="text-center d-none d-md-table-cell">Chaff (7d)</th>
               <th scope="col" width="100" class="text-center d-none d-md-table-cell">Abuse Modeling</th>
               <th scope="col" width="100" class="text-center d-none d-md-table-cell">SMS</th>
@@ -67,6 +68,15 @@
                 {{if not .ContactEmailAddresses}}
                   <span class="small bi bi-envelope-x-fill text-danger"
                     data-bs-toggle="tooltip" title="There are no contact email addresses for this realm"></span>
+                {{end}}
+              </td>
+              <td class="text-center d-none d-md-table-cell">
+                {{if .MaintenanceMode}}
+                  <span class="small bi bi-check-square-fill text-success px-2"
+                    data-bs-toggle="tooltip" title="Realm is in maintenance mode and cannot issue codes."></span>
+                {{else}}
+                  <span class="small bi bi-x-square-fill text-danger px-2"
+                    data-bs-toggle="tooltip" title="Realm is not in maintenance mode and can issue codes normally."></span>
                 {{end}}
               </td>
               <td class="text-center d-none d-md-table-cell">

--- a/pkg/controller/admin/realms.go
+++ b/pkg/controller/admin/realms.go
@@ -192,6 +192,7 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 		ShortCodeMaxMinutes           uint `form:"short_code_max_minutes"`
 		ENXCodeExpirationConfigurable bool `form:"enx_code_expiration_configurable"`
 		AllowGeneratedSMS             bool `form:"allow_generated_sms"`
+		MaintenanceMode               bool `form:"maintenance_mode"`
 	}
 
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -287,6 +288,7 @@ func (c *Controller) HandleRealmsUpdate() http.Handler {
 		realm.ShortCodeMaxMinutes = form.ShortCodeMaxMinutes
 		realm.ENXCodeExpirationConfigurable = form.ENXCodeExpirationConfigurable
 		realm.AllowGeneratedSMS = form.AllowGeneratedSMS
+		realm.MaintenanceMode = form.MaintenanceMode
 		if err := c.db.SaveRealm(realm, currentUser); err != nil {
 			if database.IsValidationError(err) {
 				w.WriteHeader(http.StatusUnprocessableEntity)

--- a/pkg/controller/codes/bulk_issue.go
+++ b/pkg/controller/codes/bulk_issue.go
@@ -51,6 +51,8 @@ func (c *Controller) HandleBulkIssue() http.Handler {
 			return
 		}
 
+		AddMaintenanceMode(currentRealm, session)
+
 		hasSMSConfig, err := currentRealm.HasSMSConfig(c.db)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)

--- a/pkg/controller/codes/controller.go
+++ b/pkg/controller/codes/controller.go
@@ -19,8 +19,10 @@ package codes
 
 import (
 	"github.com/google/exposure-notifications-verification-server/pkg/config"
+	"github.com/google/exposure-notifications-verification-server/pkg/controller"
 	"github.com/google/exposure-notifications-verification-server/pkg/database"
 	"github.com/google/exposure-notifications-verification-server/pkg/render"
+	"github.com/gorilla/sessions"
 )
 
 type Controller struct {
@@ -45,5 +47,11 @@ func NewAPI(cfg *config.AdminAPIServerConfig, db *database.Database, h *render.R
 		apiconfig: cfg,
 		db:        db,
 		h:         h,
+	}
+}
+
+func AddMaintenanceMode(realm *database.Realm, session *sessions.Session) {
+	if realm.MaintenanceMode {
+		controller.Flash(session).Warning("This realm has been placed in maintenance mode by the server operator and cannot issue codes at this time.")
 	}
 }

--- a/pkg/controller/codes/index.go
+++ b/pkg/controller/codes/index.go
@@ -47,6 +47,8 @@ func (c *Controller) HandleIndex() http.Handler {
 		currentRealm := membership.Realm
 		currentUser := membership.User
 
+		AddMaintenanceMode(currentRealm, session)
+
 		var code database.VerificationCode
 		if err := c.renderStatus(ctx, w, currentRealm, currentUser, &code); err != nil {
 			controller.InternalError(w, r, c.h, err)

--- a/pkg/controller/codes/issue.go
+++ b/pkg/controller/codes/issue.go
@@ -46,6 +46,7 @@ func (c *Controller) HandleIssue() http.Handler {
 		}
 
 		currentRealm := membership.Realm
+		AddMaintenanceMode(currentRealm, session)
 
 		hasSMSConfig, err := currentRealm.HasSMSConfig(c.db)
 		if err != nil {

--- a/pkg/controller/issueapi/issue.go
+++ b/pkg/controller/issueapi/issue.go
@@ -91,6 +91,7 @@ func (c *Controller) IssueMany(ctx context.Context, requests []*IssueRequestInte
 
 	// Generate codes
 	results := make([]*IssueResult, len(requests))
+
 	for i, req := range requests {
 		vCode, resultErr := c.BuildVerificationCode(ctx, req, realm)
 		if resultErr != nil {

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2576,6 +2576,17 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 				return nil
 			},
 		},
+		{
+			ID: "00123-AddRealmMaintenanceMode",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms ADD COLUMN IF NOT EXISTS maintenance_mode BOOLEAN DEFAULT false`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realms DROP COLUMN IF EXISTS maintenance_mode`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -178,6 +178,9 @@ type Realm struct {
 	// Name is the name of the realm.
 	Name string `gorm:"type:varchar(200);unique_index;"`
 
+	// MaintenanceMode defines if this realm is allowed to issue node codes right now.
+	MaintenanceMode bool `gorm:"column:maintenance_mode; type:bool; not null; default:false;"`
+
 	// RegionCode is both a display attribute and required field for ENX. To
 	// handle NULL and uniqueness, the field is converted from it's ptr type to a
 	// concrete type in callbacks. Do not modify RegionCodePtr directly.


### PR DESCRIPTION
Fixes #2338

## Proposed Changes

* system admin realm overview displays quick status

![image](https://user-images.githubusercontent.com/92319/160012939-2a0e3bec-0e51-4a9d-af57-8ab7d73bc41f.png)

* Per-realm settings to change

![image](https://user-images.githubusercontent.com/92319/160013208-5c6b38c9-38ac-45ce-bde0-2e65ff03ac77.png)

* Warming on realm code issue page

![image](https://user-images.githubusercontent.com/92319/160013256-540d84da-9d31-4585-9815-b856d8765118.png)

**Release Note**

```release-note
Allows for server admins to place individual realms in maintenance mode to facilitate EN turndown in a region.
```
