### PR TITLE
Change self-report interval from 90d to 30d

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -79,7 +79,7 @@ type CleanupConfig struct {
 	// UserReportUnclaimedMaxAge is how long a user report phone hash will be kept if the record goes unclaimed.
 	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=30m"`
 	// UserReportMaxAge is how long a claimed user report phone hash will be kept.
-	UserReportMaxAge time.Duration `env:"USER_REPORT_MAX_AGE, default=2160h"` // 2160h = 90 days
+	UserReportMaxAge time.Duration `env:"USER_REPORT_MAX_AGE, default=720h"` // 720h = 30 days
 }
 
 // NewCleanupConfig returns the environment config for the cleanup server.


### PR DESCRIPTION
**Release Note**

<!-- Enter your extended release note in the below block. If the PR requires
additional action from users switching to the new release, include the string
"action required". If no release note is required, write "NONE". -->

```release-note
Change the default minimum self-report interval from 90 days to 30 days.
```
