### PR TITLE
User report cleanup

### DIFF
--- a/pkg/config/cleanup_server_config.go
+++ b/pkg/config/cleanup_server_config.go
@@ -77,7 +77,7 @@ type CleanupConfig struct {
 	VerificationTokenMaxAge      time.Duration `env:"VERIFICATION_TOKEN_MAX_AGE, default=24h"`
 
 	// UserReportUnclaimedMaxAge is how long a user report phone hash will be kept if the record goes unclaimed.
-	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=30m"`
+	UserReportUnclaimedMaxAge time.Duration `env:"USER_REPORT_UNCLAIMED_MAX_AGE, default=60m"`
 	// UserReportMaxAge is how long a claimed user report phone hash will be kept.
 	UserReportMaxAge time.Duration `env:"USER_REPORT_MAX_AGE, default=720h"` // 720h = 30 days
 }

--- a/pkg/controller/cleanup/handle_cleanup.go
+++ b/pkg/controller/cleanup/handle_cleanup.go
@@ -281,12 +281,13 @@ func (c *Controller) HandleCleanup() http.Handler {
 				if realm.AllowsUserReport() {
 					realmTimeout := time.Duration(realm.ShortCodeMaxMinutes) * time.Minute
 					if realmTimeout > maxAge {
+						logger.Warnw("realm short code setting is causing user report cleanup to be delayed", "realm", realm.ID, "location", realm.RegionCode, "minutes", realm.ShortCodeMaxMinutes)
 						maxAge = realmTimeout
 					}
 				}
 			}
 
-			if count, err := c.db.PurgeUnclaimedUserReports(c.config.UserReportUnclaimedMaxAge); err != nil {
+			if count, err := c.db.PurgeUnclaimedUserReports(maxAge); err != nil {
 				merr = multierror.Append(merr, fmt.Errorf("failed to purge unclaimed user reports: %w", err))
 				result = enobs.ResultError("FAILED")
 			} else {

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1294,6 +1294,25 @@ func (r *Realm) ValidTestType(typ string) bool {
 	}
 }
 
+func (db *Database) MaximumUserReportTimeout() (time.Duration, error) {
+	// TestTypeUSerReport == 16 == 0b10000
+	sql := `
+	SELECT
+		MAX(code_duration) AS duration
+	FROM realms
+	WHERE
+	    allowed_test_types >= 16;`
+
+	var result struct {
+		Quantity int64 `gorm:"column:duration;"`
+	}
+	if err := db.db.Raw(sql).Scan(&result).Error; err != nil {
+		return 0, err
+	}
+	timeout := time.Duration(result.Quantity) * time.Second
+	return timeout, nil
+}
+
 func (db *Database) FindRealmByRegion(region string) (*Realm, error) {
 	var realm Realm
 	if err := db.db.

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -56,6 +56,7 @@ const (
 	TestTypeLikely
 	TestTypeNegative
 	TestTypeUserReport
+	// if a 5 test type is added, update MaximumUserReportTimeout
 )
 
 func (t TestType) Display() string {
@@ -1295,7 +1296,9 @@ func (r *Realm) ValidTestType(typ string) bool {
 }
 
 func (db *Database) MaximumUserReportTimeout() (time.Duration, error) {
-	// TestTypeUSerReport == 16 == 0b10000
+	// TestTypeUserReport == 16
+	// If we ever add ANOTHER test type, this statement would need
+	// to be updated.
 	sql := `
 	SELECT
 		MAX(code_duration) AS duration
@@ -1304,12 +1307,12 @@ func (db *Database) MaximumUserReportTimeout() (time.Duration, error) {
 	    allowed_test_types >= 16;`
 
 	var result struct {
-		Quantity int64 `gorm:"column:duration;"`
+		Duration int64 `gorm:"column:duration;"`
 	}
 	if err := db.db.Raw(sql).Scan(&result).Error; err != nil {
 		return 0, err
 	}
-	timeout := time.Duration(result.Quantity) * time.Second
+	timeout := time.Duration(result.Duration) * time.Second
 	return timeout, nil
 }
 


### PR DESCRIPTION

## Proposed Changes

* Fix user report cleanup

**Release Note**


```release-note
Fix a potential race condition where the system could be configured to clean up user report records (delete nonce) while the user report code is still valid. This ensures that user reports across all realms are not cleaned up sooner than the realm with the longest short code timeout AND user report enabled.
```
