### PR TITLE
Look for client IP as the second-to-last entry in the IP list

### DIFF
--- a/pkg/controller/middleware/firewall_test.go
+++ b/pkg/controller/middleware/firewall_test.go
@@ -97,7 +97,7 @@ func TestProcessFirewall(t *testing.T) {
 		{
 			name: "single_allowed_xff",
 			ctx: controller.WithRealm(ctx, &database.Realm{
-				AllowedCIDRsServer: []string{"1.2.3.4/32"},
+				AllowedCIDRsServer: []string{"5.6.7.8/32"},
 			}),
 			remoteAddr: "9.8.7.6",
 			xff:        "5.6.7.8, 1.2.3.4",

--- a/pkg/ratelimit/limitware/middleware.go
+++ b/pkg/ratelimit/limitware/middleware.go
@@ -194,9 +194,13 @@ func UserIDKeyFunc(ctx context.Context, scope string, hmacKey []byte) httplimit.
 
 // IPAddressKeyFunc uses the client IP to rate limit.
 func IPAddressKeyFunc(ctx context.Context, scope string, hmacKey []byte) httplimit.KeyFunc {
+	logger := logging.FromContext(ctx)
+
 	return func(r *http.Request) (string, error) {
 		// Get the remote addr
 		ip := realip.FromGoogleCloud(r)
+
+		logger.Debugw("falling back to rate limiting by ip address", "address", ip)
 
 		dig, err := digest.HMAC(ip, hmacKey)
 		if err != nil {

--- a/pkg/realip/realip.go
+++ b/pkg/realip/realip.go
@@ -41,7 +41,7 @@ func FromGoogleCloud(r *http.Request) string {
 	if xff != "" {
 		parts := strings.Split(xff, ",")
 		if len(parts) > 1 {
-			ip = parts[len(parts)-1]
+			ip = parts[len(parts)-2]
 		}
 	}
 

--- a/pkg/realip/realip_test.go
+++ b/pkg/realip/realip_test.go
@@ -51,18 +51,18 @@ func TestOnGoogleCloud(t *testing.T) {
 		{
 			name: "xff_multi",
 			xff:  "34.1.2.3,231.5.4.3,2.2.2.2",
-			exp:  "2.2.2.2",
+			exp:  "231.5.4.3",
 		},
 		{
 			name: "xff_multi_trim",
 			xff:  "     34.1.2.3,  231.5.4.3,2.2.2.2",
-			exp:  "2.2.2.2",
+			exp:  "231.5.4.3",
 		},
 		{
 			name:       "remote_addr_with_xff",
 			remoteAddr: "1.1.1.1",
 			xff:        "34.1.2.3,231.5.4.3,2.2.2.2",
-			exp:        "2.2.2.2",
+			exp:        "231.5.4.3",
 		},
 	}
 


### PR DESCRIPTION
Also add a debug log for when we fall back to rate limiting by IP address.

```release-note
Fix an issue where rate limiting would be improperly applied to the entire system.
```
