### PR TITLE
remove message that has aged out

### DIFF
--- a/assets/server/realmadmin/_stats_codes.html
+++ b/assets/server/realmadmin/_stats_codes.html
@@ -176,7 +176,6 @@
         <p>
           This line indicates that a code was requested but not sent to the same
           device that requested the code. This could indicate attempted system abuse.
-          <strong>This statistic was recently added and there is no historical data available.</strong>
         </p>
       </div>
     </div>


### PR DESCRIPTION

**Release Note**

```release-note
Removes advisory message on realm stats about device mismatch being a new stat with no history.
```
