### PR TITLE
[WIP] increment stats for bad nonce

### DIFF
--- a/pkg/database/composite_stats.go
+++ b/pkg/database/composite_stats.go
@@ -95,6 +95,7 @@ func (c CompositeStats) MarshalJSON() ([]byte, error) {
 			}
 			data.UserReportsIssued = stat.RealmStats.UserReportsIssued
 			data.UserReportsClaimed = stat.RealmStats.UserReportsClaimed
+			data.UserReportsInvalid = stat.RealmStats.UserReportsInvalid
 			data.TokensClaimed = stat.RealmStats.TokensClaimed
 			data.TokensInvalid = stat.RealmStats.TokensInvalid
 			data.UserReportTokensClaimed = stat.RealmStats.UserReportTokensClaimed
@@ -160,7 +161,7 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		"publish_requests_unknown", "publish_requests_android", "publish_requests_ios",
 		"total_teks_published", "requests_with_revisions", "requests_missing_onset_date", "tek_age_distribution", "onset_to_upload_distribution",
 		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
-		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android",
+		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android", "user_reports_invalid",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -219,6 +220,12 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 				row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalidByOS[OSTypeIOS]), 10))
 				row = append(row, strconv.FormatUint(uint64(stat.RealmStats.CodesInvalidByOS[OSTypeAndroid]), 10))
 			}
+		}
+
+		if stat.RealmStats == nil {
+			row = append(row, "")
+		} else {
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsInvalid), 10))
 		}
 
 		// New stats should always be added to the end to preserve existing external user applications.

--- a/pkg/database/composite_stats.go
+++ b/pkg/database/composite_stats.go
@@ -95,7 +95,7 @@ func (c CompositeStats) MarshalJSON() ([]byte, error) {
 			}
 			data.UserReportsIssued = stat.RealmStats.UserReportsIssued
 			data.UserReportsClaimed = stat.RealmStats.UserReportsClaimed
-			data.UserReportsInvalid = stat.RealmStats.UserReportsInvalid
+			data.UserReportsInvalidNonce = stat.RealmStats.UserReportsInvalidNonce
 			data.TokensClaimed = stat.RealmStats.TokensClaimed
 			data.TokensInvalid = stat.RealmStats.TokensInvalid
 			data.UserReportTokensClaimed = stat.RealmStats.UserReportTokensClaimed
@@ -161,7 +161,7 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		"publish_requests_unknown", "publish_requests_android", "publish_requests_ios",
 		"total_teks_published", "requests_with_revisions", "requests_missing_onset_date", "tek_age_distribution", "onset_to_upload_distribution",
 		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
-		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android", "user_reports_invalid",
+		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android", "user_reports_invalid_nonce",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -225,7 +225,7 @@ func (c CompositeStats) MarshalCSV() ([]byte, error) {
 		if stat.RealmStats == nil {
 			row = append(row, "")
 		} else {
-			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsInvalid), 10))
+			row = append(row, strconv.FormatUint(uint64(stat.RealmStats.UserReportsInvalidNonce), 10))
 		}
 
 		// New stats should always be added to the end to preserve existing external user applications.

--- a/pkg/database/composite_stats_test.go
+++ b/pkg/database/composite_stats_test.go
@@ -51,6 +51,7 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesInvalidByOS:         []int64{0, 1, 0},
 						UserReportsIssued:        3,
 						UserReportsClaimed:       2,
+						UserReportsInvalid:       0,
 						TokensClaimed:            7,
 						TokensInvalid:            2,
 						UserReportTokensClaimed:  2,
