### PR TITLE
No e2 e stats

### DIFF
--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -172,7 +172,7 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("failed to validate issue API configuration: %w", err)
 	}
 
-	if c.MinRealmsForSystemStatistics < 1 {
+	if c.MinRealmsForSystemStatistics < 2 {
 		return fmt.Errorf("MIN_REALMS_FOR_SYSTEM_STATS cannot be set lower than 2")
 	}
 

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -103,6 +103,9 @@ type ServerConfig struct {
 	// MinRealmsForSystemStatistics gives a minimum threshold for displaying system
 	// admin level statistics
 	MinRealmsForSystemStatistics uint `env:"MIN_REALMS_FOR_SYSTEM_STATS, default=2"`
+	// ExcludeFromSystemStatistics is the realm location to exclude from the system stats.
+	// This is the e2e testing realm by default.
+	ExcludeFromSystemStatistics string `env:"EXCLUDE_FROM_SYSTEM_STATS, default=E2E-TEST"`
 
 	// Rate limiting configuration
 	RateLimit ratelimit.Config

--- a/pkg/config/server_config.go
+++ b/pkg/config/server_config.go
@@ -103,9 +103,9 @@ type ServerConfig struct {
 	// MinRealmsForSystemStatistics gives a minimum threshold for displaying system
 	// admin level statistics
 	MinRealmsForSystemStatistics uint `env:"MIN_REALMS_FOR_SYSTEM_STATS, default=2"`
-	// ExcludeFromSystemStatistics is the realm location to exclude from the system stats.
-	// This is the e2e testing realm by default.
-	ExcludeFromSystemStatistics string `env:"EXCLUDE_FROM_SYSTEM_STATS, default=E2E-TEST"`
+	// ExcludeFromSystemStatistics is a list of realm IDs to exclude from system stats, in addition
+	// to any e2e test realms that are found.
+	ExcludeFromSystemStatistics []uint `env:"EXCLUDE_FROM_SYSTEM_STATS"`
 
 	// Rate limiting configuration
 	RateLimit ratelimit.Config
@@ -172,7 +172,7 @@ func (c *ServerConfig) Validate() error {
 		return fmt.Errorf("failed to validate issue API configuration: %w", err)
 	}
 
-	if c.MinRealmsForSystemStatistics < 2 {
+	if c.MinRealmsForSystemStatistics < 1 {
 		return fmt.Errorf("MIN_REALMS_FOR_SYSTEM_STATS cannot be set lower than 2")
 	}
 

--- a/pkg/controller/admin/code_stats.go
+++ b/pkg/controller/admin/code_stats.go
@@ -26,7 +26,8 @@ func (c *Controller) HandleCodeStats() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		stats, err := c.db.AllRealmCodeStatsCached(ctx, c.cacher, int(c.config.MinRealmsForSystemStatistics))
+		excludeReam := c.config.ExcludeFromSystemStatistics
+		stats, err := c.db.AllRealmCodeStatsCached(ctx, c.cacher, int(c.config.MinRealmsForSystemStatistics), excludeReam)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return

--- a/pkg/controller/admin/code_stats.go
+++ b/pkg/controller/admin/code_stats.go
@@ -26,8 +26,7 @@ func (c *Controller) HandleCodeStats() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		ctx := r.Context()
 
-		excludeReam := c.config.ExcludeFromSystemStatistics
-		stats, err := c.db.AllRealmCodeStatsCached(ctx, c.cacher, int(c.config.MinRealmsForSystemStatistics), excludeReam)
+		stats, err := c.db.AllRealmCodeStatsCached(ctx, c.cacher, int(c.config.MinRealmsForSystemStatistics), c.config.ExcludeFromSystemStatistics)
 		if err != nil {
 			controller.InternalError(w, r, c.h, err)
 			return

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1956,7 +1956,7 @@ func (db *Database) AllRealmCodeStats(ctx context.Context, requiredRealms int, e
 
 	realm, err := db.FindRealmByRegion(excludeReam)
 	if err != nil {
-		db.logger.Warnw("unable to find realm to exclude from system stats")
+		db.logger.Warnw("unable to find realm to exclude from system stats", "excludeRealm", excludeReam, "error", err)
 		realm = nil
 	}
 

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1989,9 +1989,7 @@ func (db *Database) AllRealmCodeStats(ctx context.Context, requiredRealms int, e
 	sql = sql + `GROUP BY d.date
 		ORDER BY date DESC`
 
-	values := make([]interface{}, 2)
-	values[0] = start
-	values[1] = stop
+	values := []interface{}{start, stop}
 	if realm != nil {
 		values = append(values, realm.ID)
 	}

--- a/pkg/database/realm.go
+++ b/pkg/database/realm.go
@@ -1977,9 +1977,7 @@ func (db *Database) AllRealmCodeStats(ctx context.Context, requiredRealms int, e
 		}
 	}
 	// Exclude other explicitly listed realms
-	for _, rID := range excludeRealms {
-		excludedRealmIDs = append(excludedRealmIDs, rID)
-	}
+	excludedRealmIDs = append(excludedRealmIDs, excludeRealms...)
 
 	sql := `
 		SELECT


### PR DESCRIPTION

## Proposed Changes

* Exclude E2E-TEST realm from system code issue stats

**Release Note**

```release-note
Note to operators, this will exclude a realm with a region code of E2E-TEST from system wide code issue/code claimed stats. If you have named this realm something else, you will need to override the EXCLUDE_FROM_SYSTEM_STATS environment variable.
```
