### PR TITLE
Secret agent man

### DIFF
--- a/pkg/controller/redirect/helpers.go
+++ b/pkg/controller/redirect/helpers.go
@@ -27,7 +27,8 @@ func isAndroid(userAgent string) bool {
 
 // isIOS determines if a User-Agent is an iOS EN device.
 func isIOS(userAgent string) bool {
-	return strings.Contains(strings.ToLower(userAgent), "iphone")
+	lAgent := strings.ToLower(userAgent)
+	return strings.Contains(lAgent, "iphone") || strings.Contains(lAgent, "Macintosh")
 }
 
 // decideRedirect selects where to redirect based on several signals.

--- a/pkg/controller/redirect/helpers.go
+++ b/pkg/controller/redirect/helpers.go
@@ -28,7 +28,7 @@ func isAndroid(userAgent string) bool {
 // isIOS determines if a User-Agent is an iOS EN device.
 func isIOS(userAgent string) bool {
 	lAgent := strings.ToLower(userAgent)
-	return strings.Contains(lAgent, "iphone") || strings.Contains(lAgent, "Macintosh")
+	return strings.Contains(lAgent, "iphone") || strings.Contains(lAgent, "macintosh")
 }
 
 // decideRedirect selects where to redirect based on several signals.

--- a/pkg/controller/redirect/helpers_test.go
+++ b/pkg/controller/redirect/helpers_test.go
@@ -229,6 +229,13 @@ func TestAgentDetection(t *testing.T) {
 			// For ENX purposes exclude iPad as it's unsupported.
 			ios: false,
 		},
+		{
+			name:      "osx_desktop",
+			userAgent: "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_9_3) AppleWebKit/537.75.14 (KHTML, like Gecko) Version/7.0.3 Safari/7046A194A",
+			android:   false,
+			// edge case, if a user has their browser in desktop mode, it sends a mac user agent
+			ios: true,
+		},
 	}
 
 	for _, tc := range cases {


### PR DESCRIPTION

## Proposed Changes

* accept macintosh desktop user agents for redirect

**Release Note**

```release-note
Accept desktop user agents from Macs. iPhone where the browser is set to "always request desktop" mode enabled, currently get an error if they tap on the link in the SMS.
```
