### PR TITLE
Don't allow longexpires in user report

### DIFF
--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -444,7 +444,7 @@
         val = val.replace(/\[longcode\]/g, longCode);
       }
 
-      isUserReport = $(target).attr('label') == "User Report";
+      isUserReport = $(target).attr('label') === "User Report";
       if (isUserReport) {
         if (val.includes(("[longexpires]"))) {
           errors.push("'User Report' template cannot contain `[longexpires]` since user report always uses the short expiration time `[expires]`, which is always in minutes.");

--- a/assets/server/realmadmin/_form_sms.html
+++ b/assets/server/realmadmin/_form_sms.html
@@ -187,7 +187,7 @@
       </div>
       <div class="form-floating mb-3">
         <textarea name="sms_text_template_{{$i}}" class="form-control font-monospace {{if $realm.ErrorsFor $v.Label}}is-invalid{{end}} sms-text-template"
-          placeholder="SMS text template" style="height:150px;">{{$v.Value}}</textarea>
+          placeholder="SMS text template" style="height:150px;" label="{{$v.Label}}">{{$v.Value}}</textarea>
         <label for="sms-text-template">SMS text template</label>
       </div>
       {{if $realm.ErrorsFor $v.Label}}
@@ -416,7 +416,7 @@
       if (val.length > {{$realm.SMSTemplateMaxLength}}) {
         errors.push('SMS Templates must be <= {{$realm.SMSTemplateMaxLength}} characters, currently ' + val.length + ' characters.');
       }
-
+    
       // Provide live feedback on errors in the SMS Template construction.
       if (enxEnabled) {
         if (!val.includes("[enslink]")) {
@@ -438,11 +438,19 @@
         hasLC = val.includes("[longcode]");
         if (!(hasSC || hasLC) || (hasSC && hasLC)) {
           errors.push('must contain exactly one of `[code]` or `[longcode]`');
-        }
+        }        
 
         val = val.replace(/\[region\]/g, region);
         val = val.replace(/\[longcode\]/g, longCode);
       }
+
+      isUserReport = $(target).attr('label') == "User Report";
+      if (isUserReport) {
+        if (val.includes(("[longexpires]"))) {
+          errors.push("'User Report' template cannot contain `[longexpires]` since user report always uses the short expiration time `[expires]`, which is always in minutes.");
+        }
+      }
+
       val = val.replace(/\[code\]/g, shortCode);
       val = val.replace(/\[expires\]/g, shortExpires);
       val = val.replace(/\[longexpires\]/g, longExpires);

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -718,6 +718,13 @@ func (r *Realm) validateSMSTemplate(label, t string) string {
 		}
 	}
 
+	if label == UserReportTemplateLabel {
+		if strings.Contains(t, SMSLongExpires) {
+			r.AddError("smsTextTemplate", fmt.Sprintf("cannot contain %q - for %q the 'short expiration' time is used an is represented in minutes", SMSLongExpires, UserReportTemplateLabel))
+			r.AddError(label, fmt.Sprintf("cannot contain %q", SMSLongExpires))
+		}
+	}
+
 	// Check template length.
 	if l := len(t); l > SMSTemplateMaxLength {
 		r.AddError("smsTextTemplate", fmt.Sprintf("must be %d characters or less, current message is %v characters long", SMSTemplateMaxLength, l))


### PR DESCRIPTION
Fixes #2369

## Proposed Changes

* don't allow `[longexpires]` in the `User Report` sms template (since it always uses the short expires)
* add visual feedback to the UI for this.

![image](https://user-images.githubusercontent.com/92319/185237853-7b0e5f1f-0f97-412b-955a-2fde7b629ec7.png)


**Release Note**

```release-note
Stop allowing `longexpires` in the User Report SMS template since it always uses the `expires` value.
```
