### PR TITLE
disallow newlines and repeated whitespace in SMS templates

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -447,6 +447,17 @@
       val = val.replace(/\[expires\]/g, shortExpires);
       val = val.replace(/\[longexpires\]/g, longExpires);
 
+      let newVal = val.replace(/[\n|\r]/g, ' ');
+      if (newVal != val) {
+        errors.push('Line breaks are not allowed in the SMS template.');      
+      }
+      val = newVal;
+      newVal = val.replace(/[\s]+/g, ' ');
+      if (newVal != val) {
+        errors.push('Multiple spaces in a row are not allowed in the SMS template.');
+      }
+      val = newVal;
+
       if (val.length > {{$realm.SMSTemplateExpansionMax}}) {
         errors.push('Fully expanded SMS Templates must be at most {{$realm.SMSTemplateExpansionMax}} characters, currently ' + val.length + ' characters.');
       }

--- a/pkg/database/realm_test.go
+++ b/pkg/database/realm_test.go
@@ -308,10 +308,10 @@ func TestRealm_BeforeSave(t *testing.T) {
 
 				Curabitur non massa urna. Phasellus sit amet nisi ut quam dapibus pretium eget in turpis. Phasellus et justo odio. In auctor, felis a tincidunt maximus, nunc erat vehicula ligula, ac posuere felis odio eget mauris. Nulla gravida.`,
 			},
-			Error: "smsTextTemplate must be 800 characters or less, current message is 807 characters long",
+			Error: "smsTextTemplate must be 800 characters or less, current message is 802 characters long",
 		},
 		{
-			Name: "text_too_long",
+			Name: "text_too_long_2",
 			Input: &Realm{
 				Name:            "a",
 				EnableENExpress: false,
@@ -454,6 +454,24 @@ func TestRealm_BeforeSave(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+func TestRealm_validateSMSTemplate(t *testing.T) {
+	t.Parallel()
+
+	realm := NewRealmWithDefaults("test")
+	realm.SMSTextTemplate = "your link     is \n\n\n\n\n \n [longcode] Expires in      [longexpires] hours"
+	realm.RegionCode = "US-WA"
+
+	db, _ := testDatabaseInstance.NewDatabase(t, nil)
+	if err := db.SaveRealm(realm, SystemTest); err != nil {
+		t.Fatalf("save error: %v issues: %+v", err, realm.ErrorMessages())
+	}
+
+	expected := "your link is [longcode] Expires in [longexpires] hours"
+	if realm.SMSTextTemplate != expected {
+		t.Fatalf("sms text template mismatch: want: %q got: %q", expected, realm.SMSTextTemplate)
 	}
 }
 


### PR DESCRIPTION

## Proposed Changes

* disallow newlines and repeated spaces in SMS template, many newlines can cause messages to be flagged and not delivered.

![image](https://user-images.githubusercontent.com/92319/178323574-2c77b178-8ce3-416e-b27b-ffee27d8a8f5.png)


**Release Note**

```release-note
Disallow newlines and repeated spaces in SMS template, many newlines can cause messages to be flagged and not delivered. Existing SMS templates are not impacted, but will be automatically changed on the next realm edit and errors will appear in the settings page when editing.
```
