### PR TITLE
Update CSS/JS elements to their latest versions

### DIFF
--- a/assets/enx-redirect/header.html
+++ b/assets/enx-redirect/header.html
@@ -14,12 +14,12 @@
 <meta name="msapplication-config" content="/static/browserconfig.xml?{{.buildID}}">
 <meta name="theme-color" content="#ffffff">
 
-{{if eq $.textDirection "rtl"}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.rtl.min.css"
-  integrity="sha384-gXt9imSW0VcJVHezoNQsP+TNrjYXoGcrqBZJpry9zJt8PCQjobwmhMGaDHTASo9N" crossorigin="anonymous">
+{{if eq (printf "%s" $.textDirection) "rtl"}}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.rtl.min.css"
+  integrity="sha512-Swm+W9nAnhHjRr94CSIoZSWqt3SQfImX8IoMjn01dLoYiEgeSSVBuS+GqVupSA5nSfGZrUfUkb8rilBv4WQ6bQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{else}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
-  integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.min.css"
+  integrity="sha512-o/MhoRPVLExxZjCFVBsm17Pkztkzmh7Dp8k7/3JrtNCHh0AQ489kwpfA3dPSHzKDe8YCuEhxXq3Y71eb/o6amg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{end}}
 
 <title>{{if .title}}{{.title}}{{else}}Exposure Notifications Express Redirect Service{{end}}</title>

--- a/assets/enx-redirect/report/header.html
+++ b/assets/enx-redirect/report/header.html
@@ -8,12 +8,12 @@
 <meta name="theme-color" content="#ffffff">
 {{.csrfMeta}}
 
-{{if eq $.textDirection "rtl"}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.rtl.min.css"
-  integrity="sha384-gXt9imSW0VcJVHezoNQsP+TNrjYXoGcrqBZJpry9zJt8PCQjobwmhMGaDHTASo9N" crossorigin="anonymous">
+{{if eq (printf "%s" $.textDirection) "rtl"}}
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.rtl.min.css"
+  integrity="sha512-Swm+W9nAnhHjRr94CSIoZSWqt3SQfImX8IoMjn01dLoYiEgeSSVBuS+GqVupSA5nSfGZrUfUkb8rilBv4WQ6bQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{else}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
-  integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.min.css"
+  integrity="sha512-o/MhoRPVLExxZjCFVBsm17Pkztkzmh7Dp8k7/3JrtNCHh0AQ489kwpfA3dPSHzKDe8YCuEhxXq3Y71eb/o6amg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{end}}
 
 <style>

--- a/assets/server/codes/bulk-issue.html
+++ b/assets/server/codes/bulk-issue.html
@@ -12,7 +12,7 @@
   <script
     src="https://cdnjs.cloudflare.com/ajax/libs/crypto-js/4.0.0/crypto-js.min.js"
     integrity="sha512-nOQuvD9nKirvxDdvQ9OMqe2dgapbPB7vYAMrzJihw5m+aNcf0dX53m6YxM4LgA9u8e9eg9QX+/+mPu8kCNpV2A=="
-    crossorigin="anonymous"></script>
+    crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 </head>
 
 <body id="bulk-issue" class="tab-content">

--- a/assets/server/firebase.html
+++ b/assets/server/firebase.html
@@ -1,7 +1,7 @@
 {{define "firebase"}}
 {{- if .firebase}}
-<script defer src="https://www.gstatic.com/firebasejs/8.10.1/firebase-app.js"></script>
-<script defer src="https://www.gstatic.com/firebasejs/8.10.1/firebase-auth.js"></script>
+<script defer src="https://www.gstatic.com/firebasejs/9.9.0/firebase-app-compat.js"></script>
+<script defer src="https://www.gstatic.com/firebasejs/9.9.0/firebase-auth-compat.js"></script>
 
 <script type="text/javascript">
   const firebaseConfig = {

--- a/assets/server/header.html
+++ b/assets/server/header.html
@@ -16,24 +16,24 @@
 {{.csrfMeta}}
 
 {{if eq (printf "%s" $.textDirection) "rtl"}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.rtl.min.css"
-  integrity="sha384-gXt9imSW0VcJVHezoNQsP+TNrjYXoGcrqBZJpry9zJt8PCQjobwmhMGaDHTASo9N" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.rtl.min.css"
+  integrity="sha512-Swm+W9nAnhHjRr94CSIoZSWqt3SQfImX8IoMjn01dLoYiEgeSSVBuS+GqVupSA5nSfGZrUfUkb8rilBv4WQ6bQ==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{else}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/css/bootstrap.min.css"
-  integrity="sha384-EVSTQN3/azprG1Anm3QDgpJLIm9Nao0Yz1ztcQTwFspd3yD65VohhpuuCOmLASjC" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/css/bootstrap.min.css"
+  integrity="sha512-o/MhoRPVLExxZjCFVBsm17Pkztkzmh7Dp8k7/3JrtNCHh0AQ489kwpfA3dPSHzKDe8YCuEhxXq3Y71eb/o6amg==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{end}}
-<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap-icons@1.7.2/font/bootstrap-icons.css"
-  integrity="sha384-EvBWSlnoFgZlXJvpzS+MAUEjvN7+gcCwH+qh7GRFOGgZO0PuwOFro7qPOJnLfe7l" crossorigin="anonymous">
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/css/intlTelInput.min.css"
-  integrity="sha384-+0L34NtZQE8CdqKYXA1psEH5gRnPhYm5Yrfl6+zHBC9rK+SuCkyS99e/a4wRIf3B" crossorigin="anonymous">
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/bootstrap-icons/1.8.3/font/bootstrap-icons.min.css"
+  integrity="sha512-YzwGgFdO1NQw1CZkPoGyRkEnUTxPSbGWXvGiXrWk8IeSqdyci0dEDYdLLjMxq1zCoU0QBa4kHAFiRhUL3z2bow==" crossorigin="anonymous" referrerpolicy="no-referrer" />
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.17/css/intlTelInput.css"
+  integrity="sha512-gxWow8Mo6q6pLa1XH/CcH8JyiSDEtiwJV78E+D+QP0EVasFs8wKXq16G8CLD4CJ2SnonHr4Lm/yY2fSI2+cbmw==" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{ cssIncludeTag }}
 
-<script defer src="https://code.jquery.com/jquery-3.6.0.min.js"
-  integrity="sha384-vtXRMe3mGCbOeY7l30aIg8H9p3GdeSe4IFlP6G8JMa7o7lXvnz3GFKzPxzJdPfGK" crossorigin="anonymous"></script>
-<script defer src="https://cdn.jsdelivr.net/npm/bootstrap@5.0.2/dist/js/bootstrap.bundle.min.js"
-  integrity="sha384-MrcW6ZMFYlzcLA8Nl+NtUVF0sA7MsXsP1UyJoMp4YLEuNSfAP+JcXn/tWtIaxVXM" crossorigin="anonymous"></script>
-<script defer src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.12/js/intlTelInput.min.js"
-  integrity="sha384-lZ7BQV5Pg5PjeG4uM5qkYztFBL5dtUWhiAtkcz6j/vj1tjZFA+3zhwsiGUmsqulm" crossorigin="anonymous"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jquery/3.6.0/jquery.min.js"
+  integrity="sha512-894YE6QWD5I59HgZOGReFYm4dnWc1Qt5NtvYSaNcOP+u1T9qYdvdihz0PPSiiqn/+/3e7Jo4EaG7TubfWGUrMQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/twitter-bootstrap/5.2.0-beta1/js/bootstrap.bundle.min.js"
+  integrity="sha512-ndrrR94PW3ckaAvvWrAzRi5JWjF71/Pw7TlSo6judANOFCmz0d+0YE+qIGamRRSnVzSvIyGs4BTtyFMm3MT/cg==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/intl-tel-input/17.0.17/js/intlTelInput.min.js"
+  integrity="sha512-1NlRc/n6l/Gl7K7u9g6Z9kxZsKqcJV5uWM/Tv/WCjxDBqUSlxlgHgQI4Z17RW7BdNJjgLj0l6x0kGd0DOvu4AQ==" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{ jsIncludeTag }}
 
 <title>{{if .title}}{{.title}}{{else}}Exposure Notifications Verification Server{{end}}</title>

--- a/pkg/render/assets.go
+++ b/pkg/render/assets.go
@@ -30,13 +30,13 @@ import (
 	"github.com/google/exposure-notifications-verification-server/internal/buildinfo"
 )
 
-const sriPrefix = "sha384-"
+const sriPrefix = "sha512-"
 
 var (
 	cssIncludeTmpl = texttemplate.Must(texttemplate.New(`cssIncludeTmpl`).Parse(strings.TrimSpace(`
 {{ range . -}}
 <link rel="stylesheet" href="/{{.Path}}?{{.BuildID}}"
-  integrity="{{.SRI}}" crossorigin="anonymous">
+  integrity="{{.SRI}}" crossorigin="anonymous" referrerpolicy="no-referrer" />
 {{ end }}
 `)))
 
@@ -47,7 +47,7 @@ var (
 	jsIncludeTmpl = texttemplate.Must(texttemplate.New(`jsIncludeTmpl`).Parse(strings.TrimSpace(`
 {{ range . -}}
 <script defer src="/{{.Path}}?{{.BuildID}}"
-  integrity="{{.SRI}}" crossorigin="anonymous"></script>
+  integrity="{{.SRI}}" crossorigin="anonymous" referrerpolicy="no-referrer"></script>
 {{ end }}
 `)))
 	jsIncludeTagCache htmltemplate.HTML
@@ -127,7 +127,7 @@ func assetIncludeTag(fsys fs.FS, search string, tmpl *texttemplate.Template, cac
 func generateSRI(r io.ReadCloser) (string, error) {
 	defer r.Close()
 
-	h := sha512.New384()
+	h := sha512.New()
 	if _, err := io.Copy(h, r); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
The new version of firebase and firebase-auth require a significant refactoring of our Javascript code; we would need to migrate to modules and use a bundler like Webpack. Fortunately there's a compat layer we can use for now to minimize code changes, but this is something we'll need to think about long term.

Fixes GH-2357

**Release Note**

```release-note
Update Javascript and CSS elements to bootstrap to 5.2.0 and Firebase to 9.9.0.
```
