### PR TITLE
add charting for bad nonce / device mismatch

### DIFF
--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -171,6 +171,13 @@
           and then successfully
           claimed a verification code and then consented to key release.
         </p>
+
+        <strong>User Report Device Mismatch</strong>
+        <p>
+          This line indicates that a code was requested but not sent to the same
+          device that requested the code. This could indicate attempted system abuse.
+          <strong>This statistic was recently added and there is no historical data available.</strong>
+        </p>
       </div>
     </div>
   </div>

--- a/assets/server/static/js/stats-codes.js
+++ b/assets/server/static/js/stats-codes.js
@@ -89,6 +89,7 @@
             dataTable.addColumn('number', 'User Report Codes Issued');
             dataTable.addColumn('number', 'User Report Codes Claimed');
             dataTable.addColumn('number', 'User Report Tokens Claimed');
+            dataTable.addColumn('number', 'User Report Device Mismatch');
           },
           rowFunc: (dataTable, row, hasKeyServerStats) => {
             dataTable.addRow([
@@ -96,6 +97,7 @@
               row.data.user_reports_issued,
               row.data.user_reports_claimed,
               row.data.user_report_tokens_claimed,
+              row.data.user_reports_invalid_nonce,
             ]);
           },
         },

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1874,7 +1874,8 @@ func (r *Realm) Stats(db *Database) (RealmStats, error) {
 			COALESCE(s.user_report_tokens_claimed, 0) AS user_report_tokens_claimed,
 			COALESCE(s.code_claim_age_distribution, array[]::integer[]) AS code_claim_age_distribution,
 			COALESCE(s.code_claim_mean_age, 0) AS code_claim_mean_age,
-			COALESCE(s.codes_invalid_by_os, array[0,0,0]::bigint[]) AS codes_invalid_by_os
+			COALESCE(s.codes_invalid_by_os, array[0,0,0]::bigint[]) AS codes_invalid_by_os,
+			COALESCE(s.user_reports_invalid_nonce, 0) AS user_reports_invalid_nonce
 		FROM (
 			SELECT date::date FROM generate_series($2, $3, '1 day'::interval) date
 		) d

--- a/pkg/database/token_test.go
+++ b/pkg/database/token_test.go
@@ -170,6 +170,7 @@ func TestIssueToken(t *testing.T) {
 		Subject      *Subject
 		ClaimError   string
 	}{
+
 		{
 			Name: "normal_token_issue",
 			Verification: func() *VerificationCode {
@@ -399,7 +400,7 @@ func TestIssueToken(t *testing.T) {
 			},
 			Nonce:    validNonce,
 			Accept:   acceptConfirmedAndSelfReport,
-			Error:    "verification code not found",
+			Error:    "",
 			TokenAge: time.Hour,
 		},
 	}
@@ -502,6 +503,10 @@ func TestIssueToken(t *testing.T) {
 						t.Fatalf("claimed token is not marked as used")
 					}
 				}
+
+				// There are deferred go funcs to update stats. Give some time
+				// for those to complete. There's no way to coordinate the execution.
+				time.Sleep(500 * time.Millisecond)
 			}
 		})
 	}


### PR DESCRIPTION

## Proposed Changes

* Adds chart for bad nonce / device mismatch
* Adds corresponding help
* Fixes bug introduced in previous commit

Added line to chart

![image](https://user-images.githubusercontent.com/92319/178546218-105302eb-217c-4a32-9f59-ff6e1ea22ca3.png)

Added help text

![image](https://user-images.githubusercontent.com/92319/178546262-92b00d74-d922-4b01-a3af-6e29ad800612.png)


**Release Note**

```release-note
Adds a chart on the realm statistics page that indicates when a user-report code was requested from one device, but sent to another (and therefore not able to be claimed).
```