@@ -72,10 +73,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
-2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2,0,1,0
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2,0,1,0,0
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 		{
 			name: "no_realm_stats",
@@ -97,10 +98,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
-2020-02-03,,,,,,,,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,,,,,,
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+2020-02-03,,,,,,,,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,,,,,,,
 `,
-			expJSON: `{"realm_id":0,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":0,"codes_claimed":0,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":0,"tokens_invalid":0,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":null,"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":0,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":0,"codes_claimed":0,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":0,"tokens_invalid":0,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":null,"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 		{
 			name: "no_keyserver_stats",
@@ -116,6 +117,7 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesInvalidByOS:         []int64{0, 1, 0},
 						UserReportsIssued:        3,
 						UserReportsClaimed:       2,
+						UserReportsInvalid:       1,
 						TokensClaimed:            7,
 						TokensInvalid:            2,
 						UserReportTokensClaimed:  2,
@@ -124,10 +126,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
-2020-02-03,10,9,1,7,2,60,1|3|4,,,,,,,,,3,2,2,0,1,0
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+2020-02-03,10,9,1,7,2,60,1|3|4,,,,,,,,,3,2,2,0,1,0,1
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":false,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":0,"android":0,"ios":0},"total_teks_published":0,"requests_with_revisions":0,"tek_age_distribution":null,"onset_to_upload_distribution":null,"requests_missing_onset_date":0,"total_publish_requests":0}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":false,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid":1,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":0,"android":0,"ios":0},"total_teks_published":0,"requests_with_revisions":0,"tek_age_distribution":null,"onset_to_upload_distribution":null,"requests_missing_onset_date":0,"total_publish_requests":0}}]}`,
 		},
 	}
 

--- a/pkg/database/composite_stats_test.go
+++ b/pkg/database/composite_stats_test.go
@@ -51,7 +51,7 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesInvalidByOS:         []int64{0, 1, 0},
 						UserReportsIssued:        3,
 						UserReportsClaimed:       2,
-						UserReportsInvalid:       0,
+						UserReportsInvalidNonce:  0,
 						TokensClaimed:            7,
 						TokensInvalid:            2,
 						UserReportTokensClaimed:  2,
@@ -73,10 +73,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid_nonce
 2020-02-03,10,9,1,7,2,60,1|3|4,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,3,2,2,0,1,0,0
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid_nonce":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 		{
 			name: "no_realm_stats",
@@ -98,10 +98,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid_nonce
 2020-02-03,,,,,,,,2,39,12,49,3,2,0|1|2|3|4|5|6|7|8|9|10|11|12|13|14,,,,,,,,
 `,
-			expJSON: `{"realm_id":0,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":0,"codes_claimed":0,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":0,"tokens_invalid":0,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":null,"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
+			expJSON: `{"realm_id":0,"has_key_server_stats":true,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":0,"codes_claimed":0,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid_nonce":0,"tokens_claimed":0,"tokens_invalid":0,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":null,"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":2,"android":39,"ios":12},"total_teks_published":49,"requests_with_revisions":3,"tek_age_distribution":[0,1,2,3,4,5,6,7,8,9,10,11,12,13,14],"onset_to_upload_distribution":null,"requests_missing_onset_date":2,"total_publish_requests":53}}]}`,
 		},
 		{
 			name: "no_keyserver_stats",
@@ -117,7 +117,7 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 						CodesInvalidByOS:         []int64{0, 1, 0},
 						UserReportsIssued:        3,
 						UserReportsClaimed:       2,
-						UserReportsInvalid:       1,
+						UserReportsInvalidNonce:  1,
 						TokensClaimed:            7,
 						TokensInvalid:            2,
 						UserReportTokensClaimed:  2,
@@ -126,10 +126,10 @@ func TestCompositeStats_MarshalCSV(t *testing.T) {
 					},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,publish_requests_unknown,publish_requests_android,publish_requests_ios,total_teks_published,requests_with_revisions,requests_missing_onset_date,tek_age_distribution,onset_to_upload_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid_nonce
 2020-02-03,10,9,1,7,2,60,1|3|4,,,,,,,,,3,2,2,0,1,0,1
 `,
-			expJSON: `{"realm_id":1,"has_key_server_stats":false,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid":1,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":0,"android":0,"ios":0},"total_teks_published":0,"requests_with_revisions":0,"tek_age_distribution":null,"onset_to_upload_distribution":null,"requests_missing_onset_date":0,"total_publish_requests":0}}]}`,
+			expJSON: `{"realm_id":1,"has_key_server_stats":false,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":1,"android":0},"user_reports_issued":3,"user_reports_claimed":2,"user_reports_invalid_nonce":1,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":2,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4],"day":"0001-01-01T00:00:00Z","publish_requests":{"unknown":0,"android":0,"ios":0},"total_teks_published":0,"requests_with_revisions":0,"tek_age_distribution":null,"onset_to_upload_distribution":null,"requests_missing_onset_date":0,"total_publish_requests":0}}]}`,
 		},
 	}
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2587,6 +2587,21 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 					`ALTER TABLE realms DROP COLUMN IF EXISTS maintenance_mode`)
 			},
 		},
+		{
+			ID: "00124-AddUserInvalid",
+			Migrate: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats
+						ADD COLUMN IF NOT EXISTS user_reports_invalid INTEGER DEFAULT 0`,
+					`ALTER TABLE realm_stats
+						ALTER COLUMN user_reports_invalid SET NOT NULL`)
+			},
+			Rollback: func(tx *gorm.DB) error {
+				return multiExec(tx,
+					`ALTER TABLE realm_stats
+						DROP COLUMN user_reports_invalid`)
+			},
+		},
 	}
 }
 

--- a/pkg/database/migrations.go
+++ b/pkg/database/migrations.go
@@ -2592,14 +2592,14 @@ func (db *Database) Migrations(ctx context.Context) []*gormigrate.Migration {
 			Migrate: func(tx *gorm.DB) error {
 				return multiExec(tx,
 					`ALTER TABLE realm_stats
-						ADD COLUMN IF NOT EXISTS user_reports_invalid INTEGER DEFAULT 0`,
+						ADD COLUMN IF NOT EXISTS user_reports_invalid_nonce INTEGER DEFAULT 0`,
 					`ALTER TABLE realm_stats
-						ALTER COLUMN user_reports_invalid SET NOT NULL`)
+						ALTER COLUMN user_reports_invalid_nonce SET NOT NULL`)
 			},
 			Rollback: func(tx *gorm.DB) error {
 				return multiExec(tx,
 					`ALTER TABLE realm_stats
-						DROP COLUMN user_reports_invalid`)
+						DROP COLUMN IF EXISTS user_reports_invalid_nonce`)
 			},
 		},
 	}

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -61,6 +61,7 @@ type RealmStat struct {
 	// in the sum of codes issued and codes claimed.
 	UserReportsIssued  uint `gorm:"column:user_reports_issued; type:integer; not null; default:0;"`
 	UserReportsClaimed uint `gorm:"column:user_reports_claimed; type:integer; not null; default:0;"`
+	UserReportsInvalid uint `gorm:"column:user_reports_invalid; type:integer; not null; default:0;"`
 
 	// TokensClaimed is the number of tokens exchanged for a certificate.
 	// TokensInvalid is the number of tokens which failed to exchange due to
@@ -98,6 +99,9 @@ func (s *RealmStat) IsEmpty() bool {
 		return false
 	}
 	if s.UserReportsClaimed > 0 {
+		return false
+	}
+	if s.UserReportsInvalid > 0 {
 		return false
 	}
 	if s.TokensClaimed > 0 {
@@ -152,6 +156,7 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 		"tokens_claimed", "tokens_invalid", "code_claim_mean_age_seconds", "code_claim_age_distribution",
 		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
 		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android",
+		"user_reports_invalid",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -172,6 +177,7 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeUnknown]), 10),
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeIOS]), 10),
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeAndroid]), 10),
+			strconv.FormatUint(uint64(stat.UserReportsInvalid), 10),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
 		}
@@ -219,6 +225,7 @@ type JSONRealmStatStatsData struct {
 	CodesInvalidByOS        CodesInvalidByOSData `json:"codes_invalid_by_os"`
 	UserReportsIssued       uint                 `json:"user_reports_issued"`
 	UserReportsClaimed      uint                 `json:"user_reports_claimed"`
+	UserReportsInvalid      uint                 `json:"user_reports_invalid"`
 	TokensClaimed           uint                 `json:"tokens_claimed"`
 	TokensInvalid           uint                 `json:"tokens_invalid"`
 	UserReportTokensClaimed uint                 `json:"user_report_tokens_claimed"`
@@ -248,6 +255,7 @@ func (s RealmStats) MarshalJSON() ([]byte, error) {
 				},
 				UserReportsIssued:       stat.UserReportsIssued,
 				UserReportsClaimed:      stat.UserReportsClaimed,
+				UserReportsInvalid:      stat.UserReportsInvalid,
 				TokensClaimed:           stat.TokensClaimed,
 				TokensInvalid:           stat.TokensInvalid,
 				UserReportTokensClaimed: stat.UserReportTokensClaimed,
@@ -297,6 +305,7 @@ func (s *RealmStats) UnmarshalJSON(b []byte) error {
 			},
 			UserReportsIssued:        stat.Data.UserReportsIssued,
 			UserReportsClaimed:       stat.Data.UserReportsClaimed,
+			UserReportsInvalid:       stat.Data.UserReportsInvalid,
 			TokensClaimed:            stat.Data.TokensClaimed,
 			TokensInvalid:            stat.Data.TokensInvalid,
 			UserReportTokensClaimed:  stat.Data.UserReportTokensClaimed,

--- a/pkg/database/realm_stats.go
+++ b/pkg/database/realm_stats.go
@@ -59,9 +59,9 @@ type RealmStat struct {
 	// UserReportsIssued is the specific number of codes that were issued because
 	// the user initiated a self-report request. These numbers are also included
 	// in the sum of codes issued and codes claimed.
-	UserReportsIssued  uint `gorm:"column:user_reports_issued; type:integer; not null; default:0;"`
-	UserReportsClaimed uint `gorm:"column:user_reports_claimed; type:integer; not null; default:0;"`
-	UserReportsInvalid uint `gorm:"column:user_reports_invalid; type:integer; not null; default:0;"`
+	UserReportsIssued       uint `gorm:"column:user_reports_issued; type:integer; not null; default:0;"`
+	UserReportsClaimed      uint `gorm:"column:user_reports_claimed; type:integer; not null; default:0;"`
+	UserReportsInvalidNonce uint `gorm:"column:user_reports_invalid_nonce; type:integer; not null; default:0;"`
 
 	// TokensClaimed is the number of tokens exchanged for a certificate.
 	// TokensInvalid is the number of tokens which failed to exchange due to
@@ -101,7 +101,7 @@ func (s *RealmStat) IsEmpty() bool {
 	if s.UserReportsClaimed > 0 {
 		return false
 	}
-	if s.UserReportsInvalid > 0 {
+	if s.UserReportsInvalidNonce > 0 {
 		return false
 	}
 	if s.TokensClaimed > 0 {
@@ -156,7 +156,7 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 		"tokens_claimed", "tokens_invalid", "code_claim_mean_age_seconds", "code_claim_age_distribution",
 		"user_reports_issued", "user_reports_claimed", "user_report_tokens_claimed",
 		"codes_invalid_unknown_os", "codes_invalid_ios", "codes_invalid_android",
-		"user_reports_invalid",
+		"user_reports_invalid_nonce",
 	}); err != nil {
 		return nil, fmt.Errorf("failed to write CSV header: %w", err)
 	}
@@ -177,7 +177,7 @@ func (s RealmStats) MarshalCSV() ([]byte, error) {
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeUnknown]), 10),
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeIOS]), 10),
 			strconv.FormatUint(uint64(stat.CodesInvalidByOS[OSTypeAndroid]), 10),
-			strconv.FormatUint(uint64(stat.UserReportsInvalid), 10),
+			strconv.FormatUint(uint64(stat.UserReportsInvalidNonce), 10),
 		}); err != nil {
 			return nil, fmt.Errorf("failed to write CSV entry %d: %w", i, err)
 		}
@@ -225,7 +225,7 @@ type JSONRealmStatStatsData struct {
 	CodesInvalidByOS        CodesInvalidByOSData `json:"codes_invalid_by_os"`
 	UserReportsIssued       uint                 `json:"user_reports_issued"`
 	UserReportsClaimed      uint                 `json:"user_reports_claimed"`
-	UserReportsInvalid      uint                 `json:"user_reports_invalid"`
+	UserReportsInvalidNonce uint                 `json:"user_reports_invalid_nonce"`
 	TokensClaimed           uint                 `json:"tokens_claimed"`
 	TokensInvalid           uint                 `json:"tokens_invalid"`
 	UserReportTokensClaimed uint                 `json:"user_report_tokens_claimed"`
@@ -255,7 +255,7 @@ func (s RealmStats) MarshalJSON() ([]byte, error) {
 				},
 				UserReportsIssued:       stat.UserReportsIssued,
 				UserReportsClaimed:      stat.UserReportsClaimed,
-				UserReportsInvalid:      stat.UserReportsInvalid,
+				UserReportsInvalidNonce: stat.UserReportsInvalidNonce,
 				TokensClaimed:           stat.TokensClaimed,
 				TokensInvalid:           stat.TokensInvalid,
 				UserReportTokensClaimed: stat.UserReportTokensClaimed,
@@ -305,7 +305,7 @@ func (s *RealmStats) UnmarshalJSON(b []byte) error {
 			},
 			UserReportsIssued:        stat.Data.UserReportsIssued,
 			UserReportsClaimed:       stat.Data.UserReportsClaimed,
-			UserReportsInvalid:       stat.Data.UserReportsInvalid,
+			UserReportsInvalidNonce:  stat.Data.UserReportsInvalidNonce,
 			TokensClaimed:            stat.Data.TokensClaimed,
 			TokensInvalid:            stat.Data.TokensInvalid,
 			UserReportTokensClaimed:  stat.Data.UserReportTokensClaimed,

--- a/pkg/database/realm_stats_test.go
+++ b/pkg/database/realm_stats_test.go
@@ -53,10 +53,10 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{1, 3, 4},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
-2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0,0,0,0
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0,0,0,0,0
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
 		},
 		{
 			name: "multi",
@@ -92,6 +92,7 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodesClaimed:             2,
 					UserReportsIssued:        2,
 					UserReportsClaimed:       1,
+					UserReportsInvalid:       32,
 					CodesInvalid:             0,
 					CodesInvalidByOS:         []int64{0, 0, 0},
 					TokensClaimed:            2,
@@ -101,12 +102,12 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{7, 8, 9},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android
-2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0,1,2,3
-2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0,0,20,9
-2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1,0,0,0
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0,1,2,3,0
+2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0,0,20,9,0
+2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1,0,0,0,32
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":2,"user_reports_claimed":1,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"codes_invalid_by_os":{"unknown_os":0,"ios":20,"android":9},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":1,"ios":2,"android":3},"user_reports_issued":0,"user_reports_claimed":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":2,"user_reports_claimed":1,"user_reports_invalid":32,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"codes_invalid_by_os":{"unknown_os":0,"ios":20,"android":9},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":1,"ios":2,"android":3},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
 		},
 	}
 

--- a/pkg/database/realm_stats_test.go
+++ b/pkg/database/realm_stats_test.go
@@ -53,10 +53,10 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{1, 3, 4},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid_nonce
 2020-02-03,10,9,1,7,2,60,1|3|4,0,0,0,0,0,0,0
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid_nonce":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,3,4]}}]}`,
 		},
 		{
 			name: "multi",
@@ -92,7 +92,7 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodesClaimed:             2,
 					UserReportsIssued:        2,
 					UserReportsClaimed:       1,
-					UserReportsInvalid:       32,
+					UserReportsInvalidNonce:  32,
 					CodesInvalid:             0,
 					CodesInvalidByOS:         []int64{0, 0, 0},
 					TokensClaimed:            2,
@@ -102,12 +102,12 @@ func TestRealmStats_MarshalCSV(t *testing.T) {
 					CodeClaimAgeDistribution: []int32{7, 8, 9},
 				},
 			},
-			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid
+			expCSV: `date,codes_issued,codes_claimed,codes_invalid,tokens_claimed,tokens_invalid,code_claim_mean_age_seconds,code_claim_age_distribution,user_reports_issued,user_reports_claimed,user_report_tokens_claimed,codes_invalid_unknown_os,codes_invalid_ios,codes_invalid_android,user_reports_invalid_nonce
 2020-02-03,10,9,1,7,2,60,1|2|3,0,0,0,1,2,3,0
 2020-02-04,45,30,29,27,2,3600,4|5|6,0,0,0,0,20,9,0
 2020-02-05,15,2,0,2,0,0,7|8|9,2,1,1,0,0,0,32
 `,
-			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":2,"user_reports_claimed":1,"user_reports_invalid":32,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"codes_invalid_by_os":{"unknown_os":0,"ios":20,"android":9},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":1,"ios":2,"android":3},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
+			expJSON: `{"realm_id":1,"statistics":[{"date":"2020-02-05T00:00:00Z","data":{"codes_issued":15,"codes_claimed":2,"codes_invalid":0,"codes_invalid_by_os":{"unknown_os":0,"ios":0,"android":0},"user_reports_issued":2,"user_reports_claimed":1,"user_reports_invalid_nonce":32,"tokens_claimed":2,"tokens_invalid":0,"user_report_tokens_claimed":1,"code_claim_mean_age_seconds":0,"code_claim_age_distribution":[7,8,9]}},{"date":"2020-02-04T00:00:00Z","data":{"codes_issued":45,"codes_claimed":30,"codes_invalid":29,"codes_invalid_by_os":{"unknown_os":0,"ios":20,"android":9},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid_nonce":0,"tokens_claimed":27,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":3600,"code_claim_age_distribution":[4,5,6]}},{"date":"2020-02-03T00:00:00Z","data":{"codes_issued":10,"codes_claimed":9,"codes_invalid":1,"codes_invalid_by_os":{"unknown_os":1,"ios":2,"android":3},"user_reports_issued":0,"user_reports_claimed":0,"user_reports_invalid_nonce":0,"tokens_claimed":7,"tokens_invalid":2,"user_report_tokens_claimed":0,"code_claim_mean_age_seconds":60,"code_claim_age_distribution":[1,2,3]}}]}`,
 		},
 	}
 

--- a/pkg/database/token.go
+++ b/pkg/database/token.go
@@ -390,7 +390,7 @@ func (db *Database) updateStatsCodeInvalid(t time.Time, authApp *AuthorizedApp, 
 		// update general codes invalid
 		existing.CodesInvalid++
 		if badNonce {
-			existing.UserReportsInvalid++
+			existing.UserReportsInvalidNonce++
 		}
 
 		sel := tx.Table("realm_stats").


### PR DESCRIPTION

## Proposed Changes

* Add a new realm stat for user_codes_invalid, incremented when a valid code is presented, but the nonce doesn't match. This is an indicator of people sending codes to someone else's phone number.

**Release Note**


```release-note
Adds new statistic for user report invalid codes. This if effectively a measure for when a user report is sent do a different device than the one requesting it.
```
